### PR TITLE
Add basic support for Feather M0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,35 +20,17 @@ There are a couple of crates provided by this repo:
   a type-safe layer over the raw `atsamd21g18a` and `atsamd21e18a` crates.  This crate
   implements traits specified by the `embedded-hal` project, making it compatible with
   various drivers in the embedded rust ecosystem.
-* [`metro_m0`](https://wez.github.io/atsamd21-rs/atsamd21g18a/metro_m0/) is a board support crate
-  for the Adafruit Metro M0 board.  It re-exports the `atsamd21-hal` crate functionality
-  using more convenient names; for example, the IO pins are exported using the labels
-  printed on the board rather than the more abstract and harder to remember port and
-  pin numbers used by the underlying device.
-* [`samd21_mini`](https://wez.github.io/atsamd21-rs/atsamd21g18a/samd21_mini/) is a board support crate
-  for the SparkFunc SAMD21 Mini board.  It re-exports the `atsamd21-hal` crate functionality
-  using more convenient names; for example, the IO pins are exported using the labels
-  printed on the board rather than the more abstract and harder to remember port and
-  pin numbers used by the underlying device.
-* [`arduino_mkrzero`](https://wez.github.io/atsamd21-rs/atsamd21g18a/arduino_mkrzero/) is a board support crate
-  for the Arduino MKR Zero board.  It re-exports the `atsamd21-hal` crate functionality
-  using more convenient names; for example, the IO pins are exported using the labels
-  printed on the board rather than the more abstract and harder to remember port and
-  pin numbers used by the underlying device.
-* [`gemma_m0`](https://wez.github.io/atsamd21-rs/atsamd21e18a/gemma_m0/) is a board support crate
-  for the Adafruit Gemma M0 board.  Similar to the Metro M0 crate, it re-exports the
-  `atsamd21-hal` crate functionality using more convenient names.
-* [`trinket_m0`](https://wez.github.io/atsamd21-rs/atsamd21e18a/trinket_m0/) is a board support crate
-  for the Adafruit Trinket M0 board.  Similar to the Metro M0 crate, it re-exports the
-  `atsamd21-hal` crate functionality using more convenient names.
-* [`itsybitsy_m0`](https://wez.github.io/atsamd21-rs/atsamd21g18a/itsybitsy_m0/) is a board support crate
-  for the Adafruit ItsyBitsy M0 board.  It re-exports the `atsamd21-hal` crate functionality
-  using more convenient names; for example, the IO pins are exported using the labels
-  printed on the board rather than the more abstract and harder to remember port and
-  pin numbers used by the underlying device.
+
+In addition to the generic crates, there are also crates for popular ATSAMD21 based development boards. They aim to rename pins to match silk screens or Arduino pin assignments, add helpers for initialization, and re-export the `atsamd21-hal` crate.
+
+* [`arduino_mkrzero`](https://wez.github.io/atsamd21-rs/atsamd21g18a/arduino_mkrzero/)
 * [`circuit_playground_express`](https://wez.github.io/atsamd21-rs/atsamd21g18a/circuit_playground_express/)
-  for the Adafruit Circuit Playground Express board.  Similar to the Metro M0 crate, it re-exports the
-  `atsamd21-hal` crate functionality using more convenient names.
+* [`feather_m0`](https://wez.github.io/atsamd21-rs/atsamd21g18a/feather_m0/)
+* [`gemma_m0`](https://wez.github.io/atsamd21-rs/atsamd21e18a/gemma_m0/)
+* [`itsybitsy_m0`](https://wez.github.io/atsamd21-rs/atsamd21g18a/itsybitsy_m0/)
+* [`metro_m0`](https://wez.github.io/atsamd21-rs/atsamd21g18a/metro_m0/)
+* [`samd21_mini`](https://wez.github.io/atsamd21-rs/atsamd21g18a/samd21_mini/)
+* [`trinket_m0`](https://wez.github.io/atsamd21-rs/atsamd21e18a/trinket_m0/)
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -3,19 +3,19 @@
 This repo holds various things that support/enable working with atmel samd21 based
 devices, such as the Adafruit Metro M0, Trinket M0 and Gemma M0, using Rust.
 
-[![Build Status](https://travis-ci.org/wez/atsamd21-rs.svg?branch=master)](https://travis-ci.org/wez/atsamd21-rs)
+[![Build Status](https://travis-ci.org/atsamd-rs/atsamd21-rs.svg?branch=master)](https://travis-ci.org/atsamd-rs/atsamd21-rs)
 
 There are a couple of crates provided by this repo:
 
-* [`atsamd21g18a`](https://wez.github.io/atsamd21-rs/atsamd21g18a/atsamd21g18a/) is an
+* [`atsamd21g18a`](https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/atsamd21g18a/) is an
   auto-generated crate providing access to the peripherals
   specified for this device by its SVD file.  This is the MCU used in the Metro M0,
   Feather M0 and Circuit Playground express boards from Adafruit.
-* [`atsamd21e18a`](https://wez.github.io/atsamd21-rs/atsamd21e18a/atsamd21e18a/) is an
+* [`atsamd21e18a`](https://atsamd-rs.github.io/atsamd21-rs/atsamd21e18a/atsamd21e18a/) is an
   auto-generated crate providing access to the peripherals
   specified for this device by its SVD file.  This is the MCU used in the Trinket M0
   and Gemma M0 boards from Adafruit.
-* [`atsamd21-hal`](https://wez.github.io/atsamd21-rs/atsamd21g18a/atsamd21_hal/) is the result
+* [`atsamd21-hal`](https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/atsamd21_hal/) is the result
   of reading the datasheet for the device and encoding
   a type-safe layer over the raw `atsamd21g18a` and `atsamd21e18a` crates.  This crate
   implements traits specified by the `embedded-hal` project, making it compatible with
@@ -23,14 +23,14 @@ There are a couple of crates provided by this repo:
 
 In addition to the generic crates, there are also crates for popular ATSAMD21 based development boards. They aim to rename pins to match silk screens or Arduino pin assignments, add helpers for initialization, and re-export the `atsamd21-hal` crate.
 
-* [`arduino_mkrzero`](https://wez.github.io/atsamd21-rs/atsamd21g18a/arduino_mkrzero/)
-* [`circuit_playground_express`](https://wez.github.io/atsamd21-rs/atsamd21g18a/circuit_playground_express/)
-* [`feather_m0`](https://wez.github.io/atsamd21-rs/atsamd21g18a/feather_m0/)
-* [`gemma_m0`](https://wez.github.io/atsamd21-rs/atsamd21e18a/gemma_m0/)
-* [`itsybitsy_m0`](https://wez.github.io/atsamd21-rs/atsamd21g18a/itsybitsy_m0/)
-* [`metro_m0`](https://wez.github.io/atsamd21-rs/atsamd21g18a/metro_m0/)
-* [`samd21_mini`](https://wez.github.io/atsamd21-rs/atsamd21g18a/samd21_mini/)
-* [`trinket_m0`](https://wez.github.io/atsamd21-rs/atsamd21e18a/trinket_m0/)
+* [`arduino_mkrzero`](https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/arduino_mkrzero/)
+* [`circuit_playground_express`](https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/circuit_playground_express/)
+* [`feather_m0`](https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/feather_m0/)
+* [`gemma_m0`](https://atsamd-rs.github.io/atsamd21-rs/atsamd21e18a/gemma_m0/)
+* [`itsybitsy_m0`](https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/itsybitsy_m0/)
+* [`metro_m0`](https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/metro_m0/)
+* [`samd21_mini`](https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/samd21_mini/)
+* [`trinket_m0`](https://atsamd-rs.github.io/atsamd21-rs/atsamd21e18a/trinket_m0/)
 
 ## Building
 

--- a/boards/arduino_mkrzero/Cargo.toml
+++ b/boards/arduino_mkrzero/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Wez Furlong <wez@wezfurlong.org>", "David McGillicuddy <contact@djmc
 description = "Board Support crate for the Arduino MKRZERO"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/wez/atsamd21-rs"
+repository = "https://github.com/atsamd-rs/atsamd21-rs"
 readme = "README.md"
-documentation = "https://wez.github.io/atsamd21-rs/atsamd21g18a/arduino_mkrzero/"
+documentation = "https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/arduino_mkrzero/"
 
 [dependencies]
 cortex-m = "~0.5"

--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -5,8 +5,9 @@ authors = ["Paul Sajna <paulsajna@gmail.com>"]
 description = "Board Support crate for the Adafruit Circuit Playground Express"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/wez/atsamd21-rs"
+repository = "https://github.com/atsamd-rs/atsamd21-rs"
 readme = "README.md"
+documentation = "https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/circuit_playground_express/"
 
 [dependencies]
 cortex-m = "~0.5"

--- a/boards/circuit_playground_express/README.md
+++ b/boards/circuit_playground_express/README.md
@@ -7,4 +7,4 @@ board](https://www.adafruit.com/product/3333).
 
 Check out the repository for examples:
 
-https://github.com/wez/atsamd21-rs/tree/master/circuit_playground_express/examples
+https://github.com/atsamd-rs/atsamd21-rs/tree/master/circuit_playground_express/examples

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "feather_m0"
-version = "0.2.2"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
+version = "0.1.0"
+authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit Feather M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 license = "MIT OR Apache-2.0"

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "feather_m0"
+version = "0.2.2"
+authors = ["Wez Furlong <wez@wezfurlong.org>"]
+description = "Board Support crate for the Adafruit Feather M0"
+keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/wez/atsamd21-rs"
+readme = "README.md"
+documentation = "https://wez.github.io/atsamd21-rs/atsamd21g18a/feather_m0/"
+
+[dependencies]
+cortex-m = "~0.5"
+embedded-hal = "~0.2"
+nb = "~0.1"
+
+[dependencies.cortex-m-rt]
+version = "~0.6"
+optional = true
+
+[dependencies.atsamd21-hal]
+path = "../../hal"
+version = "~0.2"
+default-features = false
+
+[dev-dependencies]
+panic-abort = "~0.2"
+panic-semihosting = "~0.3"
+cortex-m-semihosting = "~0.3"
+cortex-m-rtfm = "~0.3"
+sx1509 = "~0.2"
+panic_rtt = "~0.1"
+
+[features]
+# ask the HAL to enable atsamd21g18a support
+default = ["rt", "atsamd21-hal/samd21g18a"]
+rt = ["cortex-m-rt", "atsamd21-hal/samd21g18a-rt"]
+unproven = ["atsamd21-hal/unproven"]
+use_rtt = ["atsamd21-hal/use_rtt"]
+usb = ["atsamd21-hal/usb"]
+
+[profile.dev]
+incremental = false
+codegen-units = 1
+debug = true
+lto = false
+
+[profile.release]
+debug = true
+lto = true
+opt-level = "s"

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit Feather M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/wez/atsamd21-rs"
+repository = "https://github.com/atsamd-rs/atsamd21-rs"
 readme = "README.md"
-documentation = "https://wez.github.io/atsamd21-rs/atsamd21g18a/feather_m0/"
+documentation = "https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/feather_m0/"
 
 [dependencies]
 cortex-m = "~0.5"

--- a/boards/feather_m0/README.md
+++ b/boards/feather_m0/README.md
@@ -7,4 +7,4 @@ board](https://www.adafruit.com/product/2772).
 
 Check out the repository for examples:
 
-https://github.com/wez/atsamd21-rs/tree/master/feather_m0/examples
+https://github.com/atsamd-rs/atsamd21-rs/tree/master/feather_m0/examples

--- a/boards/feather_m0/README.md
+++ b/boards/feather_m0/README.md
@@ -1,0 +1,10 @@
+# Adafruit Feather M0 Board Support Crate
+
+This crate provides a type-safe API for working with the [Adafruit Feather M0
+board](https://www.adafruit.com/product/3505).
+
+## Examples?
+
+Check out the repository for examples:
+
+https://github.com/wez/atsamd21-rs/tree/master/feather_m0/examples

--- a/boards/feather_m0/README.md
+++ b/boards/feather_m0/README.md
@@ -1,7 +1,7 @@
 # Adafruit Feather M0 Board Support Crate
 
 This crate provides a type-safe API for working with the [Adafruit Feather M0
-board](https://www.adafruit.com/product/3505).
+board](https://www.adafruit.com/product/2772).
 
 ## Examples?
 

--- a/boards/feather_m0/build.rs
+++ b/boards/feather_m0/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+fn main() {
+    if env::var_os("CARGO_FEATURE_RT").is_some() {
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        File::create(out.join("memory.x"))
+            .unwrap()
+            .write_all(include_bytes!("memory.x"))
+            .unwrap();
+        println!("cargo:rustc-link-search={}", out.display());
+        println!("cargo:rerun-if-changed=memory.x");
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/boards/feather_m0/examples/blinky_basic.rs
+++ b/boards/feather_m0/examples/blinky_basic.rs
@@ -1,0 +1,36 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate cortex_m_semihosting;
+extern crate feather_m0 as hal;
+#[cfg(not(feature = "use_semihosting"))]
+extern crate panic_abort;
+#[cfg(feature = "use_semihosting")]
+extern crate panic_semihosting;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::prelude::*;
+use hal::{entry, CorePeripherals, Peripherals};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+    loop {
+        delay.delay_ms(200u8);
+        red_led.set_high();
+        delay.delay_ms(200u8);
+        red_led.set_low();
+    }
+}

--- a/boards/feather_m0/memory.x
+++ b/boards/feather_m0/memory.x
@@ -1,0 +1,8 @@
+MEMORY
+{
+  /* Leave 8k for the default bootloader on the Feather M0 */
+  FLASH (rx) : ORIGIN = 0x00000000 + 8K, LENGTH = 256K - 8K
+  RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 32K
+}
+_stack_start = ORIGIN(RAM) + LENGTH(RAM);
+

--- a/boards/feather_m0/src/lib.rs
+++ b/boards/feather_m0/src/lib.rs
@@ -1,0 +1,158 @@
+#![no_std]
+#![recursion_limit = "1024"]
+
+extern crate atsamd21_hal as hal;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::entry;
+
+pub use hal::atsamd21g18a::*;
+use hal::prelude::*;
+pub use hal::*;
+
+use gpio::{Floating, Input, Port};
+use hal::clock::GenericClockController;
+use hal::sercom::{I2CMaster3, PadPin, SPIMaster4};
+use hal::time::Hertz;
+
+#[cfg(feature = "usb")]
+pub use hal::usb::UsbBus;
+#[cfg(feature = "usb")]
+use usb_device::bus::UsbBusWrapper;
+
+define_pins!(
+    /// Maps the pins to their arduino names and
+    /// the numbers printed on the board.
+    struct Pins,
+    target_device: atsamd21g18a,
+
+    /// Analog pin 0.  Can act as a true analog output
+    /// as it has a DAC (which is not currently supported
+    /// by this hal) as well as input.
+    pin a0 = a2,
+
+    /// Analog Pin 1
+    pin a1 = b8,
+    /// Analog Pin 2
+    pin a2 = b9,
+    /// Analog Pin 3
+    pin a3 = a4,
+    /// Analog Pin 4
+    pin a4 = a5,
+    /// Analog Pin 5
+    pin a5 = b2,
+
+    /// Pin 0, rx
+    pin d0 = a11,
+    /// Pin 1, tx
+    pin d1 = a10,
+    /// Pin 5, PWM capable
+    pin d5 = a15,
+    /// Pin 6, PWM capable
+    pin d6 = a20,
+    /// Pin 9, PWM capable.  Also analog input (A7)
+    pin d9 = a7,
+    /// Pin 10, PWM capable
+    pin d10 = a18,
+    /// Pin 11, PWM capable
+    pin d11 = a16,
+    /// Pin 12, PWM capable
+    pin d12 = a19,
+    /// Pin 13, which is also attached to
+    /// the red LED.  PWM capable.
+    pin d13 = a17,
+
+    /// The I2C data line
+    pin sda = a22,
+    /// The I2C clock line
+    pin scl = a23,
+
+    /// The SPI SCK
+    pin sck = b11,
+    /// The SPI MOSI
+    pin mosi = b10,
+    /// The SPI MISO
+    pin miso = a12,
+
+    /// The USB D- pad
+    pin usb_dm = a24,
+    /// The USB D+ pad
+    pin usb_dp = a25,
+);
+
+/// Convenience for setting up the labelled SPI peripheral.
+/// This powers up SERCOM4 and configures it for use as an
+/// SPI Master in SPI Mode 0.
+pub fn spi_master<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    bus_speed: F,
+    sercom4: SERCOM4,
+    pm: &mut PM,
+    sck: gpio::Pb11<Input<Floating>>,
+    mosi: gpio::Pb10<Input<Floating>>,
+    miso: gpio::Pa12<Input<Floating>>,
+    port: &mut Port,
+) -> SPIMaster4 {
+    let gclk0 = clocks.gclk0();
+    SPIMaster4::new(
+        &clocks.sercom4_core(&gclk0).unwrap(),
+        bus_speed.into(),
+        hal::hal::spi::Mode {
+            phase: hal::hal::spi::Phase::CaptureOnFirstTransition,
+            polarity: hal::hal::spi::Polarity::IdleLow,
+        },
+        sercom4,
+        pm,
+        hal::sercom::SPI4Pinout::Dipo0Dopo1 {
+            miso: miso.into_pad(port),
+            mosi: mosi.into_pad(port),
+            sck: sck.into_pad(port),
+        },
+    )
+}
+
+/// Convenience for setting up the labelled SDA, SCL pins to
+/// operate as an I2C master running at the specified frequency.
+pub fn i2c_master<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    bus_speed: F,
+    sercom3: SERCOM3,
+    pm: &mut PM,
+    sda: gpio::Pa22<Input<Floating>>,
+    scl: gpio::Pa23<Input<Floating>>,
+    port: &mut Port,
+) -> I2CMaster3 {
+    let gclk0 = clocks.gclk0();
+    I2CMaster3::new(
+        &clocks.sercom3_core(&gclk0).unwrap(),
+        bus_speed.into(),
+        sercom3,
+        pm,
+        sda.into_pad(port),
+        scl.into_pad(port),
+    )
+}
+
+#[cfg(feature = "usb")]
+pub fn usb_bus(
+    usb: USB,
+    clocks: &mut GenericClockController,
+    pm: &mut PM,
+    dm: gpio::Pa24<Input<Floating>>,
+    dp: gpio::Pa25<Input<Floating>>,
+    port: &mut Port,
+) -> UsbBusWrapper<UsbBus> {
+    let gclk0 = clocks.gclk0();
+    dbgprint!("making usb clock");
+    let usb_clock = &clocks.usb(&gclk0).unwrap();
+    dbgprint!("got clock");
+    UsbBusWrapper::new(UsbBus::new(
+        usb_clock,
+        pm,
+        dm.into_function(port),
+        dp.into_function(port),
+        usb,
+    ))
+}

--- a/boards/gemma_m0/Cargo.toml
+++ b/boards/gemma_m0/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Wez Furlong <wez@wezfurlong.org>"]
 description = "Board Support crate for the Adafruit Gemma M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/wez/atsamd21-rs"
+repository = "https://github.com/atsamd-rs/atsamd21-rs"
 readme = "README.md"
-documentation = "https://wez.github.io/atsamd21-rs/atsamd21e18a/gemma_m0/"
+documentation = "https://atsamd-rs.github.io/atsamd21-rs/atsamd21e18a/gemma_m0/"
 
 [dependencies]
 cortex-m = "~0.5"

--- a/boards/gemma_m0/README.md
+++ b/boards/gemma_m0/README.md
@@ -7,4 +7,4 @@ board](https://www.adafruit.com/product/3501).
 
 Check out the repository for examples:
 
-https://github.com/wez/atsamd21-rs/tree/master/gemma_m0/examples
+https://github.com/atsamd-rs/atsamd21-rs/tree/master/gemma_m0/examples

--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit ItsyBitsy M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/wez/atsamd21-rs"
+repository = "https://github.com/atsamd-rs/atsamd21-rs"
 readme = "README.md"
-documentation = "https://wez.github.io/atsamd21-rs/atsamd21g18a/itsybitsy_m0/"
+documentation = "https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/itsybitsy_m0/"
 
 [dependencies]
 cortex-m = "~0.5"

--- a/boards/itsybitsy_m0/README.md
+++ b/boards/itsybitsy_m0/README.md
@@ -7,4 +7,4 @@ board](https://www.adafruit.com/product/3727).
 
 Check out the repository for examples:
 
-https://github.com/wez/atsamd21-rs/tree/master/boards/itsybitsy_m0/examples
+https://github.com/atsamd-rs/atsamd21-rs/tree/master/boards/itsybitsy_m0/examples

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Wez Furlong <wez@wezfurlong.org>"]
 description = "Board Support crate for the Adafruit Metro M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/wez/atsamd21-rs"
+repository = "https://github.com/atsamd-rs/atsamd21-rs"
 readme = "README.md"
-documentation = "https://wez.github.io/atsamd21-rs/atsamd21g18a/metro_m0/"
+documentation = "https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/metro_m0/"
 
 [dependencies]
 cortex-m = "~0.5"

--- a/boards/metro_m0/README.md
+++ b/boards/metro_m0/README.md
@@ -7,4 +7,4 @@ board](https://www.adafruit.com/product/3505).
 
 Check out the repository for examples:
 
-https://github.com/wez/atsamd21-rs/tree/master/metro_m0/examples
+https://github.com/atsamd-rs/atsamd21-rs/tree/master/metro_m0/examples

--- a/boards/samd21_mini/Cargo.toml
+++ b/boards/samd21_mini/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Ze'ev Klapow <zklapow@gmail.com>"]
 description = "Board Support crate for the Sparkfun SAMD21 Mini Breakout"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/wez/atsamd21-rs"
+repository = "https://github.com/atsamd-rs/atsamd21-rs"
 readme = "README.md"
-documentation = "https://wez.github.io/atsamd21-rs/atsamd21g18a/samd21_mini/"
+documentation = "https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/samd21_mini/"
 
 [dependencies]
 cortex-m = "~0.5"

--- a/boards/samd21_mini/README.md
+++ b/boards/samd21_mini/README.md
@@ -6,4 +6,4 @@ This crate provides a type-safe API for working with the [Sparkfun SAMD21 Mini B
 
 Check out the repository for examples:
 
-https://github.com/wez/atsamd21-rs/tree/master/samd21_mini/examples
+https://github.com/atsamd-rs/atsamd21-rs/tree/master/samd21_mini/examples

--- a/boards/trinket_m0/Cargo.toml
+++ b/boards/trinket_m0/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit Trinket M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/wez/atsamd21-rs"
+repository = "https://github.com/atsamd-rs/atsamd21-rs"
 readme = "README.md"
-documentation = "https://wez.github.io/atsamd21-rs/atsamd21e18a/trinket_m0/"
+documentation = "https://atsamd-rs.github.io/atsamd21-rs/atsamd21e18a/trinket_m0/"
 
 [dependencies]
 cortex-m = "~0.5"

--- a/boards/trinket_m0/README.md
+++ b/boards/trinket_m0/README.md
@@ -7,4 +7,4 @@ board](https://www.adafruit.com/product/3500).
 
 Check out the repository for examples:
 
-https://github.com/wez/atsamd21-rs/tree/master/boards/trinket_m0/examples
+https://github.com/atsamd-rs/atsamd21-rs/tree/master/boards/trinket_m0/examples

--- a/boards/trinket_m0/README.md
+++ b/boards/trinket_m0/README.md
@@ -1,7 +1,7 @@
 # Adafruit Trinket M0 Board Support Crate
 
 This crate provides a type-safe API for working with the [Adafruit Trinket M0
-board](https://www.adafruit.com/product/3501).
+board](https://www.adafruit.com/product/3500).
 
 ## Examples?
 

--- a/build-all.sh
+++ b/build-all.sh
@@ -7,6 +7,7 @@ set -xe
 # each board as its own entity.
 
 cargo build --manifest-path boards/metro_m0/Cargo.toml --example blinky_basic
+cargo build --manifest-path boards/feather_m0/Cargo.toml --example
 cargo build --manifest-path boards/gemma_m0/Cargo.toml --examples
 cargo build --manifest-path boards/itsybitsy_m0/Cargo.toml --examples
 cargo build --manifest-path boards/trinket_m0/Cargo.toml --examples

--- a/build-docs.py
+++ b/build-docs.py
@@ -11,7 +11,7 @@ import argparse
 # emit misleading docs.
 crates_by_pac = {
     'atsamd21e18a': ['gemma_m0', 'trinket_m0'],
-    'atsamd21g18a': ['metro_m0', 'samd21_mini', 'arduino_mkrzero', 'itsybitsy_m0', 'circuit_playground_express'],
+    'atsamd21g18a': ['metro_m0', 'samd21_mini', 'arduino_mkrzero', 'itsybitsy_m0', 'circuit_playground_express', 'feather_m0'],
 }
 
 def generate_docs():

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Wez Furlong <wez@wezfurlong.org>"]
 description = "HAL and Peripheral access API for ATSAMD21 microcontrollers"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/wez/atsamd21-rs"
+repository = "https://github.com/atsamd-rs/atsamd21-rs"
 readme = "README.md"
-documentation = "https://wez.github.io/atsamd21-rs/atsamd21g18a/atsamd21_hal/"
+documentation = "https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/atsamd21_hal/"
 
 [dependencies]
 cortex-m = "~0.5"

--- a/pac/atsamd21e18a/Cargo.toml
+++ b/pac/atsamd21e18a/Cargo.toml
@@ -5,9 +5,9 @@ version = "0.3.2"
 authors = ["Wez Furlong <wez@wezfurlong.org>"]
 keywords = ["no-std", "arm", "cortex-m"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/wez/atsamd21-rs"
+repository = "https://github.com/atsamd-rs/atsamd21-rs"
 readme = "README.md"
-documentation = "https://wez.github.io/atsamd21-rs/atsamd21e18a/atsamd21e18a/"
+documentation = "https://atsamd-rs.github.io/atsamd21-rs/atsamd21e18a/atsamd21e18a/"
 
 [dependencies]
 bare-metal = "~0.2"

--- a/pac/atsamd21g18a/Cargo.toml
+++ b/pac/atsamd21g18a/Cargo.toml
@@ -5,9 +5,9 @@ version = "0.3.2"
 authors = ["Wez Furlong <wez@wezfurlong.org>", "Blake Johnson <johnsonblake1@gmail.com>"]
 keywords = ["no-std", "arm", "cortex-m"]
 license = "MIT OR Apache-2.0"
-repository = "https://github.com/wez/atsamd21-rs"
+repository = "https://github.com/atsamd-rs/atsamd21-rs"
 readme = "README.md"
-documentation = "https://wez.github.io/atsamd21-rs/atsamd21g18a/atsamd21g18a/"
+documentation = "https://atsamd-rs.github.io/atsamd21-rs/atsamd21g18a/atsamd21g18a/"
 
 [dependencies]
 bare-metal = "~0.2"


### PR DESCRIPTION
This adds basic support for Adafruit's Basic Proto version of the Feather M0. I opened issue #20 to discuss how the other variations of the Feather M0 should be organized. I only have the Bluefruit variant to test with but all the exposed pins are the same and so I have confirmed the blink example on this board.