### PR TITLE
fix broken links from board README files to examples

### DIFF
--- a/boards/circuit_playground_express/README.md
+++ b/boards/circuit_playground_express/README.md
@@ -7,4 +7,4 @@ board](https://www.adafruit.com/product/3333).
 
 Check out the repository for examples:
 
-https://github.com/atsamd-rs/atsamd/tree/master/circuit_playground_express/examples
+https://github.com/atsamd-rs/atsamd/tree/master/boards/circuit_playground_express/examples

--- a/boards/feather_m0/README.md
+++ b/boards/feather_m0/README.md
@@ -7,4 +7,4 @@ board](https://www.adafruit.com/product/2772).
 
 Check out the repository for examples:
 
-https://github.com/atsamd-rs/atsamd/tree/master/feather_m0/examples
+https://github.com/atsamd-rs/atsamd/tree/master/boards/feather_m0/examples

--- a/boards/gemma_m0/README.md
+++ b/boards/gemma_m0/README.md
@@ -7,4 +7,4 @@ board](https://www.adafruit.com/product/3501).
 
 Check out the repository for examples:
 
-https://github.com/atsamd-rs/atsamd/tree/master/gemma_m0/examples
+https://github.com/atsamd-rs/atsamd/tree/master/boards/gemma_m0/examples

--- a/boards/metro_m0/README.md
+++ b/boards/metro_m0/README.md
@@ -7,4 +7,4 @@ board](https://www.adafruit.com/product/3505).
 
 Check out the repository for examples:
 
-https://github.com/atsamd-rs/atsamd/tree/master/metro_m0/examples
+https://github.com/atsamd-rs/atsamd/tree/master/boards/metro_m0/examples

--- a/boards/samd21_mini/README.md
+++ b/boards/samd21_mini/README.md
@@ -6,4 +6,4 @@ This crate provides a type-safe API for working with the [Sparkfun SAMD21 Mini B
 
 Check out the repository for examples:
 
-https://github.com/atsamd-rs/atsamd/tree/master/samd21_mini/examples
+https://github.com/atsamd-rs/atsamd/tree/master/boards/samd21_mini/examples


### PR DESCRIPTION
Just fix a few broken links in the READMEs.