### PR TITLE
Replace mashup with paste

### DIFF
--- a/boards/arduino_mkrzero/src/lib.rs
+++ b/boards/arduino_mkrzero/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![recursion_limit = "1024"]
 
 extern crate atsamd21_hal as hal;
 

--- a/boards/circuit_playground_express/src/lib.rs
+++ b/boards/circuit_playground_express/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![recursion_limit = "1024"]
 
 extern crate atsamd21_hal as hal;
 

--- a/boards/feather_m0/src/lib.rs
+++ b/boards/feather_m0/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![recursion_limit = "1024"]
 
 extern crate atsamd21_hal as hal;
 

--- a/boards/gemma_m0/src/lib.rs
+++ b/boards/gemma_m0/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![recursion_limit = "1024"]
 
 extern crate atsamd21_hal as hal;
 

--- a/boards/itsybitsy_m0/src/lib.rs
+++ b/boards/itsybitsy_m0/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![recursion_limit = "1024"]
 
 extern crate atsamd21_hal as hal;
 

--- a/boards/metro_m0/examples/rando.rs
+++ b/boards/metro_m0/examples/rando.rs
@@ -2,6 +2,7 @@
 #![no_main]
 
 extern crate cortex_m;
+extern crate cortex_m_rt;
 extern crate cortex_m_semihosting;
 extern crate metro_m0 as hal;
 #[cfg(not(feature = "use_semihosting"))]
@@ -9,7 +10,6 @@ extern crate panic_halt;
 #[cfg(feature = "use_semihosting")]
 extern crate panic_semihosting;
 extern crate rtfm;
-extern crate cortex_m_rt;
 // extern crate ssd1331;
 extern crate sx1509;
 

--- a/boards/metro_m0/src/lib.rs
+++ b/boards/metro_m0/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![recursion_limit = "1024"]
 
 extern crate atsamd21_hal as hal;
 

--- a/boards/samd21_mini/src/lib.rs
+++ b/boards/samd21_mini/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![recursion_limit = "1024"]
 
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;

--- a/boards/sodaq_one/src/lib.rs
+++ b/boards/sodaq_one/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![recursion_limit = "1024"]
 
 extern crate atsamd21_hal as hal;
 

--- a/boards/trinket_m0/src/lib.rs
+++ b/boards/trinket_m0/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![recursion_limit = "1024"]
 
 extern crate atsamd21_hal as hal;
 

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g18a/atsamd21_hal/"
 cortex-m = "~0.5"
 embedded-hal = "~0.2"
 nb = "~0.1"
-mashup = "^0.1.6"
+paste = "~0.1"
 bitfield = "~0.13"
 vcell = "*"
 

--- a/hal/src/gpio.rs
+++ b/hal/src/gpio.rs
@@ -529,33 +529,31 @@ macro_rules! define_pins {
      target_device: $target_device:ident,
      $( $(#[$attr:meta])* pin $name:ident = $pin_ident:ident),+ , ) => {
 
-// The `mashup` macro generates the `m` macro which performs the
-// substitutions of e.g. `"gen_pin_name" a22` to `pa22`.
-use $crate::mashup::*;
-mashup!{
-    $(
-        m["gen_pin_name" $pin_ident] = p $pin_ident;
-        m["gen_type_name" $pin_ident] = P $pin_ident;
-    )+
-}
-m!{
+$crate::paste::item! {
+    $(#[$topattr])*
+    pub struct $Type {
+        /// Opaque port reference
+        pub port: Port,
 
-$(#[$topattr])*
-pub struct $Type {
-    /// Opaque port reference
-    pub port: Port,
-
-    $($(#[$attr])* pub $name: gpio::"gen_type_name" $pin_ident <Input<Floating>>),+
+        $(
+            $(#[$attr])*
+            pub $name: gpio::[<P $pin_ident>]<Input<Floating>>
+        ),+
+    }
 }
 
 impl $Type {
     /// Returns the pins for the device
-    pub fn new(port: $target_device::PORT) -> Self {
-        let pins = port.split();
-        $Type {
-            port: pins.port,
-            $($name: pins."gen_pin_name" $pin_ident),+
+    $crate::paste::item! {
+        pub fn new(port: $target_device::PORT) -> Self {
+            let pins = port.split();
+            $Type {
+                port: pins.port,
+                $(
+                $name: pins.[<p $pin_ident>]
+                ),+
+            }
         }
     }
 }
-}}}
+}}

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![recursion_limit = "1024"]
 #![cfg_attr(feature = "usb", feature(align_offset, ptr_offset_from))]
 
 #[cfg(feature = "samd21g18a")]
@@ -41,8 +40,8 @@ macro_rules! dbgprint {
 #[cfg_attr(feature = "usb", macro_use)]
 extern crate cortex_m;
 pub extern crate embedded_hal as hal;
-pub extern crate mashup;
 extern crate nb;
+pub extern crate paste;
 
 #[cfg(feature = "usb")]
 pub extern crate usb_device;


### PR DESCRIPTION
Replaces our pin name and type generation with the paste crate.
This requires rust 1.30+