### PR TITLE
trellis_m4: use ws2812-nop-samd51, disable lto

### DIFF
--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -34,11 +34,7 @@ cortex-m-semihosting = "~0.3"
 cortex-m-rtfm = "~0.4"
 panic_rtt = "~0.2"
 smart-leds = "~0.1"
-smart-leds-trait = "~0.1" 
-
-[dev-dependencies.ws2812-timer-delay]
-version = "~0.1"
-#features = ["slow"]
+ws2812-nop-samd51 = { git = "https://github.com/smart-leds-rs/ws2812-nop-samd51.git" }
 
 [features]
 # ask the HAL to enable atsamd51g19a support
@@ -54,5 +50,5 @@ lto = false
 
 [profile.release]
 debug = true
-lto = true
+lto = false
 opt-level = "s"

--- a/boards/trellis_m4/examples/neopixel_blink.rs
+++ b/boards/trellis_m4/examples/neopixel_blink.rs
@@ -2,53 +2,48 @@
 #![no_main]
 
 extern crate cortex_m;
-extern crate trellis_m4 as hal;
 extern crate panic_halt;
 extern crate smart_leds;
-extern crate ws2812_timer_delay as ws2812;
+extern crate trellis_m4 as hal;
+extern crate ws2812_nop_samd51 as ws2812;
 
 use hal::prelude::*;
 use hal::{entry, Peripherals, CorePeripherals};
 use hal::{clock::GenericClockController, delay::Delay};
-use hal::{timer::TimerCounter};
 
-use smart_leds::Color;
-use smart_leds::colors::RED;
 use smart_leds::brightness;
+use smart_leds::colors::RED;
+use smart_leds::Color;
 use smart_leds::SmartLedsWrite;
 
 #[entry]
 fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
-    let core = CorePeripherals::take().unwrap();
-    let mut clocks = GenericClockController::with_external_32kosc(
+    let core_peripherals = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_internal_32kosc(
         peripherals.GCLK,
         &mut peripherals.MCLK,
         &mut peripherals.OSC32KCTRL,
         &mut peripherals.OSCCTRL,
         &mut peripherals.NVMCTRL,
     );
+
     let mut pins = hal::Pins::new(peripherals.PORT);
-
-    let gclk0 = clocks.gclk0();
-    let timer_clock = clocks.tc2_tc3(&gclk0).unwrap();
-    let mut timer = TimerCounter::tc3_(
-        &timer_clock, 
-        peripherals.TC3, 
-        &mut peripherals.MCLK
-    );
-    timer.start(3_000_000u32.hz());
-
-    let mut neopixel_pin = pins.neopixel.into_push_pull_output(&mut pins.port);
-    let mut neopixel = ws2812::Ws2812::new(timer, &mut neopixel_pin);
-    let mut delay = Delay::new(core.SYST, &mut clocks);
+    let mut delay = Delay::new(core_peripherals.SYST, &mut clocks);
+    let neopixel_pin = pins.neopixel.into_push_pull_output(&mut pins.port);
+    let mut neopixel = ws2812::Ws2812::new(neopixel_pin);
 
     loop {
         let data = [RED; 1];
-        neopixel.write(brightness(data.iter().cloned(), 32)).unwrap();
+        neopixel
+            .write(brightness(data.iter().cloned(), 32))
+            .unwrap();
         delay.delay_ms(250u8);
         let data2 = [Color::default(); 1];
-        neopixel.write(brightness(data2.iter().cloned(), 32)).unwrap();
+        neopixel
+            .write(brightness(data2.iter().cloned(), 32))
+            .unwrap();
         delay.delay_ms(250u8);
     }
 }

--- a/boards/trellis_m4/examples/neopixel_rainbow.rs
+++ b/boards/trellis_m4/examples/neopixel_rainbow.rs
@@ -2,24 +2,28 @@
 #![no_main]
 
 extern crate cortex_m;
-extern crate trellis_m4 as hal;
 extern crate panic_halt;
 extern crate smart_leds;
-extern crate smart_leds_trait;
-extern crate ws2812_timer_delay as ws2812;
+extern crate trellis_m4 as hal;
+extern crate ws2812_nop_samd51 as ws2812;
 
 use hal::prelude::*;
 use hal::{entry, Peripherals, CorePeripherals};
-use hal::{clock::GenericClockController, delay::Delay, timer::TimerCounter};
+use hal::{clock::GenericClockController, delay::Delay};
 
-use smart_leds::SmartLedsWrite;
-use smart_leds::Color;
 use smart_leds::brightness;
+use smart_leds::Color;
+use smart_leds::SmartLedsWrite;
 
+/// Total number of LEDs on the NeoTrellis M4
+const NUM_LEDS: usize = 32;
+
+/// Main entrypoint
 #[entry]
 fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
-    let core = CorePeripherals::take().unwrap();
+    let core_peripherals = CorePeripherals::take().unwrap();
+
     let mut clocks = GenericClockController::with_internal_32kosc(
         peripherals.GCLK,
         &mut peripherals.MCLK,
@@ -27,26 +31,23 @@ fn main() -> ! {
         &mut peripherals.OSCCTRL,
         &mut peripherals.NVMCTRL,
     );
+
     let mut pins = hal::Pins::new(peripherals.PORT);
-
-    let gclk0 = clocks.gclk0();
-    let timer_clock = clocks.tc2_tc3(&gclk0).unwrap();
-    let mut timer = TimerCounter::tc3_(&timer_clock, peripherals.TC3, &mut peripherals.MCLK);
-    timer.start(3_000_000u32.hz());
-
-    let mut neopixel_pin = pins.neopixel.into_push_pull_output(&mut pins.port);
-    let mut neopixel = ws2812::Ws2812::new(timer, &mut neopixel_pin);
-    let mut delay = Delay::new(core.SYST, &mut clocks);
-
-    const NUM_LEDS: usize = 32;
-    let mut data = [Color::default(); NUM_LEDS];
+    let mut delay = Delay::new(core_peripherals.SYST, &mut clocks);
+    let neopixel_pin = pins.neopixel.into_push_pull_output(&mut pins.port);
+    let mut neopixel = ws2812::Ws2812::new(neopixel_pin);
+    let mut values = [Color::default(); NUM_LEDS];
 
     loop {
-        for j in 0..(256*5) {
-            for i in 0..NUM_LEDS {
-                data[i] = wheel((((i * 256) as u16 / NUM_LEDS as u16 + j as u16) & 255) as u8);
+        for j in 0..(256 * 5) {
+            for (i, value) in values.iter_mut().enumerate() {
+                *value = wheel((((i * 256) as u16 / NUM_LEDS as u16 + j) & 255) as u8);
             }
-            neopixel.write(brightness(data.iter().cloned(), 32)).unwrap();
+
+            neopixel
+                .write(brightness(values.iter().cloned(), 32))
+                .unwrap();
+
             delay.delay_ms(5u8);
         }
     }
@@ -57,12 +58,12 @@ fn main() -> ! {
 fn wheel(mut wheel_pos: u8) -> Color {
     wheel_pos = 255 - wheel_pos;
     if wheel_pos < 85 {
-        return (255 - wheel_pos * 3, 0, wheel_pos * 3).into()
+        return (255 - wheel_pos * 3, 0, wheel_pos * 3).into();
     }
     if wheel_pos < 170 {
-        wheel_pos -=85;
-        return (0, wheel_pos * 3, 255 - wheel_pos * 3).into()
+        wheel_pos -= 85;
+        return (0, wheel_pos * 3, 255 - wheel_pos * 3).into();
     }
     wheel_pos -= 170;
-    (wheel_pos*3, 255 - wheel_pos * 3, 0).into()
+    (wheel_pos * 3, 255 - wheel_pos * 3, 0).into()
 }


### PR DESCRIPTION
We measured `ws2812-nop-samd51`'s bitbanged signal to the NeoPixels with a logic analyzer and discovered it was going too fast with LTO enabled (which was needed originally to get the timer-driven examples working).

With LTO off `ws2812-nop-samd51` can *correctly* drive the NeoPixels:

![ezgif-5-0284417041e6](https://user-images.githubusercontent.com/797/54087211-e957ec00-430d-11e9-9e5c-def73b47ad1e.gif)
