### PR TITLE
trellis_m4 keypad-unproven feature

### DIFF
--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -16,6 +16,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd51g19a/trellis_m4/"
 [dependencies]
 cortex-m = "~0.5"
 embedded-hal = "~0.2"
+keypad = { version = "~0.1", optional = true }
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]
@@ -41,6 +42,7 @@ ws2812-nop-samd51 = { git = "https://github.com/smart-leds-rs/ws2812-nop-samd51.
 default = ["rt", "atsamd-hal/samd51g19a", "atsamd-hal/samd51"]
 rt = ["cortex-m-rt", "atsamd-hal/samd51g19a-rt"]
 unproven = ["atsamd-hal/unproven"]
+keypad-unproven = ["keypad", "unproven"]
 
 [profile.dev]
 incremental = false

--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -54,3 +54,13 @@ lto = false
 debug = true
 lto = false
 opt-level = "s"
+
+[[example]]
+name = "neopixel_blink"
+
+[[example]]
+name = "neopixel_rainbow"
+
+[[example]]
+name = "neopixel_keypad"
+required-features = ["keypad"]

--- a/boards/trellis_m4/examples/neopixel_keypad.rs
+++ b/boards/trellis_m4/examples/neopixel_keypad.rs
@@ -1,0 +1,96 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate panic_halt;
+extern crate smart_leds;
+extern crate trellis_m4 as hal;
+extern crate ws2812_nop_samd51 as ws2812;
+
+use hal::prelude::*;
+use hal::{entry, Peripherals, CorePeripherals};
+use hal::{clock::GenericClockController, delay::Delay};
+
+use smart_leds::brightness;
+use smart_leds::{colors, Color};
+use smart_leds::SmartLedsWrite;
+
+/// Total number of LEDs on the NeoTrellis M4
+const NUM_LEDS: usize = 32;
+
+/// Main entrypoint
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core_peripherals = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.MCLK,
+        &mut peripherals.OSC32KCTRL,
+        &mut peripherals.OSCCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+    let mut delay = Delay::new(core_peripherals.SYST, &mut clocks);
+
+    let hal::pins::Sets { neopixel, keypad: keypad_pins, mut port, .. } = hal::Pins::new(peripherals.PORT).split();
+
+    // neopixels
+    let neopixel_pin = neopixel.into_push_pull_output(&mut port);
+    let mut neopixel = ws2812::Ws2812::new(neopixel_pin);
+    let mut color_values = [Color::default(); NUM_LEDS];
+
+    // keypad
+    let keypad = hal::Keypad::new(keypad_pins, &mut port);
+    let keypad_inputs = keypad.decompose();
+    let mut keypad_state = [false; NUM_LEDS];
+    let mut toggle_values = [true; NUM_LEDS];
+
+    loop {
+        for j in 0..(256 * 5) {
+            for (i, value) in color_values.iter_mut().enumerate() {
+                let keypad_column = i % 8;
+                let keypad_row = i / 8;
+                let keypad_button = &keypad_inputs[keypad_row][keypad_column];
+
+                if keypad_button.is_high() {
+                    keypad_state[i] = true;
+                } else {
+                    // toggle event
+                    if keypad_state[i] == true {
+                        keypad_state[i] = false;
+                        toggle_values[i] = !toggle_values[i];
+                    }
+                }
+
+                *value = if toggle_values[i] {
+                    wheel((((i * 256) as u16 / NUM_LEDS as u16 + j) & 255) as u8)
+                } else {
+                    colors::GHOST_WHITE
+                };
+            }
+
+            neopixel
+                .write(brightness(color_values.iter().cloned(), 32))
+                .unwrap();
+
+            delay.delay_ms(5u8);
+        }
+    }
+}
+
+/// Input a value 0 to 255 to get a color value
+/// The colours are a transition r - g - b - back to r.
+fn wheel(mut wheel_pos: u8) -> Color {
+    wheel_pos = 255 - wheel_pos;
+    if wheel_pos < 85 {
+        return (255 - wheel_pos * 3, 0, wheel_pos * 3).into();
+    }
+    if wheel_pos < 170 {
+        wheel_pos -= 85;
+        return (0, wheel_pos * 3, 255 - wheel_pos * 3).into();
+    }
+    wheel_pos -= 170;
+    (wheel_pos * 3, 255 - wheel_pos * 3, 0).into()
+}

--- a/boards/trellis_m4/src/lib.rs
+++ b/boards/trellis_m4/src/lib.rs
@@ -5,12 +5,15 @@ extern crate atsamd_hal as hal;
 
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
+
+pub mod pins;
+
 #[cfg(feature = "rt")]
 pub use cortex_m_rt::entry;
-
 pub use hal::{*, atsamd51g19a::*};
 
 use gpio::{Floating, Input, Port};
+
 use hal::prelude::*;
 use hal::clock::GenericClockController;
 use hal::sercom::{I2CMaster4, PadPin};
@@ -43,30 +46,30 @@ define_pins!(
     /// Accelerometer clock signal (SCL)
     pin accel_scl = a13,
 
-    /// Key Grid Column 0
+    /// Keypad Column 0
     pin col0 = a14,
-    /// Key Grid Column 1
+    /// Keypad Column 1
     pin col1 = a15,
-    /// Key Grid Column 2
+    /// Keypad Column 2
     pin col2 = a16,
-    /// Key Grid Column 3
+    /// Keypad Column 3
     pin col3 = a17,
-    /// Key Grid Column 4
+    /// Keypad Column 4
     pin col4 = a20,
-    /// Key Grid Column 5
+    /// Keypad Column 5
     pin col5 = a21,
-    /// Key Grid Column 6
+    /// Keypad Column 6
     pin col6 = a22,
-    /// Key Grid Column 7
+    /// Keypad Column 7
     pin col7 = a23,
 
-    /// Key Grid Row 0
+    /// Keypad Row 0
     pin row0 = a18,
-    /// Key Grid Row 1
+    /// Keypad Row 1
     pin row1 = a19,
-    /// Key Grid Row 2
+    /// Keypad Row 2
     pin row2 = b22,
-    /// Key Grid Row 3
+    /// Keypad Row 3
     pin row3 = b23,
 
     /// NeoPixels
@@ -77,6 +80,84 @@ define_pins!(
     /// APA102 (RGB LED control) MOSI
     pin dotstar_di = b3,
 );
+
+impl Pins {
+    /// Split the device pins into subsets
+    pub fn split(self) -> pins::Sets {
+        let Self {
+            port,
+            a0,
+            a1,
+            a2,
+            micout,
+            micin,
+            sda,
+            scl,
+            accel_sda,
+            accel_scl,
+            col0,
+            col1,
+            col2,
+            col3,
+            col4,
+            col5,
+            col6,
+            col7,
+            row0,
+            row1,
+            row2,
+            row3,
+            neopixel,
+            dotstar_ci,
+            dotstar_di,
+        } = self;
+
+        let accel = pins::Accelerometer {
+            sda: accel_sda,
+            scl: accel_scl,
+        };
+
+        let analog = pins::Analog { a0, a1, a2 };
+
+        let audio = pins::Audio {
+            input: micin,
+            output: micout,
+        };
+
+        let dotstar = pins::Dotstar {
+            ci: dotstar_ci,
+            di: dotstar_di,
+        };
+
+        let i2c = pins::I2C { sda, scl };
+
+        let keypad = pins::Keypad {
+            col0,
+            col1,
+            col2,
+            col3,
+            col4,
+            col5,
+            col6,
+            col7,
+            row0,
+            row1,
+            row2,
+            row3,
+        };
+
+        pins::Sets {
+            accel,
+            analog,
+            audio,
+            dotstar,
+            i2c,
+            keypad,
+            neopixel,
+            port,
+        }
+    }
+}
 
 /// Convenience for setting up the labelled SDA, SCL pins to
 /// operate as an I2C master running at the specified frequency.

--- a/boards/trellis_m4/src/lib.rs
+++ b/boards/trellis_m4/src/lib.rs
@@ -8,7 +8,7 @@ extern crate cortex_m_rt;
 
 #[cfg(feature = "keypad-unproven")]
 #[macro_use]
-extern crate keypad;
+pub extern crate keypad;
 
 pub mod pins;
 

--- a/boards/trellis_m4/src/lib.rs
+++ b/boards/trellis_m4/src/lib.rs
@@ -6,6 +6,10 @@ extern crate atsamd_hal as hal;
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
 
+#[cfg(feature = "keypad-unproven")]
+#[macro_use]
+extern crate keypad;
+
 pub mod pins;
 
 #[cfg(feature = "rt")]
@@ -18,6 +22,8 @@ use hal::prelude::*;
 use hal::clock::GenericClockController;
 use hal::sercom::{I2CMaster4, PadPin};
 use hal::time::Hertz;
+#[cfg(feature = "keypad-unproven")]
+use hal::gpio::{OpenDrain, Output, PullUp};
 
 define_pins!(
     /// Maps the pins to their arduino names and
@@ -156,6 +162,54 @@ impl Pins {
             neopixel,
             port,
         }
+    }
+}
+
+#[cfg(feature = "keypad-unproven")]
+keypad_struct! {
+    #[doc="NeoTrellis M4 Express 8x4 keypad"]
+    pub struct Keypad {
+        rows: (
+            gpio::Pa18<Input<PullUp>>,
+            gpio::Pa19<Input<PullUp>>,
+            gpio::Pb22<Input<PullUp>>,
+            gpio::Pb23<Input<PullUp>>,
+        ),
+        columns: (
+            gpio::Pa14<Output<OpenDrain>>,
+            gpio::Pa15<Output<OpenDrain>>,
+            gpio::Pa16<Output<OpenDrain>>,
+            gpio::Pa17<Output<OpenDrain>>,
+            gpio::Pa20<Output<OpenDrain>>,
+            gpio::Pa21<Output<OpenDrain>>,
+            gpio::Pa22<Output<OpenDrain>>,
+            gpio::Pa23<Output<OpenDrain>>,
+        ),
+    }
+}
+
+#[cfg(feature = "keypad-unproven")]
+impl Keypad {
+    /// Create a new Keypad from the given pins
+    pub fn new(pins: pins::Keypad, port: &mut Port) -> Self {
+        keypad_new!(Self {
+            rows: (
+                pins.row0.into_pull_up_input(port),
+                pins.row1.into_pull_up_input(port),
+                pins.row2.into_pull_up_input(port),
+                pins.row3.into_pull_up_input(port),
+            ),
+            columns: (
+                pins.col0.into_open_drain_output(port),
+                pins.col1.into_open_drain_output(port),
+                pins.col2.into_open_drain_output(port),
+                pins.col3.into_open_drain_output(port),
+                pins.col4.into_open_drain_output(port),
+                pins.col5.into_open_drain_output(port),
+                pins.col6.into_open_drain_output(port),
+                pins.col7.into_open_drain_output(port),
+            ),
+        })
     }
 }
 

--- a/boards/trellis_m4/src/pins.rs
+++ b/boards/trellis_m4/src/pins.rs
@@ -1,0 +1,81 @@
+//! NeoTrellis M4 Express pins
+
+use gpio::{Floating, Input, Port};
+use hal::gpio::*;
+
+/// Sets of pins split apart by category
+pub struct Sets {
+    /// Accelerometer pins
+    pub accel: Accelerometer,
+
+    /// Analog pins
+    pub analog: Analog,
+
+    /// Audio pins
+    pub audio: Audio,
+
+    /// Dotstar (RGB LED) pins
+    pub dotstar: Dotstar,
+
+    /// I2C pins
+    pub i2c: I2C,
+
+    /// Keypad pins
+    pub keypad: Keypad,
+
+    /// Neopixel pins
+    pub neopixel: NeoPixel,
+
+    /// Port
+    pub port: Port,
+}
+
+/// Accelerometer pins
+pub struct Accelerometer {
+    pub sda: Pa12<Input<Floating>>,
+    pub scl: Pa13<Input<Floating>>,
+}
+
+/// Analog pins
+pub struct Analog {
+    pub a0: Pa2<Input<Floating>>,
+    pub a1: Pa5<Input<Floating>>,
+    pub a2: Pa4<Input<Floating>>,
+}
+
+/// Audio pins
+pub struct Audio {
+    pub output: Pa6<Input<Floating>>,
+    pub input: Pa7<Input<Floating>>,
+}
+
+/// Dotstar pins
+pub struct Dotstar {
+    pub ci: Pb2<Input<Floating>>,
+    pub di: Pb3<Input<Floating>>,
+}
+
+/// I2C pins
+pub struct I2C {
+    pub sda: Pb8<Input<Floating>>,
+    pub scl: Pb9<Input<Floating>>,
+}
+
+/// Keypad pins
+pub struct Keypad {
+    pub col0: Pa14<Input<Floating>>,
+    pub col1: Pa15<Input<Floating>>,
+    pub col2: Pa16<Input<Floating>>,
+    pub col3: Pa17<Input<Floating>>,
+    pub col4: Pa20<Input<Floating>>,
+    pub col5: Pa21<Input<Floating>>,
+    pub col6: Pa22<Input<Floating>>,
+    pub col7: Pa23<Input<Floating>>,
+    pub row0: Pa18<Input<Floating>>,
+    pub row1: Pa19<Input<Floating>>,
+    pub row2: Pb22<Input<Floating>>,
+    pub row3: Pb23<Input<Floating>>,
+}
+
+/// NeoPixel pin
+pub type NeoPixel = Pa27<Input<Floating>>;

--- a/build-all.sh
+++ b/build-all.sh
@@ -20,4 +20,5 @@ cargo build --examples
 popd
 pushd boards/trellis_m4
 cargo build --examples
+cargo build --features=keypad-unproven --examples
 popd


### PR DESCRIPTION
Adds keypad support using the `keypad` crate.

Requires use of the `unproven` feature, so it's disabled-by-default and gated under the `keypad-unproven` feature.

Also adds a `pins` module containing sets of pins grouped by functions.

This is necessary to split up ownership of the pins so we can use the keypad-related ones with the `keypad` crate.

![ezgif-5-ec13d1fc91c7](https://user-images.githubusercontent.com/797/54203002-86da2980-448e-11e9-8343-c371119c7460.gif)
