### PR TITLE
trellis_m4: have neopixel_keypad example start out white

### DIFF
--- a/boards/trellis_m4/examples/neopixel_keypad.rs
+++ b/boards/trellis_m4/examples/neopixel_keypad.rs
@@ -45,7 +45,7 @@ fn main() -> ! {
     let keypad = hal::Keypad::new(keypad_pins, &mut port);
     let keypad_inputs = keypad.decompose();
     let mut keypad_state = [false; NUM_LEDS];
-    let mut toggle_values = [true; NUM_LEDS];
+    let mut toggle_values = [false; NUM_LEDS];
 
     loop {
         for j in 0..(256 * 5) {


### PR DESCRIPTION
This makes it a bit more fun when you hit a button for the first time