### PR TITLE
trellis_m4: ADXL343 accelerometer support (and examples)

### DIFF
--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -16,17 +16,24 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd51g19a/trellis_m4/"
 [dependencies]
 cortex-m = "~0.5"
 embedded-hal = "~0.2"
-keypad = { version = "~0.1", optional = true }
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]
 version = "~0.6"
 optional = true
 
+[dependencies.adxl343]
+version = "~0.2"
+optional = true
+
 [dependencies.atsamd-hal]
 path = "../../hal"
 version = "~0.4"
 default-features = false
+
+[dependencies.keypad]
+version = "~0.1"
+optional = true
 
 [dev-dependencies]
 panic-halt = "~0.2"
@@ -56,6 +63,10 @@ lto = false
 opt-level = "s"
 
 [[example]]
+name = "neopixel_accel"
+required-features = ["adxl343"]
+
+[[example]]
 name = "neopixel_blink"
 
 [[example]]
@@ -64,3 +75,6 @@ name = "neopixel_rainbow"
 [[example]]
 name = "neopixel_keypad"
 required-features = ["keypad"]
+
+[package.metadata.docs.rs]
+features = ["adxl343", "keypad-unproven"]

--- a/boards/trellis_m4/README.md
+++ b/boards/trellis_m4/README.md
@@ -15,6 +15,21 @@ This crate provides a type-safe Rust API for working with the
 - 4-JST hacking port with 3.3V power, ground, and two GPIO (can be I2C/ADC/UART)
 - Analog Devices [ADXL343] triple-axis accelerometer
 
+## Optional `trellis_m4` Cargo Features
+
+The following optional hardware drivers can be enabled as cargo features:
+
+- `adxl343`: [ADXL343] accelerometer support
+- `keypad-unproven`: (alpha) support for button input via the [keypad] crate
+
+To enable them, use the `features` option when adding a crate dependency to
+your Cargo.toml:
+
+```toml
+[dependencies]
+trellis_m4 = { version = "~0.1", features = ["adxl343", "keypad-unproven"] }
+```
+
 ## Examples?
 
 Check out the repository for examples:
@@ -24,3 +39,4 @@ https://github.com/atsamd-rs/atsamd/tree/master/boards/trellis_m4/examples
 [Adafruit NeoTrellis M4 board]: https://www.adafruit.com/product/3938
 [ATSAMD51G19A]: https://www.microchip.com/wwwproducts/en/ATSAMD51G19A
 [ADXL343]: https://www.analog.com/en/products/adxl343.html
+[keypad]: https://crates.io/crates/keypad

--- a/boards/trellis_m4/examples/neopixel_accel.rs
+++ b/boards/trellis_m4/examples/neopixel_accel.rs
@@ -1,0 +1,63 @@
+//! ADXL343 accelerometer example
+
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate panic_halt;
+extern crate smart_leds;
+extern crate trellis_m4 as hal;
+extern crate ws2812_nop_samd51 as ws2812;
+
+use hal::prelude::*;
+use hal::{entry, Peripherals, CorePeripherals};
+use hal::{clock::GenericClockController, delay::Delay};
+
+use smart_leds::{Color, SmartLedsWrite};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core_peripherals = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.MCLK,
+        &mut peripherals.OSC32KCTRL,
+        &mut peripherals.OSCCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+
+    let mut delay = Delay::new(core_peripherals.SYST, &mut clocks);
+    let hal::pins::Sets { neopixel, accel, mut port, .. } = hal::Pins::new(peripherals.PORT).split();
+
+    // neopixels
+    let neopixel_pin = neopixel.into_push_pull_output(&mut port);
+    let mut neopixels = ws2812::Ws2812::new(neopixel_pin);
+
+    // accelerometer
+    let mut adxl343 = accel.open(
+        &mut clocks,
+        peripherals.SERCOM2,
+        &mut peripherals.MCLK,
+        &mut port
+    ).unwrap();
+
+    loop {
+        let ax3 = adxl343.xyz().unwrap();
+
+        // RGB indicators of current accelerometer state
+        let colors = [
+            Color::from(((ax3.x >> 8 & 0b11000000) as u8, 0, 0)),
+            Color::from((0, (ax3.y >> 8 & 0b11000000) as u8, 0)),
+            Color::from((0, 0, (ax3.x >> 8 & 0b11000000) as u8)),
+        ];
+
+        neopixels
+            .write(colors.iter().cloned())
+            .unwrap();
+
+        delay.delay_ms(10u8);
+    }
+}

--- a/boards/trellis_m4/examples/neopixel_keypad.rs
+++ b/boards/trellis_m4/examples/neopixel_keypad.rs
@@ -15,9 +15,6 @@ use smart_leds::brightness;
 use smart_leds::{colors, Color};
 use smart_leds::SmartLedsWrite;
 
-/// Total number of LEDs on the NeoTrellis M4
-const NUM_LEDS: usize = 32;
-
 /// Main entrypoint
 #[entry]
 fn main() -> ! {
@@ -39,13 +36,13 @@ fn main() -> ! {
     // neopixels
     let neopixel_pin = neopixel.into_push_pull_output(&mut port);
     let mut neopixel = ws2812::Ws2812::new(neopixel_pin);
-    let mut color_values = [Color::default(); NUM_LEDS];
+    let mut color_values = [Color::default(); hal::NEOPIXEL_COUNT];
 
     // keypad
     let keypad = hal::Keypad::new(keypad_pins, &mut port);
     let keypad_inputs = keypad.decompose();
-    let mut keypad_state = [false; NUM_LEDS];
-    let mut toggle_values = [false; NUM_LEDS];
+    let mut keypad_state = [false; hal::NEOPIXEL_COUNT];
+    let mut toggle_values = [false; hal::NEOPIXEL_COUNT];
 
     loop {
         for j in 0..(256 * 5) {
@@ -65,7 +62,7 @@ fn main() -> ! {
                 }
 
                 *value = if toggle_values[i] {
-                    wheel((((i * 256) as u16 / NUM_LEDS as u16 + j) & 255) as u8)
+                    wheel((((i * 256) as u16 / hal::NEOPIXEL_COUNT as u16 + j) & 255) as u8)
                 } else {
                     colors::GHOST_WHITE
                 };

--- a/boards/trellis_m4/examples/neopixel_rainbow.rs
+++ b/boards/trellis_m4/examples/neopixel_rainbow.rs
@@ -15,9 +15,6 @@ use smart_leds::brightness;
 use smart_leds::Color;
 use smart_leds::SmartLedsWrite;
 
-/// Total number of LEDs on the NeoTrellis M4
-const NUM_LEDS: usize = 32;
-
 /// Main entrypoint
 #[entry]
 fn main() -> ! {
@@ -36,12 +33,12 @@ fn main() -> ! {
     let mut delay = Delay::new(core_peripherals.SYST, &mut clocks);
     let neopixel_pin = pins.neopixel.into_push_pull_output(&mut pins.port);
     let mut neopixel = ws2812::Ws2812::new(neopixel_pin);
-    let mut values = [Color::default(); NUM_LEDS];
+    let mut values = [Color::default(); hal::NEOPIXEL_COUNT];
 
     loop {
         for j in 0..(256 * 5) {
             for (i, value) in values.iter_mut().enumerate() {
-                *value = wheel((((i * 256) as u16 / NUM_LEDS as u16 + j) & 255) as u8);
+                *value = wheel((((i * 256) as u16 / hal::NEOPIXEL_COUNT as u16 + j) & 255) as u8);
             }
 
             neopixel

--- a/boards/trellis_m4/src/pins.rs
+++ b/boards/trellis_m4/src/pins.rs
@@ -1,7 +1,16 @@
 //! NeoTrellis M4 Express pins
 
 use gpio::{Floating, Input, Port};
+#[cfg(feature = "adxl343")]
+use hal::{prelude::*, sercom::I2CError};
+use hal::clock::*;
 use hal::gpio::*;
+use hal::sercom::{I2CMaster2, I2CMaster4, PadPin};
+use hal::time::Hertz;
+use super::{SERCOM2, SERCOM4, MCLK};
+
+#[cfg(feature = "adxl343")]
+use adxl343::Adxl343;
 
 /// Sets of pins split apart by category
 pub struct Sets {
@@ -36,6 +45,40 @@ pub struct Accelerometer {
     pub scl: Pa13<Input<Floating>>,
 }
 
+impl Accelerometer {
+    /// Open the Accelerometer I2C device
+    #[cfg(feature = "adxl343")]
+    pub fn open(
+        self,
+        clocks: &mut GenericClockController,
+        sercom: SERCOM2,
+        mclk: &mut MCLK,
+        port: &mut Port,
+    ) -> Result<Adxl343<I2CMaster2>, I2CError> {
+        Adxl343::new(self.i2c_master(clocks, 100.khz(), sercom, mclk, port))
+    }
+
+    /// Configure accelerometer's SDA and SCL pins as an I2C master"
+    pub fn i2c_master<F: Into<Hertz>>(
+        self,
+        clocks: &mut GenericClockController,
+        bus_speed: F,
+        sercom: SERCOM2,
+        mclk: &mut MCLK,
+        port: &mut Port,
+    ) -> I2CMaster2 {
+        let gclk0 = clocks.gclk0();
+        I2CMaster2::new(
+            &clocks.sercom2_core(&gclk0).unwrap(),
+            bus_speed.into(),
+            sercom,
+            mclk,
+            self.sda.into_pad(port),
+            self.scl.into_pad(port),
+        )
+    }
+}
+
 /// Analog pins
 pub struct Analog {
     pub a0: Pa2<Input<Floating>>,
@@ -59,6 +102,29 @@ pub struct Dotstar {
 pub struct I2C {
     pub sda: Pb8<Input<Floating>>,
     pub scl: Pb9<Input<Floating>>,
+}
+
+impl I2C {
+    /// Convenience for setting up the labelled SDA, SCL pins to
+    /// operate as an I2C master running at the specified frequency.
+    pub fn i2c_master<F: Into<Hertz>>(
+        self,
+        clocks: &mut GenericClockController,
+        bus_speed: F,
+        sercom4: SERCOM4,
+        mclk: &mut MCLK,
+        port: &mut Port,
+    ) -> I2CMaster4 {
+        let gclk0 = clocks.gclk0();
+        I2CMaster4::new(
+            &clocks.sercom4_core(&gclk0).unwrap(),
+            bus_speed.into(),
+            sercom4,
+            mclk,
+            self.sda.into_pad(port),
+            self.scl.into_pad(port),
+        )
+    }
 }
 
 /// Keypad pins


### PR DESCRIPTION
Uses my recently released `adxl343` crate:

https://github.com/NeoBirth/ADXL343.rs

Includes the following example to visualize the accelerometer output using the NeoPixels:

![ezgif-1-9dd510d18d2d](https://user-images.githubusercontent.com/797/54791774-97aa3e00-4bf8-11e9-9fc1-5a5c44da3c2d.gif)
