### PR TITLE
trellis_m4: Orientation detector

### DIFF
--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -76,5 +76,9 @@ name = "neopixel_rainbow"
 name = "neopixel_keypad"
 required-features = ["keypad"]
 
+[[example]]
+name = "neopixel_orientation"
+required-features = ["adxl343"]
+
 [package.metadata.docs.rs]
 features = ["adxl343", "keypad-unproven"]

--- a/boards/trellis_m4/examples/neopixel_orientation.rs
+++ b/boards/trellis_m4/examples/neopixel_orientation.rs
@@ -1,0 +1,103 @@
+//! ADXL343 accelerometer-based orientation tracking example
+
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate panic_halt;
+extern crate smart_leds;
+extern crate trellis_m4 as hal;
+extern crate ws2812_nop_samd51 as ws2812;
+
+use hal::prelude::*;
+use hal::{entry, Peripherals, CorePeripherals};
+use hal::{clock::GenericClockController, delay::Delay};
+use hal::orientation::{self, Orientation};
+
+use smart_leds::{colors, SmartLedsWrite};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core_peripherals = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.MCLK,
+        &mut peripherals.OSC32KCTRL,
+        &mut peripherals.OSCCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+
+    let mut delay = Delay::new(core_peripherals.SYST, &mut clocks);
+    let hal::pins::Sets { neopixel, accel, mut port, .. } = hal::Pins::new(peripherals.PORT).split();
+
+    // neopixels
+    let neopixel_pin = neopixel.into_push_pull_output(&mut port);
+    let mut neopixels = ws2812::Ws2812::new(neopixel_pin);
+
+    // accelerometer-based orientation tracker
+    let mut tracker = orientation::Tracker::new(accel.open(
+        &mut clocks,
+        peripherals.SERCOM2,
+        &mut peripherals.MCLK,
+        &mut port
+    ).unwrap());
+
+    let mut last_orientation = Orientation::Up;
+
+    loop {
+        let mut colors = [colors::DEEP_SKY_BLUE; hal::NEOPIXEL_COUNT];
+        let orientation = tracker.orientation().unwrap();
+
+        let pointing_up = match orientation {
+            Orientation::Up => true,
+            Orientation::Down => false,
+            Orientation::Unknown => {
+                match last_orientation {
+                    Orientation::Up => true,
+                    Orientation::Down => false,
+                    Orientation::Unknown => true
+                }
+            }
+        };
+
+        if orientation != Orientation::Unknown {
+            last_orientation = orientation;
+        }
+
+        if pointing_up {
+            for cell in &mut colors[(hal::NEOPIXEL_COUNT / 2)..] {
+                *cell = colors::FOREST_GREEN;
+            }
+        } else {
+            for cell in &mut colors[..(hal::NEOPIXEL_COUNT / 2)] {
+                *cell = colors::FOREST_GREEN;
+            }
+        }
+
+        let n = tracker.direction_avg();
+
+        if n < 0.0 {
+            colors[0] = (((-n) * 256.0) as u8, 0, 0).into();
+        } else {
+            colors[0] = (0, (n * 256.0) as u8, 0).into();
+        }
+
+        let (x_samples, y_samples, z_samples) = tracker.samples();
+        let x_scaled = (256.0 * x_samples.corrected_mean()) as u8;
+        let y_scaled = (256.0 * y_samples.corrected_mean()) as u8;
+        let z_scaled = (256.0 * z_samples.corrected_mean()) as u8;
+
+        colors[1] = (0, 0, x_scaled).into();
+        colors[2] = (0, y_scaled, 0).into();
+        colors[3] = (z_scaled, 0, 0).into();
+
+        neopixels
+            .write(colors.iter().cloned())
+            .unwrap();
+
+        delay.delay_ms(10u8);
+    }
+}

--- a/boards/trellis_m4/src/lib.rs
+++ b/boards/trellis_m4/src/lib.rs
@@ -15,6 +15,13 @@ pub extern crate keypad;
 
 pub mod pins;
 
+#[cfg(feature = "adxl343")]
+pub mod orientation;
+
+/// Adxl343 (preconfigured to use SERCOM2)
+#[cfg(feature = "adxl343")]
+type Adxl343 = adxl343::Adxl343<hal::sercom::I2CMaster2>;
+
 #[cfg(feature = "rt")]
 pub use cortex_m_rt::entry;
 pub use hal::{*, atsamd51g19a::*};

--- a/boards/trellis_m4/src/orientation.rs
+++ b/boards/trellis_m4/src/orientation.rs
@@ -1,0 +1,180 @@
+//! Orientation tracking support for the NeoTrellis M4
+//!
+//! This module provides tablet-like orientation tracking. It's designed to
+//! work when the device is being handheld, in a "portrait" orientation,
+//! and attempts to detect whether the device's plugs (USB, audio, etc)
+//! are pointed up or down.
+
+pub use adxl343::Ax3;
+
+use crate::Adxl343;
+use core::ops::{Index, IndexMut};
+use hal::sercom::I2CError;
+
+/// Number of samples used to guess the device's orientation
+const NUM_SAMPLES: usize = 32;
+
+/// Denominator to normalize acceleration rates between 0.0 and 1.0
+const ACCEL_NORMALIZE: f32 = 256.0;
+
+/// Orientation of the NeoTrellis M4, as detected by the onboard ADXL343
+/// accelerometer.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Orientation {
+    /// Device's plugs (USB, audio, etc) are pointed up
+    Up,
+
+    /// Device's plugs (USB, audio, etc) are pointed down
+    Down,
+
+    /// Unable to determine device's orientation from the current data
+    Unknown,
+}
+
+/// Orientation-tracking support: computes a moving average of accelerometer
+/// data from which the device's orientation is guessed
+pub struct Tracker {
+    /// The underlying accelerometer device
+    accel: Adxl343,
+
+    /// Samples of x-axis accelerometer data
+    x_samples: Samples,
+
+    /// Samples of y-axis accelerometer data
+    y_samples: Samples,
+
+    /// Samples of z-axis accelerometer data
+    z_samples: Samples,
+
+    /// Previously computed orientations
+    estimates: [f32; NUM_SAMPLES],
+
+    /// Current position within our sample data array
+    position: usize,
+}
+
+impl Tracker {
+    /// Create a new orientation tracker from the given Adxl343 accelerometer
+    pub fn new(accel: Adxl343) -> Self {
+        Self {
+            accel,
+            x_samples: Samples::default(),
+            y_samples: Samples::default(),
+            z_samples: Samples::default(),
+            estimates: [0.0; NUM_SAMPLES],
+            position: 0,
+        }
+    }
+
+    /// Get a moving average of acceleration readings from the underlying
+    /// `Adxl343` device
+    pub fn accel_avg(&mut self) -> Result<Ax3, I2CError> {
+        Ok(Ax3 {
+            x: self.x_samples.mean(),
+            y: self.y_samples.mean(),
+            z: self.z_samples.mean(),
+        })
+    }
+
+    /// Compute the average direction the device is pointing. This is roughly
+    /// the angle the device is offset from the vertical axis (-1 .. 1)
+    pub fn direction_avg(&self) -> f32 {
+        self.estimates.iter().sum::<f32>() / NUM_SAMPLES as f32
+    }
+
+    /// Guess the device's orientation based on a moving average of previous
+    /// accelerometer data (taking a new sample)
+    pub fn orientation(&mut self) -> Result<Orientation, I2CError> {
+        self.update()?;
+        let n = self.direction_avg();
+
+        let result = if n > 0.1 {
+            Orientation::Up
+        } else if n < -0.1 {
+            Orientation::Down
+        } else {
+            Orientation::Unknown
+        };
+
+        Ok(result)
+    }
+
+    /// Borrow the current x, y, and z sample buffers
+    pub fn samples(&self) -> (&Samples, &Samples, &Samples) {
+        (&self.x_samples, &self.y_samples, &self.z_samples)
+    }
+
+    /// Take an accelerometer reading and store it in the internal buffer
+    pub fn update(&mut self) -> Result<(), I2CError> {
+        let accel = self.accel.accel()?;
+
+        self.x_samples[self.position] = accel.x / ACCEL_NORMALIZE;
+        self.y_samples[self.position] = accel.y / ACCEL_NORMALIZE;
+        self.z_samples[self.position] = accel.z / ACCEL_NORMALIZE;
+
+        let x_corrected = self.x_samples.corrected_mean();
+        let y_corrected = self.y_samples.corrected_mean();
+
+        self.estimates[self.position] = x_corrected - y_corrected;
+        self.position = (self.position + 1) % NUM_SAMPLES;
+
+        Ok(())
+    }
+}
+
+impl From<Adxl343> for Tracker {
+    fn from(accel: Adxl343) -> Tracker {
+        Tracker::new(accel)
+    }
+}
+
+/// Buffer of samples for a given coordinate
+#[derive(Default)]
+pub struct Samples([f32; NUM_SAMPLES]);
+
+impl Samples {
+    /// Compute arithmetic mean
+    pub fn mean(&self) -> f32 {
+        self.0.iter().sum::<f32>() / NUM_SAMPLES as f32
+    }
+
+    /// Compute arithmetic mean and variance simultaneously
+    pub fn mean_and_variance(&self) -> (f32, f32) {
+        let mean = self.mean();
+
+        let variance = self
+            .0
+            .iter()
+            .fold(0.0, |sum, n| sum + (*n - mean) * (*n - mean))
+            / (NUM_SAMPLES as f32 - 1.0);
+
+        (mean, variance)
+    }
+
+    /// Compute a "corrected" mean weighted by the variance
+    pub fn corrected_mean(&self) -> f32 {
+        let (mean, variance) = self.mean_and_variance();
+
+        let weight = if variance < 0.333 {
+            1.0 - (3.0 * variance)
+        } else {
+            0.0
+        };
+
+        weight * mean
+    }
+}
+
+impl Index<usize> for Samples {
+    type Output = f32;
+
+    fn index(&self, index: usize) -> &f32 {
+        &self.0[index]
+    }
+}
+
+impl IndexMut<usize> for Samples {
+    fn index_mut(&mut self, index: usize) -> &mut f32 {
+        self.0.index_mut(index)
+    }
+}

--- a/boards/trellis_m4/src/pins.rs
+++ b/boards/trellis_m4/src/pins.rs
@@ -10,7 +10,7 @@ use hal::time::Hertz;
 use super::{SERCOM2, SERCOM4, MCLK};
 
 #[cfg(feature = "adxl343")]
-use adxl343::Adxl343;
+use super::Adxl343;
 
 /// Sets of pins split apart by category
 pub struct Sets {
@@ -54,7 +54,7 @@ impl Accelerometer {
         sercom: SERCOM2,
         mclk: &mut MCLK,
         port: &mut Port,
-    ) -> Result<Adxl343<I2CMaster2>, I2CError> {
+    ) -> Result<Adxl343, I2CError> {
         Adxl343::new(self.i2c_master(clocks, 100.khz(), sercom, mclk, port))
     }
 


### PR DESCRIPTION
~~NOTE: This P4 includes a commit from #47 (ADXL343 accelerometer support) which should get merged first.~~

This PR adds a simple orientation detector based on the ADXL343 accelerometer.

When the device is upright in a portrait orientation, or slightly tilted (either handheld, or in the stand included in the kit), attempts to detect the direction the plugs are facing (either up, down, or unknown if the data is ambiguous).

Uses a moving average to smooth out the noisy accelerometer data. The formula approximating for the device's orientation is a simple function of the accelerometer data and was calibrated empirically by testing the NeoTrellis M4 device in several positions and recording the accelerometer state in each position.

Could probably use some fine-tuning, but otherwise seems to work relatively (and perhaps surprisingly?) well. To the extent it's glitchy, it seems about as glitchy as a smartphone.

![ezgif-1-6df0dbd345cb](https://user-images.githubusercontent.com/797/54792458-6f700e80-4bfb-11e9-8a95-253a19fe92f5.gif)
