### PR TITLE
trellis_m4: update to adxl343 v0.4; add orientation example

### DIFF
--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -23,7 +23,7 @@ version = "~0.6"
 optional = true
 
 [dependencies.adxl343]
-version = "~0.2"
+version = "~0.4"
 optional = true
 
 [dependencies.atsamd-hal]
@@ -70,11 +70,15 @@ required-features = ["adxl343"]
 name = "neopixel_blink"
 
 [[example]]
+name = "neopixel_orientation"
+required-features = ["adxl343"]
+
+[[example]]
 name = "neopixel_rainbow"
 
 [[example]]
 name = "neopixel_keypad"
-required-features = ["keypad"]
+required-features = ["keypad-unproven"]
 
 [package.metadata.docs.rs]
 features = ["adxl343", "keypad-unproven"]

--- a/boards/trellis_m4/examples/neopixel_accel.rs
+++ b/boards/trellis_m4/examples/neopixel_accel.rs
@@ -12,6 +12,7 @@ extern crate ws2812_nop_samd51 as ws2812;
 use hal::prelude::*;
 use hal::{entry, Peripherals, CorePeripherals};
 use hal::{clock::GenericClockController, delay::Delay};
+use hal::adxl343::accelerometer::Accelerometer;
 
 use smart_leds::{Color, SmartLedsWrite};
 
@@ -45,7 +46,7 @@ fn main() -> ! {
     ).unwrap();
 
     loop {
-        let ax3 = adxl343.xyz().unwrap();
+        let ax3 = adxl343.acceleration().unwrap();
 
         // RGB indicators of current accelerometer state
         let colors = [

--- a/boards/trellis_m4/examples/neopixel_orientation.rs
+++ b/boards/trellis_m4/examples/neopixel_orientation.rs
@@ -1,0 +1,94 @@
+//! ADXL343 accelerometer-based orientation tracking example
+
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate panic_halt;
+extern crate smart_leds;
+extern crate trellis_m4 as hal;
+extern crate ws2812_nop_samd51 as ws2812;
+
+use hal::adxl343::accelerometer::Orientation;
+use hal::prelude::*;
+use hal::{clock::GenericClockController, delay::Delay};
+use hal::{entry, CorePeripherals, Peripherals};
+use smart_leds::{colors, SmartLedsWrite, Color};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core_peripherals = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.MCLK,
+        &mut peripherals.OSC32KCTRL,
+        &mut peripherals.OSCCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+    let mut delay = Delay::new(core_peripherals.SYST, &mut clocks);
+    let mut pins = hal::Pins::new(peripherals.PORT).split();
+
+    // neopixels
+    let neopixel_pin = pins.neopixel.into_push_pull_output(&mut pins.port);
+    let mut neopixels = ws2812::Ws2812::new(neopixel_pin);
+
+    // accelerometer
+    let adxl343 = pins.accel.open(
+        &mut clocks,
+        peripherals.SERCOM2,
+        &mut peripherals.MCLK,
+        &mut pins.port
+    ).unwrap();
+
+    let mut accel_tracker = adxl343.try_into_tracker().unwrap();
+
+    loop {
+        // update tracker's internal `last_orientation`
+        accel_tracker.orientation().unwrap();
+        neopixels.write(colors_for_orientation(accel_tracker.last_orientation()).iter().cloned()).unwrap();
+        delay.delay_ms(10u8);
+    }
+}
+
+fn colors_for_orientation(orientation: Orientation) -> [Color; hal::NEOPIXEL_COUNT] {
+    let mut colors = [colors::DEEP_SKY_BLUE; hal::NEOPIXEL_COUNT];
+    let green = colors::FOREST_GREEN;
+
+    match orientation {
+        Orientation::FaceUp | Orientation::Unknown => (),
+        Orientation::FaceDown => {
+            for cell in &mut colors {
+                *cell = green;
+            }
+        }
+        Orientation::PortraitUp => {
+            for row in 0..4 {
+                for column in 0..4 {
+                    colors[row * 8 + column] = green;
+                }
+            }
+        }
+        Orientation::PortraitDown => {
+            for row in 0..4 {
+                for column in 4..8 {
+                    colors[row * 8 + column] = green;
+                }
+            }
+        }
+        Orientation::LandscapeUp => {
+            for cell in &mut colors[(hal::NEOPIXEL_COUNT / 2)..] {
+                *cell = green;
+            }
+        },
+        Orientation::LandscapeDown => {
+            for cell in &mut colors[..(hal::NEOPIXEL_COUNT / 2)] {
+                *cell = green;
+            }
+        },
+    }
+
+    colors
+}

--- a/boards/trellis_m4/src/lib.rs
+++ b/boards/trellis_m4/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate atsamd_hal as hal;
 
 #[cfg(feature = "adxl343")]
-extern crate adxl343;
+pub extern crate adxl343;
 
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;

--- a/boards/trellis_m4/src/pins.rs
+++ b/boards/trellis_m4/src/pins.rs
@@ -54,7 +54,7 @@ impl Accelerometer {
         sercom: SERCOM2,
         mclk: &mut MCLK,
         port: &mut Port,
-    ) -> Result<Adxl343<I2CMaster2>, I2CError> {
+    ) -> Result<Adxl343<I2CMaster2>, adxl343::accelerometer::Error<I2CError>> {
         Adxl343::new(self.i2c_master(clocks, 100.khz(), sercom, mclk, port))
     }
 


### PR DESCRIPTION
Bumps the `adxl343` accelerometer crate to the latest version, and adds an orientation-detecting example which uses the accelerometer.

Action shot of the `neopixel_orientation` example:

![ezgif-1-16e98d9b86ad](https://user-images.githubusercontent.com/797/55564522-ebaf2b00-56ac-11e9-808f-9809e85c1bd2.gif)