### PR TITLE
 trellis_m4: Rust 2018 edition updates

### DIFF
--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
 description = "Board Support crate for the Adafruit NeoTrellis M4 Express"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 license = "MIT OR Apache-2.0"
+edition = "2018"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 documentation = "https://atsamd-rs.github.io/atsamd/atsamd51g19a/trellis_m4/"

--- a/boards/trellis_m4/examples/neopixel_accel.rs
+++ b/boards/trellis_m4/examples/neopixel_accel.rs
@@ -3,8 +3,8 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
-
+#[allow(unused_imports)]
+use panic_halt;
 use trellis_m4 as hal;
 use ws2812_nop_samd51 as ws2812;
 

--- a/boards/trellis_m4/examples/neopixel_accel.rs
+++ b/boards/trellis_m4/examples/neopixel_accel.rs
@@ -3,11 +3,10 @@
 #![no_std]
 #![no_main]
 
-extern crate cortex_m;
 extern crate panic_halt;
-extern crate smart_leds;
-extern crate trellis_m4 as hal;
-extern crate ws2812_nop_samd51 as ws2812;
+
+use trellis_m4 as hal;
+use ws2812_nop_samd51 as ws2812;
 
 use hal::adxl343::accelerometer::Accelerometer;
 use hal::prelude::*;

--- a/boards/trellis_m4/examples/neopixel_accel.rs
+++ b/boards/trellis_m4/examples/neopixel_accel.rs
@@ -9,10 +9,10 @@ extern crate smart_leds;
 extern crate trellis_m4 as hal;
 extern crate ws2812_nop_samd51 as ws2812;
 
-use hal::prelude::*;
-use hal::{entry, Peripherals, CorePeripherals};
-use hal::{clock::GenericClockController, delay::Delay};
 use hal::adxl343::accelerometer::Accelerometer;
+use hal::prelude::*;
+use hal::{clock::GenericClockController, delay::Delay};
+use hal::{entry, CorePeripherals, Peripherals};
 
 use smart_leds::{Color, SmartLedsWrite};
 
@@ -29,21 +29,23 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
 
-
     let mut delay = Delay::new(core_peripherals.SYST, &mut clocks);
-    let hal::pins::Sets { neopixel, accel, mut port, .. } = hal::Pins::new(peripherals.PORT).split();
+    let mut pins = hal::Pins::new(peripherals.PORT).split();
 
     // neopixels
-    let neopixel_pin = neopixel.into_push_pull_output(&mut port);
+    let neopixel_pin = pins.neopixel.into_push_pull_output(&mut pins.port);
     let mut neopixels = ws2812::Ws2812::new(neopixel_pin);
 
     // accelerometer
-    let mut adxl343 = accel.open(
-        &mut clocks,
-        peripherals.SERCOM2,
-        &mut peripherals.MCLK,
-        &mut port
-    ).unwrap();
+    let mut adxl343 = pins
+        .accel
+        .open(
+            &mut clocks,
+            peripherals.SERCOM2,
+            &mut peripherals.MCLK,
+            &mut pins.port,
+        )
+        .unwrap();
 
     loop {
         let ax3 = adxl343.acceleration().unwrap();
@@ -55,9 +57,7 @@ fn main() -> ! {
             Color::from((0, 0, (ax3.x >> 8 & 0b11000000) as u8)),
         ];
 
-        neopixels
-            .write(colors.iter().cloned())
-            .unwrap();
+        neopixels.write(colors.iter().cloned()).unwrap();
 
         delay.delay_ms(10u8);
     }

--- a/boards/trellis_m4/examples/neopixel_blink.rs
+++ b/boards/trellis_m4/examples/neopixel_blink.rs
@@ -1,8 +1,8 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
-
+#[allow(unused_imports)]
+use panic_halt;
 use trellis_m4 as hal;
 use ws2812_nop_samd51 as ws2812;
 

--- a/boards/trellis_m4/examples/neopixel_blink.rs
+++ b/boards/trellis_m4/examples/neopixel_blink.rs
@@ -1,11 +1,10 @@
 #![no_std]
 #![no_main]
 
-extern crate cortex_m;
 extern crate panic_halt;
-extern crate smart_leds;
-extern crate trellis_m4 as hal;
-extern crate ws2812_nop_samd51 as ws2812;
+
+use trellis_m4 as hal;
+use ws2812_nop_samd51 as ws2812;
 
 use hal::prelude::*;
 use hal::{clock::GenericClockController, delay::Delay};

--- a/boards/trellis_m4/examples/neopixel_blink.rs
+++ b/boards/trellis_m4/examples/neopixel_blink.rs
@@ -7,9 +7,9 @@ extern crate smart_leds;
 extern crate trellis_m4 as hal;
 extern crate ws2812_nop_samd51 as ws2812;
 
-use crate::hal::prelude::*;
-use crate::hal::{entry, Peripherals, CorePeripherals};
-use crate::hal::{clock::GenericClockController, delay::Delay};
+use hal::prelude::*;
+use hal::{clock::GenericClockController, delay::Delay};
+use hal::{entry, CorePeripherals, Peripherals};
 
 use smart_leds::brightness;
 use smart_leds::colors::RED;

--- a/boards/trellis_m4/examples/neopixel_blink.rs
+++ b/boards/trellis_m4/examples/neopixel_blink.rs
@@ -7,9 +7,9 @@ extern crate smart_leds;
 extern crate trellis_m4 as hal;
 extern crate ws2812_nop_samd51 as ws2812;
 
-use hal::prelude::*;
-use hal::{entry, Peripherals, CorePeripherals};
-use hal::{clock::GenericClockController, delay::Delay};
+use crate::hal::prelude::*;
+use crate::hal::{entry, Peripherals, CorePeripherals};
+use crate::hal::{clock::GenericClockController, delay::Delay};
 
 use smart_leds::brightness;
 use smart_leds::colors::RED;

--- a/boards/trellis_m4/examples/neopixel_keypad.rs
+++ b/boards/trellis_m4/examples/neopixel_keypad.rs
@@ -1,8 +1,8 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
-
+#[allow(unused_imports)]
+use panic_halt;
 use trellis_m4 as hal;
 use ws2812_nop_samd51 as ws2812;
 

--- a/boards/trellis_m4/examples/neopixel_keypad.rs
+++ b/boards/trellis_m4/examples/neopixel_keypad.rs
@@ -8,12 +8,12 @@ extern crate trellis_m4 as hal;
 extern crate ws2812_nop_samd51 as ws2812;
 
 use hal::prelude::*;
-use hal::{entry, Peripherals, CorePeripherals};
 use hal::{clock::GenericClockController, delay::Delay};
+use hal::{entry, CorePeripherals, Peripherals};
 
 use smart_leds::brightness;
-use smart_leds::{colors, Color};
 use smart_leds::SmartLedsWrite;
+use smart_leds::{colors, Color};
 
 /// Main entrypoint
 #[entry]
@@ -31,15 +31,15 @@ fn main() -> ! {
 
     let mut delay = Delay::new(core_peripherals.SYST, &mut clocks);
 
-    let hal::pins::Sets { neopixel, keypad: keypad_pins, mut port, .. } = hal::Pins::new(peripherals.PORT).split();
+    let mut pins = hal::Pins::new(peripherals.PORT).split();
 
     // neopixels
-    let neopixel_pin = neopixel.into_push_pull_output(&mut port);
+    let neopixel_pin = pins.neopixel.into_push_pull_output(&mut pins.port);
     let mut neopixel = ws2812::Ws2812::new(neopixel_pin);
     let mut color_values = [Color::default(); hal::NEOPIXEL_COUNT];
 
     // keypad
-    let keypad = hal::Keypad::new(keypad_pins, &mut port);
+    let keypad = hal::Keypad::new(pins.keypad, &mut pins.port);
     let keypad_inputs = keypad.decompose();
     let mut keypad_state = [false; hal::NEOPIXEL_COUNT];
     let mut toggle_values = [false; hal::NEOPIXEL_COUNT];

--- a/boards/trellis_m4/examples/neopixel_keypad.rs
+++ b/boards/trellis_m4/examples/neopixel_keypad.rs
@@ -1,11 +1,10 @@
 #![no_std]
 #![no_main]
 
-extern crate cortex_m;
 extern crate panic_halt;
-extern crate smart_leds;
-extern crate trellis_m4 as hal;
-extern crate ws2812_nop_samd51 as ws2812;
+
+use trellis_m4 as hal;
+use ws2812_nop_samd51 as ws2812;
 
 use hal::prelude::*;
 use hal::{clock::GenericClockController, delay::Delay};

--- a/boards/trellis_m4/examples/neopixel_orientation.rs
+++ b/boards/trellis_m4/examples/neopixel_orientation.rs
@@ -3,8 +3,8 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
-
+#[allow(unused_imports)]
+use panic_halt;
 use trellis_m4 as hal;
 use ws2812_nop_samd51 as ws2812;
 

--- a/boards/trellis_m4/examples/neopixel_orientation.rs
+++ b/boards/trellis_m4/examples/neopixel_orientation.rs
@@ -13,7 +13,7 @@ use hal::adxl343::accelerometer::Orientation;
 use hal::prelude::*;
 use hal::{clock::GenericClockController, delay::Delay};
 use hal::{entry, CorePeripherals, Peripherals};
-use smart_leds::{colors, SmartLedsWrite, Color};
+use smart_leds::{colors, Color, SmartLedsWrite};
 
 #[entry]
 fn main() -> ! {
@@ -36,19 +36,28 @@ fn main() -> ! {
     let mut neopixels = ws2812::Ws2812::new(neopixel_pin);
 
     // accelerometer
-    let adxl343 = pins.accel.open(
-        &mut clocks,
-        peripherals.SERCOM2,
-        &mut peripherals.MCLK,
-        &mut pins.port
-    ).unwrap();
+    let adxl343 = pins
+        .accel
+        .open(
+            &mut clocks,
+            peripherals.SERCOM2,
+            &mut peripherals.MCLK,
+            &mut pins.port,
+        )
+        .unwrap();
 
     let mut accel_tracker = adxl343.try_into_tracker().unwrap();
 
     loop {
         // update tracker's internal `last_orientation`
         accel_tracker.orientation().unwrap();
-        neopixels.write(colors_for_orientation(accel_tracker.last_orientation()).iter().cloned()).unwrap();
+        neopixels
+            .write(
+                colors_for_orientation(accel_tracker.last_orientation())
+                    .iter()
+                    .cloned(),
+            )
+            .unwrap();
         delay.delay_ms(10u8);
     }
 }
@@ -82,12 +91,12 @@ fn colors_for_orientation(orientation: Orientation) -> [Color; hal::NEOPIXEL_COU
             for cell in &mut colors[(hal::NEOPIXEL_COUNT / 2)..] {
                 *cell = green;
             }
-        },
+        }
         Orientation::LandscapeDown => {
             for cell in &mut colors[..(hal::NEOPIXEL_COUNT / 2)] {
                 *cell = green;
             }
-        },
+        }
     }
 
     colors

--- a/boards/trellis_m4/examples/neopixel_orientation.rs
+++ b/boards/trellis_m4/examples/neopixel_orientation.rs
@@ -3,11 +3,10 @@
 #![no_std]
 #![no_main]
 
-extern crate cortex_m;
 extern crate panic_halt;
-extern crate smart_leds;
-extern crate trellis_m4 as hal;
-extern crate ws2812_nop_samd51 as ws2812;
+
+use trellis_m4 as hal;
+use ws2812_nop_samd51 as ws2812;
 
 use hal::adxl343::accelerometer::Orientation;
 use hal::prelude::*;

--- a/boards/trellis_m4/examples/neopixel_rainbow.rs
+++ b/boards/trellis_m4/examples/neopixel_rainbow.rs
@@ -1,8 +1,8 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
-
+#[allow(unused_imports)]
+use panic_halt;
 use trellis_m4 as hal;
 use ws2812_nop_samd51 as ws2812;
 

--- a/boards/trellis_m4/examples/neopixel_rainbow.rs
+++ b/boards/trellis_m4/examples/neopixel_rainbow.rs
@@ -7,9 +7,9 @@ extern crate smart_leds;
 extern crate trellis_m4 as hal;
 extern crate ws2812_nop_samd51 as ws2812;
 
-use crate::hal::prelude::*;
-use crate::hal::{entry, Peripherals, CorePeripherals};
-use crate::hal::{clock::GenericClockController, delay::Delay};
+use hal::prelude::*;
+use hal::{clock::GenericClockController, delay::Delay};
+use hal::{entry, CorePeripherals, Peripherals};
 
 use smart_leds::brightness;
 use smart_leds::Color;

--- a/boards/trellis_m4/examples/neopixel_rainbow.rs
+++ b/boards/trellis_m4/examples/neopixel_rainbow.rs
@@ -1,11 +1,10 @@
 #![no_std]
 #![no_main]
 
-extern crate cortex_m;
 extern crate panic_halt;
-extern crate smart_leds;
-extern crate trellis_m4 as hal;
-extern crate ws2812_nop_samd51 as ws2812;
+
+use trellis_m4 as hal;
+use ws2812_nop_samd51 as ws2812;
 
 use hal::prelude::*;
 use hal::{clock::GenericClockController, delay::Delay};

--- a/boards/trellis_m4/examples/neopixel_rainbow.rs
+++ b/boards/trellis_m4/examples/neopixel_rainbow.rs
@@ -7,9 +7,9 @@ extern crate smart_leds;
 extern crate trellis_m4 as hal;
 extern crate ws2812_nop_samd51 as ws2812;
 
-use hal::prelude::*;
-use hal::{entry, Peripherals, CorePeripherals};
-use hal::{clock::GenericClockController, delay::Delay};
+use crate::hal::prelude::*;
+use crate::hal::{entry, Peripherals, CorePeripherals};
+use crate::hal::{clock::GenericClockController, delay::Delay};
 
 use smart_leds::brightness;
 use smart_leds::Color;

--- a/boards/trellis_m4/src/lib.rs
+++ b/boards/trellis_m4/src/lib.rs
@@ -14,7 +14,7 @@ pub mod pins;
 
 #[cfg(feature = "rt")]
 pub use cortex_m_rt::entry;
-pub use hal::{*, atsamd51g19a::*};
+pub use hal::{atsamd51g19a::*, *};
 pub use pins::Pins;
 
 use gpio::{Input, Port};

--- a/boards/trellis_m4/src/lib.rs
+++ b/boards/trellis_m4/src/lib.rs
@@ -6,9 +6,6 @@ extern crate atsamd_hal as hal;
 #[cfg(feature = "adxl343")]
 pub extern crate adxl343;
 
-#[cfg(feature = "rt")]
-extern crate cortex_m_rt;
-
 #[cfg(feature = "keypad-unproven")]
 #[macro_use]
 pub extern crate keypad;

--- a/boards/trellis_m4/src/lib.rs
+++ b/boards/trellis_m4/src/lib.rs
@@ -1,16 +1,15 @@
 #![no_std]
 #![recursion_limit = "1024"]
 
-extern crate atsamd_hal as hal;
+pub mod pins;
 
 #[cfg(feature = "adxl343")]
-pub extern crate adxl343;
+pub use adxl343;
 
 #[cfg(feature = "keypad-unproven")]
-#[macro_use]
-pub extern crate keypad;
+pub use keypad;
 
-pub mod pins;
+use atsamd_hal as hal;
 
 #[cfg(feature = "rt")]
 pub use cortex_m_rt::entry;
@@ -24,6 +23,8 @@ use hal::time::Hertz;
 
 #[cfg(feature = "keypad-unproven")]
 use hal::gpio::{OpenDrain, Output, PullUp};
+#[cfg(feature = "keypad-unproven")]
+use keypad::{keypad_new, keypad_struct};
 
 /// Number of Neopixels on the device
 pub const NEOPIXEL_COUNT: usize = 32;

--- a/boards/trellis_m4/src/lib.rs
+++ b/boards/trellis_m4/src/lib.rs
@@ -15,159 +15,18 @@ pub mod pins;
 #[cfg(feature = "rt")]
 pub use cortex_m_rt::entry;
 pub use hal::{*, atsamd51g19a::*};
+pub use pins::Pins;
 
-use gpio::{Floating, Input, Port};
+use gpio::{Input, Port};
 use hal::clock::GenericClockController;
 use hal::sercom::I2CMaster4;
 use hal::time::Hertz;
 
-use hal::prelude::*;
 #[cfg(feature = "keypad-unproven")]
 use hal::gpio::{OpenDrain, Output, PullUp};
 
 /// Number of Neopixels on the device
 pub const NEOPIXEL_COUNT: usize = 32;
-
-// TODO(tarcieri): move this to the `pins` module (the macro doesn't work?
-define_pins!(
-    /// Maps the pins to their arduino names and
-    /// the numbers printed on the board.
-    struct Pins,
-    target_device: atsamd51g19a,
-
-    /// Analog pin 0
-    pin a0 = a2,
-    /// Analog pin 1
-    pin a1 = a5,
-    /// INT pin
-    pin a2 = a4,
-    /// Microphone out
-    pin micout = a6,
-    /// Microphone in
-    pin micin = a7,
-
-    /// SDA
-    pin sda = b8,
-    /// SCL
-    pin scl = b9,
-
-    /// Accelerometer data signal (SDA)
-    pin accel_sda = a12,
-    /// Accelerometer clock signal (SCL)
-    pin accel_scl = a13,
-
-    /// Keypad Column 0
-    pin col0 = a14,
-    /// Keypad Column 1
-    pin col1 = a15,
-    /// Keypad Column 2
-    pin col2 = a16,
-    /// Keypad Column 3
-    pin col3 = a17,
-    /// Keypad Column 4
-    pin col4 = a20,
-    /// Keypad Column 5
-    pin col5 = a21,
-    /// Keypad Column 6
-    pin col6 = a22,
-    /// Keypad Column 7
-    pin col7 = a23,
-
-    /// Keypad Row 0
-    pin row0 = a18,
-    /// Keypad Row 1
-    pin row1 = a19,
-    /// Keypad Row 2
-    pin row2 = b22,
-    /// Keypad Row 3
-    pin row3 = b23,
-
-    /// NeoPixels
-    pin neopixel = a27,
-
-    /// APA102 (RGB LED control) SCK
-    pin dotstar_ci = b2,
-    /// APA102 (RGB LED control) MOSI
-    pin dotstar_di = b3,
-);
-
-impl Pins {
-    /// Split the device pins into subsets
-    pub fn split(self) -> pins::Sets {
-        let Self {
-            port,
-            a0,
-            a1,
-            a2,
-            micout,
-            micin,
-            sda,
-            scl,
-            accel_sda,
-            accel_scl,
-            col0,
-            col1,
-            col2,
-            col3,
-            col4,
-            col5,
-            col6,
-            col7,
-            row0,
-            row1,
-            row2,
-            row3,
-            neopixel,
-            dotstar_ci,
-            dotstar_di,
-        } = self;
-
-        let accel = pins::Accelerometer {
-            sda: accel_sda,
-            scl: accel_scl,
-        };
-
-        let analog = pins::Analog { a0, a1, a2 };
-
-        let audio = pins::Audio {
-            input: micin,
-            output: micout,
-        };
-
-        let dotstar = pins::Dotstar {
-            ci: dotstar_ci,
-            di: dotstar_di,
-        };
-
-        let i2c = pins::I2C { sda, scl };
-
-        let keypad = pins::Keypad {
-            col0,
-            col1,
-            col2,
-            col3,
-            col4,
-            col5,
-            col6,
-            col7,
-            row0,
-            row1,
-            row2,
-            row3,
-        };
-
-        pins::Sets {
-            accel,
-            analog,
-            audio,
-            dotstar,
-            i2c,
-            keypad,
-            neopixel,
-            port,
-        }
-    }
-}
 
 #[cfg(feature = "keypad-unproven")]
 keypad_struct! {

--- a/boards/trellis_m4/src/pins.rs
+++ b/boards/trellis_m4/src/pins.rs
@@ -1,13 +1,13 @@
 //! NeoTrellis M4 Express pins
 
-#[cfg(feature = "adxl343")]
-use hal::{prelude::*, sercom::I2CError};
-use hal::define_pins;
+use super::{atsamd51g19a, MCLK, SERCOM2, SERCOM4};
 use hal::clock::*;
+use hal::define_pins;
 use hal::gpio::{self, *};
 use hal::sercom::{I2CMaster2, I2CMaster4, PadPin};
 use hal::time::Hertz;
-use super::{atsamd51g19a, SERCOM2, SERCOM4, MCLK};
+#[cfg(feature = "adxl343")]
+use hal::{prelude::*, sercom::I2CError};
 
 #[cfg(feature = "adxl343")]
 use adxl343::Adxl343;
@@ -82,7 +82,11 @@ impl Pins {
             scl: self.accel_scl,
         };
 
-        let analog = Analog { a0: self.a0, a1: self.a1, a2: self.a2 };
+        let analog = Analog {
+            a0: self.a0,
+            a1: self.a1,
+            a2: self.a2,
+        };
 
         let audio = Audio {
             input: self.micin,
@@ -94,7 +98,10 @@ impl Pins {
             di: self.dotstar_di,
         };
 
-        let i2c = I2C { sda: self.sda, scl: self.scl };
+        let i2c = I2C {
+            sda: self.sda,
+            scl: self.scl,
+        };
 
         let keypad = Keypad {
             col0: self.col0,

--- a/boards/trellis_m4/src/pins.rs
+++ b/boards/trellis_m4/src/pins.rs
@@ -1,6 +1,7 @@
 //! NeoTrellis M4 Express pins
 
-use super::{atsamd51g19a, MCLK, SERCOM2, SERCOM4};
+use super::{atsamd51g19a, hal, MCLK, SERCOM2, SERCOM4};
+
 use hal::clock::*;
 use hal::define_pins;
 use hal::gpio::{self, *};

--- a/boards/trellis_m4/src/pins.rs
+++ b/boards/trellis_m4/src/pins.rs
@@ -1,12 +1,12 @@
 //! NeoTrellis M4 Express pins
 
-use gpio::{Floating, Input, Port};
+use crate::gpio::{Floating, Input, Port};
 #[cfg(feature = "adxl343")]
 use hal::{prelude::*, sercom::I2CError};
-use hal::clock::*;
-use hal::gpio::*;
-use hal::sercom::{I2CMaster2, I2CMaster4, PadPin};
-use hal::time::Hertz;
+use crate::hal::clock::*;
+use crate::hal::gpio::*;
+use crate::hal::sercom::{I2CMaster2, I2CMaster4, PadPin};
+use crate::hal::time::Hertz;
 use super::{SERCOM2, SERCOM4, MCLK};
 
 #[cfg(feature = "adxl343")]

--- a/boards/trellis_m4/src/pins.rs
+++ b/boards/trellis_m4/src/pins.rs
@@ -1,16 +1,128 @@
 //! NeoTrellis M4 Express pins
 
-use crate::gpio::{Floating, Input, Port};
 #[cfg(feature = "adxl343")]
 use hal::{prelude::*, sercom::I2CError};
-use crate::hal::clock::*;
-use crate::hal::gpio::*;
-use crate::hal::sercom::{I2CMaster2, I2CMaster4, PadPin};
-use crate::hal::time::Hertz;
-use super::{SERCOM2, SERCOM4, MCLK};
+use hal::define_pins;
+use hal::clock::*;
+use hal::gpio::{self, *};
+use hal::sercom::{I2CMaster2, I2CMaster4, PadPin};
+use hal::time::Hertz;
+use super::{atsamd51g19a, SERCOM2, SERCOM4, MCLK};
 
 #[cfg(feature = "adxl343")]
 use adxl343::Adxl343;
+
+define_pins!(
+    /// Maps the pins to their arduino names and
+    /// the numbers printed on the board.
+    struct Pins,
+    target_device: atsamd51g19a,
+
+    /// Analog pin 0
+    pin a0 = a2,
+    /// Analog pin 1
+    pin a1 = a5,
+    /// INT pin
+    pin a2 = a4,
+    /// Microphone out
+    pin micout = a6,
+    /// Microphone in
+    pin micin = a7,
+
+    /// SDA
+    pin sda = b8,
+    /// SCL
+    pin scl = b9,
+
+    /// Accelerometer data signal (SDA)
+    pin accel_sda = a12,
+    /// Accelerometer clock signal (SCL)
+    pin accel_scl = a13,
+
+    /// Keypad Column 0
+    pin col0 = a14,
+    /// Keypad Column 1
+    pin col1 = a15,
+    /// Keypad Column 2
+    pin col2 = a16,
+    /// Keypad Column 3
+    pin col3 = a17,
+    /// Keypad Column 4
+    pin col4 = a20,
+    /// Keypad Column 5
+    pin col5 = a21,
+    /// Keypad Column 6
+    pin col6 = a22,
+    /// Keypad Column 7
+    pin col7 = a23,
+
+    /// Keypad Row 0
+    pin row0 = a18,
+    /// Keypad Row 1
+    pin row1 = a19,
+    /// Keypad Row 2
+    pin row2 = b22,
+    /// Keypad Row 3
+    pin row3 = b23,
+
+    /// NeoPixels
+    pin neopixel = a27,
+
+    /// APA102 (RGB LED control) SCK
+    pin dotstar_ci = b2,
+    /// APA102 (RGB LED control) MOSI
+    pin dotstar_di = b3,
+);
+
+impl Pins {
+    /// Split the device pins into subsets
+    pub fn split(self) -> Sets {
+        let accel = Accelerometer {
+            sda: self.accel_sda,
+            scl: self.accel_scl,
+        };
+
+        let analog = Analog { a0: self.a0, a1: self.a1, a2: self.a2 };
+
+        let audio = Audio {
+            input: self.micin,
+            output: self.micout,
+        };
+
+        let dotstar = Dotstar {
+            ci: self.dotstar_ci,
+            di: self.dotstar_di,
+        };
+
+        let i2c = I2C { sda: self.sda, scl: self.scl };
+
+        let keypad = Keypad {
+            col0: self.col0,
+            col1: self.col1,
+            col2: self.col2,
+            col3: self.col3,
+            col4: self.col4,
+            col5: self.col5,
+            col6: self.col6,
+            col7: self.col7,
+            row0: self.row0,
+            row1: self.row1,
+            row2: self.row2,
+            row3: self.row3,
+        };
+
+        Sets {
+            accel,
+            analog,
+            audio,
+            dotstar,
+            i2c,
+            keypad,
+            neopixel: self.neopixel,
+            port: self.port,
+        }
+    }
+}
 
 /// Sets of pins split apart by category
 pub struct Sets {


### PR DESCRIPTION
Updated using `cargo fix --edition` and `cargo fix --edition-idioms`, then removing some unnecessary `crate::` prefixes on imports coming from other crates.

This also enables moving the `define_pins!` call into the `pins` module (while still re-exporting `pins::Pins` from the crate root).

Additionally runs `rustfmt` over the code.