### PR TITLE
Feather M4 Express board support

### DIFF
--- a/boards/feather_m4/.cargo/config
+++ b/boards/feather_m4/.cargo/config
@@ -1,0 +1,9 @@
+# vim:ft=toml:
+[target.thumbv7em-none-eabihf]
+runner = 'arm-none-eabi-gdb'
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]
+
+[build]
+target = "thumbv7em-none-eabihf"

--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "feather_m4"
+version = "0.1.0"
+authors = ["Theodore DeRego <tderego94@gmail.com>"]
+description = "Board Support crate for the Adafruit Feather M4"
+keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/atsamd-rs/atsamd"
+readme = "README.md"
+documentation = "https://atsamd-rs.github.io/atsamd/atsamd51j19a/feather_m4/"
+
+[dependencies]
+cortex-m = "~0.5"
+embedded-hal = "~0.2"
+nb = "~0.1"
+
+[dependencies.cortex-m-rt]
+version = "~0.6"
+optional = true
+
+[dependencies.atsamd-hal]
+path = "../../hal"
+version = "~0.4"
+default-features = false
+
+[dev-dependencies]
+panic-halt = "~0.2"
+panic-semihosting = "~0.5"
+panic_rtt = "~0.2"
+cortex-m-semihosting = "~0.3"
+cortex-m-rtfm = "~0.4"
+smart-leds = "~0.1"
+smart-leds-trait = "~0.1"
+
+[dev-dependencies.ws2812-timer-delay]
+version = "~0.1"
+features = ["slow"]
+
+[features]
+# ask the HAL to enable atsamd51j19a support
+default = ["rt", "atsamd-hal/samd51j19a", "atsamd-hal/samd51"]
+rt = ["cortex-m-rt", "atsamd-hal/samd51j19a-rt"]
+unproven = ["atsamd-hal/unproven"]
+
+[profile.dev]
+incremental = false
+codegen-units = 1
+debug = true
+lto = false
+
+[profile.release]
+debug = true
+lto = false
+opt-level = "s"

--- a/boards/feather_m4/README.md
+++ b/boards/feather_m4/README.md
@@ -1,0 +1,10 @@
+# Adafruit Feather M4 Board Support Crate
+
+This crate provides a type-safe API for working with the [Adafruit Feather M4
+board](https://www.adafruit.com/product/3857).
+
+## Examples?
+
+Check out the repository for examples:
+
+https://github.com/atsamd-rs/atsamd/tree/master/boards/feather_m4/examples

--- a/boards/feather_m4/build.rs
+++ b/boards/feather_m4/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+fn main() {
+    if env::var_os("CARGO_FEATURE_RT").is_some() {
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        File::create(out.join("memory.x"))
+            .unwrap()
+            .write_all(include_bytes!("memory.x"))
+            .unwrap();
+        println!("cargo:rustc-link-search={}", out.display());
+        println!("cargo:rerun-if-changed=memory.x");
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/boards/feather_m4/examples/blinky_basic.rs
+++ b/boards/feather_m4/examples/blinky_basic.rs
@@ -1,0 +1,37 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate cortex_m_semihosting;
+extern crate feather_m4 as hal;
+#[cfg(not(feature = "use_semihosting"))]
+extern crate panic_halt;
+#[cfg(feature = "use_semihosting")]
+extern crate panic_semihosting;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::prelude::*;
+use hal::{entry, CorePeripherals, Peripherals};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.MCLK,
+        &mut peripherals.OSC32KCTRL,
+        &mut peripherals.OSCCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+    loop {
+        delay.delay_ms(2000u16);
+        red_led.set_high();
+        delay.delay_ms(2000u16);
+        red_led.set_low();
+    }
+}

--- a/boards/feather_m4/memory.x
+++ b/boards/feather_m4/memory.x
@@ -1,0 +1,8 @@
+MEMORY
+{
+  /* Leave 16k for the default bootloader on the Feather M4 */
+  FLASH (rx) : ORIGIN = 0x00000000 + 16K, LENGTH = 512K - 16K
+  RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 192K
+}
+_stack_start = ORIGIN(RAM) + LENGTH(RAM);
+

--- a/boards/feather_m4/src/lib.rs
+++ b/boards/feather_m4/src/lib.rs
@@ -57,6 +57,8 @@ define_pins!(
     pin d5 = a16,
     /// Pin 6, PWM capable
     pin d6 = a18,
+    /// Pin 8, Also NEOPIX.
+    pin d8 = b3,
     /// Pin 9, PWM capable.  Also analog input (A7)
     pin d9 = a19,
     /// Pin 10, PWM capable

--- a/boards/feather_m4/src/lib.rs
+++ b/boards/feather_m4/src/lib.rs
@@ -1,0 +1,163 @@
+#![no_std]
+#![recursion_limit = "1024"]
+
+extern crate atsamd_hal as hal;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::entry;
+
+pub use hal::atsamd51j19a::*;
+use hal::prelude::*;
+pub use hal::*;
+
+use gpio::{Floating, Input, Port};
+use hal::clock::GenericClockController;
+use hal::sercom::{I2CMaster2, PadPin, SPIMaster1};
+use hal::time::Hertz;
+
+#[cfg(feature = "usb")]
+use gpio::IntoFunction;
+#[cfg(feature = "usb")]
+pub use hal::usb::UsbBus;
+#[cfg(feature = "usb")]
+use usb_device::bus::UsbBusWrapper;
+
+define_pins!(
+    /// Maps the pins to their arduino names and
+    /// the numbers printed on the board.
+    struct Pins,
+    target_device: atsamd51j19a,
+
+    /// Analog pin 0.  Can act as a true analog output
+    /// as it has a DAC (which is not currently supported
+    /// by this hal) as well as input.
+    pin a0 = a2,
+
+    /// Analog Pin 1
+    pin a1 = a5,
+    /// Analog Pin 2
+    pin a2 = b8,
+    /// Analog Pin 3
+    pin a3 = b9,
+    /// Analog Pin 4
+    pin a4 = a4,
+    /// Analog Pin 5
+    pin a5 = a6,
+
+    /// Pin 0, rx
+    pin d0 = b16,
+    /// Pin 1, tx
+    pin d1 = b17,
+    /// Pin 4, PWM capable
+    pin d4 = a14,
+
+    /// Pin 5, PWM capable
+    pin d5 = a16,
+    /// Pin 6, PWM capable
+    pin d6 = a18,
+    /// Pin 9, PWM capable.  Also analog input (A7)
+    pin d9 = a19,
+    /// Pin 10, PWM capable
+    pin d10 = a20,
+    /// Pin 11, PWM capable
+    pin d11 = a21,
+    /// Pin 12, PWM capable
+    pin d12 = a22,
+    /// Pin 13, which is also attached to
+    /// the red LED.  PWM capable.
+    pin d13 = a23,
+
+    /// The I2C data line
+    pin sda = a12,
+    /// The I2C clock line
+    pin scl = a13,
+
+    /// The SPI SCK
+    pin sck = a17,
+    /// The SPI MOSI
+    pin mosi = b23,
+    /// The SPI MISO
+    pin miso = b22,
+
+    /// The USB D- pad
+    pin usb_dm = a24,
+    /// The USB D+ pad
+    pin usb_dp = a25,
+);
+
+/// Convenience for setting up the labelled SPI peripheral.
+/// This powers up SERCOM1 and configures it for use as an
+/// SPI Master in SPI Mode 0.
+pub fn spi_master<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    bus_speed: F,
+    sercom1: SERCOM1,
+    mclk: &mut MCLK,
+    sck: gpio::Pa17<Input<Floating>>,
+    mosi: gpio::Pb23<Input<Floating>>,
+    miso: gpio::Pb22<Input<Floating>>,
+    port: &mut Port,
+) -> SPIMaster1 {
+    let gclk0 = clocks.gclk0();
+    SPIMaster1::new(
+        &clocks.sercom1_core(&gclk0).unwrap(),
+        bus_speed.into(),
+        hal::hal::spi::Mode {
+            phase: hal::hal::spi::Phase::CaptureOnFirstTransition,
+            polarity: hal::hal::spi::Polarity::IdleLow,
+        },
+        sercom1,
+        mclk,
+        hal::sercom::SPI1Pinout::Dipo2Dopo2 {
+            miso: miso.into_pad(port),
+            mosi: mosi.into_pad(port),
+            sck: sck.into_pad(port),
+        },
+    )
+}
+
+/// Convenience for setting up the labelled SDA, SCL pins to
+/// operate as an I2C master running at the specified frequency.
+pub fn i2c_master<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    bus_speed: F,
+    sercom2: SERCOM2,
+    mclk: &mut MCLK,
+    sda: gpio::Pa12<Input<Floating>>,
+    scl: gpio::Pa13<Input<Floating>>,
+    port: &mut Port,
+) -> I2CMaster2 {
+    let gclk0 = clocks.gclk0();
+    I2CMaster2::new(
+        &clocks.sercom2_core(&gclk0).unwrap(),
+        bus_speed.into(),
+        sercom2,
+        mclk,
+        sda.into_pad(port),
+        scl.into_pad(port),
+    )
+}
+
+#[cfg(feature = "usb")]
+pub fn usb_bus(
+    usb: USB,
+    clocks: &mut GenericClockController,
+    mclk: &mut MCLK,
+    dm: gpio::Pa24<Input<Floating>>,
+    dp: gpio::Pa25<Input<Floating>>,
+    port: &mut Port,
+) -> UsbBusWrapper<UsbBus> {
+    let gclk0 = clocks.gclk0();
+    dbgprint!("making usb clock");
+    let usb_clock = &clocks.usb(&gclk0).unwrap();
+    dbgprint!("got clock");
+    UsbBusWrapper::new(UsbBus::new(
+        usb_clock,
+        mclk,
+        dm.into_function(port),
+        dp.into_function(port),
+        usb,
+    ))
+}


### PR DESCRIPTION
This PR adds support for Adafruit's Feather M4 Express board. It also contains my quick attempt at getting the USB cdc_acm example working.

Paging @wez! I'll read the USB chapters of both the samd21 and samd51 datasheets to try to spot differences, but in the meantime maybe you'll notice something obvious that I missed?