### PR TITLE
Pyportal fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ There are a couple of crates provided by this repo:
   auto-generated crate providing access to the peripherals
   specified for this device by its SVD file.  This is the MCU used in the Trinket M0
   and Gemma M0 boards from Adafruit.
-* [`atsamd51j19a`](https://atsamd-rs.github.io/atsamd/atsamd51j19a/atsamd51j19a/) is an auto-generated crate providing accesss to the peripherals specified for this device by its SVD file. This is the MCU used in the Metro M4 and Feather M4 boards from Adafruit.
-* [`atsamd51g19a`](https://atsamd-rs.github.io/atsamd/atsamd51g19a/atsamd51g19a/) is an auto-generated crate providing accesss to the peripherals specified for this device by its SVD file. This is the MCU used in the Trellis M4 and ItsyBitsy M4 boards from Adafruit.
+* [`atsamd51j19a`](https://atsamd-rs.github.io/atsamd/atsamd51j19a/atsamd51j19a/) is an auto-generated crate providing access to the peripherals specified for this device by its SVD file. This is the MCU used in the Metro M4 and Feather M4 boards from Adafruit.
+* [`atsamd51j20a`](https://atsamd-rs.github.io/atsamd/atsamd51j20a/atsamd51j20a/) is an auto-generated crate providing access to the peripherals specified for this device by its SVD file. This is the MCU used in the PyPortal board from Adafruit.
+* [`atsamd51g19a`](https://atsamd-rs.github.io/atsamd/atsamd51g19a/atsamd51g19a/) is an auto-generated crate providing access to the peripherals specified for this device by its SVD file. This is the MCU used in the Trellis M4 and ItsyBitsy M4 boards from Adafruit.
 * [`atsamd-hal`](https://atsamd-rs.github.io/atsamd/atsamd21g18a/atsamd_hal/) is the result
   of reading the datasheet for the device and encoding
   a type-safe layer over the raw `atsamd21g18a`, `atsamd21e18a`, `atsamd51j19a`, and `atsamd51g19a` crates.  This crate

--- a/pac/atsamd51j20a/Cargo.toml
+++ b/pac/atsamd51j20a/Cargo.toml
@@ -2,7 +2,11 @@
 name = "atsamd51j20a"
 description = "Peripheral access API for ATSAMD5J20A microcontrollers (generated using svd2rust)"
 version = "0.4.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>", "Paul Sajna <sajattack@gmail.com>"]
+authors = [
+   "Wez Furlong <wez@wezfurlong.org>",
+   "Paul Sajna <sajattack@gmail.com>",
+   "Shella Stephens <shella@infracoven.io",
+]
 keywords = ["no-std", "arm", "cortex-m"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"

--- a/pac/atsamd51j20a/README.md
+++ b/pac/atsamd51j20a/README.md
@@ -1,0 +1,27 @@
+# ATSAMD51J20A
+
+A peripheral access crate for the ATSAMD51J20A chip from Microchip (née Atmel)
+for Rust Embedded projects.
+
+https://crates.io/crates/atsamd51j20a
+
+## [Documentation](https://atsamd-rs.github.io/atsamd/atsamd51j20a/atsamd51j20a/)
+
+This source was automatically generated using `svd2rust`, split into smaller
+pieces using `form` and formatted via `rustfmt`.
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall
+be dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
Published the [`atsamd51j20a`](https://crates.io/crates/atsamd51j20a) crate. Also attempted to publish `pyportal` but ran into the following error. Think `atsamd-hal` needs a release?

```
error: failed to verify package tarball

Caused by:
  failed to select a version for `atsamd-hal`.
    ... required by package `pyportal v0.1.2 (/Users/shella/codez/atsamd/boards/pyportal/target/package/pyportal-0.1.2)`
versions that meet the requirements `~0.4` are: 0.4.1, 0.4.0

the package `pyportal` depends on `atsamd-hal`, with features: `samd51j20a-rt, samd51j20a` but `atsamd-hal` does not have these features.


failed to select a version for `atsamd-hal` which could resolve this conflict
```