### PR TITLE
Adds UART setup for all Adafruit boards

### DIFF
--- a/boards/gemma_m0/src/lib.rs
+++ b/boards/gemma_m0/src/lib.rs
@@ -11,7 +11,11 @@ use hal::prelude::*;
 pub use hal::target_device::*;
 pub use hal::*;
 
-use gpio::{Floating, Input, Port};
+use gpio::{Floating, Input, PfD, Port};
+
+use hal::clock::GenericClockController;
+use hal::sercom::{PadPin, UART0};
+use hal::time::Hertz;
 
 define_pins!(
     /// Maps the pins to their arduino names and
@@ -19,13 +23,44 @@ define_pins!(
     struct Pins,
     target_device: target_device,
 
+    /// I2C SDA, UART TX, SPI MOSI
     pin d0 = a4,
+    /// ADC, DAC
     pin d1 = a2,
+    /// I2C SCL, UART RX, SPI CLK
     pin d2 = a5,
 
     /// Digital pin number 13, which is also attached to
     /// the red LED.  PWM capable.
     pin d13 = a23,
+
+    // DotStar MOSI
     pin mosi = a0,
+    // DotStar SCLK
     pin sck = a1,
 );
+
+/// Convenience for setting up the D2 and D0 pins to
+/// operate as UART RX/TX (respectively) running at the specified baud.
+pub fn uart<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    baud: F,
+    sercom0: SERCOM0,
+    nvic: &mut NVIC,
+    pm: &mut PM,
+    d2: gpio::Pa5<Input<Floating>>,
+    d0: gpio::Pa4<Input<Floating>>,
+    port: &mut Port,
+) -> UART0<hal::sercom::Sercom0Pad1<gpio::Pa5<PfD>>, hal::sercom::Sercom0Pad0<gpio::Pa4<PfD>>, (), ()>
+{
+    let gclk0 = clocks.gclk0();
+
+    UART0::new(
+        &clocks.sercom0_core(&gclk0).unwrap(),
+        baud.into(),
+        sercom0,
+        nvic,
+        pm,
+        (d2.into_pad(port), d0.into_pad(port)),
+    )
+}

--- a/boards/itsybitsy_m0/src/lib.rs
+++ b/boards/itsybitsy_m0/src/lib.rs
@@ -11,9 +11,9 @@ use hal::prelude::*;
 pub use hal::target_device::*;
 pub use hal::*;
 
-use gpio::{Floating, Input, Output, Port, PushPull};
+use gpio::{Floating, Input, Port, PfC};
 use hal::clock::GenericClockController;
-use hal::sercom::{I2CMaster3, PadPin, SPIMaster4, SPIMaster5};
+use hal::sercom::{I2CMaster3, PadPin, SPIMaster4, SPIMaster5, UART0};
 use hal::time::Hertz;
 
 define_pins!(
@@ -184,6 +184,35 @@ pub fn i2c_master<F: Into<Hertz>>(
         pm,
         sda.into_pad(port),
         scl.into_pad(port),
+    )
+}
+
+/// Convenience for setting up the labelled RX, TX pins to
+/// operate as a UART device running at the specified baud.
+pub fn uart<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    baud: F,
+    sercom0: SERCOM0,
+    nvic: &mut NVIC,
+    pm: &mut PM,
+    d0: gpio::Pa11<Input<Floating>>,
+    d1: gpio::Pa10<Input<Floating>>,
+    port: &mut Port,
+) -> UART0<
+    hal::sercom::Sercom0Pad3<gpio::Pa11<PfC>>,
+    hal::sercom::Sercom0Pad2<gpio::Pa10<PfC>>,
+    (),
+    (),
+> {
+    let gclk0 = clocks.gclk0();
+
+    UART0::new(
+        &clocks.sercom0_core(&gclk0).unwrap(),
+        baud.into(),
+        sercom0,
+        nvic,
+        pm,
+        (d0.into_pad(port), d1.into_pad(port)),
     )
 }
 

--- a/boards/metro_m0/src/lib.rs
+++ b/boards/metro_m0/src/lib.rs
@@ -12,8 +12,8 @@ pub use hal::*;
 use hal::clock::GenericClockController;
 #[cfg(feature = "usb")]
 use hal::gpio::IntoFunction;
-use hal::gpio::{Floating, Input, Output, Port, PushPull};
-use hal::sercom::{I2CMaster3, PadPin, SPIMaster4, SPIMaster5};
+use hal::gpio::{Floating, Input, Port, PfC};
+use hal::sercom::{I2CMaster3, PadPin, SPIMaster4, SPIMaster5, UART0};
 use hal::time::Hertz;
 
 #[cfg(feature = "usb")]
@@ -193,6 +193,35 @@ pub fn i2c_master<F: Into<Hertz>>(
         pm,
         sda.into_pad(port),
         scl.into_pad(port),
+    )
+}
+
+/// Convenience for setting up the labelled RX, TX pins to
+/// operate as a UART device running at the specified baud.
+pub fn uart<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    baud: F,
+    sercom0: SERCOM0,
+    nvic: &mut NVIC,
+    pm: &mut PM,
+    d0: gpio::Pa11<Input<Floating>>,
+    d1: gpio::Pa10<Input<Floating>>,
+    port: &mut Port,
+) -> UART0<
+    hal::sercom::Sercom0Pad3<gpio::Pa11<PfC>>,
+    hal::sercom::Sercom0Pad2<gpio::Pa10<PfC>>,
+    (),
+    (),
+> {
+    let gclk0 = clocks.gclk0();
+
+    UART0::new(
+        &clocks.sercom0_core(&gclk0).unwrap(),
+        baud.into(),
+        sercom0,
+        nvic,
+        pm,
+        (d0.into_pad(port), d1.into_pad(port)),
     )
 }
 

--- a/boards/pygamer/src/lib.rs
+++ b/boards/pygamer/src/lib.rs
@@ -11,14 +11,13 @@ pub use crate::pins::Pins;
 pub use hal::target_device::*;
 pub use hal::*;
 
-use hal::prelude::*;
-use gpio::{Floating, Input, Port};
-use hal::clock::GenericClockController;
-use hal::sercom::{I2CMaster2, PadPin, SPIMaster1, SPIMaster4};
-use hal::time::Hertz;
-use hal::timer::TimerCounter;
-use hal::pwm::Pwm2;
 use cortex_m::peripheral::SYST;
+use gpio::{Floating, Input, PfC, Port};
+use hal::clock::GenericClockController;
+use hal::prelude::*;
+use hal::pwm::Pwm2;
+use hal::sercom::{I2CMaster2, PadPin, SPIMaster1, SPIMaster4, UART5};
+use hal::time::Hertz;
 
 use st7735_lcd::{Orientation, ST7735};
 
@@ -41,7 +40,11 @@ pub fn spi_master<F: Into<Hertz>>(
     mosi: gpio::Pb23<Input<Floating>>,
     sck: gpio::Pa17<Input<Floating>>,
     port: &mut Port,
-) -> SPIMaster1<hal::sercom::Sercom1Pad2<gpio::Pb22<gpio::PfC>>, hal::sercom::Sercom1Pad3<gpio::Pb23<gpio::PfC>>, hal::sercom::Sercom1Pad1<gpio::Pa17<gpio::PfC>>> {
+) -> SPIMaster1<
+    hal::sercom::Sercom1Pad2<gpio::Pb22<gpio::PfC>>,
+    hal::sercom::Sercom1Pad3<gpio::Pb23<gpio::PfC>>,
+    hal::sercom::Sercom1Pad1<gpio::Pa17<gpio::PfC>>,
+> {
     let gclk0 = clocks.gclk0();
     SPIMaster1::new(
         &clocks.sercom1_core(&gclk0).unwrap(),
@@ -52,11 +55,7 @@ pub fn spi_master<F: Into<Hertz>>(
         },
         sercom1,
         mclk,
-        (
-            miso.into_pad(port),
-            mosi.into_pad(port),
-            sck.into_pad(port),
-        ),
+        (miso.into_pad(port), mosi.into_pad(port), sck.into_pad(port)),
     )
 }
 
@@ -75,18 +74,21 @@ pub fn display(
     timer2: TC2,
     syst: SYST,
     port: &mut Port,
-) -> Result<(
+) -> Result<
+    (
         ST7735<
             SPIMaster4<
                 hal::sercom::Sercom4Pad2<hal::gpio::Pb14<hal::gpio::PfC>>,
                 hal::sercom::Sercom4Pad3<hal::gpio::Pb15<hal::gpio::PfC>>,
-                hal::sercom::Sercom4Pad1<hal::gpio::Pb13<hal::gpio::PfC>>
+                hal::sercom::Sercom4Pad1<hal::gpio::Pb13<hal::gpio::PfC>>,
             >,
             gpio::Pb5<gpio::Output<gpio::PushPull>>,
-            gpio::Pa0<gpio::Output<gpio::PushPull>>
+            gpio::Pa0<gpio::Output<gpio::PushPull>>,
         >,
-        Pwm2
-    ), ()> {
+        Pwm2,
+    ),
+    (),
+> {
     let gclk0 = clocks.gclk0();
     let tft_spi = SPIMaster4::new(
         &clocks.sercom4_core(&gclk0).ok_or(())?,
@@ -140,7 +142,10 @@ pub fn i2c_master<F: Into<Hertz>>(
     sda: gpio::Pa12<Input<Floating>>,
     scl: gpio::Pa13<Input<Floating>>,
     port: &mut Port,
-) -> I2CMaster2<hal::sercom::Sercom2Pad0<gpio::Pa12<gpio::PfC>>, hal::sercom::Sercom2Pad1<gpio::Pa13<gpio::PfC>>> {
+) -> I2CMaster2<
+    hal::sercom::Sercom2Pad0<gpio::Pa12<gpio::PfC>>,
+    hal::sercom::Sercom2Pad1<gpio::Pa13<gpio::PfC>>,
+> {
     let gclk0 = clocks.gclk0();
     I2CMaster2::new(
         &clocks.sercom2_core(&gclk0).unwrap(),
@@ -149,5 +154,34 @@ pub fn i2c_master<F: Into<Hertz>>(
         mclk,
         sda.into_pad(port),
         scl.into_pad(port),
+    )
+}
+
+/// Convenience for setting up UART on the FeatherWing socket’s
+/// RX/TX pins
+pub fn uart<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    baud: F,
+    sercom5: SERCOM5,
+    mclk: &mut MCLK,
+    nvic: &mut NVIC,
+    rx: gpio::Pb17<Input<Floating>>,
+    tx: gpio::Pb16<Input<Floating>>,
+    port: &mut Port,
+) -> UART5<
+    hal::sercom::Sercom5Pad1<gpio::Pb17<PfC>>,
+    hal::sercom::Sercom5Pad0<gpio::Pb16<PfC>>,
+    (),
+    (),
+> {
+    let gclk0 = clocks.gclk0();
+
+    UART5::new(
+        &clocks.sercom5_core(&gclk0).unwrap(),
+        baud.into(),
+        sercom5,
+        nvic,
+        mclk,
+        (rx.into_pad(port), tx.into_pad(port)),
     )
 }

--- a/boards/pygamer/src/pins.rs
+++ b/boards/pygamer/src/pins.rs
@@ -83,7 +83,7 @@ define_pins!(
     /// Pin SCK
     pin sck = a17,
 
-    // I2C
+    // I2C (connected to LIS3DH accelerometer)
     /// STEMMA SDA
     pin sda = a12,
     /// STEMMA SCL 

--- a/boards/trellis_m4/src/lib.rs
+++ b/boards/trellis_m4/src/lib.rs
@@ -82,7 +82,7 @@ impl Keypad {
 /// Convenience for setting up the labelled SDA, SCL pins to
 /// operate as an I2C master running at the specified frequency.
 pub fn i2c_master<F: Into<Hertz>>(
-    pins: pins::JST,
+    pins: pins::STEMMA,
     clocks: &mut GenericClockController,
     bus_speed: F,
     sercom4: SERCOM4,
@@ -96,11 +96,12 @@ pub fn i2c_master<F: Into<Hertz>>(
 }
 
 /// Convenience for setting up the labelled SDA, SCL pins in the
-/// JST connector to operate as a UART device at the specified baud rate.
+/// STEMMA JST connector to operate as a UART device at the specified
+/// baud rate.
 ///
 /// Here SCL is the RX pin and SDA is the TX pin.
 pub fn uart<F: Into<Hertz>>(
-    pins: pins::JST,
+    pins: pins::STEMMA,
     clocks: &mut GenericClockController,
     baud: F,
     sercom4: SERCOM4,

--- a/boards/trellis_m4/src/pins.rs
+++ b/boards/trellis_m4/src/pins.rs
@@ -99,7 +99,7 @@ impl Pins {
             di: self.dotstar_di,
         };
 
-        let jst = JST {
+        let stemma = STEMMA {
             sda: self.sda,
             scl: self.scl,
         };
@@ -124,7 +124,7 @@ impl Pins {
             analog,
             audio,
             dotstar,
-            jst,
+            stemma,
             keypad,
             neopixel: self.neopixel,
             port: self.port,
@@ -146,8 +146,8 @@ pub struct Sets {
     /// Dotstar (RGB LED) pins
     pub dotstar: Dotstar,
 
-    /// JST pins, which can be I2C, SPI, or UART
-    pub jst: JST,
+    /// STEMMA JST connector, which can be I2C, SPI, or UART
+    pub stemma: STEMMA,
 
     /// Keypad pins
     pub keypad: Keypad,
@@ -229,13 +229,13 @@ pub struct Dotstar {
     pub di: Pb3<Input<Floating>>,
 }
 
-/// JST pins
-pub struct JST {
+/// STEMMA JST pins
+pub struct STEMMA {
     pub sda: Pb8<Input<Floating>>,
     pub scl: Pb9<Input<Floating>>,
 }
 
-impl JST {
+impl STEMMA {
     /// Convenience for setting up the labelled SDA, SCL pins to
     /// operate as an I2C master running at the specified frequency.
     pub fn i2c_master<F: Into<Hertz>>(
@@ -275,16 +275,13 @@ impl JST {
     ) -> UART4<Sercom4Pad1<Pb9<PfD>>, Sercom4Pad0<Pb8<PfD>>, (), ()> {
         let gclk0 = clocks.gclk0();
 
-        let rx: Sercom4Pad1<_> = self.scl.into_pull_down_input(port).into_pad(port);
-        let tx: Sercom4Pad0<_> = self.sda.into_pull_down_input(port).into_pad(port);
-
         UART4::new(
             &clocks.sercom4_core(&gclk0).unwrap(),
             baud.into(),
             sercom4,
             nvic,
             mclk,
-            (rx, tx),
+            (self.scl.into_pad(port), self.sda.into_pad(port)),
         )
     }
 }


### PR DESCRIPTION
Pin parameters to uart functions are named after the names in
Pins struct so that it’s clearer to find out what needs to be
passed in.

Not directly tested because I don’t have access to all of the
boards. Pin info was taken from variant.cpp files and SERCOM
type safety ensures that the rest is set up correctly.

Also tweaks Trellis M4 to be "STEMMA" instead of "JST" since that’s
what it’s called in pygamer.