### PR TITLE
Add clock configurator for RTC.

### DIFF
--- a/hal/src/clock.rs
+++ b/hal/src/clock.rs
@@ -311,6 +311,7 @@ clock_generator!(
     (sercom4_core, Sercom4CoreClock, SERCOM4_CORE),
     (sercom5_core, Sercom5CoreClock, SERCOM5_CORE),
     (usb, UsbClock, USB),
+    (rtc, RtcClock, RTC),
 );
 
 /// The frequency of the 48Mhz source.


### PR DESCRIPTION
You can use this the same as the rest of the configurators, with the exception that, at least according to the SAMD21 data sheet, you shouldn't use gclk0 for it.