### PR TITLE
Modify the $pincfg register to retain a pullen config for alternate modes

### DIFF
--- a/hal/src/gpio.rs
+++ b/hal/src/gpio.rs
@@ -141,7 +141,7 @@ macro_rules! pin {
                         w.pmuxe().$variant()
                     }
                 });
-                port.$pincfg()[$pin_no].write(|bits| {
+                port.$pincfg()[$pin_no].modify(|_, bits| {
                     bits.pmuxen().set_bit()
                 });
 


### PR DESCRIPTION
Using `write` clears this register which means an alternate function like extint cannot use a pull up/down. Replacing this with a `modify` operation ensures the pullen config remains after moving the pin into an alternate function.

I yet haven’t reasoned through how this will interact with other values that may be set in the $pincfg register and whether the hal was relying on these being cleared.