### PR TITLE
Adds write_iter trait to SPI implementation

### DIFF
--- a/hal/src/sercom/spi.rs
+++ b/hal/src/sercom/spi.rs
@@ -214,6 +214,8 @@ macro_rules! spi_master {
 
         impl<MISO, MOSI, SCK> ::hal::blocking::spi::transfer::Default<u8> for $Type<MISO, MOSI, SCK> {}
         impl<MISO, MOSI, SCK> ::hal::blocking::spi::write::Default<u8> for $Type<MISO, MOSI, SCK> {}
+        #[cfg(feature = "unproven")]
+        impl<MISO, MOSI, SCK> ::hal::blocking::spi::write_iter::Default<u8> for $Type<MISO, MOSI, SCK> {}
 
     };
 

--- a/hal/src/sercom51/spi.rs
+++ b/hal/src/sercom51/spi.rs
@@ -209,6 +209,8 @@ macro_rules! spi_master {
 
             impl<MISO, MOSI, SCK> ::hal::blocking::spi::transfer::Default<u8> for $Type<MISO, MOSI, SCK> {}
             impl<MISO, MOSI, SCK> ::hal::blocking::spi::write::Default<u8> for $Type<MISO, MOSI, SCK> {}
+            #[cfg(feature = "unproven")]
+            impl<MISO, MOSI, SCK> ::hal::blocking::spi::write_iter::Default<u8> for $Type<MISO, MOSI, SCK> {}
         }
     };
 }


### PR DESCRIPTION
Keeps it behind the "unproven" feature, since that’s how it is in
embedded_hal.

See: https://github.com/rust-embedded/embedded-hal/blob/48d9c820416cb708b71e0368ac590a0a876dc0e6/src/blocking/spi.rs#L23