### PR TITLE
Add host-enable-pin and SOF pad for trinket m0.

### DIFF
--- a/boards/trinket_m0/src/lib.rs
+++ b/boards/trinket_m0/src/lib.rs
@@ -45,6 +45,11 @@ define_pins!(
     pin swdio = a31,
     pin swdclk = a30,
 
+    /// USB host enable pin
+    pin usb_host_enable = a28,
+
+    /// The USB SOF 1kHz pad
+    pin usb_sof = a23,
     /// The USB D- pad
     pin usb_dm = a24,
     /// The USB D+ pad


### PR DESCRIPTION
This exposes the SOF pad for use. The `host-enable-pin` is optional, but I put it in because it's in Arduino's USBHost library.