### PR TITLE
Don't depend on USB feature for USB calibration data.

### DIFF
--- a/hal/src/calibration.rs
+++ b/hal/src/calibration.rs
@@ -41,19 +41,16 @@ pub fn dfll48m_coarse_cal() -> u8 {
     cal_with_errata(4, 26, 0x3f, 0x3f, 0x1f) as u8
 }
 
-#[cfg(feature = "usb")]
 /// USB TRANSN calibration value. Should be written to USB PADCAL register.
 pub fn usb_transn_cal() -> u8 {
     cal_with_errata(4, 13, 0x1f, 0x1f, 5) as u8
 }
 
-#[cfg(feature = "usb")]
 /// USB TRANSP calibration value. Should be written to USB PADCAL register.
 pub fn usb_transp_cal() -> u8 {
     cal_with_errata(4, 18, 0x1f, 0x1f, 29) as u8
 }
 
-#[cfg(feature = "usb")]
 /// USB TRIM calibration value. Should be written to USB PADCAL register.
 pub fn usb_trim_cal() -> u8 {
     cal_with_errata(4, 23, 7, 7, 5) as u8


### PR DESCRIPTION
These address exist in the NVM calibration area always, so they should
be referrable regardless of what features are enabled.