### PR TITLE
Make calibration module publically accessable.

### DIFF
--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -41,7 +41,7 @@ pub extern crate embedded_hal as hal;
 pub use paste;
 
 #[cfg(not(feature="samd51"))]
-mod calibration;
+pub mod calibration;
 
 #[cfg(not(feature = "samd51"))]
 pub mod clock;


### PR DESCRIPTION
I missed this in the last PR. Sorry about that!