### PR TITLE
Adc helper methods

### DIFF
--- a/hal/src/samd21/adc.rs
+++ b/hal/src/samd21/adc.rs
@@ -1,13 +1,13 @@
-use crate::hal::adc::{Channel, OneShot};
-use crate::target_device::{adc, ADC, PM};
 use crate::clock::GenericClockController;
 use crate::gpio::{
-    Pa2, Pa3, Pa4, Pa5, Pa6, Pa7, Pa8, Pa9, Pa10, Pa11, Pb0, Pb1, Pb2, Pb3, Pb4, 
-    Pb5, Pb6, Pb7, Pb8, Pb9, PfB
+    Pa10, Pa11, Pa2, Pa3, Pa4, Pa5, Pa6, Pa7, Pa8, Pa9, Pb0, Pb1, Pb2, Pb3, Pb4, Pb5, Pb6, Pb7,
+    Pb8, Pb9, PfB,
 };
+use crate::hal::adc::{Channel, OneShot};
+use crate::target_device::{adc, ADC, PM};
 
 pub struct Adc<ADC> {
-    adc: ADC
+    adc: ADC,
 }
 
 impl Adc<ADC> {
@@ -77,7 +77,8 @@ impl Adc<ADC> {
         while self.adc.status.read().syncbusy().bit_is_set() {}
         // Clear the interrupt flag
         self.adc.intflag.modify(|_, w| w.resrdy().set_bit());
-        // Start conversion again, since The first conversion after the reference is changed must not be used.
+        // Start conversion again, since The first conversion after the reference is
+        // changed must not be used.
         self.adc.swtrig.modify(|_, w| w.start().set_bit());
         while self.adc.intflag.read().resrdy().bit_is_clear() {}
         while self.adc.status.read().syncbusy().bit_is_set() {}
@@ -88,22 +89,24 @@ impl Adc<ADC> {
 
 impl<WORD, PIN> OneShot<ADC, WORD, PIN> for Adc<ADC>
 where
-   WORD: From<u16>,
-   PIN: Channel<ADC, ID=u8>,
+    WORD: From<u16>,
+    PIN: Channel<ADC, ID = u8>,
 {
-   type Error = ();
+    type Error = ();
 
-   fn read(&mut self, _pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
+    fn read(&mut self, _pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
         let chan = PIN::channel();
         while self.adc.status.read().syncbusy().bit_is_set() {}
-        self.adc.inputctrl.modify(|_, w| unsafe{ w.muxpos().bits(chan) });
+        self.adc
+            .inputctrl
+            .modify(|_, w| unsafe { w.muxpos().bits(chan) });
         self.power_up();
         let result = self.convert();
         self.power_down();
         Ok(result.into())
     }
 }
- 
+
 macro_rules! adc_pins {
     ($($pin:ident: $chan:expr),+) => {
         $(

--- a/hal/src/samd51/adc.rs
+++ b/hal/src/samd51/adc.rs
@@ -1,15 +1,15 @@
-use crate::hal::adc::{Channel, OneShot};
-use crate::target_device::{adc0, ADC0, ADC1, MCLK};
-use crate::target_device::gclk::genctrl::SRC_A::DFLL;
-use crate::target_device::gclk::pchctrl::GEN_A::GCLK11;
 use crate::clock::GenericClockController;
 use crate::gpio::{
-    Pa2, Pa3, Pa4, Pa5, Pa6, Pa7, Pa8, Pa9, Pa10, Pa11, Pb0, Pb1, Pb2, Pb3, Pb4,
-    Pb5, Pb6, Pb7, Pb8, Pb9, PfB
+    Pa10, Pa11, Pa2, Pa3, Pa4, Pa5, Pa6, Pa7, Pa8, Pa9, Pb0, Pb1, Pb2, Pb3, Pb4, Pb5, Pb6, Pb7,
+    Pb8, Pb9, PfB,
 };
+use crate::hal::adc::{Channel, OneShot};
+use crate::target_device::gclk::genctrl::SRC_A::DFLL;
+use crate::target_device::gclk::pchctrl::GEN_A::GCLK11;
+use crate::target_device::{adc0, ADC0, ADC1, MCLK};
 
 pub struct Adc<ADC> {
-    adc: ADC
+    adc: ADC,
 }
 
 macro_rules! adc_hal {
@@ -69,11 +69,11 @@ impl Adc<$ADC> {
     fn convert(&mut self) -> u16 {
         // start conversion
         self.adc.swtrig.modify(|_, w| w.start().set_bit());
-        // do it again because the datasheet tells us to 
+        // do it again because the datasheet tells us to
         self.adc.swtrig.modify(|_, w| w.start().set_bit());
         while self.adc.intflag.read().resrdy().bit_is_clear() {}
         let result = self.adc.result.read().result().bits();
-        result 
+        result
     }
 }
 
@@ -133,7 +133,7 @@ adc_pins! {
     Pb1:  (ADC0, 13),
     Pb2:  (ADC0, 14),
     Pb3:  (ADC0, 15),
-    
+
     Pb8:  (ADC1, 0),
     Pb9:  (ADC1, 1),
     Pa8:  (ADC1, 2),


### PR DESCRIPTION
Implement some helper methods on the ADC HAL to change things like the gain, reference source, and number of samples. Tested on a feather M0 but no SAMD51 targets. Also, the gain functionality is omitted from the SAMD51 target since it's so different than SAMD21 and there is no existing use of the gain correction feature.

First commit is functional changes, the second is rust formatting changes on those two files.