### PR TITLE
samd51 sercom pin fixes

### DIFF
--- a/boards/metro_m4/examples/spi.rs
+++ b/boards/metro_m4/examples/spi.rs
@@ -4,17 +4,17 @@
 extern crate cortex_m;
 extern crate cortex_m_semihosting;
 extern crate metro_m4 as hal;
+extern crate nb;
 #[cfg(not(feature = "use_semihosting"))]
 extern crate panic_halt;
 #[cfg(feature = "use_semihosting")]
 extern crate panic_semihosting;
-extern crate nb;
 
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
-use hal::prelude::*;
 use hal::entry;
 use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
 use hal::sercom::PadPin;
 use nb::block;
 
@@ -35,10 +35,10 @@ fn main() -> ! {
     let gclk = clocks.gclk0();
 
     let mut spi: hal::sercom::SPIMaster3<
-            hal::sercom::Sercom3Pad1<hal::gpio::Pa23<hal::gpio::PfC>>,
-            hal::sercom::Sercom3Pad0<hal::gpio::Pa22<hal::gpio::PfC>>,
-            hal::sercom::Sercom3Pad3<hal::gpio::Pa21<hal::gpio::PfD>>,
-        > = hal::sercom::SPIMaster3::new(
+        hal::sercom::Sercom3Pad1<hal::gpio::Pa23<hal::gpio::PfC>>,
+        hal::sercom::Sercom3Pad0<hal::gpio::Pa22<hal::gpio::PfC>>,
+        hal::sercom::Sercom3Pad3<hal::gpio::Pa21<hal::gpio::PfD>>,
+    > = hal::sercom::SPIMaster3::new(
         &clocks.sercom3_core(&gclk).unwrap(),
         3_000_000u32.hz(),
         embedded_hal::spi::Mode {
@@ -47,7 +47,11 @@ fn main() -> ! {
         },
         peripherals.SERCOM3,
         &mut peripherals.MCLK,
-        (pins.d0.into_pad(&mut pins.port), pins.d1.into_pad(&mut pins.port), pins.d8.into_pad(&mut pins.port)),
+        (
+            pins.d0.into_pad(&mut pins.port),
+            pins.d1.into_pad(&mut pins.port),
+            pins.d8.into_pad(&mut pins.port),
+        ),
     );
 
     loop {
@@ -56,5 +60,4 @@ fn main() -> ! {
         }
         delay.delay_ms(1000u16);
     }
-
 }

--- a/boards/metro_m4/examples/spi.rs
+++ b/boards/metro_m4/examples/spi.rs
@@ -35,9 +35,9 @@ fn main() -> ! {
     let gclk = clocks.gclk0();
 
     let mut spi: hal::sercom::SPIMaster3<
-        hal::sercom::Sercom3Pad1<hal::gpio::Pa23<hal::gpio::PfC>>,
-        hal::sercom::Sercom3Pad0<hal::gpio::Pa22<hal::gpio::PfC>>,
         hal::sercom::Sercom3Pad3<hal::gpio::Pa21<hal::gpio::PfD>>,
+        hal::sercom::Sercom3Pad0<hal::gpio::Pa22<hal::gpio::PfC>>,
+        hal::sercom::Sercom3Pad1<hal::gpio::Pa23<hal::gpio::PfC>>,
     > = hal::sercom::SPIMaster3::new(
         &clocks.sercom3_core(&gclk).unwrap(),
         3_000_000u32.hz(),
@@ -48,9 +48,9 @@ fn main() -> ! {
         peripherals.SERCOM3,
         &mut peripherals.MCLK,
         (
-            pins.d0.into_pad(&mut pins.port),
-            pins.d1.into_pad(&mut pins.port),
             pins.d8.into_pad(&mut pins.port),
+            pins.d1.into_pad(&mut pins.port),
+            pins.d0.into_pad(&mut pins.port),
         ),
     );
 

--- a/hal/src/samd51/sercom/pads.rs
+++ b/hal/src/samd51/sercom/pads.rs
@@ -2,7 +2,7 @@ use crate::gpio::{self, IntoFunction, Port};
 pub use crate::pad::PadPin;
 
 // sercom0[0]:  PA04:D   PA08:C     PC17:D      PB24:C
-// sercom0[1]:  PA05:D   PA09:C     PC16:C      PB25:C
+// sercom0[1]:  PA05:D   PA09:C     PC16:D      PB25:C
 // sercom0[2]:  PA06:D   PA10:C     PC18:D      PC24:C
 // sercom0[3]:  PA07:D   PA11:C     PC19:D      PC25:C
 
@@ -16,7 +16,7 @@ pad!(Sercom0Pad0 {
 pad!(Sercom0Pad1 {
     Pa5(PfD),
     Pa9(PfC),
-    // Pc16(PfC),
+    // Pc16(PfD),
     // Pb25(PfC),
 });
 
@@ -250,7 +250,7 @@ pad!(Sercom5Pad3 {
 // pad!(Sercom7Pad1 {
 //     Pb20(PfD),
 //     Pc13(PfC),
-//     Pd09(PfC),
+//     Pd9(PfC),
 // });
 
 // pad!(Sercom7Pad2 {

--- a/hal/src/samd51/sercom/pads.rs
+++ b/hal/src/samd51/sercom/pads.rs
@@ -1,168 +1,268 @@
 use crate::gpio::{self, IntoFunction, Port};
 pub use crate::pad::PadPin;
 
-// sercom0[0]:  PA04:D   PA08:C
-// sercom0[1]:  PA05:D   PA09:C
-// sercom0[2]:  PA06:D   PA10:C
-// sercom0[3]:  PA07:D   PA11:C
+// sercom0[0]:  PA04:D   PA08:C     PC17:D      PB24:C
+// sercom0[1]:  PA05:D   PA09:C     PC16:C      PB25:C
+// sercom0[2]:  PA06:D   PA10:C     PC18:D      PC24:C
+// sercom0[3]:  PA07:D   PA11:C     PC19:D      PC25:C
 
 pad!(Sercom0Pad0 {
     Pa4(PfD),
     Pa8(PfC),
+    // Pc17(PfD),
+    // Pb24(PfC),
 });
 
 pad!(Sercom0Pad1 {
     Pa5(PfD),
     Pa9(PfC),
+    // Pc16(PfC),
+    // Pb25(PfC),
 });
 
 pad!(Sercom0Pad2 {
     Pa6(PfD),
     Pa10(PfC),
+    // Pc18(PfD),
+    // Pc24(PfC),
 });
 
 pad!(Sercom0Pad3 {
     Pa7(PfD),
     Pa11(PfC),
+    // Pc19(PfD),
+    // Pc25(PfC),
 });
 
-// sercom1[0]:  PA16:C   PA00:D
-// sercom1[1]:  PA17:C   PA01:D
-// sercom1[2]:  PA18:C   PA30:D
-// sercom1[3]:  PA19:C   PA31:D   PB23:C
+// sercom1[0]:  PA00:D   PA16:C   PC22:C    PC27:C
+// sercom1[1]:  PA01:D   PA17:C   PC23:C    PC28:C
+// sercom1[2]:  PA18:C   PA30:D   PB22:C    PD20:C
+// sercom1[3]:  PA19:C   PA31:D   PB23:C    PD21:C
 
 pad!(Sercom1Pad0 {
     Pa0(PfD),
     Pa16(PfC),
+    // Pc22(PfC),
+    // Pc27(PfC),
 });
 
 pad!(Sercom1Pad1 {
     Pa1(PfD),
     Pa17(PfC),
+    // Pc23(PfC),
+    // Pc28(PfC),
 });
 
 pad!(Sercom1Pad2 {
     Pa18(PfC),
     Pa30(PfD),
     Pb22(PfC),
+    // Pd20(PfC),
 });
 
 pad!(Sercom1Pad3 {
     Pa19(PfC),
     Pa31(PfD),
     Pb23(PfC),
+    // Pd21(PfC),
 });
 
-// sercom2[0]:  PA12:C   PA08:D
-// sercom2[1]:  PA13:C   PA09:D
-// sercom2[2]:  PA14:C   PA10:D
-// sercom2[3]:  PA15:C   PA11:D
+// sercom2[0]:  PA09:D   PA12:C     PB25:D      PB26:C
+// sercom2[1]:  PA08:D   PA13:C     PB24:D      PB27:C
+// sercom2[2]:  PA10:D   PA14:C     PB28:C      PC24:D
+// sercom2[3]:  PA11:D   PA15:C     PB29:C      PC25:D
 
 pad!(Sercom2Pad0 {
-    Pa8(PfD),
+    Pa9(PfD),
     Pa12(PfC),
+    // Pb25(PfD),
+    // Pb26(PfC),
 });
 
 pad!(Sercom2Pad1 {
-    Pa9(PfD),
+    Pa8(PfD),
     Pa13(PfC),
+    // Pb24(PfD),
+    // Pb27(PfC),
 });
 
 pad!(Sercom2Pad2 {
     Pa10(PfD),
     Pa14(PfC),
+    // Pb28(PfC),
+    // Pc24(PfD),
 });
 
 pad!(Sercom2Pad3 {
     Pa11(PfD),
     Pa15(PfC),
+    // Pb29(PfC),
+    // Pc25(PfD),
 });
 
-// sercom3[0]:  PA17:D   PA22:C
-// sercom3[1]:  PA16:D   PA23:C
-// sercom3[2]:  PA18:D   PA24:C   PA20:D
-// sercom3[3]:  PA19:D   PA25:C   PA21:D
+// sercom3[0]:  PA17:D   PA22:C   PB20:C    PC23:D
+// sercom3[1]:  PA16:D   PA23:C   PB21:C    PC22:D
+// sercom3[2]:  PA18:D   PA20:D   PA24:C    PD20:D
+// sercom3[3]:  PA19:D   PA21:D   PA25:C    PD21:D
 
 pad!(Sercom3Pad0 {
     Pa17(PfD),
     Pa22(PfC),
+    // Pb20(PfC),
+    // Pc23(PfD),
 });
 
 pad!(Sercom3Pad1 {
     Pa16(PfD),
     Pa23(PfC),
+    // Pb21(PfC),
+    // Pc22(PfD),
 });
 
 pad!(Sercom3Pad2 {
     Pa18(PfD),
     Pa20(PfD),
     Pa24(PfC),
+    // Pd20(PfD),
 });
 
 pad!(Sercom3Pad3 {
     Pa19(PfD),
     Pa21(PfD),
     Pa25(PfC),
+    // Pd21(PfD),
 });
 
-// sercom4[0]:  PA12:D   PB08:D   PB12:C
-// sercom4[1]:  PA13:D   PB09:D   PB13:C
-// sercom4[2]:  PA14:D   PB10:D   PB14:C
-// sercom4[3]:  PA15:D   PB11:D   PB15:C
+// sercom4[0]:  PA13:D   PB08:D   PB12:C    PB27:D
+// sercom4[1]:  PA12:D   PB09:D   PB13:C    PB26:D
+// sercom4[2]:  PA14:D   PB10:D   PB14:C    PB28:D
+// sercom4[3]:  PA15:D   PB11:D   PB15:C    PB29:D
 
 pad!(Sercom4Pad0 {
-    Pa12(PfD),
+    Pa13(PfD),
     Pb8(PfD),
     Pb12(PfC),
+    // Pb27(PfD),
 });
 
 pad!(Sercom4Pad1 {
-    Pa13(PfD),
+    Pa12(PfD),
     Pb9(PfD),
     Pb13(PfC),
+    // Pb26(PfD),
 });
 
 pad!(Sercom4Pad2 {
     Pa14(PfD),
     Pb10(PfD),
     Pb14(PfC),
+    // Pb28(PfD),
 });
 
 pad!(Sercom4Pad3 {
     Pa15(PfD),
     Pb11(PfD),
     Pb15(PfC),
+    // Pb29(PfD),
 });
 
-// sercom5[0]:  PA23:D   PB02:D   PB31:D   PB16:C
-// sercom5[1]:  PA22:D   PB03:D   PB30:D   PB17:C
-// sercom5[2]:  PA24:D   PB00:D   PA20:C   PB22:D
-// sercom5[3]:  PA25:D   PB01:D   PA21:C   PB23:D
+// sercom5[0]:  PA23:D   PB02:D   PB16:C   PB31:D
+// sercom5[1]:  PA22:D   PB03:D   PB17:C   PB30:D
+// sercom5[2]:  PA20:C   PA24:D   PB00:D   PB18:C   PB22:D
+// sercom5[3]:  PA21:C   PA25:D   PB01:D   PB19:C   PB23:D
 
 pad!(Sercom5Pad0 {
     Pa23(PfD),
     Pb2(PfD),
-    Pb31(PfD),
     Pb16(PfC),
+    Pb31(PfD),
 });
 
 pad!(Sercom5Pad1 {
     Pa22(PfD),
     Pb3(PfD),
-    Pb30(PfD),
     Pb17(PfC),
+    Pb30(PfD),
 });
 
 pad!(Sercom5Pad2 {
+    Pa20(PfC),
     Pa24(PfD),
     Pb0(PfD),
-    Pa20(PfC),
+    // Pb18(PfC),
     Pb22(PfD),
 });
 
 pad!(Sercom5Pad3 {
+    Pa21(PfC),
     Pa25(PfD),
     Pb1(PfD),
-    Pa21(PfC),
+    // Pb19(PfC),
     Pb23(PfD),
 });
+
+// // sercom6[0]:  PC04:C   PC13:D   PC16:C   PD09:D
+// // sercom6[1]:  PC05:C   PC12:D   PC17:C   PD08:D
+// // sercom6[2]:  PC06:C   PC10:C   PC14:D   PC18:C   PD10:D
+// // sercom6[3]:  PC07:C   PC11:C   PC15:D   PC19:C   PD11:D
+
+// pad!(Sercom6Pad0 {
+//     Pc4(PfC),
+//     Pc13(PfD),
+//     Pc16(PfC),
+//     Pd9(PfD),
+// });
+
+// pad!(Sercom6Pad1 {
+//     Pc5(PfC),
+//     Pc12(PfD),
+//     Pc17(PfC),
+//     Pd8(PfD),
+// });
+
+// pad!(Sercom6Pad2 {
+//     Pc6(PfC),
+//     Pc10(PfC),
+//     Pc14(PfD),
+//     Pc18(PfC),
+//     Pd10(PfD),
+// });
+
+// pad!(Sercom6Pad3 {
+//     Pc7(PfC),
+//     Pc11(PfC),
+//     Pc15(PfD),
+//     Pc19(PfC),
+//     Pd11(PfD),
+// });
+
+// // sercom7[0]:  PB21:D   PC12:C   PD08:C
+// // sercom7[1]:  PB20:D   PC13:C   PD09:C
+// // sercom7[2]:  PB18:D   PC10:D   PC14:C   PD10:C
+// // sercom7[3]:  PC11:D   PC15:C   PD11:C   PB19:D
+
+// pad!(Sercom7Pad0 {
+//     Pb21(PfD),
+//     Pc12(PfC),
+//     Pd8(PfC),
+// });
+
+// pad!(Sercom7Pad1 {
+//     Pb20(PfD),
+//     Pc13(PfC),
+//     Pd09(PfC),
+// });
+
+// pad!(Sercom7Pad2 {
+//     Pb18(PfD),
+//     Pc10(PfD),
+//     Pc14(PfC),
+//     Pd10(PfC),
+// });
+
+// pad!(Sercom7Pad3 {
+//     Pc11(PfD),
+//     Pc15(PfC),
+//     Pd11(PfC),
+//     Pb19(PfD),
+// });

--- a/hal/src/samd51/sercom/spi.rs
+++ b/hal/src/samd51/sercom/spi.rs
@@ -1,11 +1,11 @@
 use crate::clock;
-use crate::time::Hertz;
 use crate::hal::spi::{FullDuplex, Mode, Phase, Polarity};
-use nb;
 use crate::sercom::pads::*;
 use crate::target_device::sercom0::SPI;
 use crate::target_device::{MCLK, SERCOM0, SERCOM1, SERCOM2, SERCOM3};
 use crate::target_device::{SERCOM4, SERCOM5};
+use crate::time::Hertz;
+use nb;
 
 #[derive(Debug)]
 pub enum Error {
@@ -65,16 +65,14 @@ macro_rules! spi_master {
             };
         }
 
-        padout!((0, 1) => Pad0, Pad2, Pad3);
+        // dipo In master operation, DI is MISO Pad number 0-3
+        // dopo 0 MOSI PAD 0
+        // dopo 2 MOSI PAD 3
+        // SCK can only be on PAD 1
+        // (dipo,dopo) => (MISO, MOSI, SCK)
         padout!((0, 2) => Pad0, Pad3, Pad1);
-
-        padout!((1, 1) => Pad1, Pad2, Pad3);
-        padout!((1, 3) => Pad1, Pad0, Pad3);
-
         padout!((2, 0) => Pad2, Pad0, Pad1);
         padout!((2, 2) => Pad2, Pad3, Pad1);
-        padout!((2, 3) => Pad2, Pad0, Pad3);
-
         padout!((3, 0) => Pad3, Pad0, Pad1);
 
         $crate::paste::item! {

--- a/hal/src/samd51/sercom/uart.rs
+++ b/hal/src/samd51/sercom/uart.rs
@@ -89,16 +89,24 @@ macro_rules! uart {
             };
         }
 
-        padout!((0, 1) => Pad0, Pad2);
-
+        // rxpo 0-3 RX on PAD 0-3
+        // TX always PAD 0
+        // txpo 0 no RTS/CTS
+        // txpo 1 reserved and can't be used
+        // txpo 2 RTS PAD 2, CTS PAD 3
+        // txpo 3 RTS PAD 2, no CTS
+        // (rxpo_txpo) => (RX, TX, RTS, CTS)
         padout!((1, 0) => Pad1, Pad0);
         padout!((1, 2) => Pad1, Pad0, Pad2, Pad3);
-        padout!((1, 1) => Pad1, Pad2);
+
+        // todo we could support an RTS without a CTS
+        // padout!((1, 3) => Pad1, Pad0, Pad2);
 
         padout!((2, 0) => Pad2, Pad0);
-
         padout!((3, 0) => Pad3, Pad0);
-        padout!((3, 1) => Pad3, Pad2);
+
+        // todo we could support an RTS without a CTS
+        // padout!((3, 3) => Pad3, Pad0, Pad2);
 
         $crate::paste::item! {
             /// UARTX represents the corresponding SERCOMX instance

--- a/hal/src/samd51/sercom/uart.rs
+++ b/hal/src/samd51/sercom/uart.rs
@@ -1,13 +1,13 @@
 use crate::clock;
-use crate::time::Hertz;
 use crate::hal::blocking::serial::{write::Default, Write};
 use crate::hal::serial;
-use nb;
 use crate::sercom::pads::*;
 use crate::target_device::sercom0::USART;
 use crate::target_device::{MCLK, SERCOM0, SERCOM1, SERCOM2, SERCOM3};
 use crate::target_device::{SERCOM4, SERCOM5};
+use crate::time::Hertz;
 use core::fmt;
+use nb;
 
 /// The RxpoTxpo trait defines a way to get the data in and data out pin out
 /// values for a given UARTXPadout configuration. You should not implement
@@ -35,7 +35,7 @@ macro_rules! uart {
         $crate::paste::item! {
             /// A pad mapping configuration for the SERCOM in UART mode.
             ///
-            /// This type can only be constructed using the From implementations 
+            /// This type can only be constructed using the From implementations
             /// in this module, which are restricted to valid configurations.
             ///
             /// Defines which sercom pad is mapped to which UART function.
@@ -268,12 +268,84 @@ macro_rules! uart {
     }
 }
 
-uart!(UART0: (Sercom0, SERCOM0, sercom0_, Sercom0CoreClock, apbamask, SERCOM0_0, SERCOM0_1, SERCOM0_2));
-uart!(UART1: (Sercom1, SERCOM1, sercom1_, Sercom1CoreClock, apbamask, SERCOM1_0, SERCOM1_1, SERCOM1_2));
-uart!(UART2: (Sercom2, SERCOM2, sercom2_, Sercom2CoreClock, apbbmask, SERCOM2_0, SERCOM2_1, SERCOM2_2));
-uart!(UART3: (Sercom3, SERCOM3, sercom3_, Sercom3CoreClock, apbbmask, SERCOM3_0, SERCOM3_1, SERCOM3_2));
-uart!(UART4: (Sercom4, SERCOM4, sercom4_, Sercom4CoreClock, apbdmask, SERCOM4_0, SERCOM4_1, SERCOM4_2));
-uart!(UART5: (Sercom5, SERCOM5, sercom5_, Sercom5CoreClock, apbdmask, SERCOM5_0, SERCOM5_1, SERCOM5_2));
+uart!(
+    UART0:
+        (
+            Sercom0,
+            SERCOM0,
+            sercom0_,
+            Sercom0CoreClock,
+            apbamask,
+            SERCOM0_0,
+            SERCOM0_1,
+            SERCOM0_2
+        )
+);
+uart!(
+    UART1:
+        (
+            Sercom1,
+            SERCOM1,
+            sercom1_,
+            Sercom1CoreClock,
+            apbamask,
+            SERCOM1_0,
+            SERCOM1_1,
+            SERCOM1_2
+        )
+);
+uart!(
+    UART2:
+        (
+            Sercom2,
+            SERCOM2,
+            sercom2_,
+            Sercom2CoreClock,
+            apbbmask,
+            SERCOM2_0,
+            SERCOM2_1,
+            SERCOM2_2
+        )
+);
+uart!(
+    UART3:
+        (
+            Sercom3,
+            SERCOM3,
+            sercom3_,
+            Sercom3CoreClock,
+            apbbmask,
+            SERCOM3_0,
+            SERCOM3_1,
+            SERCOM3_2
+        )
+);
+uart!(
+    UART4:
+        (
+            Sercom4,
+            SERCOM4,
+            sercom4_,
+            Sercom4CoreClock,
+            apbdmask,
+            SERCOM4_0,
+            SERCOM4_1,
+            SERCOM4_2
+        )
+);
+uart!(
+    UART5:
+        (
+            Sercom5,
+            SERCOM5,
+            sercom5_,
+            Sercom5CoreClock,
+            apbdmask,
+            SERCOM5_0,
+            SERCOM5_1,
+            SERCOM5_2
+        )
+);
 
 const SHIFT: u8 = 32;
 


### PR DESCRIPTION
Going off this datasheet
6. I/O Multiplexing and Considerations6.1 Multiplexed Signals
http://ww1.microchip.com/downloads/en/DeviceDoc/60001507E.pdf

I believe I found  a8/a9 and a12/a13 swapped

In the process of checking I documented all the other pins for variants not currently covered. I dont want to waste that work so left it in commented, someone will thank me some day.


Secondly. I THINK dipo_dopo and rxpo_txpo macros are more broad than they should be allowed for samd51? But this is my first time looking at these macros and sercom, so Id love a second look.


Even with these changes though I cant actually solve my personal problem.  I was trying to implement an SPI like
```
    let gclk0 = clocks.gclk0();
    let spi = SPIMaster2::new(
        &clocks.sercom2_core(&gclk0).unwrap(),
        MegaHertz(3).into(),
        hal::hal::spi::Mode {
            phase: hal::hal::spi::Phase::CaptureOnFirstTransition,
            polarity: hal::hal::spi::Polarity::IdleLow,
        },
        peripherals.SERCOM2,
        &mut peripherals.PM,
        (
            pins.sda.into_pad(&mut pins.port), //miso pa12 SERCOM2/PAD[0
            pins.neopixel_pin.into_pad(&mut pins.port), //mosi pa15 is SERCOM2/PAD[3
            pins.scl.into_pad(&mut pins.port), //sck pa13 SERCOM2/PAD[1
        ),
    );
```

which wouldnt work, and still doesnt with the above changes. Any thoughts on if Im correct on the above changes, and where to track this to next if Im implementing SPI correctly?
```
error[E0277]: the trait bound `atsamd_hal::samd51::sercom::spi::SPIMaster2Padout<atsamd_hal::samd51::sercom::pads::Sercom2Pad1<atsamd_hal::common::gpio::Pa13<atsamd_hal::common::gpio::PfC>>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<atsamd_hal::common::gpio::Pa15<atsamd_hal::common::gpio::PfC>>, atsamd_hal::samd51::sercom::pads::Sercom2Pad0<atsamd_hal::common::gpio::Pa12<atsamd_hal::common::gpio::PfC>>>: atsamd_hal::samd51::sercom::spi::DipoDopo` is not satisfied
   --> src/lib.rs:121:5
    |
121 |     SPIMaster2::new(
    |     ^^^^^^^^^^^^^^^ the trait `atsamd_hal::samd51::sercom::spi::DipoDopo` is not implemented for `atsamd_hal::samd51::sercom::spi::SPIMaster2Padout<atsamd_hal::samd51::sercom::pads::Sercom2Pad1<atsamd_hal::common::gpio::Pa13<atsamd_hal::common::gpio::PfC>>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<atsamd_hal::common::gpio::Pa15<atsamd_hal::common::gpio::PfC>>, atsamd_hal::samd51::sercom::pads::Sercom2Pad0<atsamd_hal::common::gpio::Pa12<atsamd_hal::common::gpio::PfC>>>`
    |
    = help: the following implementations were found:
              <atsamd_hal::samd51::sercom::spi::SPIMaster2Padout<atsamd_hal::samd51::sercom::pads::Sercom2Pad0<PIN0>, atsamd_hal::samd51::sercom::pads::Sercom2Pad2<PIN1>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<PIN2>> as atsamd_hal::samd51::sercom::spi::DipoDopo>
              <atsamd_hal::samd51::sercom::spi::SPIMaster2Padout<atsamd_hal::samd51::sercom::pads::Sercom2Pad0<PIN0>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<PIN1>, atsamd_hal::samd51::sercom::pads::Sercom2Pad1<PIN2>> as atsamd_hal::samd51::sercom::spi::DipoDopo>
              <atsamd_hal::samd51::sercom::spi::SPIMaster2Padout<atsamd_hal::samd51::sercom::pads::Sercom2Pad1<PIN0>, atsamd_hal::samd51::sercom::pads::Sercom2Pad0<PIN1>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<PIN2>> as atsamd_hal::samd51::sercom::spi::DipoDopo>
              <atsamd_hal::samd51::sercom::spi::SPIMaster2Padout<atsamd_hal::samd51::sercom::pads::Sercom2Pad1<PIN0>, atsamd_hal::samd51::sercom::pads::Sercom2Pad2<PIN1>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<PIN2>> as atsamd_hal::samd51::sercom::spi::DipoDopo>
            and 4 others
    = note: required by `atsamd_hal::samd51::sercom::spi::SPIMaster2::<MISO, MOSI, SCK>::new`

error[E0277]: the trait bound `atsamd_hal::samd51::sercom::spi::SPIMaster2Padout<atsamd_hal::samd51::sercom::pads::Sercom2Pad1<atsamd_hal::common::gpio::Pa13<atsamd_hal::common::gpio::PfC>>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<atsamd_hal::common::gpio::Pa15<atsamd_hal::common::gpio::PfC>>, atsamd_hal::samd51::sercom::pads::Sercom2Pad0<atsamd_hal::common::gpio::Pa12<atsamd_hal::common::gpio::PfC>>>: core::convert::From<(_, _, _)>` is not satisfied
   --> src/lib.rs:121:5
    |
121 |     SPIMaster2::new(
    |     ^^^^^^^^^^^^^^^ the trait `core::convert::From<(_, _, _)>` is not implemented for `atsamd_hal::samd51::sercom::spi::SPIMaster2Padout<atsamd_hal::samd51::sercom::pads::Sercom2Pad1<atsamd_hal::common::gpio::Pa13<atsamd_hal::common::gpio::PfC>>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<atsamd_hal::common::gpio::Pa15<atsamd_hal::common::gpio::PfC>>, atsamd_hal::samd51::sercom::pads::Sercom2Pad0<atsamd_hal::common::gpio::Pa12<atsamd_hal::common::gpio::PfC>>>`
    |
    = help: the following implementations were found:
              <atsamd_hal::samd51::sercom::spi::SPIMaster2Padout<atsamd_hal::samd51::sercom::pads::Sercom2Pad0<PIN0>, atsamd_hal::samd51::sercom::pads::Sercom2Pad2<PIN1>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<PIN2>> as core::convert::From<(atsamd_hal::samd51::sercom::pads::Sercom2Pad0<PIN0>, atsamd_hal::samd51::sercom::pads::Sercom2Pad2<PIN1>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<PIN2>)>>
              <atsamd_hal::samd51::sercom::spi::SPIMaster2Padout<atsamd_hal::samd51::sercom::pads::Sercom2Pad0<PIN0>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<PIN1>, atsamd_hal::samd51::sercom::pads::Sercom2Pad1<PIN2>> as core::convert::From<(atsamd_hal::samd51::sercom::pads::Sercom2Pad0<PIN0>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<PIN1>, atsamd_hal::samd51::sercom::pads::Sercom2Pad1<PIN2>)>>
              <atsamd_hal::samd51::sercom::spi::SPIMaster2Padout<atsamd_hal::samd51::sercom::pads::Sercom2Pad1<PIN0>, atsamd_hal::samd51::sercom::pads::Sercom2Pad0<PIN1>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<PIN2>> as core::convert::From<(atsamd_hal::samd51::sercom::pads::Sercom2Pad1<PIN0>, atsamd_hal::samd51::sercom::pads::Sercom2Pad0<PIN1>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<PIN2>)>>
              <atsamd_hal::samd51::sercom::spi::SPIMaster2Padout<atsamd_hal::samd51::sercom::pads::Sercom2Pad1<PIN0>, atsamd_hal::samd51::sercom::pads::Sercom2Pad2<PIN1>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<PIN2>> as core::convert::From<(atsamd_hal::samd51::sercom::pads::Sercom2Pad1<PIN0>, atsamd_hal::samd51::sercom::pads::Sercom2Pad2<PIN1>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<PIN2>)>>
            and 4 others
    = note: required because of the requirements on the impl of `core::convert::Into<atsamd_hal::samd51::sercom::spi::SPIMaster2Padout<atsamd_hal::samd51::sercom::pads::Sercom2Pad1<atsamd_hal::common::gpio::Pa13<atsamd_hal::common::gpio::PfC>>, atsamd_hal::samd51::sercom::pads::Sercom2Pad3<atsamd_hal::common::gpio::Pa15<atsamd_hal::common::gpio::PfC>>, atsamd_hal::samd51::sercom::pads::Sercom2Pad0<atsamd_hal::common::gpio::Pa12<atsamd_hal::common::gpio::PfC>>>>` for `(_, _, _)`
    = note: required by `atsamd_hal::samd51::sercom::spi::SPIMaster2::<MISO, MOSI, SCK>::new`

```



