### PR TITLE
Add initial support for SAMD11C14A

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   - CRATE=boards/itsybitsy_m0
   - CRATE=boards/itsybitsy_m4 FEATURES="--features=unproven,usb,use_uart_debug"
   - CRATE=boards/trinket_m0
-  - CRATE=boards/samd11_bare FEATURES="--features=unproven"
+  - CRATE=boards/samd11_bare FEATURES="--features=unproven" BUILDMODE="--release"
   - CRATE=boards/samd21_mini
   - CRATE=boards/arduino_mkrzero
   - CRATE=boards/circuit_playground_express
@@ -35,7 +35,7 @@ before_install:
 
 script:
   - "cd $CRATE"
-  - "cargo build ${EXAMPLES:---examples} $FEATURES"
+  - "cargo build ${EXAMPLES:---examples} $FEATURES $BUILDMODE"
 
 stages:
   - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - CRATE=boards/itsybitsy_m0
   - CRATE=boards/itsybitsy_m4 FEATURES="--features=unproven,usb,use_uart_debug"
   - CRATE=boards/trinket_m0
+  - CRATE=boards/samd11_bare FEATURES="--features=unproven"
   - CRATE=boards/samd21_mini
   - CRATE=boards/arduino_mkrzero
   - CRATE=boards/circuit_playground_express

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # atsamd support for Rust
 
-This repo holds various things that support/enable working with atmel samd21 and samd51 based
+This repo holds various things that support/enable working with atmel samd11, samd21 and samd51 based
 devices, such as the Adafruit Metro M0, Trinket M0 and Gemma M0, using Rust.
 
 [![Build Status](https://travis-ci.org/atsamd-rs/atsamd.svg?branch=master)](https://travis-ci.org/atsamd-rs/atsamd)
@@ -51,7 +51,7 @@ In addition to the generic crates, there are also crates for popular ATSAMD21/51
 ## Building
 
  You'll need to install support for
-`thumbv6m-none-eabi` if you're targeting samd21 or `thumbv7em-none-eabihf` if you're targeting samd51.  Make sure that you have a new enough version of the
+`thumbv6m-none-eabi` if you're targeting samd11 or samd21, or `thumbv7em-none-eabihf` if you're targeting samd51.  Make sure that you have a new enough version of the
 gcc toolchain; the one installable even on recent versions of ubuntu can
 fail to correctly link the vector table:
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ devices, such as the Adafruit Metro M0, Trinket M0 and Gemma M0, using Rust.
 
 There are a couple of crates provided by this repo:
 
+* [`atsamd11c14a`](https://docs.rs/atsamd11c14a/) is an auto-generated crate providing access to the peripherals specified for this device by its SVD file.
 * [`atsamd21g18a`](https://docs.rs/atsamd21g18a/) is an
   auto-generated crate providing access to the peripherals
   specified for this device by its SVD file.  This is the MCU used in the Metro M0,
@@ -25,7 +26,7 @@ There are a couple of crates provided by this repo:
 * [`atsamd51g19a`](https://docs.rs/atsamd51g19a/) is an auto-generated crate providing access to the peripherals specified for this device by its SVD file. This is the MCU used in the Trellis M4 and ItsyBitsy M4 boards from Adafruit.
 * [`atsamd-hal`](https://docs.rs/atsamd_hal/) is the result
   of reading the datasheet for the device and encoding
-  a type-safe layer over the raw `atsamd21g18a`, `atsamd21e18a`, `atsamd21j18a`, `atsamd51j19a`, and `atsamd51g19a` crates.  This crate
+  a type-safe layer over the raw `atsamd11c14a`, `atsamd21g18a`, `atsamd21e18a`, `atsamd21j18a`, `atsamd51j19a`, and `atsamd51g19a` crates.  This crate
   implements traits specified by the `embedded-hal` project, making it compatible with
   various drivers in the embedded rust ecosystem.
 

--- a/boards/samd11_bare/.cargo/config
+++ b/boards/samd11_bare/.cargo/config
@@ -1,0 +1,7 @@
+# samd21 is a Cortex-M0 and thus thumbv6m
+
+[build]
+target = "thumbv6m-none-eabi"
+
+[target.thumbv6m-none-eabi]
+runner = 'arm-none-eabi-gdb'

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "samd11_bare"
+version = "0.1.0"
+authors = ["Jesse Braham <jesse@beta7.io>"]
+description = "Support crate for the ATSAMD11C14A"
+keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/atsamd-rs/atsamd"
+readme = "README.md"
+documentation = "https://atsamd-rs.github.io/atsamd/atsamd11c14a/samd11_bare/"
+
+[dependencies]
+cortex-m = "~0.6"
+embedded-hal = "~0.2"
+nb = "~0.1"
+
+[dependencies.cortex-m-rt]
+version = "~0.6"
+optional = true
+
+[dependencies.atsamd-hal]
+path = "../../hal"
+version = "~0.7"
+default-features = false
+
+[dev-dependencies]
+cortex-m-semihosting = "0.3.5"
+panic-halt = "~0.2"
+
+[features]
+# ask the HAL to enable atsamd11c14a support
+default = ["rt", "atsamd-hal/samd11c14a"]
+rt = ["cortex-m-rt", "atsamd-hal/samd11c14a-rt"]
+unproven = ["atsamd-hal/unproven"]
+use_semihosting = []
+
+[[example]]
+name = "adc"
+
+[[example]]
+name = "blinky_basic"
+
+[[example]]
+name = "pwm"
+
+[[example]]
+name = "serial"
+
+[[example]]
+name = "timer"

--- a/boards/samd11_bare/README.md
+++ b/boards/samd11_bare/README.md
@@ -1,0 +1,9 @@
+# ATSAMD11C14A Support Crate
+
+This crate provides a type-safe API for working with the [ATSAMD11C14A](https://www.microchip.com/wwwproducts/en/ATSAMD11C14).
+
+## Examples?
+
+Check out the repository for examples:
+
+https://github.com/atsamd-rs/atsamd/tree/master/boards/samd11_bare/examples

--- a/boards/samd11_bare/build.rs
+++ b/boards/samd11_bare/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+fn main() {
+    if env::var_os("CARGO_FEATURE_RT").is_some() {
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        File::create(out.join("memory.x"))
+            .unwrap()
+            .write_all(include_bytes!("memory.x"))
+            .unwrap();
+        println!("cargo:rustc-link-search={}", out.display());
+        println!("cargo:rerun-if-changed=memory.x");
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/boards/samd11_bare/examples/adc.rs
+++ b/boards/samd11_bare/examples/adc.rs
@@ -1,0 +1,43 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate cortex_m_semihosting;
+extern crate embedded_hal;
+extern crate samd11_bare as hal;
+
+#[cfg(not(feature = "use_semihosting"))]
+extern crate panic_halt;
+#[cfg(feature = "use_semihosting")]
+extern crate panic_semihosting;
+
+use cortex_m_semihosting::hprintln;
+use hal::adc::Adc;
+use hal::clock::GenericClockController;
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut delay = hal::delay::Delay::new(core.SYST, &mut clocks);
+    let mut pins = hal::Pins::new(peripherals.PORT);
+
+    let mut adc = Adc::adc(peripherals.ADC, &mut peripherals.PM, &mut clocks);
+    let mut a0 = pins.d1.into_function_b(&mut pins.port);
+
+    loop {
+        let data: u16 = adc.read(&mut a0).unwrap();
+        hprintln!("{}", data).unwrap();
+        delay.delay_ms(1000u16);
+    }
+}

--- a/boards/samd11_bare/examples/blinky_basic.rs
+++ b/boards/samd11_bare/examples/blinky_basic.rs
@@ -1,0 +1,35 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+extern crate samd11_bare as hal;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut red_led = pins.d2.into_open_drain_output(&mut pins.port);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    loop {
+        delay.delay_ms(200u8);
+        red_led.set_high().unwrap();
+        delay.delay_ms(200u8);
+        red_led.set_low().unwrap();
+    }
+}

--- a/boards/samd11_bare/examples/pwm.rs
+++ b/boards/samd11_bare/examples/pwm.rs
@@ -1,0 +1,47 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m_rt;
+extern crate panic_halt;
+extern crate samd11_bare as hal;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+use hal::pwm::Pwm1;
+
+use cortex_m_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+    let mut pins = hal::Pins::new(peripherals.PORT);
+
+    let gclk0 = clocks.gclk0();
+    let d1 = pins.d1.into_function_e(&mut pins.port);
+    let mut pwm1 = Pwm1::new(
+        &clocks.tc1_tc2(&gclk0).unwrap(),
+        1.khz(),
+        peripherals.TC1,
+        hal::pwm::TC1Pinout::Pa5(d1),
+        &mut peripherals.PM,
+    );
+    let max_duty = pwm1.get_max_duty();
+
+    loop {
+        pwm1.set_duty(max_duty / 2);
+        delay.delay_ms(1000u16);
+        pwm1.set_duty(max_duty / 8);
+        delay.delay_ms(1000u16);
+    }
+}

--- a/boards/samd11_bare/examples/serial.rs
+++ b/boards/samd11_bare/examples/serial.rs
@@ -1,0 +1,75 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate cortex_m_semihosting;
+extern crate samd11_bare as hal;
+
+#[cfg(not(feature = "use_semihosting"))]
+extern crate panic_halt;
+#[cfg(feature = "use_semihosting")]
+extern crate panic_semihosting;
+
+#[macro_use(block)]
+extern crate nb;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+
+use hal::pac::gclk::clkctrl::GEN_A;
+use hal::pac::gclk::genctrl::SRC_A;
+use hal::sercom::{PadPin, Sercom0Pad0, Sercom0Pad1, UART0};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+    clocks.configure_gclk_divider_and_source(GEN_A::GCLK2, 1, SRC_A::DFLL48M, false);
+    let gclk2 = clocks
+        .get_gclk(GEN_A::GCLK2)
+        .expect("Could not get clock 2");
+
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    let rx: Sercom0Pad1<_> = pins
+        .d1
+        .into_pull_down_input(&mut pins.port)
+        .into_pad(&mut pins.port);
+    let tx: Sercom0Pad0<_> = pins
+        .d14
+        .into_pull_down_input(&mut pins.port)
+        .into_pad(&mut pins.port);
+
+    let uart_clk = clocks
+        .sercom0_core(&gclk2)
+        .expect("Could not configure sercom0 clock");
+
+    let mut uart = UART0::new(
+        &uart_clk,
+        9600.hz(),
+        peripherals.SERCOM0,
+        &mut peripherals.PM,
+        (rx, tx),
+    );
+
+    loop {
+        for byte in b"Hello, world!" {
+            // NOTE `block!` blocks until `uart.write()` completes and returns
+            // `Result<(), Error>`
+            block!(uart.write(*byte)).unwrap();
+        }
+        delay.delay_ms(1000u16);
+    }
+}

--- a/boards/samd11_bare/examples/timer.rs
+++ b/boards/samd11_bare/examples/timer.rs
@@ -1,0 +1,43 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+extern crate samd11_bare as hal;
+
+extern crate cortex_m_rt;
+extern crate embedded_hal;
+extern crate nb;
+
+use hal::clock::GenericClockController;
+use hal::entry;
+use hal::pac::Peripherals;
+use hal::prelude::*;
+use hal::timer::TimerCounter;
+use nb::block;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+    let gclk0 = clocks.gclk0();
+    let timer_clock = clocks.tc1_tc2(&gclk0).unwrap();
+    let mut timer = TimerCounter::tc1_(&timer_clock, peripherals.TC1, &mut peripherals.PM);
+    timer.start(1u32.hz());
+
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut d2 = pins.d2.into_open_drain_output(&mut pins.port);
+
+    loop {
+        d2.set_high().unwrap();
+        block!(timer.wait()).ok();
+        d2.set_low().unwrap();
+        block!(timer.wait()).ok();
+    }
+}

--- a/boards/samd11_bare/memory.x
+++ b/boards/samd11_bare/memory.x
@@ -1,0 +1,6 @@
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 16K
+  RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 4K
+}
+_stack_start = ORIGIN(RAM) + LENGTH(RAM);

--- a/boards/samd11_bare/src/lib.rs
+++ b/boards/samd11_bare/src/lib.rs
@@ -1,0 +1,93 @@
+#![no_std]
+
+extern crate atsamd_hal as hal;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::entry;
+
+use hal::prelude::*;
+use hal::*;
+
+pub use hal::common::*;
+pub use hal::samd11::*;
+pub use hal::target_device as pac;
+
+use gpio::{Floating, Input, PfC, Port};
+
+use hal::clock::GenericClockController;
+use hal::sercom::{I2CMaster0, PadPin, UART0};
+use hal::time::Hertz;
+
+define_pins!(
+    /// Maps the pins to their physical pins.
+    struct Pins,
+    target_device: target_device,
+
+    pin d1 = a5,
+    pin d2 = a8,
+    pin d3 = a9,
+    pin d4 = a14,
+    pin d5 = a15,
+    pin d6 = a28, // RST
+    pin d7 = a30,
+
+    pin d8 = a31,
+    pin d9 = a24,
+    pin d10 = a25,
+
+    // 11 & 12 are GND/VCC
+
+    pin d13 = a2,
+    pin d14 = a4,
+);
+
+/// Convenience for setting up the D1 and D14 pins to
+/// operate as UART RX/TX (respectively) running at the specified baud.
+pub fn uart<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    baud: F,
+    sercom0: pac::SERCOM0,
+    pm: &mut pac::PM,
+    d1: gpio::Pa5<Input<Floating>>,
+    d14: gpio::Pa4<Input<Floating>>,
+    port: &mut Port,
+) -> UART0<hal::sercom::Sercom0Pad3<gpio::Pa5<PfC>>, hal::sercom::Sercom0Pad2<gpio::Pa4<PfC>>, (), ()>
+{
+    let gclk0 = clocks.gclk0();
+
+    UART0::new(
+        &clocks.sercom0_core(&gclk0).unwrap(),
+        baud.into(),
+        sercom0,
+        pm,
+        (d1.into_pad(port), d14.into_pad(port)),
+    )
+}
+
+/// Convenience for setting up the D4 and D5 pins to operate as I²C
+/// SDA/SDL (respectively) running at the specified baud.
+pub fn i2c_master<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    bus_speed: F,
+    sercom0: pac::SERCOM0,
+    pm: &mut pac::PM,
+    sda: gpio::Pa14<Input<Floating>>,
+    scl: gpio::Pa15<Input<Floating>>,
+    port: &mut Port,
+) -> I2CMaster0<
+    hal::sercom::Sercom0Pad0<gpio::Pa14<gpio::PfC>>,
+    hal::sercom::Sercom0Pad1<gpio::Pa15<gpio::PfC>>,
+> {
+    let gclk0 = clocks.gclk0();
+
+    I2CMaster0::new(
+        &clocks.sercom0_core(&gclk0).unwrap(),
+        bus_speed.into(),
+        sercom0,
+        pm,
+        sda.into_pad(port),
+        scl.into_pad(port),
+    )
+}

--- a/build-all.py
+++ b/build-all.py
@@ -30,6 +30,10 @@ for env in travis['env']:
 	if features != None:
 		cmd.extend(shlex.split(features))
 
+	buildmode = d.get("BUILDMODE", None)
+	if buildmode != None:
+		cmd.extend(shlex.split(buildmode))
+
 	print(cmd)
 	
 	subprocess.check_call(cmd, cwd=crate_dir)

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atsamd-hal"
 version = "0.7.4"
 authors = ["Wez Furlong <wez@wezfurlong.org>", "Paul Sajna <sajattack@gmail.com>"]
-description = "HAL and Peripheral access API for ATSAMD21 and ATSAMD51 microcontrollers"
+description = "HAL and Peripheral access API for ATSAMD11, ATSAMD21 and ATSAMD51 microcontrollers"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
@@ -30,6 +30,11 @@ version = "~1.0"
 # Each of the supported chips is listed as an optional dependency here.
 # This makes it available when the corresponding feature name is referenced.
 # We use a feature named "samdFOO" to pull in the dependency named "atsamdFOO"
+[dependencies.atsamd11c14a]
+path = "../pac/atsamd11c14a"
+version = "~0.1"
+optional = true
+
 [dependencies.atsamd21g18a]
 path = "../pac/atsamd21g18a"
 version = "~0.6"
@@ -79,6 +84,8 @@ cortex-m-rtfm = "~0.3"
 # If we simply used feature names that matched the dependency names, enabling the
 # rt feature would link all possible parts in and cause a linker error due to
 # the high degree of similar symbols present in the various parts.
+samd11c14a = ["atsamd11c14a"]
+samd11c14a-rt = ["atsamd11c14a", "atsamd11c14a/rt"]
 samd21g18a = ["atsamd21g18a"]
 samd21g18a-rt = ["atsamd21g18a", "atsamd21g18a/rt"]
 samd21e18a = ["atsamd21e18a"]

--- a/hal/README.md
+++ b/hal/README.md
@@ -1,8 +1,8 @@
 # HAL for working with atsamd devices
 
-This crate provides a type-safe API for working with atsamd21 and atsamd51 based devices.
-Currently this crate supports `atsamd21g18a`, `atsamd21e18a` or `atsamd51j19a` 
-(selectable via the `samd21g18a`, `samd21e18a`, or `samd51j19a` features),
+This crate provides a type-safe API for working with atsamd11, atsamd21 and atsamd51 based devices.
+Currently this crate supports `atsamd11c14a`, `atsamd21g18a`, `atsamd21e18a` or `atsamd51j19a` 
+(selectable via the `samd11c14a`, `samd21g18a`, `samd21e18a`, or `samd51j19a` features),
 and should be able to support other variants in a similar fashion; 
 pull requests for this are welcomed!
 

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -4,6 +4,9 @@ pub extern crate embedded_hal as hal;
 
 pub use paste;
 
+#[cfg(feature = "samd11c14a")]
+pub use atsamd11c14a as target_device;
+
 #[cfg(feature = "samd21e18a")]
 pub use atsamd21e18a as target_device;
 
@@ -47,17 +50,22 @@ macro_rules! dbgprint {
 pub mod common;
 pub use self::common::*;
 
-#[cfg(feature="samd51")]
+#[cfg(feature = "samd51")]
 pub mod samd51;
-#[cfg(feature="samd51")]
+#[cfg(feature = "samd51")]
 pub use self::samd51::*;
 
-#[cfg(not(feature="samd51"))]
+#[cfg(not(any(feature = "samd11c14a", feature = "samd51")))]
 pub mod samd21;
-#[cfg(not(feature="samd51"))]
+#[cfg(not(any(feature = "samd11c14a", feature = "samd51")))]
 pub use self::samd21::*;
 
-#[cfg(all(feature = "usb", feature="samd21"))]
+#[cfg(feature = "samd11c14a")]
+pub mod samd11;
+#[cfg(feature = "samd11c14a")]
+pub use self::samd11::*;
+
+#[cfg(all(feature = "usb", feature = "samd21"))]
 pub use self::samd21::usb;
-#[cfg(all(feature = "usb", feature="samd51"))]
+#[cfg(all(feature = "usb", feature = "samd51"))]
 pub use self::samd51::usb;

--- a/hal/src/samd11/adc.rs
+++ b/hal/src/samd11/adc.rs
@@ -1,0 +1,130 @@
+use crate::clock::GenericClockController;
+use crate::gpio::{Pa10, Pa11, Pa2, Pa3, Pa4, Pa5, Pa6, Pa7, Pa8, Pa9, PfB};
+use crate::hal::adc::{Channel, OneShot};
+use crate::target_device::{adc, ADC, PM};
+
+pub struct Adc<ADC> {
+    adc: ADC,
+}
+
+impl Adc<ADC> {
+    pub fn adc(adc: ADC, pm: &mut PM, clocks: &mut GenericClockController) -> Self {
+        pm.apbcmask.modify(|_, w| w.adc_().set_bit());
+        // set to 1/(1/(48000000/32) * 6) = 250000 SPS
+        let gclk0 = clocks.gclk0();
+        clocks.adc(&gclk0).expect("adc clock setup failed");
+        while adc.status.read().syncbusy().bit_is_set() {}
+        adc.ctrla.modify(|_, w| w.swrst().set_bit());
+        while adc.status.read().syncbusy().bit_is_set() {}
+        adc.ctrlb.modify(|_, w| {
+            w.prescaler().div32();
+            w.ressel()._12bit()
+        });
+        while adc.status.read().syncbusy().bit_is_set() {}
+        adc.sampctrl.modify(|_, w| unsafe { w.samplen().bits(5) }); //sample length
+        while adc.status.read().syncbusy().bit_is_set() {}
+        adc.inputctrl.modify(|_, w| w.muxneg().gnd()); // No negative input (internal gnd)
+        while adc.status.read().syncbusy().bit_is_set() {}
+
+        let mut newadc = Self { adc };
+        newadc.samples(adc::avgctrl::SAMPLENUM_A::_1);
+        newadc.gain(adc::inputctrl::GAIN_A::DIV2);
+        newadc.reference(adc::refctrl::REFSEL_A::INTVCC1);
+
+        newadc
+    }
+
+    pub fn samples(&mut self, samples: adc::avgctrl::SAMPLENUM_A) {
+        self.adc.avgctrl.modify(|_, w| {
+            w.samplenum().variant(samples);
+            // I don't see any reason to divide ourselves. peripheral will automatically
+            // shift as needed
+            unsafe { w.adjres().bits(0) }
+        });
+        while self.adc.status.read().syncbusy().bit_is_set() {}
+    }
+
+    pub fn gain(&mut self, gain: adc::inputctrl::GAIN_A) {
+        self.adc.inputctrl.modify(|_, w| w.gain().variant(gain));
+        while self.adc.status.read().syncbusy().bit_is_set() {}
+    }
+
+    pub fn reference(&mut self, reference: adc::refctrl::REFSEL_A) {
+        self.adc
+            .refctrl
+            .modify(|_, w| w.refsel().variant(reference));
+        while self.adc.status.read().syncbusy().bit_is_set() {}
+    }
+
+    fn power_up(&mut self) {
+        while self.adc.status.read().syncbusy().bit_is_set() {}
+        self.adc.ctrla.modify(|_, w| w.enable().set_bit());
+        while self.adc.status.read().syncbusy().bit_is_set() {}
+    }
+
+    fn power_down(&mut self) {
+        while self.adc.status.read().syncbusy().bit_is_set() {}
+        self.adc.ctrla.modify(|_, w| w.enable().clear_bit());
+        while self.adc.status.read().syncbusy().bit_is_set() {}
+    }
+
+    fn convert(&mut self) -> u16 {
+        self.adc.swtrig.modify(|_, w| w.start().set_bit());
+        while self.adc.intflag.read().resrdy().bit_is_clear() {}
+        while self.adc.status.read().syncbusy().bit_is_set() {}
+        // Clear the interrupt flag
+        self.adc.intflag.modify(|_, w| w.resrdy().set_bit());
+        // Start conversion again, since The first conversion after the reference is
+        // changed must not be used.
+        self.adc.swtrig.modify(|_, w| w.start().set_bit());
+        while self.adc.intflag.read().resrdy().bit_is_clear() {}
+        while self.adc.status.read().syncbusy().bit_is_set() {}
+        let result = self.adc.result.read().result().bits();
+        result
+    }
+}
+
+impl<WORD, PIN> OneShot<ADC, WORD, PIN> for Adc<ADC>
+where
+    WORD: From<u16>,
+    PIN: Channel<ADC, ID = u8>,
+{
+    type Error = ();
+
+    fn read(&mut self, _pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
+        let chan = PIN::channel();
+        while self.adc.status.read().syncbusy().bit_is_set() {}
+        self.adc
+            .inputctrl
+            .modify(|_, w| unsafe { w.muxpos().bits(chan) });
+        self.power_up();
+        let result = self.convert();
+        self.power_down();
+        Ok(result.into())
+    }
+}
+
+macro_rules! adc_pins {
+    ($($pin:ident: $chan:expr),+) => {
+        $(
+
+impl Channel<ADC> for $pin<PfB> {
+   type ID = u8;
+   fn channel() -> u8 { $chan }
+}
+        )+
+    }
+}
+
+adc_pins! {
+    Pa2: 0,
+    Pa3: 1,
+    Pa4: 4,
+    Pa5: 5,
+    Pa6: 6,
+    Pa7: 7,
+    Pa8: 16,
+    Pa9: 17,
+    Pa10: 18,
+    Pa11: 19
+}

--- a/hal/src/samd11/adc.rs
+++ b/hal/src/samd11/adc.rs
@@ -1,5 +1,5 @@
 use crate::clock::GenericClockController;
-use crate::gpio::{Pa10, Pa11, Pa2, Pa3, Pa4, Pa5, Pa6, Pa7, Pa8, Pa9, PfB};
+use crate::gpio::{Pa2, Pa3, Pa4, Pa5, Pa6, Pa7, Pa10, Pa11, Pa14, Pa15, PfB};
 use crate::hal::adc::{Channel, OneShot};
 use crate::target_device::{adc, ADC, PM};
 
@@ -119,12 +119,12 @@ impl Channel<ADC> for $pin<PfB> {
 adc_pins! {
     Pa2: 0,
     Pa3: 1,
-    Pa4: 4,
-    Pa5: 5,
-    Pa6: 6,
-    Pa7: 7,
-    Pa8: 16,
-    Pa9: 17,
-    Pa10: 18,
-    Pa11: 19
+    Pa4: 2,
+    Pa5: 3,
+    Pa6: 4,
+    Pa7: 5,
+    Pa10: 8,
+    Pa11: 9,
+    Pa14: 6,
+    Pa15: 7
 }

--- a/hal/src/samd11/calibration.rs
+++ b/hal/src/samd11/calibration.rs
@@ -1,0 +1,57 @@
+//! NVM Software Calibration Row Mapping
+// See 9.5 NVM Software Calibration Area Mapping, page 24
+
+use core::ptr;
+
+const ADDR: u32 = 0x806020u32;
+
+fn cal(addr_offset: u32, bit_shift: u32, bit_mask: u32) -> u32 {
+    unsafe {
+        let addr: *const u32 = (ADDR + addr_offset) as *const _;
+        let value = ptr::read(addr);
+
+        (value >> bit_shift) & bit_mask
+    }
+}
+
+fn cal_with_errata(
+    addr_offset: u32,
+    bit_shift: u32,
+    bit_mask: u32,
+    bad_val: u32,
+    def_val: u32,
+) -> u32 {
+    let val = cal(addr_offset, bit_shift, bit_mask);
+    // if the value matches the bad value, use an alternative value
+    // specified in the the errata section of the datasheet
+    if val == bad_val {
+        def_val
+    } else {
+        val
+    }
+}
+
+/// Returns the osc32k calibration value from the NVM calibration area
+pub fn osc32k_cal() -> u8 {
+    cal(4, 6, 0x7f) as u8
+}
+
+/// Returns the dfll48m coarse calibration value
+pub fn dfll48m_coarse_cal() -> u8 {
+    cal_with_errata(4, 26, 0x3f, 0x3f, 0x1f) as u8
+}
+
+/// USB TRANSN calibration value. Should be written to USB PADCAL register.
+pub fn usb_transn_cal() -> u8 {
+    cal_with_errata(4, 13, 0x1f, 0x1f, 5) as u8
+}
+
+/// USB TRANSP calibration value. Should be written to USB PADCAL register.
+pub fn usb_transp_cal() -> u8 {
+    cal_with_errata(4, 18, 0x1f, 0x1f, 29) as u8
+}
+
+/// USB TRIM calibration value. Should be written to USB PADCAL register.
+pub fn usb_trim_cal() -> u8 {
+    cal_with_errata(4, 23, 7, 7, 5) as u8
+}

--- a/hal/src/samd11/clock.rs
+++ b/hal/src/samd11/clock.rs
@@ -1,0 +1,440 @@
+//! Configuring the system clock sources.
+//! You will typically need to create an instance of `GenericClockController`
+//! before you can set up most of the peripherals on the atsamd21 device.
+//! The other types in this module are used to enforce at compile time
+//! that the peripherals have been correctly configured.
+use crate::target_device::gclk::clkctrl::GEN_A::*;
+use crate::target_device::gclk::clkctrl::ID_A::*;
+use crate::target_device::gclk::genctrl::SRC_A::*;
+use crate::target_device::{self, GCLK, NVMCTRL, PM, SYSCTRL};
+use crate::time::{Hertz, U32Ext};
+
+pub type ClockId = target_device::gclk::clkctrl::ID_A;
+pub type ClockGenId = target_device::gclk::clkctrl::GEN_A;
+pub type ClockSource = target_device::gclk::genctrl::SRC_A;
+
+/// Represents a configured clock generator.
+/// Can be converted into the effective clock frequency.
+/// Its primary purpose is to be passed in to methods
+/// such as `GenericClockController::tcc2_tc3` to configure
+/// the clock for a peripheral.
+#[derive(Clone, Copy)]
+pub struct GClock {
+    gclk: ClockGenId,
+    freq: Hertz,
+}
+
+impl Into<Hertz> for GClock {
+    fn into(self) -> Hertz {
+        self.freq
+    }
+}
+
+struct State {
+    gclk: GCLK,
+}
+
+impl State {
+    fn reset_gclk(&mut self) {
+        self.gclk.ctrl.write(|w| w.swrst().set_bit());
+        while self.gclk.ctrl.read().swrst().bit_is_set()
+            || self.gclk.status.read().syncbusy().bit_is_set()
+        {}
+    }
+
+    fn wait_for_sync(&mut self) {
+        while self.gclk.status.read().syncbusy().bit_is_set() {}
+    }
+
+    fn set_gclk_divider_and_source(
+        &mut self,
+        gclk: ClockGenId,
+        divider: u16,
+        src: ClockSource,
+        improve_duty_cycle: bool,
+    ) {
+        self.gclk.gendiv.write(|w| unsafe {
+            w.id().bits(u8::from(gclk));
+            w.div().bits(divider)
+        });
+        self.wait_for_sync();
+
+        self.gclk.genctrl.write(|w| unsafe {
+            w.id().bits(u8::from(gclk));
+            w.src().bits(u8::from(src));
+            // divide directly by divider, rather than exponential
+            w.divsel().clear_bit();
+            w.idc().bit(improve_duty_cycle);
+            w.genen().set_bit()
+        });
+        self.wait_for_sync();
+    }
+
+    fn enable_clock_generator(&mut self, clock: ClockId, generator: ClockGenId) {
+        self.gclk.clkctrl.write(|w| unsafe {
+            w.id().bits(u8::from(clock));
+            w.gen().bits(u8::from(generator));
+            w.clken().set_bit()
+        });
+        self.wait_for_sync();
+    }
+}
+
+/// `GenericClockController` encapsulates the GCLK hardware.
+/// It provides a type safe way to configure the system clocks.
+/// Initializing the `GenericClockController` instance configures
+/// the system to run at 48Mhz by setting gclk1 as a 32khz source
+/// and feeding it into the DFLL48 hardware which in turn drives
+/// gclk0 at 48Mhz.
+pub struct GenericClockController {
+    state: State,
+    gclks: [Hertz; 8],
+    used_clocks: u64,
+}
+
+impl GenericClockController {
+    /// Reset the clock controller, configure the system to run
+    /// at 48Mhz and reset various clock dividers.
+    pub fn with_internal_32kosc(
+        gclk: GCLK,
+        pm: &mut PM,
+        sysctrl: &mut SYSCTRL,
+        nvmctrl: &mut NVMCTRL,
+    ) -> Self {
+        Self::new(gclk, pm, sysctrl, nvmctrl, false)
+    }
+
+    /// Reset the clock controller, configure the system to run
+    /// at 48Mhz and reset various clock dividers.
+    pub fn with_external_32kosc(
+        gclk: GCLK,
+        pm: &mut PM,
+        sysctrl: &mut SYSCTRL,
+        nvmctrl: &mut NVMCTRL,
+    ) -> Self {
+        Self::new(gclk, pm, sysctrl, nvmctrl, true)
+    }
+
+    fn new(
+        gclk: GCLK,
+        pm: &mut PM,
+        sysctrl: &mut SYSCTRL,
+        nvmctrl: &mut NVMCTRL,
+        use_external_crystal: bool,
+    ) -> Self {
+        let mut state = State { gclk };
+
+        set_flash_to_half_auto_wait_state(nvmctrl);
+        enable_gclk_apb(pm);
+        if use_external_crystal {
+            enable_external_32kosc(sysctrl);
+        } else {
+            enable_internal_32kosc(sysctrl);
+        }
+
+        state.reset_gclk();
+
+        // Enable a 32khz source -> GCLK1
+        if use_external_crystal {
+            state.set_gclk_divider_and_source(GCLK1, 1, XOSC32K, false);
+        } else {
+            state.set_gclk_divider_and_source(GCLK1, 1, OSC32K, false);
+        }
+
+        // Feed 32khz into the DFLL48
+        state.enable_clock_generator(DFLL48, GCLK1);
+        // Enable the DFLL48
+        configure_and_enable_dfll48m(sysctrl, use_external_crystal);
+        // Feed DFLL48 into the main clock
+        state.set_gclk_divider_and_source(GCLK0, 1, DFLL48M, true);
+        // We are now running at 48Mhz
+
+        // Reset various dividers back to 1
+        sysctrl.osc8m.modify(|_, w| {
+            w.presc()._0();
+            w.ondemand().clear_bit()
+        });
+        pm.cpusel.write(|w| w.cpudiv().div1());
+        pm.apbasel.write(|w| w.apbadiv().div1());
+        pm.apbbsel.write(|w| w.apbbdiv().div1());
+        pm.apbcsel.write(|w| w.apbcdiv().div1());
+
+        Self {
+            state,
+            gclks: [
+                OSC48M_FREQ,
+                OSC32K_FREQ,
+                Hertz(0),
+                Hertz(0),
+                Hertz(0),
+                Hertz(0),
+                Hertz(0),
+                Hertz(0),
+            ],
+            used_clocks: 1u64 << u8::from(DFLL48M),
+        }
+    }
+
+    /// Returns a `GClock` for gclk0, the system clock generator at 48Mhz
+    pub fn gclk0(&mut self) -> GClock {
+        GClock {
+            gclk: GCLK0,
+            freq: self.gclks[0],
+        }
+    }
+
+    /// Returns a `GClock` for gclk1, the 32Khz oscillator.
+    pub fn gclk1(&mut self) -> GClock {
+        GClock {
+            gclk: GCLK1,
+            freq: self.gclks[1],
+        }
+    }
+
+    /// Returns the `GClock` for the specified clock generator.
+    /// If that clock generator has not yet been configured,
+    /// returns None.
+    pub fn get_gclk(&mut self, gclk: ClockGenId) -> Option<GClock> {
+        let idx = u8::from(gclk) as usize;
+        if self.gclks[idx].0 == 0 {
+            None
+        } else {
+            Some(GClock {
+                gclk,
+                freq: self.gclks[idx],
+            })
+        }
+    }
+
+    /// Configures a clock generator with the specified divider and
+    /// source.
+    /// `divider` is a linear divider to be applied to the clock
+    /// source.  While the hardware also supports an exponential divider,
+    /// this function doesn't expose that functionality at this time.
+    /// `improve_duty_cycle` is a boolean that, when set to true, enables
+    /// a 5o/50 duty cycle for odd divider values.
+    /// Returns a `GClock` for the configured clock generator.
+    /// Returns `None` if the clock generator has already been configured.
+    pub fn configure_gclk_divider_and_source(
+        &mut self,
+        gclk: ClockGenId,
+        divider: u16,
+        src: ClockSource,
+        improve_duty_cycle: bool,
+    ) -> Option<GClock> {
+        let idx = u8::from(gclk) as usize;
+        if self.gclks[idx].0 != 0 {
+            return None;
+        }
+        self.state
+            .set_gclk_divider_and_source(gclk, divider, src, improve_duty_cycle);
+        let freq: Hertz = match src {
+            XOSC32K | OSC32K | OSCULP32K => OSC32K_FREQ,
+            GCLKGEN1 => self.gclks[1],
+            OSC8M => 8.mhz().into(),
+            DFLL48M => OSC48M_FREQ,
+            DPLL96M => 96.mhz().into(),
+            GCLKIN | XOSC => unimplemented!(),
+        };
+        self.gclks[idx] = Hertz(freq.0 / divider as u32);
+        Some(GClock { gclk, freq })
+    }
+}
+
+macro_rules! clock_generator {
+    ($(($id:ident, $Type:ident, $clock:ident),)+) => {
+
+$(
+/// A typed token that indicates that the clock for the peripheral(s)
+/// with the matching name has been configured.
+/// The effective clock frequency is available via the `freq` method,
+/// or by converting the object into a `Hertz` instance.
+/// The peripheral initialization code will typically require passing
+/// in this object to prove at compile time that the clock has been
+/// correctly initialized.
+#[derive(Debug)]
+pub struct $Type {
+    freq: Hertz,
+}
+
+impl $Type {
+    /// Returns the frequency of the configured clock
+    pub fn freq(&self) -> Hertz {
+        self.freq
+    }
+}
+impl Into<Hertz> for $Type {
+    fn into(self) -> Hertz {
+        self.freq
+    }
+}
+)+
+
+impl GenericClockController {
+    $(
+    /// Configure the clock for peripheral(s) that match the name
+    /// of this function to use the specific clock generator.
+    /// The `GClock` parameter may be one of default clocks
+    /// return from `gclk0()`, `gclk1()` or a clock configured
+    /// by the host application using the `configure_gclk_divider_and_source`
+    /// method.
+    /// Returns a typed token that proves that the clock has been configured;
+    /// the peripheral initialization code will typically require that this
+    /// clock token be passed in to ensure that the clock has been initialized
+    /// appropriately.
+    /// Returns `None` is the specified generic clock has already been
+    /// configured.
+    pub fn $id(&mut self, generator: &GClock) -> Option<$Type> {
+        let bits : u64 = 1<<u8::from($clock) as u64;
+        if (self.used_clocks & bits) != 0 {
+            return None;
+        }
+        self.used_clocks |= bits;
+
+        self.state.enable_clock_generator($clock, generator.gclk);
+        let freq = self.gclks[u8::from(generator.gclk) as usize];
+        Some($Type{freq})
+    }
+    )+
+}
+    }
+}
+
+clock_generator!(
+    (tcc0, Tcc0Clock, TCC0),
+    (tc1_tc2, Tc1Tc2Clock, TC1_TC2),
+    (sercom0_core, Sercom0CoreClock, SERCOM0_CORE),
+    (sercom1_core, Sercom1CoreClock, SERCOM1_CORE),
+    (sercom2_core, Sercom2CoreClock, SERCOM2_CORE),
+    (usb, UsbClock, USB),
+    (rtc, RtcClock, RTC),
+    (adc, AdcClock, ADC),
+);
+
+/// The frequency of the 48Mhz source.
+pub const OSC48M_FREQ: Hertz = Hertz(48_000_000);
+/// The frequency of the 32Khz source.
+pub const OSC32K_FREQ: Hertz = Hertz(32_000);
+
+fn set_flash_to_half_auto_wait_state(nvmctrl: &mut NVMCTRL) {
+    nvmctrl.ctrlb.modify(|_, w| w.rws().half());
+}
+
+fn enable_gclk_apb(pm: &mut PM) {
+    pm.apbamask.modify(|_, w| w.gclk_().set_bit());
+}
+
+/// Turn on the internal 32hkz oscillator
+fn enable_internal_32kosc(sysctrl: &mut SYSCTRL) {
+    let calibration = super::calibration::osc32k_cal();
+    sysctrl.osc32k.write(|w| {
+        unsafe {
+            w.ondemand().clear_bit();
+            w.calib().bits(calibration);
+            // 6 here means: use 66 cycles of OSC32k to start up this oscillator
+            w.startup().bits(6);
+        }
+        w.en32k().set_bit();
+        w.enable().set_bit()
+    });
+    while sysctrl.pclksr.read().osc32krdy().bit_is_clear() {
+        // Wait for the oscillator to stabilize
+    }
+}
+
+/// Turn on the external 32hkz oscillator
+fn enable_external_32kosc(sysctrl: &mut SYSCTRL) {
+    sysctrl.xosc32k.modify(|_, w| {
+        unsafe {
+            // 6 here means: use 64k cycles of OSCULP32k to start up this oscillator
+            w.startup().bits(6);
+        }
+        w.ondemand().clear_bit();
+        // Enable 32khz output
+        w.en32k().set_bit();
+        // Crystal connected to xin32/xout32
+        w.xtalen().set_bit()
+    });
+    sysctrl.xosc32k.modify(|_, w| w.enable().set_bit());
+    while sysctrl.pclksr.read().xosc32krdy().bit_is_clear() {
+        // Wait for the oscillator to stabilize
+    }
+}
+
+fn wait_for_dfllrdy(sysctrl: &mut SYSCTRL) {
+    while sysctrl.pclksr.read().dfllrdy().bit_is_clear() {}
+}
+
+/// Configure the dfll48m to operate at 48Mhz
+fn configure_and_enable_dfll48m(sysctrl: &mut SYSCTRL, use_external_crystal: bool) {
+    // Turn it off while we configure it.
+    // Note that we need to turn off on-demand mode and
+    // disable it here, rather than just reseting the ctrl
+    // register, otherwise our configuration attempt fails.
+    sysctrl.dfllctrl.write(|w| w.ondemand().clear_bit());
+    wait_for_dfllrdy(sysctrl);
+
+    if use_external_crystal {
+        sysctrl.dfllmul.write(|w| unsafe {
+            w.cstep().bits(31);
+            w.fstep().bits(511);
+            // scaling factor between the clocks
+            w.mul().bits(((48_000_000u32 + 32768 / 2) / 32768) as u16)
+        });
+
+        // Turn it on
+        sysctrl.dfllctrl.write(|w| {
+            // always on
+            w.ondemand().clear_bit();
+
+            // closed loop mode
+            w.mode().set_bit();
+
+            w.waitlock().set_bit();
+
+            // Disable quick lock
+            w.qldis().set_bit()
+        });
+    } else {
+        // Apply calibration
+        let coarse = super::calibration::dfll48m_coarse_cal();
+        let fine = 0x1ff;
+
+        sysctrl.dfllval.write(|w| unsafe {
+            w.coarse().bits(coarse);
+            w.fine().bits(fine)
+        });
+
+        sysctrl.dfllmul.write(|w| unsafe {
+            w.cstep().bits(coarse / 4);
+            w.fstep().bits(10);
+            // scaling factor between the clocks
+            w.mul().bits((48_000_000u32 / 32768) as u16)
+        });
+
+        // Turn it on
+        sysctrl.dfllctrl.write(|w| {
+            // always on
+            w.ondemand().clear_bit();
+
+            // closed loop mode
+            w.mode().set_bit();
+
+            // chill cycle disable
+            w.ccdis().set_bit();
+
+            // usb correction
+            w.usbcrm().set_bit();
+
+            // bypass coarse lock (have calibration data)
+            w.bplckc().set_bit()
+        });
+    }
+
+    wait_for_dfllrdy(sysctrl);
+
+    // and finally enable it!
+    sysctrl.dfllctrl.modify(|_, w| w.enable().set_bit());
+
+    wait_for_dfllrdy(sysctrl);
+}

--- a/hal/src/samd11/mod.rs
+++ b/hal/src/samd11/mod.rs
@@ -1,0 +1,8 @@
+pub mod calibration;
+pub mod clock;
+pub mod pwm;
+pub mod sercom;
+pub mod timer;
+
+#[cfg(feature = "unproven")]
+pub mod adc;

--- a/hal/src/samd11/pwm.rs
+++ b/hal/src/samd11/pwm.rs
@@ -1,0 +1,142 @@
+use crate::clock;
+use crate::gpio::{Pa15, Pa19, PfE};
+use crate::hal::PwmPin;
+use crate::time::Hertz;
+use crate::timer::TimerParams;
+
+use crate::target_device::{PM, TC1};
+
+pub enum TC1Pinout {
+    Pa15(Pa15<PfE>),
+    Pa19(Pa19<PfE>),
+}
+
+pub enum Channel {
+    C0,
+}
+
+macro_rules! pwm {
+    ($($TYPE:ident: ($TC:ident, $pinout:ident, $clock:ident, $apmask:ident, $apbits:ident, $wrapper:ident),)+) => {
+        $(
+
+pub struct $TYPE {
+    /// The frequency of the attached clock, not the period of the pwm.
+    /// Used to calculate the period of the pwm.
+    clock_freq: Hertz,
+    tc: $TC,
+    #[allow(dead_code)]
+    pinout: $pinout,
+}
+
+impl $TYPE {
+    pub fn new<F: Into<Hertz>> (
+        clock: &clock::$clock,
+        freq: F,
+        tc: $TC,
+        pinout: $pinout,
+        pm: &mut PM,
+    ) -> Self {
+        let freq = freq.into();
+        {
+            let count = tc.count16();
+            let params = TimerParams::new(freq, clock.freq().0);
+            pm.$apmask.modify(|_, w| w.$apbits().set_bit());
+            count.ctrla.write(|w| w.swrst().set_bit());
+            while count.ctrla.read().bits() & 1 != 0 {}
+            count.ctrla.modify(|_, w| w.enable().clear_bit());
+            count.ctrla.modify(|_, w| {
+                match params.divider {
+                    1 => w.prescaler().div1(),
+                    2 => w.prescaler().div2(),
+                    4 => w.prescaler().div4(),
+                    8 => w.prescaler().div8(),
+                    16 => w.prescaler().div16(),
+                    64 => w.prescaler().div64(),
+                    256 => w.prescaler().div256(),
+                    1024 => w.prescaler().div1024(),
+                    _ => unreachable!(),
+                }
+            });
+            count.ctrla.write(|w| w.wavegen().mpwm());
+            count.cc[0].write(|w| unsafe { w.cc().bits(params.cycles as u16) });
+            count.cc[1].write(|w| unsafe { w.cc().bits(0) });
+            count.ctrla.modify(|_, w| w.enable().set_bit());
+        }
+
+        Self {
+            clock_freq: clock.freq(),
+            tc,
+            pinout,
+        }
+    }
+
+    pub fn set_period<P>(&mut self, period: P)
+    where
+        P: Into<Hertz>
+    {
+        let period = period.into();
+        let params = TimerParams::new(period, self.clock_freq.0);
+        let count = self.tc.count16();
+        count.ctrla.modify(|_, w| w.enable().clear_bit());
+        count.ctrla.modify(|_, w| {
+                match params.divider {
+                    1 => w.prescaler().div1(),
+                    2 => w.prescaler().div2(),
+                    4 => w.prescaler().div4(),
+                    8 => w.prescaler().div8(),
+                    16 => w.prescaler().div16(),
+                    64 => w.prescaler().div64(),
+                    256 => w.prescaler().div256(),
+                    1024 => w.prescaler().div1024(),
+                    _ => unreachable!(),
+                }
+            });
+        count.ctrla.modify(|_, w| w.enable().set_bit());
+        count.cc[0].write(|w| unsafe { w.cc().bits(params.cycles as u16) });
+    }
+
+    pub fn get_period(&self) -> Hertz {
+        let count = self.tc.count16();
+        let divisor = count.ctrla.read().prescaler().bits();
+        let top = count.cc[0].read().cc().bits();
+        Hertz(self.clock_freq.0 / divisor as u32 / (top + 1) as u32)
+    }
+}
+
+impl PwmPin for $TYPE {
+    type Duty = u16;
+
+    fn disable(&mut self) {
+        let count = self.tc.count16();
+        count.ctrla.modify(|_, w| w.enable().clear_bit());
+    }
+
+    fn enable(&mut self) {
+        let count = self.tc.count16();
+        count.ctrla.modify(|_, w| w.enable().set_bit());
+    }
+
+
+    fn get_duty(&self) -> Self::Duty {
+        let count = self.tc.count16();
+        let duty: u16 = count.cc[1].read().cc().bits();
+        duty
+    }
+
+    fn get_max_duty(&self) -> Self::Duty {
+        let count = self.tc.count16();
+        let top = count.cc[0].read().cc().bits();
+        top
+    }
+
+    fn set_duty(&mut self, duty: Self::Duty) {
+        let count = self.tc.count16();
+        count.cc[1].write(|w| unsafe {w.cc().bits(duty)});
+    }
+}
+
+)+}}
+
+pwm! {
+    Pwm3: (TC1, TC1Pinout, Tcc0Clock, apbcmask, tc1_, Pwm3Wrapper),
+}

--- a/hal/src/samd11/pwm.rs
+++ b/hal/src/samd11/pwm.rs
@@ -1,5 +1,5 @@
 use crate::clock;
-use crate::gpio::{Pa15, Pa19, PfE};
+use crate::gpio::{Pa5, Pa15, Pa17, Pa23, PfE};
 use crate::hal::PwmPin;
 use crate::time::Hertz;
 use crate::timer::TimerParams;
@@ -7,8 +7,10 @@ use crate::timer::TimerParams;
 use crate::target_device::{PM, TC1};
 
 pub enum TC1Pinout {
+    Pa5(Pa5<PfE>),
     Pa15(Pa15<PfE>),
-    Pa19(Pa19<PfE>),
+    Pa17(Pa17<PfE>),
+    Pa23(Pa23<PfE>),
 }
 
 pub enum Channel {
@@ -138,5 +140,5 @@ impl PwmPin for $TYPE {
 )+}}
 
 pwm! {
-    Pwm3: (TC1, TC1Pinout, Tcc0Clock, apbcmask, tc1_, Pwm3Wrapper),
+    Pwm1: (TC1, TC1Pinout, Tc1Tc2Clock, apbcmask, tc1_, Pwm1Wrapper),
 }

--- a/hal/src/samd11/sercom/i2c.rs
+++ b/hal/src/samd11/sercom/i2c.rs
@@ -1,0 +1,329 @@
+// Note: section 7.2.3 shows which pins support I2C Hs mode
+
+use crate::clock;
+use crate::hal::blocking::i2c::{Read, Write, WriteRead};
+use crate::target_device::sercom0::I2CM;
+use crate::target_device::{PM, SERCOM0, SERCOM1};
+use crate::time::Hertz;
+
+const BUS_STATE_IDLE: u8 = 1;
+const BUS_STATE_OWNED: u8 = 2;
+
+const MASTER_ACT_READ: u8 = 2;
+const MASTER_ACT_STOP: u8 = 3;
+
+/// Define an I2C master type for the given SERCOM and pad pair.
+macro_rules! i2c {
+    ([
+        $($Type:ident: ($pad0:ident, $pad1:ident, $SERCOM:ident, $powermask:ident, $clock:ident),)+
+    ]) => {
+        $(
+/// Represents the Sercom instance configured to act as an I2C Master.
+/// The embedded_hal blocking I2C traits are implemented by this instance.
+pub struct $Type<$pad0, $pad1> {
+    sda: $pad0,
+    scl: $pad1,
+    sercom: $SERCOM,
+}
+
+impl<$pad0, $pad1> $Type<$pad0, $pad1> {
+    /// Configures the sercom instance to work as an I2C Master.
+    /// The clock is obtained via the `GenericClockGenerator` type.
+    /// `freq` specifies the bus frequency to use for I2C communication.
+    /// There are typically a handful of values that tend to be supported;
+    /// standard mode is 100.khz(), full speed mode is 400.khz().
+    /// The hardware in the atsamd device supports fast mode at 1.mhz()
+    /// and fast mode, but there may be additional hardware configuration
+    /// missing from the current software implementation that prevents that
+    /// from working as-written today.
+    ///
+    /// ```no_run
+    /// let mut i2c = I2CMaster3::new(
+    ///     &clocks.sercom3_core(&gclk0).unwrap(),
+    ///     400.khz(),
+    ///     p.device.SERCOM3,
+    ///     &mut p.device.PM,
+    ///     // Metro M0 express has I2C on pins PA22, PA23
+    ///     pins.pa22.into_pad(&mut pins.port),
+    ///     pins.pa23.into_pad(&mut pins.port),
+    /// );
+    /// ```
+    pub fn new<F: Into<Hertz>>(
+        clock: &clock::$clock,
+        freq: F,
+        sercom: $SERCOM,
+        pm: &mut PM,
+        sda: $pad0,
+        scl: $pad1,
+    ) -> Self {
+        // Power up the peripheral bus clock.
+        // safe because we're exclusively owning SERCOM
+        pm.apbcmask.modify(|_, w| w.$powermask().set_bit());
+
+        unsafe {
+            // reset the sercom instance
+            sercom.i2cm().ctrla.modify(|_, w| w.swrst().set_bit());
+            // wait for reset to complete
+            while sercom.i2cm().syncbusy.read().swrst().bit_is_set()
+                || sercom.i2cm().ctrla.read().swrst().bit_is_set()
+            {}
+
+            // Put the hardware into i2c master mode
+            sercom.i2cm().ctrla.modify(|_, w| w.mode().i2c_master());
+            // wait for configuration to take effect
+            while sercom.i2cm().syncbusy.read().enable().bit_is_set() {}
+
+            // set the baud rate
+            let gclk = clock.freq();
+            let baud = (gclk.0 / (2 * freq.into().0) - 1) as u8;
+            sercom.i2cm().baud.modify(|_, w| w.baud().bits(baud));
+
+            sercom.i2cm().ctrla.modify(|_, w| w.enable().set_bit());
+            // wait for configuration to take effect
+            while sercom.i2cm().syncbusy.read().enable().bit_is_set() {}
+
+            // set the bus idle
+            sercom
+                .i2cm()
+                .status
+                .modify(|_, w| w.busstate().bits(BUS_STATE_IDLE));
+            // wait for it to take effect
+            while sercom.i2cm().syncbusy.read().sysop().bit_is_set() {}
+        }
+
+        Self { sda, scl, sercom }
+    }
+
+    /// Breaks the sercom device up into its constituent pins and the SERCOM
+    /// instance.  Does not make any changes to power management.
+    pub fn free(self) -> ($pad0, $pad1, $SERCOM) {
+        (self.sda, self.scl, self.sercom)
+    }
+
+    fn start_tx_write(&mut self, addr: u8) -> Result<(), I2CError> {
+        loop {
+            match self.i2cm().status.read().busstate().bits() {
+                BUS_STATE_IDLE | BUS_STATE_OWNED => break,
+                _ => continue,
+            }
+        }
+
+        // Signal start and transmit encoded address.
+        unsafe {
+            self.i2cm()
+                .addr
+                .write(|w| w.addr().bits((addr as u16) << 1));
+        }
+
+        // wait for transmission to complete
+        while !self.i2cm().intflag.read().mb().bit_is_set() {}
+
+        self.status_to_err()
+    }
+
+    fn status_to_err(&mut self) -> Result<(), I2CError> {
+        let status = self.i2cm().status.read();
+        if status.arblost().bit_is_set() {
+            return Err(I2CError::ArbitrationLost);
+        }
+        if status.buserr().bit_is_set() {
+            return Err(I2CError::BusError);
+        }
+        if status.rxnack().bit_is_set() {
+            return Err(I2CError::Nack);
+        }
+        if status.lowtout().bit_is_set() || status.sexttout().bit_is_set()
+            || status.mexttout().bit_is_set()
+        {
+            return Err(I2CError::Timeout);
+        }
+
+        Ok(())
+    }
+
+    fn start_tx_read(&mut self, addr: u8) -> Result<(), I2CError> {
+        loop {
+            match self.i2cm().status.read().busstate().bits() {
+                BUS_STATE_IDLE | BUS_STATE_OWNED => break,
+                _ => continue,
+            }
+        }
+
+        self.i2cm().intflag.modify(|_, w| w.error().clear_bit());
+
+        // Signal start (or rep start if appropriate)
+        // and transmit encoded address.
+        unsafe {
+            self.i2cm()
+                .addr
+                .write(|w| w.addr().bits(((addr as u16) << 1) | 1));
+        }
+
+        // wait for transmission to complete
+        loop {
+            let intflag = self.i2cm().intflag.read();
+            // If arbitration was lost, it will be signalled via the mb bit
+            if intflag.mb().bit_is_set() {
+                return Err(I2CError::ArbitrationLost);
+            }
+            if intflag.sb().bit_is_set() || intflag.error().bit_is_set() {
+                break;
+            }
+        }
+
+        self.status_to_err()
+    }
+
+    fn wait_sync(&mut self) {
+        while self.i2cm().syncbusy.read().sysop().bit_is_set() {}
+    }
+
+    fn cmd(&mut self, cmd: u8) {
+        unsafe {
+            self.i2cm().ctrlb.modify(|_, w| w.cmd().bits(cmd));
+        }
+        self.wait_sync();
+    }
+
+    fn cmd_stop(&mut self) {
+        self.cmd(MASTER_ACT_STOP)
+    }
+
+    fn cmd_read(&mut self) {
+        unsafe {
+            self.i2cm().ctrlb.modify(|_, w| {
+                // clear bit means send ack
+                w.ackact().clear_bit();
+                w.cmd().bits(MASTER_ACT_READ)
+            });
+        }
+        self.wait_sync();
+    }
+
+    fn i2cm(&mut self) -> &I2CM {
+        &self.sercom.i2cm()
+    }
+
+    fn send_bytes(&mut self, bytes: &[u8]) -> Result<(), I2CError> {
+        for b in bytes {
+            unsafe {
+                self.i2cm().data.write(|w| w.bits(*b));
+            }
+
+            loop {
+                let intflag = self.i2cm().intflag.read();
+                if intflag.mb().bit_is_set() || intflag.error().bit_is_set() {
+                    break;
+                }
+            }
+            self.status_to_err()?;
+        }
+        Ok(())
+    }
+
+    fn read_one(&mut self) -> u8 {
+        while !self.i2cm().intflag.read().sb().bit_is_set() {}
+        self.i2cm().data.read().bits()
+    }
+
+    fn fill_buffer(&mut self, buffer: &mut [u8]) -> Result<(), I2CError> {
+        // Some manual iterator gumph because we need to ack bytes after the first.
+        let mut iter = buffer.iter_mut();
+        *iter.next().expect("buffer len is at least 1") = self.read_one();
+
+        loop {
+            match iter.next() {
+                None => break,
+                Some(dest) => {
+                    // Ack the last byte so that we can receive another one
+                    self.cmd_read();
+                    *dest = self.read_one();
+                }
+            }
+        }
+
+        // arrange to send nack on next command to
+        // stop slave from transmitting more data
+        self.i2cm().ctrlb.modify(|_, w| w.ackact().set_bit());
+
+        Ok(())
+    }
+
+    fn do_write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), I2CError> {
+        self.start_tx_write(addr)?;
+        self.send_bytes(bytes)
+    }
+
+    fn do_read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), I2CError> {
+        self.start_tx_read(addr)?;
+        self.fill_buffer(buffer)
+    }
+
+    fn do_write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), I2CError> {
+        self.start_tx_write(addr)?;
+        self.send_bytes(bytes)?;
+        self.start_tx_read(addr)?;
+        self.fill_buffer(buffer)
+    }
+}
+impl<$pad0, $pad1> Write for $Type<$pad0, $pad1> {
+    type Error = I2CError;
+
+    /// Sends bytes to slave with address `addr`
+    fn write(&mut self, addr: u8, bytes: &[u8]) -> Result<(), Self::Error> {
+        let res = self.do_write(addr, bytes);
+        self.cmd_stop();
+        res
+    }
+}
+
+impl<$pad0, $pad1> Read for $Type<$pad0, $pad1> {
+    type Error = I2CError;
+
+    fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+        let res = self.do_read(addr, buffer);
+        self.cmd_stop();
+        res
+    }
+}
+
+impl<$pad0, $pad1> WriteRead for $Type<$pad0, $pad1> {
+    type Error = I2CError;
+
+    fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {
+        let res = self.do_write_read(addr, bytes, buffer);
+        self.cmd_stop();
+        res
+    }
+}
+        )+
+    };
+}
+
+i2c!([
+    I2CMaster0:
+        (
+            Sercom0Pad0,
+            Sercom0Pad1,
+            SERCOM0,
+            sercom0_,
+            Sercom0CoreClock
+        ),
+    I2CMaster1:
+        (
+            Sercom1Pad0,
+            Sercom1Pad1,
+            SERCOM1,
+            sercom1_,
+            Sercom1CoreClock
+        ),
+]);
+
+#[derive(Debug)]
+pub enum I2CError {
+    ArbitrationLost,
+    AddressError,
+    BusError,
+    Timeout,
+    Nack,
+}

--- a/hal/src/samd11/sercom/mod.rs
+++ b/hal/src/samd11/sercom/mod.rs
@@ -1,0 +1,19 @@
+//! Working with the SERCOM peripherals.
+//!
+//! The atsamd21 hardware has several SERCOM instances that can
+//! be configured to perform a variety of serial communication
+//! tasks.  This configuration is expressed through the use of
+//! type states to make it difficult to misuse.
+//! Each sercom instance is associated with a group of IO pins
+//! referred to as a Pad.  When the pins are set to the appropriate
+//! peripheral function mode they are routed to the sercom pad.
+
+mod i2c;
+mod pads;
+mod spi;
+mod uart;
+
+pub use self::i2c::*;
+pub use self::pads::*;
+pub use self::spi::*;
+pub use self::uart::*;

--- a/hal/src/samd11/sercom/pads.rs
+++ b/hal/src/samd11/sercom/pads.rs
@@ -60,3 +60,30 @@ pad!(Sercom1Pad3 {
     Pa31(PfD),
     Pa25(PfC),
 });
+
+// sercom2[0]:  PA14:D   PA22:D
+// sercom2[1]:  PA15:D   PA23:D
+// sercom2[2]:  PA10:D   PA16:D   PA24:D
+// sercom2[3]:  PA11:D   PA17:D   PA25:D
+
+pad!(Sercom2Pad0 {
+    Pa14(PfD),
+    Pa22(PfD),
+});
+
+pad!(Sercom2Pad1 {
+    Pa15(PfD),
+    Pa23(PfD),
+});
+
+pad!(Sercom2Pad2 {
+    Pa10(PfD),
+    Pa16(PfD),
+    Pa24(PfD),
+});
+
+pad!(Sercom2Pad3 {
+    Pa11(PfD),
+    Pa17(PfD),
+    Pa25(PfD),
+});

--- a/hal/src/samd11/sercom/pads.rs
+++ b/hal/src/samd11/sercom/pads.rs
@@ -1,0 +1,62 @@
+use crate::gpio::{self, IntoFunction, Port};
+pub use crate::pad::PadPin;
+
+// sercom0[0]:  PA04:D   PA06:C   PA14:C
+// sercom0[1]:  PA05:D   PA07:C   PA15:C
+// sercom0[2]:  PA04:C   PA06:D   PA08:D   PA10:C
+// sercom0[3]:  PA05:C   PA07:D   PA09:D   PA11:C
+
+pad!(Sercom0Pad0 {
+    Pa4(PfD),
+    Pa6(PfC),
+    Pa14(PfC),
+});
+
+pad!(Sercom0Pad1 {
+    Pa5(PfD),
+    Pa7(PfC),
+    Pa15(PfC),
+});
+
+pad!(Sercom0Pad2 {
+    Pa4(PfC),
+    Pa6(PfD),
+    Pa8(PfD),
+    Pa10(PfC),
+});
+
+pad!(Sercom0Pad3 {
+    Pa5(PfC),
+    Pa7(PfD),
+    Pa9(PfD),
+    Pa11(PfC),
+});
+
+// sercom1[0]:  PA22:C   PA30:C
+// sercom1[1]:  PA23:C   PA31:C
+// sercom1[2]:  PA08:C   PA16:C   PA30:D   PA24:C
+// sercom1[3]:  PA09:C   PA17:C   PA31:D   PA25:C
+
+pad!(Sercom1Pad0 {
+    Pa22(PfC),
+    Pa30(PfC),
+});
+
+pad!(Sercom1Pad1 {
+    Pa23(PfC),
+    Pa31(PfC),
+});
+
+pad!(Sercom1Pad2 {
+    Pa8(PfC),
+    Pa16(PfC),
+    Pa30(PfD),
+    Pa24(PfC),
+});
+
+pad!(Sercom1Pad3 {
+    Pa9(PfC),
+    Pa17(PfC),
+    Pa31(PfD),
+    Pa25(PfC),
+});

--- a/hal/src/samd11/sercom/spi.rs
+++ b/hal/src/samd11/sercom/spi.rs
@@ -1,0 +1,223 @@
+use crate::clock;
+use crate::hal::spi::{FullDuplex, Mode, Phase, Polarity};
+use crate::sercom::pads::*;
+use crate::target_device::sercom0::SPI;
+use crate::target_device::{PM, SERCOM0, SERCOM1};
+use crate::time::Hertz;
+use nb;
+
+#[derive(Debug)]
+pub enum Error {
+    Overrun,
+}
+
+/// The DipoDopo trait defines a way to get the data in and data out pin out
+/// values for a given SPIMasterXPadout configuration. You should not implement
+/// this trait for yourself; only the implementations in the sercom module make
+/// sense.
+pub trait DipoDopo {
+    fn dipo_dopo(&self) -> (u8, u8);
+}
+
+/// Define an SPIMasterX type for the given Sercom number.
+///
+/// Also defines the valid "pad to spi function" mappings for this instance so
+/// that construction is restricted to correct configurations.
+macro_rules! spi_master {
+    ($Type:ident: ($Sercom:ident, $SERCOM:ident, $powermask:ident, $clock:ident)) => {
+        $crate::paste::item! {
+            /// A pad mapping configuration for the SERCOM in SPI master mode.
+            ///
+            /// This type can only be constructed using the From implementations
+            /// in this module, which are restricted to valid configurations.
+            ///
+            /// Defines which sercom pad is mapped to which SPI function.
+            pub struct [<$Type Padout>]<MISO, MOSI, SCK> {
+                _miso: MISO,
+                _mosi: MOSI,
+                _sck: SCK,
+            }
+        }
+
+        /// Define a From instance for a tuple of SercomXPadX instances that
+        /// converts them into an SPIMasterXPadout instance.
+        ///
+        /// Also defines a DipoDopo instance for the constructed padout instance
+        /// that returns the values used to configure the sercom pads for the
+        /// appropriate function in the sercom register file.
+        macro_rules! padout {
+            ($dipo_dopo:expr => $pad0:ident, $pad1:ident, $pad2:ident) => {
+                $crate::paste::item! {
+                    /// Convert from a tuple of (MISO, MOSI, SCK) to SPIMasterXPadout
+                    impl<PIN0, PIN1, PIN2> From<([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>)> for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>> {
+                        fn from(pads: ([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>)) -> [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>> {
+                            [<$Type Padout>] { _miso: pads.0, _mosi: pads.1, _sck: pads.2 }
+                        }
+                    }
+
+                    impl<PIN0, PIN1, PIN2> DipoDopo for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>> {
+                        fn dipo_dopo(&self) -> (u8, u8) {
+                            $dipo_dopo
+                        }
+                    }
+                }
+            };
+        }
+
+        padout!((0, 1) => Pad0, Pad2, Pad3);
+        padout!((0, 2) => Pad0, Pad3, Pad1);
+
+        padout!((1, 1) => Pad1, Pad2, Pad3);
+        padout!((1, 3) => Pad1, Pad0, Pad3);
+
+        padout!((2, 0) => Pad2, Pad0, Pad1);
+        padout!((2, 2) => Pad2, Pad3, Pad1);
+        padout!((2, 3) => Pad2, Pad0, Pad3);
+
+        padout!((3, 0) => Pad3, Pad0, Pad1);
+
+        $crate::paste::item! {
+            /// SPIMasterX represents the corresponding SERCOMX instance
+            /// configured to act in the role of an SPI Master.
+            /// Objects of this type implement the HAL `FullDuplex` and blocking
+            /// SPI traits.
+            ///
+            /// This type is generic over any valid pad mapping where there is
+            /// a defined "data in pin out data out pin out" implementation.
+            pub struct $Type<MISO, MOSI, SCK> {
+                padout: [<$Type Padout>]<MISO, MOSI, SCK>,
+                sercom: $SERCOM,
+            }
+
+            impl<MISO, MOSI, SCK> $Type<MISO, MOSI, SCK> {
+                /// Power on and configure SERCOMX to work as an SPI Master operating
+                /// with the specified frequency and SPI Mode. The padout specifies
+                /// which pins are bound to the MISO, MOSI, SCK functions.
+                ///
+                /// You can use a tuple of three SercomXPadY instances for which
+                /// there exists a From implementation for SPIMasterXPadout.
+                pub fn new<F: Into<Hertz>, T: Into<[<$Type Padout>]<MISO, MOSI, SCK>>>(
+                    clock:&clock::$clock,
+                    freq: F,
+                    mode: Mode,
+                    sercom: $SERCOM,
+                    pm: &mut PM,
+                    padout: T,
+                ) -> Self where
+                    [<$Type Padout>]<MISO, MOSI, SCK>: DipoDopo {
+                    let padout = padout.into();
+
+                    // Power up the peripheral bus clock.
+                    // safe because we're exclusively owning SERCOM
+                    pm.apbcmask.modify(|_, w| w.$powermask().set_bit());
+
+                    unsafe {
+                        // reset the sercom instance
+                        sercom.spi().ctrla.modify(|_, w| w.swrst().set_bit());
+                        // wait for reset to complete
+                        while sercom.spi().syncbusy.read().swrst().bit_is_set()
+                            || sercom.spi().ctrla.read().swrst().bit_is_set()
+                        {}
+
+                        // Put the hardware into spi master mode
+                        sercom.spi().ctrla.modify(|_, w| w.mode().spi_master());
+                        // wait for configuration to take effect
+                        while sercom.spi().syncbusy.read().enable().bit_is_set() {}
+
+                        // 8 bit data size and enable the receiver
+                        sercom.spi().ctrlb.modify(|_, w|{
+                            w.chsize().bits(0);
+                            w.rxen().set_bit()
+                        });
+
+                        // set the baud rate
+                        let gclk = clock.freq();
+                        let baud = (gclk.0 / (2 * freq.into().0) - 1) as u8;
+                        sercom.spi().baud.modify(|_, w| w.baud().bits(baud));
+
+                        sercom.spi().ctrla.modify(|_, w| {
+                            match mode.polarity {
+                                Polarity::IdleLow => w.cpol().clear_bit(),
+                                Polarity::IdleHigh => w.cpol().set_bit(),
+                            };
+
+                            match mode.phase {
+                                Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
+                                Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
+                            };
+
+                            let (dipo, dopo) = padout.dipo_dopo();
+                            w.dipo().bits(dipo);
+                            w.dopo().bits(dopo);
+
+                            // MSB first
+                            w.dord().clear_bit()
+                        });
+
+
+                        sercom.spi().ctrla.modify(|_, w| w.enable().set_bit());
+                        // wait for configuration to take effect
+                        while sercom.spi().syncbusy.read().enable().bit_is_set() {}
+
+                    }
+
+                    Self {
+                        padout,
+                        sercom,
+                    }
+                }
+
+                /// Tear down the SPI instance and yield the constituent pins and
+                /// SERCOM instance.  No explicit de-initialization is performed.
+                pub fn free(self) -> ([<$Type Padout>]<MISO, MOSI, SCK>, $SERCOM) {
+                    (self.padout, self.sercom)
+                }
+
+                /// Helper for accessing the spi member of the sercom instance
+                fn spi(&mut self) -> &SPI {
+                    &self.sercom.spi()
+                }
+            }
+        }
+
+        impl<MISO, MOSI, SCK> FullDuplex<u8> for $Type<MISO, MOSI, SCK> {
+            type Error = Error;
+
+            fn read(&mut self) -> nb::Result<u8, Error> {
+                let status = self.spi().status.read();
+                if status.bufovf().bit_is_set() {
+                    return Err(nb::Error::Other(Error::Overrun));
+                }
+
+                let intflag = self.spi().intflag.read();
+                // rxc is receive complete
+                if intflag.rxc().bit_is_set() {
+                    Ok(self.spi().data.read().data().bits() as u8)
+                } else {
+                    Err(nb::Error::WouldBlock)
+                }
+            }
+
+            fn send(&mut self, byte: u8) -> nb::Result<(), Error> {
+                let intflag = self.spi().intflag.read();
+                // dre is data register empty
+                if intflag.dre().bit_is_set() {
+                    self.spi().data.write(|w| unsafe{w.data().bits(byte as u16)});
+                    Ok(())
+                } else {
+                    Err(nb::Error::WouldBlock)
+                }
+            }
+        }
+
+        impl<MISO, MOSI, SCK> ::hal::blocking::spi::transfer::Default<u8> for $Type<MISO, MOSI, SCK> {}
+        impl<MISO, MOSI, SCK> ::hal::blocking::spi::write::Default<u8> for $Type<MISO, MOSI, SCK> {}
+        #[cfg(feature = "unproven")]
+        impl<MISO, MOSI, SCK> ::hal::blocking::spi::write_iter::Default<u8> for $Type<MISO, MOSI, SCK> {}
+
+    };
+
+}
+
+spi_master!(SPIMaster0: (Sercom0, SERCOM0, sercom0_, Sercom0CoreClock));
+spi_master!(SPIMaster1: (Sercom1, SERCOM1, sercom1_, Sercom1CoreClock));

--- a/hal/src/samd11/sercom/uart.rs
+++ b/hal/src/samd11/sercom/uart.rs
@@ -1,0 +1,274 @@
+use crate::clock;
+use crate::hal::blocking::serial::{write::Default, Write};
+use crate::hal::serial;
+use crate::sercom::pads::*;
+use crate::target_device::sercom0::USART;
+use crate::target_device::{PM, SERCOM0, SERCOM1};
+use crate::time::Hertz;
+use core::fmt;
+use nb;
+
+/// The RxpoTxpo trait defines a way to get the data in and data out pin out
+/// values for a given UARTXPadout configuration. You should not implement
+/// this trait for yourself; only the implementations in the sercom module make
+/// sense.
+pub trait RxpoTxpo {
+    fn rxpo_txpo(&self) -> (u8, u8);
+}
+
+/// Define a UARTX type for the given Sercom.
+///
+/// Also defines the valid "pad to uart function" mappings for this instance so
+/// that construction is restricted to valid configurations.
+macro_rules! uart {
+    ($Type:ident: ($Sercom:ident, $SERCOM:ident, $powermask:ident, $clock:ident)) => {
+        $crate::paste::item! {
+            /// A pad mapping configuration for the SERCOM in UART mode.
+            ///
+            /// This type can only be constructed using the From implementations
+            /// in this module, which are restricted to valid configurations.
+            ///
+            /// Defines which sercom pad is mapped to which UART function.
+            pub struct [<$Type Padout>]<RX, TX, RTS, CTS> {
+                _rx: RX,
+                _tx: TX,
+                _rts: RTS,
+                _cts: CTS,
+            }
+        }
+
+        /// Define a From instance for either a tuple of two SercomXPadX
+        /// instances, or a tuple of four SercomXPadX instances that converts
+        /// them into an UARTXPadout instance.
+        ///
+        /// Also defines a RxpoTxpo instance for the constructed padout instance
+        /// that returns the values used to configure the sercom pads for the
+        /// appropriate function in the sercom register file.
+        macro_rules! padout {
+            ($rxpo_txpo:expr => $pad0:ident, $pad1:ident) => {
+                $crate::paste::item! {
+                    /// Convert from a tuple of (RX, TX) to UARTXPadout
+                    impl<PIN0, PIN1> From<([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>)> for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, (), ()> {
+                        fn from(pads: ([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>)) -> [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, (), ()> {
+                            [<$Type Padout>] { _rx: pads.0, _tx: pads.1, _rts: (), _cts: () }
+                        }
+                    }
+
+                    impl<PIN0, PIN1> RxpoTxpo for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, (), ()> {
+                        fn rxpo_txpo(&self) -> (u8, u8) {
+                            $rxpo_txpo
+                        }
+                    }
+                }
+            };
+            ($rxpo_txpo:expr => $pad0:ident, $pad1:ident, $pad2:ident, $pad3:ident) => {
+                $crate::paste::item! {
+                    /// Convert from a tuple of (RX, TX, RTS, CTS) to UARTXPadout
+                    impl<PIN0, PIN1, PIN2, PIN3> From<([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>, [<$Sercom $pad3>]<PIN3>)> for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>, [<$Sercom $pad3>]<PIN3>> {
+                        fn from(pads: ([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>, [<$Sercom $pad3>]<PIN3>)) -> [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>, [<$Sercom $pad3>]<PIN3>> {
+                            [<$Type Padout>] { _rx: pads.0, _tx: pads.1, _rts: pads.2, _cts: pads.3 }
+                        }
+                    }
+
+                    impl<PIN0, PIN1, PIN2, PIN3> RxpoTxpo for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>, [<$Sercom $pad3>]<PIN3>> {
+                        fn rxpo_txpo(&self) -> (u8, u8) {
+                            $rxpo_txpo
+                        }
+                    }
+                }
+            };
+        }
+
+        padout!((0, 1) => Pad0, Pad2);
+
+        padout!((1, 0) => Pad1, Pad0);
+        padout!((1, 2) => Pad1, Pad0, Pad2, Pad3);
+        padout!((1, 1) => Pad1, Pad2);
+
+        padout!((2, 0) => Pad2, Pad0);
+
+        padout!((3, 0) => Pad3, Pad0);
+        padout!((3, 1) => Pad3, Pad2);
+
+        $crate::paste::item! {
+            /// UARTX represents the corresponding SERCOMX instance
+            /// configured to act in the role of a UART Master.
+            /// Objects of this type implement the HAL `serial::Read`,
+            /// `serial::Write` traits.
+            ///
+            /// This type is generic over any valid pad mapping where there is
+            /// a defined "receive pin out transmit pin out" implementation.
+            pub struct $Type<RX, TX, RTS, CTS> {
+                padout: [<$Type Padout>]<RX, TX, RTS, CTS>,
+                sercom: $SERCOM,
+            }
+
+            impl<RX, TX, RTS, CTS> $Type<RX, TX, RTS, CTS> {
+                /// Power on and configure SERCOMX to work as a UART Master operating
+                /// with the specified frequency. The padout specifies
+                /// which pins are bound to the RX, TX and optionally RTS and CTS
+                /// functions.
+                ///
+                /// You can use any tuple of two or four SercomXPadY instances
+                /// for which there exists a From implementation for
+                /// UARTXPadout.
+                pub fn new<F: Into<Hertz>, T: Into<[<$Type Padout>]<RX, TX, RTS, CTS>>>(
+                    clock: &clock::$clock,
+                    freq: F,
+                    sercom: $SERCOM,
+                    pm: &mut PM,
+                    padout: T
+                ) -> $Type<RX, TX, RTS, CTS> where
+                    [<$Type Padout>]<RX, TX, RTS, CTS>: RxpoTxpo {
+                    let padout = padout.into();
+
+                    pm.apbcmask.modify(|_, w| w.$powermask().set_bit());
+
+                    // Lots of union fields which require unsafe access
+                    unsafe {
+                        // Reset
+                        sercom.usart().ctrla.modify(|_, w| w.swrst().set_bit());
+                        while sercom.usart().syncbusy.read().swrst().bit_is_set()
+                            || sercom.usart().ctrla.read().swrst().bit_is_set() {
+                            // wait for sync of CTRLA.SWRST
+                        }
+
+                        // Unsafe b/c of direct call to bits on rxpo/txpo
+                        sercom.usart().ctrla.modify(|_, w| {
+                            w.dord().set_bit();
+
+                            let (rxpo, txpo) = padout.rxpo_txpo();
+                            w.rxpo().bits(rxpo);
+                            w.txpo().bits(txpo);
+
+                            w.form().bits(0x00);
+                            w.sampr().bits(0x00); // 16x oversample fractional
+                            w.runstdby().set_bit(); // Run in standby
+                            w.form().bits(0); // 0 is no parity bits
+
+                            w.mode().usart_int_clk() // Internal clock mode
+                        });
+
+                        // Calculate value for BAUD register
+                        let sample_rate: u8 = 16;
+                        let fref = clock.freq().0;
+
+            //          TODO: Support fractional BAUD mode
+            //            let mul_ratio = (fref.0 * 1000) / (freq.into().0 * 16);
+            //
+            //            let baud = mul_ratio / 1000;
+            //            let fp = ((mul_ratio - (baud*1000))*8)/1000;
+            //
+            //            sercom.usart().baud()_frac_mode.modify(|_, w| {
+            //                w.baud().bits(baud as u16);
+            //                w.fp().bits(fp as u8)
+            //            });
+
+                        // Asynchronous arithmetic mode (Table 24-2 in datasheet)
+                        let baud = calculate_baud_value(freq.into().0, fref, sample_rate);
+
+                        sercom.usart().baud().modify(|_, w| {
+                            w.baud().bits(baud)
+                        });
+
+                        sercom.usart().ctrlb.modify(|_, w| {
+                            w.sbmode().clear_bit(); // 0 is one stop bit see sec 25.8.2
+                            w.chsize().bits(0x0);
+                            w.txen().set_bit();
+                            w.rxen().set_bit()
+                        });
+
+                        while sercom.usart().syncbusy.read().ctrlb().bit_is_set() {}
+
+                        sercom.usart().ctrla.modify(|_, w| w.enable().set_bit());
+                        // wait for sync of ENABLE
+                        while sercom.usart().syncbusy.read().enable().bit_is_set() {}
+                    }
+
+                    Self {
+                        padout,
+                        sercom,
+                    }
+                }
+
+                pub fn free(self) -> ([<$Type Padout>]<RX, TX, RTS, CTS>, $SERCOM) {
+                    (self.padout, self.sercom)
+                }
+
+                fn usart(&self) -> &USART {
+                    return &self.sercom.usart();
+                }
+
+                fn dre(&self) -> bool {
+                    self.usart().intflag.read().dre().bit_is_set()
+                }
+            }
+
+
+            impl<RX, TX, RTS, CTS> serial::Write<u8> for $Type<RX, TX, RTS, CTS> {
+                type Error = ();
+
+                fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+                    unsafe {
+                        if !self.dre() {
+                            return Err(nb::Error::WouldBlock);
+                        }
+
+                        self.sercom.usart().data.write(|w| {
+                            w.bits(word as u16)
+                        });
+                    }
+
+                    Ok(())
+                }
+
+                fn flush(&mut self) -> nb::Result<(), Self::Error> {
+                    // simply await DRE empty
+                    if !self.dre() {
+                        return Err(nb::Error::WouldBlock);
+                    }
+
+                    Ok(())
+                }
+            }
+
+            impl<RX, TX, RTS, CTS> serial::Read<u8> for $Type<RX, TX, RTS, CTS> {
+                type Error = ();
+
+                fn read(&mut self) -> nb::Result<u8, Self::Error> {
+                    let has_data = self.usart().intflag.read().rxc().bit_is_set();
+
+                    if !has_data {
+                        return Err(nb::Error::WouldBlock);
+                    }
+
+                    let data = self.usart().data.read().bits();
+
+                    Ok(data as u8)
+                }
+            }
+
+            impl<RX, TX, RTS, CTS> Default<u8> for $Type<RX, TX, RTS, CTS> {}
+
+            impl<RX, TX, RTS, CTS> fmt::Write for $Type<RX, TX, RTS, CTS> {
+                fn write_str(&mut self, s: &str) -> fmt::Result {
+                    self.bwrite_all(s.as_bytes()).map_err(|_| fmt::Error)
+                }
+            }
+        }
+    }
+}
+
+uart!(UART0: (Sercom0, SERCOM0, sercom0_, Sercom0CoreClock));
+uart!(UART1: (Sercom1, SERCOM1, sercom1_, Sercom1CoreClock));
+
+const SHIFT: u8 = 32;
+
+fn calculate_baud_value(baudrate: u32, clk_freq: u32, n_samples: u8) -> u16 {
+    let sample_rate = (n_samples as u64 * baudrate as u64) << 32;
+    let ratio = sample_rate / clk_freq as u64;
+    let scale = (1u64 << SHIFT) - ratio;
+    let baud_calculated = (65536u64 * scale) >> SHIFT;
+
+    return baud_calculated as u16;
+}

--- a/hal/src/samd11/timer.rs
+++ b/hal/src/samd11/timer.rs
@@ -1,0 +1,208 @@
+//! Working with timer counter hardware
+use crate::target_device::tc1::COUNT16;
+#[allow(unused)]
+use crate::target_device::{PM, TC1};
+use hal::timer::{CountDown, Periodic};
+
+use crate::clock;
+use crate::time::Hertz;
+use nb;
+use void::Void;
+
+/// A generic hardware timer counter.
+/// The counters are exposed in 16-bit mode only.
+/// The hardware allows configuring the 8-bit mode
+/// and pairing up some instances to run in 32-bit
+/// mode, but that functionality is not currently
+/// exposed by this hal implementation.
+/// TimerCounter implements both the `Periodic` and
+/// the `CountDown` embedded_hal timer traits.
+/// Before a hardware timer can be used, it must first
+/// have a clock configured.
+pub struct TimerCounter<TC> {
+    freq: Hertz,
+    tc: TC,
+}
+
+/// This is a helper trait to make it easier to make most of the
+/// TimerCounter impl generic.  It doesn't make too much sense to
+/// to try to implement this trait outside of this module.
+pub trait Count16 {
+    fn count_16(&self) -> &COUNT16;
+}
+
+impl<TC> Periodic for TimerCounter<TC> {}
+impl<TC> CountDown for TimerCounter<TC>
+where
+    TC: Count16,
+{
+    type Time = Hertz;
+
+    fn start<T>(&mut self, timeout: T)
+    where
+        T: Into<Hertz>,
+    {
+        let params = TimerParams::new(timeout, self.freq.0);
+        let divider = params.divider;
+        let cycles = params.cycles;
+
+        let count = self.tc.count_16();
+
+        // Disable the timer while we reconfigure it
+        count.ctrla.modify(|_, w| w.enable().clear_bit());
+        while count.status.read().syncbusy().bit_is_set() {}
+
+        // Now that we have a clock routed to the peripheral, we
+        // can ask it to perform a reset.
+        count.ctrla.write(|w| w.swrst().set_bit());
+        while count.status.read().syncbusy().bit_is_set() {}
+        // the SVD erroneously marks swrst as write-only, so we
+        // need to manually read the bit here
+        while count.ctrla.read().bits() & 1 != 0 {}
+
+        count.ctrlbset.write(|w| {
+            // Count up when the direction bit is zero
+            w.dir().clear_bit();
+            // Periodic
+            w.oneshot().clear_bit()
+        });
+
+        // Set TOP value for mfrq mode
+        count.cc[0].write(|w| unsafe { w.cc().bits(cycles as u16) });
+
+        count.ctrla.modify(|_, w| {
+            match divider {
+                1 => w.prescaler().div1(),
+                2 => w.prescaler().div2(),
+                4 => w.prescaler().div4(),
+                8 => w.prescaler().div8(),
+                16 => w.prescaler().div16(),
+                64 => w.prescaler().div64(),
+                256 => w.prescaler().div256(),
+                1024 => w.prescaler().div1024(),
+                _ => unreachable!(),
+            };
+            // Enable Match Frequency Waveform generation
+            w.wavegen().mfrq();
+            w.enable().set_bit()
+        });
+    }
+
+    fn wait(&mut self) -> nb::Result<(), Void> {
+        let count = self.tc.count_16();
+        if count.intflag.read().ovf().bit_is_set() {
+            // Writing a 1 clears the flag
+            count.intflag.modify(|_, w| w.ovf().set_bit());
+            Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+}
+
+impl<TC> TimerCounter<TC>
+where
+    TC: Count16,
+{
+    /// Enable the interrupt generation for this hardware timer.
+    /// This method only sets the clock configuration to trigger
+    /// the interrupt; it does not configure the interrupt controller
+    /// or define an interrupt handler.
+    pub fn enable_interrupt(&mut self) {
+        self.tc.count_16().intenset.write(|w| w.ovf().set_bit());
+    }
+
+    /// Disables interrupt generation for this hardware timer.
+    /// This method only sets the clock configuration to prevent
+    /// triggering the interrupt; it does not configure the interrupt
+    /// controller.
+    pub fn disable_interrupt(&mut self) {
+        self.tc.count_16().intenclr.write(|w| w.ovf().set_bit());
+    }
+}
+
+macro_rules! tc {
+    ($($TYPE:ident: ($TC:ident, $pm:ident, $clock:ident),)+) => {
+        $(
+pub type $TYPE = TimerCounter<$TC>;
+
+impl Count16 for $TC {
+    fn count_16(&self) -> &COUNT16 {
+        self.count16()
+    }
+}
+
+impl TimerCounter<$TC>
+{
+    /// Configure this timer counter instance.
+    /// The clock is obtained from the `GenericClockController` instance
+    /// and its frequency impacts the resolution and maximum range of
+    /// the timeout values that can be passed to the `start` method.
+    /// Note that some hardware timer instances share the same clock
+    /// generator instance and thus will be clocked at the same rate.
+    pub fn $pm(clock: &clock::$clock, tc: $TC, pm: &mut PM) -> Self {
+        // this is safe because we're constrained to just the tc3 bit
+        pm.apbcmask.modify(|_, w| w.$pm().set_bit());
+        {
+            let count = tc.count_16();
+
+            // Disable the timer while we reconfigure it
+            count.ctrla.modify(|_, w| w.enable().clear_bit());
+            while count.status.read().syncbusy().bit_is_set() {}
+        }
+        Self {
+            freq: clock.freq(),
+            tc,
+        }
+    }
+}
+        )+
+    }
+}
+
+/// Helper type for computing cycles and divider given frequency
+#[derive(Debug, Clone, Copy)]
+pub struct TimerParams {
+    pub divider: u16,
+    pub cycles: u32,
+}
+
+impl TimerParams {
+    pub fn new<T>(timeout: T, src_freq: u32) -> Self
+    where
+        T: Into<Hertz>,
+    {
+        let timeout = timeout.into();
+        let ticks: u32 = src_freq / timeout.0.max(1);
+        let divider = ((ticks >> 16) + 1).next_power_of_two();
+        let divider = match divider {
+            1 | 2 | 4 | 8 | 16 | 64 | 256 | 1024 => divider,
+            // There are a couple of gaps, so we round up to the next largest
+            // divider; we'll need to count twice as many but it will work.
+            32 => 64,
+            128 => 256,
+            512 => 1024,
+            // Catch all case; this is lame.  Would be great to detect this
+            // and fail at compile time.
+            _ => 1024,
+        };
+
+        let cycles: u32 = ticks / divider as u32;
+
+        if cycles > u16::max_value() as u32 {
+            panic!(
+                "cycles {} is out of range for a 16 bit counter (timeout={})",
+                cycles, timeout.0
+            );
+        }
+
+        TimerParams {
+            divider: divider as u16,
+            cycles,
+        }
+    }
+}
+
+tc! {
+    TimerCounter1: (TC1, tc1_, Tc1Tc2Clock),
+}

--- a/pac/atsamd11c14a/Cargo.toml
+++ b/pac/atsamd11c14a/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "atsamd11c14a"
+description = "Peripheral access API for ATSAMD11C14A microcontrollers (generated using svd2rust)"
+version = "0.1.0"
+authors = ["Jesse Braham <jesse@beta7.io>"]
+keywords = ["no-std", "arm", "cortex-m"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/atsamd-rs/atsamd"
+readme = "README.md"
+documentation = "https://atsamd-rs.github.io/atsamd/atsamd11c14a/atsamd11c14a/"
+
+[dependencies]
+bare-metal = "~0.2"
+cortex-m = "~0.6"
+vcell = "~0.1"
+
+[dependencies.cortex-m-rt]
+optional = true
+version = "~0.6"
+
+[features]
+rt = ["cortex-m-rt/device"]

--- a/pac/atsamd11c14a/README.md
+++ b/pac/atsamd11c14a/README.md
@@ -1,0 +1,27 @@
+# ATSAMD11C14A
+
+A board support package for the ATSAMD11C14A chip from Microchip (née Atmel)
+for Rust Embedded projects.
+
+https://crates.io/crates/atsamd11c14a
+
+## [Documentation](https://docs.rs/atsamd11c14a)
+
+This source was automatically generated using `svd2rust`, split into smaller
+pieces using `form` and formatted via `rustfmt`.
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall
+be dual licensed as above, without any additional terms or conditions.

--- a/pac/atsamd11c14a/build.rs
+++ b/pac/atsamd11c14a/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+fn main() {
+    if env::var_os("CARGO_FEATURE_RT").is_some() {
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        File::create(out.join("device.x"))
+            .unwrap()
+            .write_all(include_bytes!("device.x"))
+            .unwrap();
+        println!("cargo:rustc-link-search={}", out.display());
+        println!("cargo:rerun-if-changed=device.x");
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/pac/atsamd11c14a/device.x
+++ b/pac/atsamd11c14a/device.x
@@ -1,0 +1,18 @@
+PROVIDE(PM = DefaultHandler);
+PROVIDE(SYSCTRL = DefaultHandler);
+PROVIDE(WDT = DefaultHandler);
+PROVIDE(RTC = DefaultHandler);
+PROVIDE(EIC = DefaultHandler);
+PROVIDE(NVMCTRL = DefaultHandler);
+PROVIDE(DMAC = DefaultHandler);
+PROVIDE(USB = DefaultHandler);
+PROVIDE(EVSYS = DefaultHandler);
+PROVIDE(SERCOM0 = DefaultHandler);
+PROVIDE(SERCOM1 = DefaultHandler);
+PROVIDE(TCC0 = DefaultHandler);
+PROVIDE(TC1 = DefaultHandler);
+PROVIDE(TC2 = DefaultHandler);
+PROVIDE(ADC = DefaultHandler);
+PROVIDE(AC = DefaultHandler);
+PROVIDE(DAC = DefaultHandler);
+

--- a/pac/atsamd11c14a/src/ac.rs
+++ b/pac/atsamd11c14a/src/ac.rs
@@ -1,0 +1,156 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Control A"]
+    pub ctrla: CTRLA,
+    #[doc = "0x01 - Control B"]
+    pub ctrlb: CTRLB,
+    #[doc = "0x02 - Event Control"]
+    pub evctrl: EVCTRL,
+    #[doc = "0x04 - Interrupt Enable Clear"]
+    pub intenclr: INTENCLR,
+    #[doc = "0x05 - Interrupt Enable Set"]
+    pub intenset: INTENSET,
+    #[doc = "0x06 - Interrupt Flag Status and Clear"]
+    pub intflag: INTFLAG,
+    _reserved6: [u8; 1usize],
+    #[doc = "0x08 - Status A"]
+    pub statusa: STATUSA,
+    #[doc = "0x09 - Status B"]
+    pub statusb: STATUSB,
+    #[doc = "0x0a - Status C"]
+    pub statusc: STATUSC,
+    _reserved9: [u8; 1usize],
+    #[doc = "0x0c - Window Control"]
+    pub winctrl: WINCTRL,
+    _reserved10: [u8; 3usize],
+    #[doc = "0x10 - Comparator Control n"]
+    pub compctrl: [COMPCTRL; 2],
+    _reserved11: [u8; 8usize],
+    #[doc = "0x20 - Scaler n"]
+    pub scaler: [SCALER; 2],
+}
+#[doc = "Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrla](ctrla) module"]
+pub type CTRLA = crate::Reg<u8, _CTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLA;
+#[doc = "`read()` method returns [ctrla::R](ctrla::R) reader structure"]
+impl crate::Readable for CTRLA {}
+#[doc = "`write(|w| ..)` method takes [ctrla::W](ctrla::W) writer structure"]
+impl crate::Writable for CTRLA {}
+#[doc = "Control A"]
+pub mod ctrla;
+#[doc = "Control B\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlb](ctrlb) module"]
+pub type CTRLB = crate::Reg<u8, _CTRLB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLB;
+#[doc = "`write(|w| ..)` method takes [ctrlb::W](ctrlb::W) writer structure"]
+impl crate::Writable for CTRLB {}
+#[doc = "Control B"]
+pub mod ctrlb;
+#[doc = "Event Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [evctrl](evctrl) module"]
+pub type EVCTRL = crate::Reg<u16, _EVCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EVCTRL;
+#[doc = "`read()` method returns [evctrl::R](evctrl::R) reader structure"]
+impl crate::Readable for EVCTRL {}
+#[doc = "`write(|w| ..)` method takes [evctrl::W](evctrl::W) writer structure"]
+impl crate::Writable for EVCTRL {}
+#[doc = "Event Control"]
+pub mod evctrl;
+#[doc = "Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Status A\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [statusa](statusa) module"]
+pub type STATUSA = crate::Reg<u8, _STATUSA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUSA;
+#[doc = "`read()` method returns [statusa::R](statusa::R) reader structure"]
+impl crate::Readable for STATUSA {}
+#[doc = "Status A"]
+pub mod statusa;
+#[doc = "Status B\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [statusb](statusb) module"]
+pub type STATUSB = crate::Reg<u8, _STATUSB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUSB;
+#[doc = "`read()` method returns [statusb::R](statusb::R) reader structure"]
+impl crate::Readable for STATUSB {}
+#[doc = "Status B"]
+pub mod statusb;
+#[doc = "Status C\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [statusc](statusc) module"]
+pub type STATUSC = crate::Reg<u8, _STATUSC>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUSC;
+#[doc = "`read()` method returns [statusc::R](statusc::R) reader structure"]
+impl crate::Readable for STATUSC {}
+#[doc = "Status C"]
+pub mod statusc;
+#[doc = "Window Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [winctrl](winctrl) module"]
+pub type WINCTRL = crate::Reg<u8, _WINCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WINCTRL;
+#[doc = "`read()` method returns [winctrl::R](winctrl::R) reader structure"]
+impl crate::Readable for WINCTRL {}
+#[doc = "`write(|w| ..)` method takes [winctrl::W](winctrl::W) writer structure"]
+impl crate::Writable for WINCTRL {}
+#[doc = "Window Control"]
+pub mod winctrl;
+#[doc = "Comparator Control n\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [compctrl](compctrl) module"]
+pub type COMPCTRL = crate::Reg<u32, _COMPCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _COMPCTRL;
+#[doc = "`read()` method returns [compctrl::R](compctrl::R) reader structure"]
+impl crate::Readable for COMPCTRL {}
+#[doc = "`write(|w| ..)` method takes [compctrl::W](compctrl::W) writer structure"]
+impl crate::Writable for COMPCTRL {}
+#[doc = "Comparator Control n"]
+pub mod compctrl;
+#[doc = "Scaler n\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [scaler](scaler) module"]
+pub type SCALER = crate::Reg<u8, _SCALER>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _SCALER;
+#[doc = "`read()` method returns [scaler::R](scaler::R) reader structure"]
+impl crate::Readable for SCALER {}
+#[doc = "`write(|w| ..)` method takes [scaler::W](scaler::W) writer structure"]
+impl crate::Writable for SCALER {}
+#[doc = "Scaler n"]
+pub mod scaler;

--- a/pac/atsamd11c14a/src/ac/compctrl.rs
+++ b/pac/atsamd11c14a/src/ac/compctrl.rs
@@ -1,0 +1,791 @@
+#[doc = "Reader of register COMPCTRL%s"]
+pub type R = crate::R<u32, super::COMPCTRL>;
+#[doc = "Writer for register COMPCTRL%s"]
+pub type W = crate::W<u32, super::COMPCTRL>;
+#[doc = "Register COMPCTRL%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::COMPCTRL {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `SINGLE`"]
+pub type SINGLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SINGLE`"]
+pub struct SINGLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SINGLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Speed Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SPEED_A {
+    #[doc = "0: Low speed"]
+    LOW,
+    #[doc = "1: High speed"]
+    HIGH,
+}
+impl From<SPEED_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SPEED_A) -> Self {
+        match variant {
+            SPEED_A::LOW => 0,
+            SPEED_A::HIGH => 1,
+        }
+    }
+}
+#[doc = "Reader of field `SPEED`"]
+pub type SPEED_R = crate::R<u8, SPEED_A>;
+impl SPEED_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, SPEED_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(SPEED_A::LOW),
+            1 => Val(SPEED_A::HIGH),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `LOW`"]
+    #[inline(always)]
+    pub fn is_low(&self) -> bool {
+        *self == SPEED_A::LOW
+    }
+    #[doc = "Checks if the value of the field is `HIGH`"]
+    #[inline(always)]
+    pub fn is_high(&self) -> bool {
+        *self == SPEED_A::HIGH
+    }
+}
+#[doc = "Write proxy for field `SPEED`"]
+pub struct SPEED_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SPEED_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SPEED_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Low speed"]
+    #[inline(always)]
+    pub fn low(self) -> &'a mut W {
+        self.variant(SPEED_A::LOW)
+    }
+    #[doc = "High speed"]
+    #[inline(always)]
+    pub fn high(self) -> &'a mut W {
+        self.variant(SPEED_A::HIGH)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 2)) | (((value as u32) & 0x03) << 2);
+        self.w
+    }
+}
+#[doc = "Interrupt Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum INTSEL_A {
+    #[doc = "0: Interrupt on comparator output toggle"]
+    TOGGLE,
+    #[doc = "1: Interrupt on comparator output rising"]
+    RISING,
+    #[doc = "2: Interrupt on comparator output falling"]
+    FALLING,
+    #[doc = "3: Interrupt on end of comparison (single-shot mode only)"]
+    EOC,
+}
+impl From<INTSEL_A> for u8 {
+    #[inline(always)]
+    fn from(variant: INTSEL_A) -> Self {
+        match variant {
+            INTSEL_A::TOGGLE => 0,
+            INTSEL_A::RISING => 1,
+            INTSEL_A::FALLING => 2,
+            INTSEL_A::EOC => 3,
+        }
+    }
+}
+#[doc = "Reader of field `INTSEL`"]
+pub type INTSEL_R = crate::R<u8, INTSEL_A>;
+impl INTSEL_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> INTSEL_A {
+        match self.bits {
+            0 => INTSEL_A::TOGGLE,
+            1 => INTSEL_A::RISING,
+            2 => INTSEL_A::FALLING,
+            3 => INTSEL_A::EOC,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `TOGGLE`"]
+    #[inline(always)]
+    pub fn is_toggle(&self) -> bool {
+        *self == INTSEL_A::TOGGLE
+    }
+    #[doc = "Checks if the value of the field is `RISING`"]
+    #[inline(always)]
+    pub fn is_rising(&self) -> bool {
+        *self == INTSEL_A::RISING
+    }
+    #[doc = "Checks if the value of the field is `FALLING`"]
+    #[inline(always)]
+    pub fn is_falling(&self) -> bool {
+        *self == INTSEL_A::FALLING
+    }
+    #[doc = "Checks if the value of the field is `EOC`"]
+    #[inline(always)]
+    pub fn is_eoc(&self) -> bool {
+        *self == INTSEL_A::EOC
+    }
+}
+#[doc = "Write proxy for field `INTSEL`"]
+pub struct INTSEL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INTSEL_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: INTSEL_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Interrupt on comparator output toggle"]
+    #[inline(always)]
+    pub fn toggle(self) -> &'a mut W {
+        self.variant(INTSEL_A::TOGGLE)
+    }
+    #[doc = "Interrupt on comparator output rising"]
+    #[inline(always)]
+    pub fn rising(self) -> &'a mut W {
+        self.variant(INTSEL_A::RISING)
+    }
+    #[doc = "Interrupt on comparator output falling"]
+    #[inline(always)]
+    pub fn falling(self) -> &'a mut W {
+        self.variant(INTSEL_A::FALLING)
+    }
+    #[doc = "Interrupt on end of comparison (single-shot mode only)"]
+    #[inline(always)]
+    pub fn eoc(self) -> &'a mut W {
+        self.variant(INTSEL_A::EOC)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 5)) | (((value as u32) & 0x03) << 5);
+        self.w
+    }
+}
+#[doc = "Negative Input Mux Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MUXNEG_A {
+    #[doc = "0: I/O pin 0"]
+    PIN0,
+    #[doc = "1: I/O pin 1"]
+    PIN1,
+    #[doc = "2: I/O pin 2"]
+    PIN2,
+    #[doc = "3: I/O pin 3"]
+    PIN3,
+    #[doc = "4: Ground"]
+    GND,
+    #[doc = "5: VDD scaler"]
+    VSCALE,
+    #[doc = "6: Internal bandgap voltage"]
+    BANDGAP,
+    #[doc = "7: DAC output"]
+    DAC,
+}
+impl From<MUXNEG_A> for u8 {
+    #[inline(always)]
+    fn from(variant: MUXNEG_A) -> Self {
+        match variant {
+            MUXNEG_A::PIN0 => 0,
+            MUXNEG_A::PIN1 => 1,
+            MUXNEG_A::PIN2 => 2,
+            MUXNEG_A::PIN3 => 3,
+            MUXNEG_A::GND => 4,
+            MUXNEG_A::VSCALE => 5,
+            MUXNEG_A::BANDGAP => 6,
+            MUXNEG_A::DAC => 7,
+        }
+    }
+}
+#[doc = "Reader of field `MUXNEG`"]
+pub type MUXNEG_R = crate::R<u8, MUXNEG_A>;
+impl MUXNEG_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> MUXNEG_A {
+        match self.bits {
+            0 => MUXNEG_A::PIN0,
+            1 => MUXNEG_A::PIN1,
+            2 => MUXNEG_A::PIN2,
+            3 => MUXNEG_A::PIN3,
+            4 => MUXNEG_A::GND,
+            5 => MUXNEG_A::VSCALE,
+            6 => MUXNEG_A::BANDGAP,
+            7 => MUXNEG_A::DAC,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `PIN0`"]
+    #[inline(always)]
+    pub fn is_pin0(&self) -> bool {
+        *self == MUXNEG_A::PIN0
+    }
+    #[doc = "Checks if the value of the field is `PIN1`"]
+    #[inline(always)]
+    pub fn is_pin1(&self) -> bool {
+        *self == MUXNEG_A::PIN1
+    }
+    #[doc = "Checks if the value of the field is `PIN2`"]
+    #[inline(always)]
+    pub fn is_pin2(&self) -> bool {
+        *self == MUXNEG_A::PIN2
+    }
+    #[doc = "Checks if the value of the field is `PIN3`"]
+    #[inline(always)]
+    pub fn is_pin3(&self) -> bool {
+        *self == MUXNEG_A::PIN3
+    }
+    #[doc = "Checks if the value of the field is `GND`"]
+    #[inline(always)]
+    pub fn is_gnd(&self) -> bool {
+        *self == MUXNEG_A::GND
+    }
+    #[doc = "Checks if the value of the field is `VSCALE`"]
+    #[inline(always)]
+    pub fn is_vscale(&self) -> bool {
+        *self == MUXNEG_A::VSCALE
+    }
+    #[doc = "Checks if the value of the field is `BANDGAP`"]
+    #[inline(always)]
+    pub fn is_bandgap(&self) -> bool {
+        *self == MUXNEG_A::BANDGAP
+    }
+    #[doc = "Checks if the value of the field is `DAC`"]
+    #[inline(always)]
+    pub fn is_dac(&self) -> bool {
+        *self == MUXNEG_A::DAC
+    }
+}
+#[doc = "Write proxy for field `MUXNEG`"]
+pub struct MUXNEG_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MUXNEG_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: MUXNEG_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "I/O pin 0"]
+    #[inline(always)]
+    pub fn pin0(self) -> &'a mut W {
+        self.variant(MUXNEG_A::PIN0)
+    }
+    #[doc = "I/O pin 1"]
+    #[inline(always)]
+    pub fn pin1(self) -> &'a mut W {
+        self.variant(MUXNEG_A::PIN1)
+    }
+    #[doc = "I/O pin 2"]
+    #[inline(always)]
+    pub fn pin2(self) -> &'a mut W {
+        self.variant(MUXNEG_A::PIN2)
+    }
+    #[doc = "I/O pin 3"]
+    #[inline(always)]
+    pub fn pin3(self) -> &'a mut W {
+        self.variant(MUXNEG_A::PIN3)
+    }
+    #[doc = "Ground"]
+    #[inline(always)]
+    pub fn gnd(self) -> &'a mut W {
+        self.variant(MUXNEG_A::GND)
+    }
+    #[doc = "VDD scaler"]
+    #[inline(always)]
+    pub fn vscale(self) -> &'a mut W {
+        self.variant(MUXNEG_A::VSCALE)
+    }
+    #[doc = "Internal bandgap voltage"]
+    #[inline(always)]
+    pub fn bandgap(self) -> &'a mut W {
+        self.variant(MUXNEG_A::BANDGAP)
+    }
+    #[doc = "DAC output"]
+    #[inline(always)]
+    pub fn dac(self) -> &'a mut W {
+        self.variant(MUXNEG_A::DAC)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 8)) | (((value as u32) & 0x07) << 8);
+        self.w
+    }
+}
+#[doc = "Positive Input Mux Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MUXPOS_A {
+    #[doc = "0: I/O pin 0"]
+    PIN0,
+    #[doc = "1: I/O pin 1"]
+    PIN1,
+    #[doc = "2: I/O pin 2"]
+    PIN2,
+    #[doc = "3: I/O pin 3"]
+    PIN3,
+}
+impl From<MUXPOS_A> for u8 {
+    #[inline(always)]
+    fn from(variant: MUXPOS_A) -> Self {
+        match variant {
+            MUXPOS_A::PIN0 => 0,
+            MUXPOS_A::PIN1 => 1,
+            MUXPOS_A::PIN2 => 2,
+            MUXPOS_A::PIN3 => 3,
+        }
+    }
+}
+#[doc = "Reader of field `MUXPOS`"]
+pub type MUXPOS_R = crate::R<u8, MUXPOS_A>;
+impl MUXPOS_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> MUXPOS_A {
+        match self.bits {
+            0 => MUXPOS_A::PIN0,
+            1 => MUXPOS_A::PIN1,
+            2 => MUXPOS_A::PIN2,
+            3 => MUXPOS_A::PIN3,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `PIN0`"]
+    #[inline(always)]
+    pub fn is_pin0(&self) -> bool {
+        *self == MUXPOS_A::PIN0
+    }
+    #[doc = "Checks if the value of the field is `PIN1`"]
+    #[inline(always)]
+    pub fn is_pin1(&self) -> bool {
+        *self == MUXPOS_A::PIN1
+    }
+    #[doc = "Checks if the value of the field is `PIN2`"]
+    #[inline(always)]
+    pub fn is_pin2(&self) -> bool {
+        *self == MUXPOS_A::PIN2
+    }
+    #[doc = "Checks if the value of the field is `PIN3`"]
+    #[inline(always)]
+    pub fn is_pin3(&self) -> bool {
+        *self == MUXPOS_A::PIN3
+    }
+}
+#[doc = "Write proxy for field `MUXPOS`"]
+pub struct MUXPOS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MUXPOS_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: MUXPOS_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "I/O pin 0"]
+    #[inline(always)]
+    pub fn pin0(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN0)
+    }
+    #[doc = "I/O pin 1"]
+    #[inline(always)]
+    pub fn pin1(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN1)
+    }
+    #[doc = "I/O pin 2"]
+    #[inline(always)]
+    pub fn pin2(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN2)
+    }
+    #[doc = "I/O pin 3"]
+    #[inline(always)]
+    pub fn pin3(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN3)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 12)) | (((value as u32) & 0x03) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `SWAP`"]
+pub type SWAP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWAP`"]
+pub struct SWAP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWAP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Output\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum OUT_A {
+    #[doc = "0: The output of COMPn is not routed to the COMPn I/O port"]
+    OFF,
+    #[doc = "1: The asynchronous output of COMPn is routed to the COMPn I/O port"]
+    ASYNC,
+    #[doc = "2: The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port"]
+    SYNC,
+}
+impl From<OUT_A> for u8 {
+    #[inline(always)]
+    fn from(variant: OUT_A) -> Self {
+        match variant {
+            OUT_A::OFF => 0,
+            OUT_A::ASYNC => 1,
+            OUT_A::SYNC => 2,
+        }
+    }
+}
+#[doc = "Reader of field `OUT`"]
+pub type OUT_R = crate::R<u8, OUT_A>;
+impl OUT_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, OUT_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(OUT_A::OFF),
+            1 => Val(OUT_A::ASYNC),
+            2 => Val(OUT_A::SYNC),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `OFF`"]
+    #[inline(always)]
+    pub fn is_off(&self) -> bool {
+        *self == OUT_A::OFF
+    }
+    #[doc = "Checks if the value of the field is `ASYNC`"]
+    #[inline(always)]
+    pub fn is_async(&self) -> bool {
+        *self == OUT_A::ASYNC
+    }
+    #[doc = "Checks if the value of the field is `SYNC`"]
+    #[inline(always)]
+    pub fn is_sync(&self) -> bool {
+        *self == OUT_A::SYNC
+    }
+}
+#[doc = "Write proxy for field `OUT`"]
+pub struct OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OUT_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: OUT_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "The output of COMPn is not routed to the COMPn I/O port"]
+    #[inline(always)]
+    pub fn off(self) -> &'a mut W {
+        self.variant(OUT_A::OFF)
+    }
+    #[doc = "The asynchronous output of COMPn is routed to the COMPn I/O port"]
+    #[inline(always)]
+    pub fn async(self) -> &'a mut W {
+        self.variant(OUT_A::ASYNC)
+    }
+    #[doc = "The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port"]
+    #[inline(always)]
+    pub fn sync(self) -> &'a mut W {
+        self.variant(OUT_A::SYNC)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 16)) | (((value as u32) & 0x03) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `HYST`"]
+pub type HYST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `HYST`"]
+pub struct HYST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HYST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 19)) | (((value as u32) & 0x01) << 19);
+        self.w
+    }
+}
+#[doc = "Filter Length\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FLEN_A {
+    #[doc = "0: No filtering"]
+    OFF,
+    #[doc = "1: 3-bit majority function (2 of 3)"]
+    MAJ3,
+    #[doc = "2: 5-bit majority function (3 of 5)"]
+    MAJ5,
+}
+impl From<FLEN_A> for u8 {
+    #[inline(always)]
+    fn from(variant: FLEN_A) -> Self {
+        match variant {
+            FLEN_A::OFF => 0,
+            FLEN_A::MAJ3 => 1,
+            FLEN_A::MAJ5 => 2,
+        }
+    }
+}
+#[doc = "Reader of field `FLEN`"]
+pub type FLEN_R = crate::R<u8, FLEN_A>;
+impl FLEN_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, FLEN_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(FLEN_A::OFF),
+            1 => Val(FLEN_A::MAJ3),
+            2 => Val(FLEN_A::MAJ5),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `OFF`"]
+    #[inline(always)]
+    pub fn is_off(&self) -> bool {
+        *self == FLEN_A::OFF
+    }
+    #[doc = "Checks if the value of the field is `MAJ3`"]
+    #[inline(always)]
+    pub fn is_maj3(&self) -> bool {
+        *self == FLEN_A::MAJ3
+    }
+    #[doc = "Checks if the value of the field is `MAJ5`"]
+    #[inline(always)]
+    pub fn is_maj5(&self) -> bool {
+        *self == FLEN_A::MAJ5
+    }
+}
+#[doc = "Write proxy for field `FLEN`"]
+pub struct FLEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FLEN_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: FLEN_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No filtering"]
+    #[inline(always)]
+    pub fn off(self) -> &'a mut W {
+        self.variant(FLEN_A::OFF)
+    }
+    #[doc = "3-bit majority function (2 of 3)"]
+    #[inline(always)]
+    pub fn maj3(self) -> &'a mut W {
+        self.variant(FLEN_A::MAJ3)
+    }
+    #[doc = "5-bit majority function (3 of 5)"]
+    #[inline(always)]
+    pub fn maj5(self) -> &'a mut W {
+        self.variant(FLEN_A::MAJ5)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 24)) | (((value as u32) & 0x07) << 24);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Single-Shot Mode"]
+    #[inline(always)]
+    pub fn single(&self) -> SINGLE_R {
+        SINGLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 2:3 - Speed Selection"]
+    #[inline(always)]
+    pub fn speed(&self) -> SPEED_R {
+        SPEED_R::new(((self.bits >> 2) & 0x03) as u8)
+    }
+    #[doc = "Bits 5:6 - Interrupt Selection"]
+    #[inline(always)]
+    pub fn intsel(&self) -> INTSEL_R {
+        INTSEL_R::new(((self.bits >> 5) & 0x03) as u8)
+    }
+    #[doc = "Bits 8:10 - Negative Input Mux Selection"]
+    #[inline(always)]
+    pub fn muxneg(&self) -> MUXNEG_R {
+        MUXNEG_R::new(((self.bits >> 8) & 0x07) as u8)
+    }
+    #[doc = "Bits 12:13 - Positive Input Mux Selection"]
+    #[inline(always)]
+    pub fn muxpos(&self) -> MUXPOS_R {
+        MUXPOS_R::new(((self.bits >> 12) & 0x03) as u8)
+    }
+    #[doc = "Bit 15 - Swap Inputs and Invert"]
+    #[inline(always)]
+    pub fn swap(&self) -> SWAP_R {
+        SWAP_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bits 16:17 - Output"]
+    #[inline(always)]
+    pub fn out(&self) -> OUT_R {
+        OUT_R::new(((self.bits >> 16) & 0x03) as u8)
+    }
+    #[doc = "Bit 19 - Hysteresis Enable"]
+    #[inline(always)]
+    pub fn hyst(&self) -> HYST_R {
+        HYST_R::new(((self.bits >> 19) & 0x01) != 0)
+    }
+    #[doc = "Bits 24:26 - Filter Length"]
+    #[inline(always)]
+    pub fn flen(&self) -> FLEN_R {
+        FLEN_R::new(((self.bits >> 24) & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bit 1 - Single-Shot Mode"]
+    #[inline(always)]
+    pub fn single(&mut self) -> SINGLE_W {
+        SINGLE_W { w: self }
+    }
+    #[doc = "Bits 2:3 - Speed Selection"]
+    #[inline(always)]
+    pub fn speed(&mut self) -> SPEED_W {
+        SPEED_W { w: self }
+    }
+    #[doc = "Bits 5:6 - Interrupt Selection"]
+    #[inline(always)]
+    pub fn intsel(&mut self) -> INTSEL_W {
+        INTSEL_W { w: self }
+    }
+    #[doc = "Bits 8:10 - Negative Input Mux Selection"]
+    #[inline(always)]
+    pub fn muxneg(&mut self) -> MUXNEG_W {
+        MUXNEG_W { w: self }
+    }
+    #[doc = "Bits 12:13 - Positive Input Mux Selection"]
+    #[inline(always)]
+    pub fn muxpos(&mut self) -> MUXPOS_W {
+        MUXPOS_W { w: self }
+    }
+    #[doc = "Bit 15 - Swap Inputs and Invert"]
+    #[inline(always)]
+    pub fn swap(&mut self) -> SWAP_W {
+        SWAP_W { w: self }
+    }
+    #[doc = "Bits 16:17 - Output"]
+    #[inline(always)]
+    pub fn out(&mut self) -> OUT_W {
+        OUT_W { w: self }
+    }
+    #[doc = "Bit 19 - Hysteresis Enable"]
+    #[inline(always)]
+    pub fn hyst(&mut self) -> HYST_W {
+        HYST_W { w: self }
+    }
+    #[doc = "Bits 24:26 - Filter Length"]
+    #[inline(always)]
+    pub fn flen(&mut self) -> FLEN_W {
+        FLEN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/ac/ctrla.rs
+++ b/pac/atsamd11c14a/src/ac/ctrla.rs
@@ -1,0 +1,145 @@
+#[doc = "Reader of register CTRLA"]
+pub type R = crate::R<u8, super::CTRLA>;
+#[doc = "Writer for register CTRLA"]
+pub type W = crate::W<u8, super::CTRLA>;
+#[doc = "Register CTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLA {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `LPMUX`"]
+pub type LPMUX_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LPMUX`"]
+pub struct LPMUX_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LPMUX_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Low-Power Mux"]
+    #[inline(always)]
+    pub fn lpmux(&self) -> LPMUX_R {
+        LPMUX_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bit 2 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bit 7 - Low-Power Mux"]
+    #[inline(always)]
+    pub fn lpmux(&mut self) -> LPMUX_W {
+        LPMUX_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/ac/ctrlb.rs
+++ b/pac/atsamd11c14a/src/ac/ctrlb.rs
@@ -1,0 +1,66 @@
+#[doc = "Writer for register CTRLB"]
+pub type W = crate::W<u8, super::CTRLB>;
+#[doc = "Register CTRLB `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLB {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Write proxy for field `START0`"]
+pub struct START0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> START0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `START1`"]
+pub struct START1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> START1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Comparator 0 Start Comparison"]
+    #[inline(always)]
+    pub fn start0(&mut self) -> START0_W {
+        START0_W { w: self }
+    }
+    #[doc = "Bit 1 - Comparator 1 Start Comparison"]
+    #[inline(always)]
+    pub fn start1(&mut self) -> START1_W {
+        START1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/ac/evctrl.rs
+++ b/pac/atsamd11c14a/src/ac/evctrl.rs
@@ -1,0 +1,186 @@
+#[doc = "Reader of register EVCTRL"]
+pub type R = crate::R<u16, super::EVCTRL>;
+#[doc = "Writer for register EVCTRL"]
+pub type W = crate::W<u16, super::EVCTRL>;
+#[doc = "Register EVCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::EVCTRL {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `COMPEO0`"]
+pub type COMPEO0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `COMPEO0`"]
+pub struct COMPEO0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COMPEO0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `COMPEO1`"]
+pub type COMPEO1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `COMPEO1`"]
+pub struct COMPEO1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COMPEO1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `WINEO0`"]
+pub type WINEO0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WINEO0`"]
+pub struct WINEO0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WINEO0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `COMPEI0`"]
+pub type COMPEI0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `COMPEI0`"]
+pub struct COMPEI0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COMPEI0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `COMPEI1`"]
+pub type COMPEI1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `COMPEI1`"]
+pub struct COMPEI1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COMPEI1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u16) & 0x01) << 9);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Comparator 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn compeo0(&self) -> COMPEO0_R {
+        COMPEO0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Comparator 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn compeo1(&self) -> COMPEO1_R {
+        COMPEO1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Window 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn wineo0(&self) -> WINEO0_R {
+        WINEO0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Comparator 0 Event Input"]
+    #[inline(always)]
+    pub fn compei0(&self) -> COMPEI0_R {
+        COMPEI0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Comparator 1 Event Input"]
+    #[inline(always)]
+    pub fn compei1(&self) -> COMPEI1_R {
+        COMPEI1_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Comparator 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn compeo0(&mut self) -> COMPEO0_W {
+        COMPEO0_W { w: self }
+    }
+    #[doc = "Bit 1 - Comparator 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn compeo1(&mut self) -> COMPEO1_W {
+        COMPEO1_W { w: self }
+    }
+    #[doc = "Bit 4 - Window 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn wineo0(&mut self) -> WINEO0_W {
+        WINEO0_W { w: self }
+    }
+    #[doc = "Bit 8 - Comparator 0 Event Input"]
+    #[inline(always)]
+    pub fn compei0(&mut self) -> COMPEI0_W {
+        COMPEI0_W { w: self }
+    }
+    #[doc = "Bit 9 - Comparator 1 Event Input"]
+    #[inline(always)]
+    pub fn compei1(&mut self) -> COMPEI1_W {
+        COMPEI1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/ac/intenclr.rs
+++ b/pac/atsamd11c14a/src/ac/intenclr.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `COMP0`"]
+pub type COMP0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `COMP0`"]
+pub struct COMP0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COMP0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `COMP1`"]
+pub type COMP1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `COMP1`"]
+pub struct COMP1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COMP1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `WIN0`"]
+pub type WIN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WIN0`"]
+pub struct WIN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WIN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Comparator 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn comp0(&self) -> COMP0_R {
+        COMP0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Comparator 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn comp1(&self) -> COMP1_R {
+        COMP1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Window 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn win0(&self) -> WIN0_R {
+        WIN0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Comparator 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn comp0(&mut self) -> COMP0_W {
+        COMP0_W { w: self }
+    }
+    #[doc = "Bit 1 - Comparator 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn comp1(&mut self) -> COMP1_W {
+        COMP1_W { w: self }
+    }
+    #[doc = "Bit 4 - Window 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn win0(&mut self) -> WIN0_W {
+        WIN0_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/ac/intenset.rs
+++ b/pac/atsamd11c14a/src/ac/intenset.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `COMP0`"]
+pub type COMP0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `COMP0`"]
+pub struct COMP0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COMP0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `COMP1`"]
+pub type COMP1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `COMP1`"]
+pub struct COMP1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COMP1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `WIN0`"]
+pub type WIN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WIN0`"]
+pub struct WIN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WIN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Comparator 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn comp0(&self) -> COMP0_R {
+        COMP0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Comparator 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn comp1(&self) -> COMP1_R {
+        COMP1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Window 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn win0(&self) -> WIN0_R {
+        WIN0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Comparator 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn comp0(&mut self) -> COMP0_W {
+        COMP0_W { w: self }
+    }
+    #[doc = "Bit 1 - Comparator 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn comp1(&mut self) -> COMP1_W {
+        COMP1_W { w: self }
+    }
+    #[doc = "Bit 4 - Window 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn win0(&mut self) -> WIN0_W {
+        WIN0_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/ac/intflag.rs
+++ b/pac/atsamd11c14a/src/ac/intflag.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `COMP0`"]
+pub type COMP0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `COMP0`"]
+pub struct COMP0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COMP0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `COMP1`"]
+pub type COMP1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `COMP1`"]
+pub struct COMP1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COMP1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `WIN0`"]
+pub type WIN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WIN0`"]
+pub struct WIN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WIN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Comparator 0"]
+    #[inline(always)]
+    pub fn comp0(&self) -> COMP0_R {
+        COMP0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Comparator 1"]
+    #[inline(always)]
+    pub fn comp1(&self) -> COMP1_R {
+        COMP1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Window 0"]
+    #[inline(always)]
+    pub fn win0(&self) -> WIN0_R {
+        WIN0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Comparator 0"]
+    #[inline(always)]
+    pub fn comp0(&mut self) -> COMP0_W {
+        COMP0_W { w: self }
+    }
+    #[doc = "Bit 1 - Comparator 1"]
+    #[inline(always)]
+    pub fn comp1(&mut self) -> COMP1_W {
+        COMP1_W { w: self }
+    }
+    #[doc = "Bit 4 - Window 0"]
+    #[inline(always)]
+    pub fn win0(&mut self) -> WIN0_W {
+        WIN0_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/ac/scaler.rs
+++ b/pac/atsamd11c14a/src/ac/scaler.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register SCALER%s"]
+pub type R = crate::R<u8, super::SCALER>;
+#[doc = "Writer for register SCALER%s"]
+pub type W = crate::W<u8, super::SCALER>;
+#[doc = "Register SCALER%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::SCALER {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `VALUE`"]
+pub type VALUE_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `VALUE`"]
+pub struct VALUE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> VALUE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x3f) | ((value as u8) & 0x3f);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:5 - Scaler Value"]
+    #[inline(always)]
+    pub fn value(&self) -> VALUE_R {
+        VALUE_R::new((self.bits & 0x3f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:5 - Scaler Value"]
+    #[inline(always)]
+    pub fn value(&mut self) -> VALUE_W {
+        VALUE_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/ac/statusa.rs
+++ b/pac/atsamd11c14a/src/ac/statusa.rs
@@ -1,0 +1,73 @@
+#[doc = "Reader of register STATUSA"]
+pub type R = crate::R<u8, super::STATUSA>;
+#[doc = "Reader of field `STATE0`"]
+pub type STATE0_R = crate::R<bool, bool>;
+#[doc = "Reader of field `STATE1`"]
+pub type STATE1_R = crate::R<bool, bool>;
+#[doc = "Window 0 Current State\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum WSTATE0_A {
+    #[doc = "0: Signal is above window"]
+    ABOVE,
+    #[doc = "1: Signal is inside window"]
+    INSIDE,
+    #[doc = "2: Signal is below window"]
+    BELOW,
+}
+impl From<WSTATE0_A> for u8 {
+    #[inline(always)]
+    fn from(variant: WSTATE0_A) -> Self {
+        match variant {
+            WSTATE0_A::ABOVE => 0,
+            WSTATE0_A::INSIDE => 1,
+            WSTATE0_A::BELOW => 2,
+        }
+    }
+}
+#[doc = "Reader of field `WSTATE0`"]
+pub type WSTATE0_R = crate::R<u8, WSTATE0_A>;
+impl WSTATE0_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, WSTATE0_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(WSTATE0_A::ABOVE),
+            1 => Val(WSTATE0_A::INSIDE),
+            2 => Val(WSTATE0_A::BELOW),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `ABOVE`"]
+    #[inline(always)]
+    pub fn is_above(&self) -> bool {
+        *self == WSTATE0_A::ABOVE
+    }
+    #[doc = "Checks if the value of the field is `INSIDE`"]
+    #[inline(always)]
+    pub fn is_inside(&self) -> bool {
+        *self == WSTATE0_A::INSIDE
+    }
+    #[doc = "Checks if the value of the field is `BELOW`"]
+    #[inline(always)]
+    pub fn is_below(&self) -> bool {
+        *self == WSTATE0_A::BELOW
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Comparator 0 Current State"]
+    #[inline(always)]
+    pub fn state0(&self) -> STATE0_R {
+        STATE0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Comparator 1 Current State"]
+    #[inline(always)]
+    pub fn state1(&self) -> STATE1_R {
+        STATE1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 4:5 - Window 0 Current State"]
+    #[inline(always)]
+    pub fn wstate0(&self) -> WSTATE0_R {
+        WSTATE0_R::new(((self.bits >> 4) & 0x03) as u8)
+    }
+}

--- a/pac/atsamd11c14a/src/ac/statusb.rs
+++ b/pac/atsamd11c14a/src/ac/statusb.rs
@@ -1,0 +1,25 @@
+#[doc = "Reader of register STATUSB"]
+pub type R = crate::R<u8, super::STATUSB>;
+#[doc = "Reader of field `READY0`"]
+pub type READY0_R = crate::R<bool, bool>;
+#[doc = "Reader of field `READY1`"]
+pub type READY1_R = crate::R<bool, bool>;
+#[doc = "Reader of field `SYNCBUSY`"]
+pub type SYNCBUSY_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Comparator 0 Ready"]
+    #[inline(always)]
+    pub fn ready0(&self) -> READY0_R {
+        READY0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Comparator 1 Ready"]
+    #[inline(always)]
+    pub fn ready1(&self) -> READY1_R {
+        READY1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Synchronization Busy"]
+    #[inline(always)]
+    pub fn syncbusy(&self) -> SYNCBUSY_R {
+        SYNCBUSY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/ac/statusc.rs
+++ b/pac/atsamd11c14a/src/ac/statusc.rs
@@ -1,0 +1,73 @@
+#[doc = "Reader of register STATUSC"]
+pub type R = crate::R<u8, super::STATUSC>;
+#[doc = "Reader of field `STATE0`"]
+pub type STATE0_R = crate::R<bool, bool>;
+#[doc = "Reader of field `STATE1`"]
+pub type STATE1_R = crate::R<bool, bool>;
+#[doc = "Window 0 Current State\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum WSTATE0_A {
+    #[doc = "0: Signal is above window"]
+    ABOVE,
+    #[doc = "1: Signal is inside window"]
+    INSIDE,
+    #[doc = "2: Signal is below window"]
+    BELOW,
+}
+impl From<WSTATE0_A> for u8 {
+    #[inline(always)]
+    fn from(variant: WSTATE0_A) -> Self {
+        match variant {
+            WSTATE0_A::ABOVE => 0,
+            WSTATE0_A::INSIDE => 1,
+            WSTATE0_A::BELOW => 2,
+        }
+    }
+}
+#[doc = "Reader of field `WSTATE0`"]
+pub type WSTATE0_R = crate::R<u8, WSTATE0_A>;
+impl WSTATE0_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, WSTATE0_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(WSTATE0_A::ABOVE),
+            1 => Val(WSTATE0_A::INSIDE),
+            2 => Val(WSTATE0_A::BELOW),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `ABOVE`"]
+    #[inline(always)]
+    pub fn is_above(&self) -> bool {
+        *self == WSTATE0_A::ABOVE
+    }
+    #[doc = "Checks if the value of the field is `INSIDE`"]
+    #[inline(always)]
+    pub fn is_inside(&self) -> bool {
+        *self == WSTATE0_A::INSIDE
+    }
+    #[doc = "Checks if the value of the field is `BELOW`"]
+    #[inline(always)]
+    pub fn is_below(&self) -> bool {
+        *self == WSTATE0_A::BELOW
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Comparator 0 Current State"]
+    #[inline(always)]
+    pub fn state0(&self) -> STATE0_R {
+        STATE0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Comparator 1 Current State"]
+    #[inline(always)]
+    pub fn state1(&self) -> STATE1_R {
+        STATE1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 4:5 - Window 0 Current State"]
+    #[inline(always)]
+    pub fn wstate0(&self) -> WSTATE0_R {
+        WSTATE0_R::new(((self.bits >> 4) & 0x03) as u8)
+    }
+}

--- a/pac/atsamd11c14a/src/ac/winctrl.rs
+++ b/pac/atsamd11c14a/src/ac/winctrl.rs
@@ -1,0 +1,157 @@
+#[doc = "Reader of register WINCTRL"]
+pub type R = crate::R<u8, super::WINCTRL>;
+#[doc = "Writer for register WINCTRL"]
+pub type W = crate::W<u8, super::WINCTRL>;
+#[doc = "Register WINCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::WINCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `WEN0`"]
+pub type WEN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WEN0`"]
+pub struct WEN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WEN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Window 0 Interrupt Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum WINTSEL0_A {
+    #[doc = "0: Interrupt on signal above window"]
+    ABOVE,
+    #[doc = "1: Interrupt on signal inside window"]
+    INSIDE,
+    #[doc = "2: Interrupt on signal below window"]
+    BELOW,
+    #[doc = "3: Interrupt on signal outside window"]
+    OUTSIDE,
+}
+impl From<WINTSEL0_A> for u8 {
+    #[inline(always)]
+    fn from(variant: WINTSEL0_A) -> Self {
+        match variant {
+            WINTSEL0_A::ABOVE => 0,
+            WINTSEL0_A::INSIDE => 1,
+            WINTSEL0_A::BELOW => 2,
+            WINTSEL0_A::OUTSIDE => 3,
+        }
+    }
+}
+#[doc = "Reader of field `WINTSEL0`"]
+pub type WINTSEL0_R = crate::R<u8, WINTSEL0_A>;
+impl WINTSEL0_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> WINTSEL0_A {
+        match self.bits {
+            0 => WINTSEL0_A::ABOVE,
+            1 => WINTSEL0_A::INSIDE,
+            2 => WINTSEL0_A::BELOW,
+            3 => WINTSEL0_A::OUTSIDE,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `ABOVE`"]
+    #[inline(always)]
+    pub fn is_above(&self) -> bool {
+        *self == WINTSEL0_A::ABOVE
+    }
+    #[doc = "Checks if the value of the field is `INSIDE`"]
+    #[inline(always)]
+    pub fn is_inside(&self) -> bool {
+        *self == WINTSEL0_A::INSIDE
+    }
+    #[doc = "Checks if the value of the field is `BELOW`"]
+    #[inline(always)]
+    pub fn is_below(&self) -> bool {
+        *self == WINTSEL0_A::BELOW
+    }
+    #[doc = "Checks if the value of the field is `OUTSIDE`"]
+    #[inline(always)]
+    pub fn is_outside(&self) -> bool {
+        *self == WINTSEL0_A::OUTSIDE
+    }
+}
+#[doc = "Write proxy for field `WINTSEL0`"]
+pub struct WINTSEL0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WINTSEL0_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: WINTSEL0_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Interrupt on signal above window"]
+    #[inline(always)]
+    pub fn above(self) -> &'a mut W {
+        self.variant(WINTSEL0_A::ABOVE)
+    }
+    #[doc = "Interrupt on signal inside window"]
+    #[inline(always)]
+    pub fn inside(self) -> &'a mut W {
+        self.variant(WINTSEL0_A::INSIDE)
+    }
+    #[doc = "Interrupt on signal below window"]
+    #[inline(always)]
+    pub fn below(self) -> &'a mut W {
+        self.variant(WINTSEL0_A::BELOW)
+    }
+    #[doc = "Interrupt on signal outside window"]
+    #[inline(always)]
+    pub fn outside(self) -> &'a mut W {
+        self.variant(WINTSEL0_A::OUTSIDE)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 1)) | (((value as u8) & 0x03) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Window 0 Mode Enable"]
+    #[inline(always)]
+    pub fn wen0(&self) -> WEN0_R {
+        WEN0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bits 1:2 - Window 0 Interrupt Selection"]
+    #[inline(always)]
+    pub fn wintsel0(&self) -> WINTSEL0_R {
+        WINTSEL0_R::new(((self.bits >> 1) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Window 0 Mode Enable"]
+    #[inline(always)]
+    pub fn wen0(&mut self) -> WEN0_W {
+        WEN0_W { w: self }
+    }
+    #[doc = "Bits 1:2 - Window 0 Interrupt Selection"]
+    #[inline(always)]
+    pub fn wintsel0(&mut self) -> WINTSEL0_W {
+        WINTSEL0_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc.rs
+++ b/pac/atsamd11c14a/src/adc.rs
@@ -1,0 +1,266 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Control A"]
+    pub ctrla: CTRLA,
+    #[doc = "0x01 - Reference Control"]
+    pub refctrl: REFCTRL,
+    #[doc = "0x02 - Average Control"]
+    pub avgctrl: AVGCTRL,
+    #[doc = "0x03 - Sampling Time Control"]
+    pub sampctrl: SAMPCTRL,
+    #[doc = "0x04 - Control B"]
+    pub ctrlb: CTRLB,
+    _reserved5: [u8; 2usize],
+    #[doc = "0x08 - Window Monitor Control"]
+    pub winctrl: WINCTRL,
+    _reserved6: [u8; 3usize],
+    #[doc = "0x0c - Software Trigger"]
+    pub swtrig: SWTRIG,
+    _reserved7: [u8; 3usize],
+    #[doc = "0x10 - Input Control"]
+    pub inputctrl: INPUTCTRL,
+    #[doc = "0x14 - Event Control"]
+    pub evctrl: EVCTRL,
+    _reserved9: [u8; 1usize],
+    #[doc = "0x16 - Interrupt Enable Clear"]
+    pub intenclr: INTENCLR,
+    #[doc = "0x17 - Interrupt Enable Set"]
+    pub intenset: INTENSET,
+    #[doc = "0x18 - Interrupt Flag Status and Clear"]
+    pub intflag: INTFLAG,
+    #[doc = "0x19 - Status"]
+    pub status: STATUS,
+    #[doc = "0x1a - Result"]
+    pub result: RESULT,
+    #[doc = "0x1c - Window Monitor Lower Threshold"]
+    pub winlt: WINLT,
+    _reserved15: [u8; 2usize],
+    #[doc = "0x20 - Window Monitor Upper Threshold"]
+    pub winut: WINUT,
+    _reserved16: [u8; 2usize],
+    #[doc = "0x24 - Gain Correction"]
+    pub gaincorr: GAINCORR,
+    #[doc = "0x26 - Offset Correction"]
+    pub offsetcorr: OFFSETCORR,
+    #[doc = "0x28 - Calibration"]
+    pub calib: CALIB,
+    #[doc = "0x2a - Debug Control"]
+    pub dbgctrl: DBGCTRL,
+}
+#[doc = "Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrla](ctrla) module"]
+pub type CTRLA = crate::Reg<u8, _CTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLA;
+#[doc = "`read()` method returns [ctrla::R](ctrla::R) reader structure"]
+impl crate::Readable for CTRLA {}
+#[doc = "`write(|w| ..)` method takes [ctrla::W](ctrla::W) writer structure"]
+impl crate::Writable for CTRLA {}
+#[doc = "Control A"]
+pub mod ctrla;
+#[doc = "Reference Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [refctrl](refctrl) module"]
+pub type REFCTRL = crate::Reg<u8, _REFCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _REFCTRL;
+#[doc = "`read()` method returns [refctrl::R](refctrl::R) reader structure"]
+impl crate::Readable for REFCTRL {}
+#[doc = "`write(|w| ..)` method takes [refctrl::W](refctrl::W) writer structure"]
+impl crate::Writable for REFCTRL {}
+#[doc = "Reference Control"]
+pub mod refctrl;
+#[doc = "Average Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [avgctrl](avgctrl) module"]
+pub type AVGCTRL = crate::Reg<u8, _AVGCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _AVGCTRL;
+#[doc = "`read()` method returns [avgctrl::R](avgctrl::R) reader structure"]
+impl crate::Readable for AVGCTRL {}
+#[doc = "`write(|w| ..)` method takes [avgctrl::W](avgctrl::W) writer structure"]
+impl crate::Writable for AVGCTRL {}
+#[doc = "Average Control"]
+pub mod avgctrl;
+#[doc = "Sampling Time Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sampctrl](sampctrl) module"]
+pub type SAMPCTRL = crate::Reg<u8, _SAMPCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _SAMPCTRL;
+#[doc = "`read()` method returns [sampctrl::R](sampctrl::R) reader structure"]
+impl crate::Readable for SAMPCTRL {}
+#[doc = "`write(|w| ..)` method takes [sampctrl::W](sampctrl::W) writer structure"]
+impl crate::Writable for SAMPCTRL {}
+#[doc = "Sampling Time Control"]
+pub mod sampctrl;
+#[doc = "Control B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlb](ctrlb) module"]
+pub type CTRLB = crate::Reg<u16, _CTRLB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLB;
+#[doc = "`read()` method returns [ctrlb::R](ctrlb::R) reader structure"]
+impl crate::Readable for CTRLB {}
+#[doc = "`write(|w| ..)` method takes [ctrlb::W](ctrlb::W) writer structure"]
+impl crate::Writable for CTRLB {}
+#[doc = "Control B"]
+pub mod ctrlb;
+#[doc = "Window Monitor Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [winctrl](winctrl) module"]
+pub type WINCTRL = crate::Reg<u8, _WINCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WINCTRL;
+#[doc = "`read()` method returns [winctrl::R](winctrl::R) reader structure"]
+impl crate::Readable for WINCTRL {}
+#[doc = "`write(|w| ..)` method takes [winctrl::W](winctrl::W) writer structure"]
+impl crate::Writable for WINCTRL {}
+#[doc = "Window Monitor Control"]
+pub mod winctrl;
+#[doc = "Software Trigger\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [swtrig](swtrig) module"]
+pub type SWTRIG = crate::Reg<u8, _SWTRIG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _SWTRIG;
+#[doc = "`read()` method returns [swtrig::R](swtrig::R) reader structure"]
+impl crate::Readable for SWTRIG {}
+#[doc = "`write(|w| ..)` method takes [swtrig::W](swtrig::W) writer structure"]
+impl crate::Writable for SWTRIG {}
+#[doc = "Software Trigger"]
+pub mod swtrig;
+#[doc = "Input Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [inputctrl](inputctrl) module"]
+pub type INPUTCTRL = crate::Reg<u32, _INPUTCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INPUTCTRL;
+#[doc = "`read()` method returns [inputctrl::R](inputctrl::R) reader structure"]
+impl crate::Readable for INPUTCTRL {}
+#[doc = "`write(|w| ..)` method takes [inputctrl::W](inputctrl::W) writer structure"]
+impl crate::Writable for INPUTCTRL {}
+#[doc = "Input Control"]
+pub mod inputctrl;
+#[doc = "Event Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [evctrl](evctrl) module"]
+pub type EVCTRL = crate::Reg<u8, _EVCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EVCTRL;
+#[doc = "`read()` method returns [evctrl::R](evctrl::R) reader structure"]
+impl crate::Readable for EVCTRL {}
+#[doc = "`write(|w| ..)` method takes [evctrl::W](evctrl::W) writer structure"]
+impl crate::Writable for EVCTRL {}
+#[doc = "Event Control"]
+pub mod evctrl;
+#[doc = "Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u8, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "Status"]
+pub mod status;
+#[doc = "Result\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [result](result) module"]
+pub type RESULT = crate::Reg<u16, _RESULT>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _RESULT;
+#[doc = "`read()` method returns [result::R](result::R) reader structure"]
+impl crate::Readable for RESULT {}
+#[doc = "Result"]
+pub mod result;
+#[doc = "Window Monitor Lower Threshold\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [winlt](winlt) module"]
+pub type WINLT = crate::Reg<u16, _WINLT>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WINLT;
+#[doc = "`read()` method returns [winlt::R](winlt::R) reader structure"]
+impl crate::Readable for WINLT {}
+#[doc = "`write(|w| ..)` method takes [winlt::W](winlt::W) writer structure"]
+impl crate::Writable for WINLT {}
+#[doc = "Window Monitor Lower Threshold"]
+pub mod winlt;
+#[doc = "Window Monitor Upper Threshold\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [winut](winut) module"]
+pub type WINUT = crate::Reg<u16, _WINUT>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WINUT;
+#[doc = "`read()` method returns [winut::R](winut::R) reader structure"]
+impl crate::Readable for WINUT {}
+#[doc = "`write(|w| ..)` method takes [winut::W](winut::W) writer structure"]
+impl crate::Writable for WINUT {}
+#[doc = "Window Monitor Upper Threshold"]
+pub mod winut;
+#[doc = "Gain Correction\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [gaincorr](gaincorr) module"]
+pub type GAINCORR = crate::Reg<u16, _GAINCORR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _GAINCORR;
+#[doc = "`read()` method returns [gaincorr::R](gaincorr::R) reader structure"]
+impl crate::Readable for GAINCORR {}
+#[doc = "`write(|w| ..)` method takes [gaincorr::W](gaincorr::W) writer structure"]
+impl crate::Writable for GAINCORR {}
+#[doc = "Gain Correction"]
+pub mod gaincorr;
+#[doc = "Offset Correction\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [offsetcorr](offsetcorr) module"]
+pub type OFFSETCORR = crate::Reg<u16, _OFFSETCORR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _OFFSETCORR;
+#[doc = "`read()` method returns [offsetcorr::R](offsetcorr::R) reader structure"]
+impl crate::Readable for OFFSETCORR {}
+#[doc = "`write(|w| ..)` method takes [offsetcorr::W](offsetcorr::W) writer structure"]
+impl crate::Writable for OFFSETCORR {}
+#[doc = "Offset Correction"]
+pub mod offsetcorr;
+#[doc = "Calibration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [calib](calib) module"]
+pub type CALIB = crate::Reg<u16, _CALIB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CALIB;
+#[doc = "`read()` method returns [calib::R](calib::R) reader structure"]
+impl crate::Readable for CALIB {}
+#[doc = "`write(|w| ..)` method takes [calib::W](calib::W) writer structure"]
+impl crate::Writable for CALIB {}
+#[doc = "Calibration"]
+pub mod calib;
+#[doc = "Debug Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dbgctrl](dbgctrl) module"]
+pub type DBGCTRL = crate::Reg<u8, _DBGCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DBGCTRL;
+#[doc = "`read()` method returns [dbgctrl::R](dbgctrl::R) reader structure"]
+impl crate::Readable for DBGCTRL {}
+#[doc = "`write(|w| ..)` method takes [dbgctrl::W](dbgctrl::W) writer structure"]
+impl crate::Writable for DBGCTRL {}
+#[doc = "Debug Control"]
+pub mod dbgctrl;

--- a/pac/atsamd11c14a/src/adc/avgctrl.rs
+++ b/pac/atsamd11c14a/src/adc/avgctrl.rs
@@ -1,0 +1,244 @@
+#[doc = "Reader of register AVGCTRL"]
+pub type R = crate::R<u8, super::AVGCTRL>;
+#[doc = "Writer for register AVGCTRL"]
+pub type W = crate::W<u8, super::AVGCTRL>;
+#[doc = "Register AVGCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::AVGCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Number of Samples to be Collected\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SAMPLENUM_A {
+    #[doc = "0: 1 sample"]
+    _1,
+    #[doc = "1: 2 samples"]
+    _2,
+    #[doc = "2: 4 samples"]
+    _4,
+    #[doc = "3: 8 samples"]
+    _8,
+    #[doc = "4: 16 samples"]
+    _16,
+    #[doc = "5: 32 samples"]
+    _32,
+    #[doc = "6: 64 samples"]
+    _64,
+    #[doc = "7: 128 samples"]
+    _128,
+    #[doc = "8: 256 samples"]
+    _256,
+    #[doc = "9: 512 samples"]
+    _512,
+    #[doc = "10: 1024 samples"]
+    _1024,
+}
+impl From<SAMPLENUM_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SAMPLENUM_A) -> Self {
+        match variant {
+            SAMPLENUM_A::_1 => 0,
+            SAMPLENUM_A::_2 => 1,
+            SAMPLENUM_A::_4 => 2,
+            SAMPLENUM_A::_8 => 3,
+            SAMPLENUM_A::_16 => 4,
+            SAMPLENUM_A::_32 => 5,
+            SAMPLENUM_A::_64 => 6,
+            SAMPLENUM_A::_128 => 7,
+            SAMPLENUM_A::_256 => 8,
+            SAMPLENUM_A::_512 => 9,
+            SAMPLENUM_A::_1024 => 10,
+        }
+    }
+}
+#[doc = "Reader of field `SAMPLENUM`"]
+pub type SAMPLENUM_R = crate::R<u8, SAMPLENUM_A>;
+impl SAMPLENUM_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, SAMPLENUM_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(SAMPLENUM_A::_1),
+            1 => Val(SAMPLENUM_A::_2),
+            2 => Val(SAMPLENUM_A::_4),
+            3 => Val(SAMPLENUM_A::_8),
+            4 => Val(SAMPLENUM_A::_16),
+            5 => Val(SAMPLENUM_A::_32),
+            6 => Val(SAMPLENUM_A::_64),
+            7 => Val(SAMPLENUM_A::_128),
+            8 => Val(SAMPLENUM_A::_256),
+            9 => Val(SAMPLENUM_A::_512),
+            10 => Val(SAMPLENUM_A::_1024),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `_1`"]
+    #[inline(always)]
+    pub fn is_1(&self) -> bool {
+        *self == SAMPLENUM_A::_1
+    }
+    #[doc = "Checks if the value of the field is `_2`"]
+    #[inline(always)]
+    pub fn is_2(&self) -> bool {
+        *self == SAMPLENUM_A::_2
+    }
+    #[doc = "Checks if the value of the field is `_4`"]
+    #[inline(always)]
+    pub fn is_4(&self) -> bool {
+        *self == SAMPLENUM_A::_4
+    }
+    #[doc = "Checks if the value of the field is `_8`"]
+    #[inline(always)]
+    pub fn is_8(&self) -> bool {
+        *self == SAMPLENUM_A::_8
+    }
+    #[doc = "Checks if the value of the field is `_16`"]
+    #[inline(always)]
+    pub fn is_16(&self) -> bool {
+        *self == SAMPLENUM_A::_16
+    }
+    #[doc = "Checks if the value of the field is `_32`"]
+    #[inline(always)]
+    pub fn is_32(&self) -> bool {
+        *self == SAMPLENUM_A::_32
+    }
+    #[doc = "Checks if the value of the field is `_64`"]
+    #[inline(always)]
+    pub fn is_64(&self) -> bool {
+        *self == SAMPLENUM_A::_64
+    }
+    #[doc = "Checks if the value of the field is `_128`"]
+    #[inline(always)]
+    pub fn is_128(&self) -> bool {
+        *self == SAMPLENUM_A::_128
+    }
+    #[doc = "Checks if the value of the field is `_256`"]
+    #[inline(always)]
+    pub fn is_256(&self) -> bool {
+        *self == SAMPLENUM_A::_256
+    }
+    #[doc = "Checks if the value of the field is `_512`"]
+    #[inline(always)]
+    pub fn is_512(&self) -> bool {
+        *self == SAMPLENUM_A::_512
+    }
+    #[doc = "Checks if the value of the field is `_1024`"]
+    #[inline(always)]
+    pub fn is_1024(&self) -> bool {
+        *self == SAMPLENUM_A::_1024
+    }
+}
+#[doc = "Write proxy for field `SAMPLENUM`"]
+pub struct SAMPLENUM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SAMPLENUM_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SAMPLENUM_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "1 sample"]
+    #[inline(always)]
+    pub fn _1(self) -> &'a mut W {
+        self.variant(SAMPLENUM_A::_1)
+    }
+    #[doc = "2 samples"]
+    #[inline(always)]
+    pub fn _2(self) -> &'a mut W {
+        self.variant(SAMPLENUM_A::_2)
+    }
+    #[doc = "4 samples"]
+    #[inline(always)]
+    pub fn _4(self) -> &'a mut W {
+        self.variant(SAMPLENUM_A::_4)
+    }
+    #[doc = "8 samples"]
+    #[inline(always)]
+    pub fn _8(self) -> &'a mut W {
+        self.variant(SAMPLENUM_A::_8)
+    }
+    #[doc = "16 samples"]
+    #[inline(always)]
+    pub fn _16(self) -> &'a mut W {
+        self.variant(SAMPLENUM_A::_16)
+    }
+    #[doc = "32 samples"]
+    #[inline(always)]
+    pub fn _32(self) -> &'a mut W {
+        self.variant(SAMPLENUM_A::_32)
+    }
+    #[doc = "64 samples"]
+    #[inline(always)]
+    pub fn _64(self) -> &'a mut W {
+        self.variant(SAMPLENUM_A::_64)
+    }
+    #[doc = "128 samples"]
+    #[inline(always)]
+    pub fn _128(self) -> &'a mut W {
+        self.variant(SAMPLENUM_A::_128)
+    }
+    #[doc = "256 samples"]
+    #[inline(always)]
+    pub fn _256(self) -> &'a mut W {
+        self.variant(SAMPLENUM_A::_256)
+    }
+    #[doc = "512 samples"]
+    #[inline(always)]
+    pub fn _512(self) -> &'a mut W {
+        self.variant(SAMPLENUM_A::_512)
+    }
+    #[doc = "1024 samples"]
+    #[inline(always)]
+    pub fn _1024(self) -> &'a mut W {
+        self.variant(SAMPLENUM_A::_1024)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0f) | ((value as u8) & 0x0f);
+        self.w
+    }
+}
+#[doc = "Reader of field `ADJRES`"]
+pub type ADJRES_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `ADJRES`"]
+pub struct ADJRES_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ADJRES_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 4)) | (((value as u8) & 0x07) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:3 - Number of Samples to be Collected"]
+    #[inline(always)]
+    pub fn samplenum(&self) -> SAMPLENUM_R {
+        SAMPLENUM_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:6 - Adjusting Result / Division Coefficient"]
+    #[inline(always)]
+    pub fn adjres(&self) -> ADJRES_R {
+        ADJRES_R::new(((self.bits >> 4) & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Number of Samples to be Collected"]
+    #[inline(always)]
+    pub fn samplenum(&mut self) -> SAMPLENUM_W {
+        SAMPLENUM_W { w: self }
+    }
+    #[doc = "Bits 4:6 - Adjusting Result / Division Coefficient"]
+    #[inline(always)]
+    pub fn adjres(&mut self) -> ADJRES_W {
+        ADJRES_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/calib.rs
+++ b/pac/atsamd11c14a/src/adc/calib.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register CALIB"]
+pub type R = crate::R<u16, super::CALIB>;
+#[doc = "Writer for register CALIB"]
+pub type W = crate::W<u16, super::CALIB>;
+#[doc = "Register CALIB `reset()`'s with value 0"]
+impl crate::ResetValue for super::CALIB {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `LINEARITY_CAL`"]
+pub type LINEARITY_CAL_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `LINEARITY_CAL`"]
+pub struct LINEARITY_CAL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LINEARITY_CAL_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xff) | ((value as u16) & 0xff);
+        self.w
+    }
+}
+#[doc = "Reader of field `BIAS_CAL`"]
+pub type BIAS_CAL_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `BIAS_CAL`"]
+pub struct BIAS_CAL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BIAS_CAL_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 8)) | (((value as u16) & 0x07) << 8);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:7 - Linearity Calibration Value"]
+    #[inline(always)]
+    pub fn linearity_cal(&self) -> LINEARITY_CAL_R {
+        LINEARITY_CAL_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bits 8:10 - Bias Calibration Value"]
+    #[inline(always)]
+    pub fn bias_cal(&self) -> BIAS_CAL_R {
+        BIAS_CAL_R::new(((self.bits >> 8) & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Linearity Calibration Value"]
+    #[inline(always)]
+    pub fn linearity_cal(&mut self) -> LINEARITY_CAL_W {
+        LINEARITY_CAL_W { w: self }
+    }
+    #[doc = "Bits 8:10 - Bias Calibration Value"]
+    #[inline(always)]
+    pub fn bias_cal(&mut self) -> BIAS_CAL_W {
+        BIAS_CAL_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/ctrla.rs
+++ b/pac/atsamd11c14a/src/adc/ctrla.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register CTRLA"]
+pub type R = crate::R<u8, super::CTRLA>;
+#[doc = "Writer for register CTRLA"]
+pub type W = crate::W<u8, super::CTRLA>;
+#[doc = "Register CTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLA {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bit 2 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/ctrlb.rs
+++ b/pac/atsamd11c14a/src/adc/ctrlb.rs
@@ -1,0 +1,422 @@
+#[doc = "Reader of register CTRLB"]
+pub type R = crate::R<u16, super::CTRLB>;
+#[doc = "Writer for register CTRLB"]
+pub type W = crate::W<u16, super::CTRLB>;
+#[doc = "Register CTRLB `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLB {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DIFFMODE`"]
+pub type DIFFMODE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DIFFMODE`"]
+pub struct DIFFMODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIFFMODE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `LEFTADJ`"]
+pub type LEFTADJ_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LEFTADJ`"]
+pub struct LEFTADJ_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LEFTADJ_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `FREERUN`"]
+pub type FREERUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FREERUN`"]
+pub struct FREERUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FREERUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `CORREN`"]
+pub type CORREN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CORREN`"]
+pub struct CORREN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CORREN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u16) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Conversion Result Resolution\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum RESSEL_A {
+    #[doc = "0: 12-bit result"]
+    _12BIT,
+    #[doc = "1: For averaging mode output"]
+    _16BIT,
+    #[doc = "2: 10-bit result"]
+    _10BIT,
+    #[doc = "3: 8-bit result"]
+    _8BIT,
+}
+impl From<RESSEL_A> for u8 {
+    #[inline(always)]
+    fn from(variant: RESSEL_A) -> Self {
+        match variant {
+            RESSEL_A::_12BIT => 0,
+            RESSEL_A::_16BIT => 1,
+            RESSEL_A::_10BIT => 2,
+            RESSEL_A::_8BIT => 3,
+        }
+    }
+}
+#[doc = "Reader of field `RESSEL`"]
+pub type RESSEL_R = crate::R<u8, RESSEL_A>;
+impl RESSEL_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> RESSEL_A {
+        match self.bits {
+            0 => RESSEL_A::_12BIT,
+            1 => RESSEL_A::_16BIT,
+            2 => RESSEL_A::_10BIT,
+            3 => RESSEL_A::_8BIT,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `_12BIT`"]
+    #[inline(always)]
+    pub fn is_12bit(&self) -> bool {
+        *self == RESSEL_A::_12BIT
+    }
+    #[doc = "Checks if the value of the field is `_16BIT`"]
+    #[inline(always)]
+    pub fn is_16bit(&self) -> bool {
+        *self == RESSEL_A::_16BIT
+    }
+    #[doc = "Checks if the value of the field is `_10BIT`"]
+    #[inline(always)]
+    pub fn is_10bit(&self) -> bool {
+        *self == RESSEL_A::_10BIT
+    }
+    #[doc = "Checks if the value of the field is `_8BIT`"]
+    #[inline(always)]
+    pub fn is_8bit(&self) -> bool {
+        *self == RESSEL_A::_8BIT
+    }
+}
+#[doc = "Write proxy for field `RESSEL`"]
+pub struct RESSEL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RESSEL_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: RESSEL_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "12-bit result"]
+    #[inline(always)]
+    pub fn _12bit(self) -> &'a mut W {
+        self.variant(RESSEL_A::_12BIT)
+    }
+    #[doc = "For averaging mode output"]
+    #[inline(always)]
+    pub fn _16bit(self) -> &'a mut W {
+        self.variant(RESSEL_A::_16BIT)
+    }
+    #[doc = "10-bit result"]
+    #[inline(always)]
+    pub fn _10bit(self) -> &'a mut W {
+        self.variant(RESSEL_A::_10BIT)
+    }
+    #[doc = "8-bit result"]
+    #[inline(always)]
+    pub fn _8bit(self) -> &'a mut W {
+        self.variant(RESSEL_A::_8BIT)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 4)) | (((value as u16) & 0x03) << 4);
+        self.w
+    }
+}
+#[doc = "Prescaler Configuration\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PRESCALER_A {
+    #[doc = "0: Peripheral clock divided by 4"]
+    DIV4,
+    #[doc = "1: Peripheral clock divided by 8"]
+    DIV8,
+    #[doc = "2: Peripheral clock divided by 16"]
+    DIV16,
+    #[doc = "3: Peripheral clock divided by 32"]
+    DIV32,
+    #[doc = "4: Peripheral clock divided by 64"]
+    DIV64,
+    #[doc = "5: Peripheral clock divided by 128"]
+    DIV128,
+    #[doc = "6: Peripheral clock divided by 256"]
+    DIV256,
+    #[doc = "7: Peripheral clock divided by 512"]
+    DIV512,
+}
+impl From<PRESCALER_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PRESCALER_A) -> Self {
+        match variant {
+            PRESCALER_A::DIV4 => 0,
+            PRESCALER_A::DIV8 => 1,
+            PRESCALER_A::DIV16 => 2,
+            PRESCALER_A::DIV32 => 3,
+            PRESCALER_A::DIV64 => 4,
+            PRESCALER_A::DIV128 => 5,
+            PRESCALER_A::DIV256 => 6,
+            PRESCALER_A::DIV512 => 7,
+        }
+    }
+}
+#[doc = "Reader of field `PRESCALER`"]
+pub type PRESCALER_R = crate::R<u8, PRESCALER_A>;
+impl PRESCALER_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> PRESCALER_A {
+        match self.bits {
+            0 => PRESCALER_A::DIV4,
+            1 => PRESCALER_A::DIV8,
+            2 => PRESCALER_A::DIV16,
+            3 => PRESCALER_A::DIV32,
+            4 => PRESCALER_A::DIV64,
+            5 => PRESCALER_A::DIV128,
+            6 => PRESCALER_A::DIV256,
+            7 => PRESCALER_A::DIV512,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DIV4`"]
+    #[inline(always)]
+    pub fn is_div4(&self) -> bool {
+        *self == PRESCALER_A::DIV4
+    }
+    #[doc = "Checks if the value of the field is `DIV8`"]
+    #[inline(always)]
+    pub fn is_div8(&self) -> bool {
+        *self == PRESCALER_A::DIV8
+    }
+    #[doc = "Checks if the value of the field is `DIV16`"]
+    #[inline(always)]
+    pub fn is_div16(&self) -> bool {
+        *self == PRESCALER_A::DIV16
+    }
+    #[doc = "Checks if the value of the field is `DIV32`"]
+    #[inline(always)]
+    pub fn is_div32(&self) -> bool {
+        *self == PRESCALER_A::DIV32
+    }
+    #[doc = "Checks if the value of the field is `DIV64`"]
+    #[inline(always)]
+    pub fn is_div64(&self) -> bool {
+        *self == PRESCALER_A::DIV64
+    }
+    #[doc = "Checks if the value of the field is `DIV128`"]
+    #[inline(always)]
+    pub fn is_div128(&self) -> bool {
+        *self == PRESCALER_A::DIV128
+    }
+    #[doc = "Checks if the value of the field is `DIV256`"]
+    #[inline(always)]
+    pub fn is_div256(&self) -> bool {
+        *self == PRESCALER_A::DIV256
+    }
+    #[doc = "Checks if the value of the field is `DIV512`"]
+    #[inline(always)]
+    pub fn is_div512(&self) -> bool {
+        *self == PRESCALER_A::DIV512
+    }
+}
+#[doc = "Write proxy for field `PRESCALER`"]
+pub struct PRESCALER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PRESCALER_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PRESCALER_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Peripheral clock divided by 4"]
+    #[inline(always)]
+    pub fn div4(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV4)
+    }
+    #[doc = "Peripheral clock divided by 8"]
+    #[inline(always)]
+    pub fn div8(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV8)
+    }
+    #[doc = "Peripheral clock divided by 16"]
+    #[inline(always)]
+    pub fn div16(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV16)
+    }
+    #[doc = "Peripheral clock divided by 32"]
+    #[inline(always)]
+    pub fn div32(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV32)
+    }
+    #[doc = "Peripheral clock divided by 64"]
+    #[inline(always)]
+    pub fn div64(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV64)
+    }
+    #[doc = "Peripheral clock divided by 128"]
+    #[inline(always)]
+    pub fn div128(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV128)
+    }
+    #[doc = "Peripheral clock divided by 256"]
+    #[inline(always)]
+    pub fn div256(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV256)
+    }
+    #[doc = "Peripheral clock divided by 512"]
+    #[inline(always)]
+    pub fn div512(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV512)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 8)) | (((value as u16) & 0x07) << 8);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Differential Mode"]
+    #[inline(always)]
+    pub fn diffmode(&self) -> DIFFMODE_R {
+        DIFFMODE_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Left-Adjusted Result"]
+    #[inline(always)]
+    pub fn leftadj(&self) -> LEFTADJ_R {
+        LEFTADJ_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Free Running Mode"]
+    #[inline(always)]
+    pub fn freerun(&self) -> FREERUN_R {
+        FREERUN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Digital Correction Logic Enabled"]
+    #[inline(always)]
+    pub fn corren(&self) -> CORREN_R {
+        CORREN_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bits 4:5 - Conversion Result Resolution"]
+    #[inline(always)]
+    pub fn ressel(&self) -> RESSEL_R {
+        RESSEL_R::new(((self.bits >> 4) & 0x03) as u8)
+    }
+    #[doc = "Bits 8:10 - Prescaler Configuration"]
+    #[inline(always)]
+    pub fn prescaler(&self) -> PRESCALER_R {
+        PRESCALER_R::new(((self.bits >> 8) & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Differential Mode"]
+    #[inline(always)]
+    pub fn diffmode(&mut self) -> DIFFMODE_W {
+        DIFFMODE_W { w: self }
+    }
+    #[doc = "Bit 1 - Left-Adjusted Result"]
+    #[inline(always)]
+    pub fn leftadj(&mut self) -> LEFTADJ_W {
+        LEFTADJ_W { w: self }
+    }
+    #[doc = "Bit 2 - Free Running Mode"]
+    #[inline(always)]
+    pub fn freerun(&mut self) -> FREERUN_W {
+        FREERUN_W { w: self }
+    }
+    #[doc = "Bit 3 - Digital Correction Logic Enabled"]
+    #[inline(always)]
+    pub fn corren(&mut self) -> CORREN_W {
+        CORREN_W { w: self }
+    }
+    #[doc = "Bits 4:5 - Conversion Result Resolution"]
+    #[inline(always)]
+    pub fn ressel(&mut self) -> RESSEL_W {
+        RESSEL_W { w: self }
+    }
+    #[doc = "Bits 8:10 - Prescaler Configuration"]
+    #[inline(always)]
+    pub fn prescaler(&mut self) -> PRESCALER_W {
+        PRESCALER_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/dbgctrl.rs
+++ b/pac/atsamd11c14a/src/adc/dbgctrl.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register DBGCTRL"]
+pub type R = crate::R<u8, super::DBGCTRL>;
+#[doc = "Writer for register DBGCTRL"]
+pub type W = crate::W<u8, super::DBGCTRL>;
+#[doc = "Register DBGCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::DBGCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DBGRUN`"]
+pub type DBGRUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DBGRUN`"]
+pub struct DBGRUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DBGRUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Debug Run"]
+    #[inline(always)]
+    pub fn dbgrun(&self) -> DBGRUN_R {
+        DBGRUN_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Debug Run"]
+    #[inline(always)]
+    pub fn dbgrun(&mut self) -> DBGRUN_W {
+        DBGRUN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/evctrl.rs
+++ b/pac/atsamd11c14a/src/adc/evctrl.rs
@@ -1,0 +1,152 @@
+#[doc = "Reader of register EVCTRL"]
+pub type R = crate::R<u8, super::EVCTRL>;
+#[doc = "Writer for register EVCTRL"]
+pub type W = crate::W<u8, super::EVCTRL>;
+#[doc = "Register EVCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::EVCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `STARTEI`"]
+pub type STARTEI_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `STARTEI`"]
+pub struct STARTEI_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STARTEI_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCEI`"]
+pub type SYNCEI_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCEI`"]
+pub struct SYNCEI_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCEI_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RESRDYEO`"]
+pub type RESRDYEO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RESRDYEO`"]
+pub struct RESRDYEO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RESRDYEO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `WINMONEO`"]
+pub type WINMONEO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WINMONEO`"]
+pub struct WINMONEO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WINMONEO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Start Conversion Event In"]
+    #[inline(always)]
+    pub fn startei(&self) -> STARTEI_R {
+        STARTEI_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Synchronization Event In"]
+    #[inline(always)]
+    pub fn syncei(&self) -> SYNCEI_R {
+        SYNCEI_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Result Ready Event Out"]
+    #[inline(always)]
+    pub fn resrdyeo(&self) -> RESRDYEO_R {
+        RESRDYEO_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Window Monitor Event Out"]
+    #[inline(always)]
+    pub fn winmoneo(&self) -> WINMONEO_R {
+        WINMONEO_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Start Conversion Event In"]
+    #[inline(always)]
+    pub fn startei(&mut self) -> STARTEI_W {
+        STARTEI_W { w: self }
+    }
+    #[doc = "Bit 1 - Synchronization Event In"]
+    #[inline(always)]
+    pub fn syncei(&mut self) -> SYNCEI_W {
+        SYNCEI_W { w: self }
+    }
+    #[doc = "Bit 4 - Result Ready Event Out"]
+    #[inline(always)]
+    pub fn resrdyeo(&mut self) -> RESRDYEO_W {
+        RESRDYEO_W { w: self }
+    }
+    #[doc = "Bit 5 - Window Monitor Event Out"]
+    #[inline(always)]
+    pub fn winmoneo(&mut self) -> WINMONEO_W {
+        WINMONEO_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/gaincorr.rs
+++ b/pac/atsamd11c14a/src/adc/gaincorr.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register GAINCORR"]
+pub type R = crate::R<u16, super::GAINCORR>;
+#[doc = "Writer for register GAINCORR"]
+pub type W = crate::W<u16, super::GAINCORR>;
+#[doc = "Register GAINCORR `reset()`'s with value 0"]
+impl crate::ResetValue for super::GAINCORR {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `GAINCORR`"]
+pub type GAINCORR_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `GAINCORR`"]
+pub struct GAINCORR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> GAINCORR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0fff) | ((value as u16) & 0x0fff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:11 - Gain Correction Value"]
+    #[inline(always)]
+    pub fn gaincorr(&self) -> GAINCORR_R {
+        GAINCORR_R::new((self.bits & 0x0fff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:11 - Gain Correction Value"]
+    #[inline(always)]
+    pub fn gaincorr(&mut self) -> GAINCORR_W {
+        GAINCORR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/inputctrl.rs
+++ b/pac/atsamd11c14a/src/adc/inputctrl.rs
@@ -1,0 +1,788 @@
+#[doc = "Reader of register INPUTCTRL"]
+pub type R = crate::R<u32, super::INPUTCTRL>;
+#[doc = "Writer for register INPUTCTRL"]
+pub type W = crate::W<u32, super::INPUTCTRL>;
+#[doc = "Register INPUTCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::INPUTCTRL {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Positive Mux Input Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MUXPOS_A {
+    #[doc = "0: ADC AIN0 Pin"]
+    PIN0,
+    #[doc = "1: ADC AIN1 Pin"]
+    PIN1,
+    #[doc = "2: ADC AIN2 Pin"]
+    PIN2,
+    #[doc = "3: ADC AIN3 Pin"]
+    PIN3,
+    #[doc = "4: ADC AIN4 Pin"]
+    PIN4,
+    #[doc = "5: ADC AIN5 Pin"]
+    PIN5,
+    #[doc = "6: ADC AIN6 Pin"]
+    PIN6,
+    #[doc = "7: ADC AIN7 Pin"]
+    PIN7,
+    #[doc = "8: ADC AIN8 Pin"]
+    PIN8,
+    #[doc = "9: ADC AIN9 Pin"]
+    PIN9,
+    #[doc = "10: ADC AIN10 Pin"]
+    PIN10,
+    #[doc = "11: ADC AIN11 Pin"]
+    PIN11,
+    #[doc = "12: ADC AIN12 Pin"]
+    PIN12,
+    #[doc = "13: ADC AIN13 Pin"]
+    PIN13,
+    #[doc = "14: ADC AIN14 Pin"]
+    PIN14,
+    #[doc = "15: ADC AIN15 Pin"]
+    PIN15,
+    #[doc = "16: ADC AIN16 Pin"]
+    PIN16,
+    #[doc = "17: ADC AIN17 Pin"]
+    PIN17,
+    #[doc = "18: ADC AIN18 Pin"]
+    PIN18,
+    #[doc = "19: ADC AIN19 Pin"]
+    PIN19,
+    #[doc = "24: Temperature Reference"]
+    TEMP,
+    #[doc = "25: Bandgap Voltage"]
+    BANDGAP,
+    #[doc = "26: 1/4  Scaled Core Supply"]
+    SCALEDCOREVCC,
+    #[doc = "27: 1/4  Scaled I/O Supply"]
+    SCALEDIOVCC,
+    #[doc = "28: DAC Output"]
+    DAC,
+}
+impl From<MUXPOS_A> for u8 {
+    #[inline(always)]
+    fn from(variant: MUXPOS_A) -> Self {
+        match variant {
+            MUXPOS_A::PIN0 => 0,
+            MUXPOS_A::PIN1 => 1,
+            MUXPOS_A::PIN2 => 2,
+            MUXPOS_A::PIN3 => 3,
+            MUXPOS_A::PIN4 => 4,
+            MUXPOS_A::PIN5 => 5,
+            MUXPOS_A::PIN6 => 6,
+            MUXPOS_A::PIN7 => 7,
+            MUXPOS_A::PIN8 => 8,
+            MUXPOS_A::PIN9 => 9,
+            MUXPOS_A::PIN10 => 10,
+            MUXPOS_A::PIN11 => 11,
+            MUXPOS_A::PIN12 => 12,
+            MUXPOS_A::PIN13 => 13,
+            MUXPOS_A::PIN14 => 14,
+            MUXPOS_A::PIN15 => 15,
+            MUXPOS_A::PIN16 => 16,
+            MUXPOS_A::PIN17 => 17,
+            MUXPOS_A::PIN18 => 18,
+            MUXPOS_A::PIN19 => 19,
+            MUXPOS_A::TEMP => 24,
+            MUXPOS_A::BANDGAP => 25,
+            MUXPOS_A::SCALEDCOREVCC => 26,
+            MUXPOS_A::SCALEDIOVCC => 27,
+            MUXPOS_A::DAC => 28,
+        }
+    }
+}
+#[doc = "Reader of field `MUXPOS`"]
+pub type MUXPOS_R = crate::R<u8, MUXPOS_A>;
+impl MUXPOS_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, MUXPOS_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(MUXPOS_A::PIN0),
+            1 => Val(MUXPOS_A::PIN1),
+            2 => Val(MUXPOS_A::PIN2),
+            3 => Val(MUXPOS_A::PIN3),
+            4 => Val(MUXPOS_A::PIN4),
+            5 => Val(MUXPOS_A::PIN5),
+            6 => Val(MUXPOS_A::PIN6),
+            7 => Val(MUXPOS_A::PIN7),
+            8 => Val(MUXPOS_A::PIN8),
+            9 => Val(MUXPOS_A::PIN9),
+            10 => Val(MUXPOS_A::PIN10),
+            11 => Val(MUXPOS_A::PIN11),
+            12 => Val(MUXPOS_A::PIN12),
+            13 => Val(MUXPOS_A::PIN13),
+            14 => Val(MUXPOS_A::PIN14),
+            15 => Val(MUXPOS_A::PIN15),
+            16 => Val(MUXPOS_A::PIN16),
+            17 => Val(MUXPOS_A::PIN17),
+            18 => Val(MUXPOS_A::PIN18),
+            19 => Val(MUXPOS_A::PIN19),
+            24 => Val(MUXPOS_A::TEMP),
+            25 => Val(MUXPOS_A::BANDGAP),
+            26 => Val(MUXPOS_A::SCALEDCOREVCC),
+            27 => Val(MUXPOS_A::SCALEDIOVCC),
+            28 => Val(MUXPOS_A::DAC),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `PIN0`"]
+    #[inline(always)]
+    pub fn is_pin0(&self) -> bool {
+        *self == MUXPOS_A::PIN0
+    }
+    #[doc = "Checks if the value of the field is `PIN1`"]
+    #[inline(always)]
+    pub fn is_pin1(&self) -> bool {
+        *self == MUXPOS_A::PIN1
+    }
+    #[doc = "Checks if the value of the field is `PIN2`"]
+    #[inline(always)]
+    pub fn is_pin2(&self) -> bool {
+        *self == MUXPOS_A::PIN2
+    }
+    #[doc = "Checks if the value of the field is `PIN3`"]
+    #[inline(always)]
+    pub fn is_pin3(&self) -> bool {
+        *self == MUXPOS_A::PIN3
+    }
+    #[doc = "Checks if the value of the field is `PIN4`"]
+    #[inline(always)]
+    pub fn is_pin4(&self) -> bool {
+        *self == MUXPOS_A::PIN4
+    }
+    #[doc = "Checks if the value of the field is `PIN5`"]
+    #[inline(always)]
+    pub fn is_pin5(&self) -> bool {
+        *self == MUXPOS_A::PIN5
+    }
+    #[doc = "Checks if the value of the field is `PIN6`"]
+    #[inline(always)]
+    pub fn is_pin6(&self) -> bool {
+        *self == MUXPOS_A::PIN6
+    }
+    #[doc = "Checks if the value of the field is `PIN7`"]
+    #[inline(always)]
+    pub fn is_pin7(&self) -> bool {
+        *self == MUXPOS_A::PIN7
+    }
+    #[doc = "Checks if the value of the field is `PIN8`"]
+    #[inline(always)]
+    pub fn is_pin8(&self) -> bool {
+        *self == MUXPOS_A::PIN8
+    }
+    #[doc = "Checks if the value of the field is `PIN9`"]
+    #[inline(always)]
+    pub fn is_pin9(&self) -> bool {
+        *self == MUXPOS_A::PIN9
+    }
+    #[doc = "Checks if the value of the field is `PIN10`"]
+    #[inline(always)]
+    pub fn is_pin10(&self) -> bool {
+        *self == MUXPOS_A::PIN10
+    }
+    #[doc = "Checks if the value of the field is `PIN11`"]
+    #[inline(always)]
+    pub fn is_pin11(&self) -> bool {
+        *self == MUXPOS_A::PIN11
+    }
+    #[doc = "Checks if the value of the field is `PIN12`"]
+    #[inline(always)]
+    pub fn is_pin12(&self) -> bool {
+        *self == MUXPOS_A::PIN12
+    }
+    #[doc = "Checks if the value of the field is `PIN13`"]
+    #[inline(always)]
+    pub fn is_pin13(&self) -> bool {
+        *self == MUXPOS_A::PIN13
+    }
+    #[doc = "Checks if the value of the field is `PIN14`"]
+    #[inline(always)]
+    pub fn is_pin14(&self) -> bool {
+        *self == MUXPOS_A::PIN14
+    }
+    #[doc = "Checks if the value of the field is `PIN15`"]
+    #[inline(always)]
+    pub fn is_pin15(&self) -> bool {
+        *self == MUXPOS_A::PIN15
+    }
+    #[doc = "Checks if the value of the field is `PIN16`"]
+    #[inline(always)]
+    pub fn is_pin16(&self) -> bool {
+        *self == MUXPOS_A::PIN16
+    }
+    #[doc = "Checks if the value of the field is `PIN17`"]
+    #[inline(always)]
+    pub fn is_pin17(&self) -> bool {
+        *self == MUXPOS_A::PIN17
+    }
+    #[doc = "Checks if the value of the field is `PIN18`"]
+    #[inline(always)]
+    pub fn is_pin18(&self) -> bool {
+        *self == MUXPOS_A::PIN18
+    }
+    #[doc = "Checks if the value of the field is `PIN19`"]
+    #[inline(always)]
+    pub fn is_pin19(&self) -> bool {
+        *self == MUXPOS_A::PIN19
+    }
+    #[doc = "Checks if the value of the field is `TEMP`"]
+    #[inline(always)]
+    pub fn is_temp(&self) -> bool {
+        *self == MUXPOS_A::TEMP
+    }
+    #[doc = "Checks if the value of the field is `BANDGAP`"]
+    #[inline(always)]
+    pub fn is_bandgap(&self) -> bool {
+        *self == MUXPOS_A::BANDGAP
+    }
+    #[doc = "Checks if the value of the field is `SCALEDCOREVCC`"]
+    #[inline(always)]
+    pub fn is_scaledcorevcc(&self) -> bool {
+        *self == MUXPOS_A::SCALEDCOREVCC
+    }
+    #[doc = "Checks if the value of the field is `SCALEDIOVCC`"]
+    #[inline(always)]
+    pub fn is_scalediovcc(&self) -> bool {
+        *self == MUXPOS_A::SCALEDIOVCC
+    }
+    #[doc = "Checks if the value of the field is `DAC`"]
+    #[inline(always)]
+    pub fn is_dac(&self) -> bool {
+        *self == MUXPOS_A::DAC
+    }
+}
+#[doc = "Write proxy for field `MUXPOS`"]
+pub struct MUXPOS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MUXPOS_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: MUXPOS_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "ADC AIN0 Pin"]
+    #[inline(always)]
+    pub fn pin0(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN0)
+    }
+    #[doc = "ADC AIN1 Pin"]
+    #[inline(always)]
+    pub fn pin1(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN1)
+    }
+    #[doc = "ADC AIN2 Pin"]
+    #[inline(always)]
+    pub fn pin2(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN2)
+    }
+    #[doc = "ADC AIN3 Pin"]
+    #[inline(always)]
+    pub fn pin3(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN3)
+    }
+    #[doc = "ADC AIN4 Pin"]
+    #[inline(always)]
+    pub fn pin4(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN4)
+    }
+    #[doc = "ADC AIN5 Pin"]
+    #[inline(always)]
+    pub fn pin5(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN5)
+    }
+    #[doc = "ADC AIN6 Pin"]
+    #[inline(always)]
+    pub fn pin6(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN6)
+    }
+    #[doc = "ADC AIN7 Pin"]
+    #[inline(always)]
+    pub fn pin7(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN7)
+    }
+    #[doc = "ADC AIN8 Pin"]
+    #[inline(always)]
+    pub fn pin8(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN8)
+    }
+    #[doc = "ADC AIN9 Pin"]
+    #[inline(always)]
+    pub fn pin9(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN9)
+    }
+    #[doc = "ADC AIN10 Pin"]
+    #[inline(always)]
+    pub fn pin10(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN10)
+    }
+    #[doc = "ADC AIN11 Pin"]
+    #[inline(always)]
+    pub fn pin11(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN11)
+    }
+    #[doc = "ADC AIN12 Pin"]
+    #[inline(always)]
+    pub fn pin12(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN12)
+    }
+    #[doc = "ADC AIN13 Pin"]
+    #[inline(always)]
+    pub fn pin13(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN13)
+    }
+    #[doc = "ADC AIN14 Pin"]
+    #[inline(always)]
+    pub fn pin14(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN14)
+    }
+    #[doc = "ADC AIN15 Pin"]
+    #[inline(always)]
+    pub fn pin15(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN15)
+    }
+    #[doc = "ADC AIN16 Pin"]
+    #[inline(always)]
+    pub fn pin16(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN16)
+    }
+    #[doc = "ADC AIN17 Pin"]
+    #[inline(always)]
+    pub fn pin17(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN17)
+    }
+    #[doc = "ADC AIN18 Pin"]
+    #[inline(always)]
+    pub fn pin18(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN18)
+    }
+    #[doc = "ADC AIN19 Pin"]
+    #[inline(always)]
+    pub fn pin19(self) -> &'a mut W {
+        self.variant(MUXPOS_A::PIN19)
+    }
+    #[doc = "Temperature Reference"]
+    #[inline(always)]
+    pub fn temp(self) -> &'a mut W {
+        self.variant(MUXPOS_A::TEMP)
+    }
+    #[doc = "Bandgap Voltage"]
+    #[inline(always)]
+    pub fn bandgap(self) -> &'a mut W {
+        self.variant(MUXPOS_A::BANDGAP)
+    }
+    #[doc = "1/4 Scaled Core Supply"]
+    #[inline(always)]
+    pub fn scaledcorevcc(self) -> &'a mut W {
+        self.variant(MUXPOS_A::SCALEDCOREVCC)
+    }
+    #[doc = "1/4 Scaled I/O Supply"]
+    #[inline(always)]
+    pub fn scalediovcc(self) -> &'a mut W {
+        self.variant(MUXPOS_A::SCALEDIOVCC)
+    }
+    #[doc = "DAC Output"]
+    #[inline(always)]
+    pub fn dac(self) -> &'a mut W {
+        self.variant(MUXPOS_A::DAC)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x1f) | ((value as u32) & 0x1f);
+        self.w
+    }
+}
+#[doc = "Negative Mux Input Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MUXNEG_A {
+    #[doc = "0: ADC AIN0 Pin"]
+    PIN0,
+    #[doc = "1: ADC AIN1 Pin"]
+    PIN1,
+    #[doc = "2: ADC AIN2 Pin"]
+    PIN2,
+    #[doc = "3: ADC AIN3 Pin"]
+    PIN3,
+    #[doc = "4: ADC AIN4 Pin"]
+    PIN4,
+    #[doc = "5: ADC AIN5 Pin"]
+    PIN5,
+    #[doc = "6: ADC AIN6 Pin"]
+    PIN6,
+    #[doc = "7: ADC AIN7 Pin"]
+    PIN7,
+    #[doc = "24: Internal Ground"]
+    GND,
+    #[doc = "25: I/O Ground"]
+    IOGND,
+}
+impl From<MUXNEG_A> for u8 {
+    #[inline(always)]
+    fn from(variant: MUXNEG_A) -> Self {
+        match variant {
+            MUXNEG_A::PIN0 => 0,
+            MUXNEG_A::PIN1 => 1,
+            MUXNEG_A::PIN2 => 2,
+            MUXNEG_A::PIN3 => 3,
+            MUXNEG_A::PIN4 => 4,
+            MUXNEG_A::PIN5 => 5,
+            MUXNEG_A::PIN6 => 6,
+            MUXNEG_A::PIN7 => 7,
+            MUXNEG_A::GND => 24,
+            MUXNEG_A::IOGND => 25,
+        }
+    }
+}
+#[doc = "Reader of field `MUXNEG`"]
+pub type MUXNEG_R = crate::R<u8, MUXNEG_A>;
+impl MUXNEG_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, MUXNEG_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(MUXNEG_A::PIN0),
+            1 => Val(MUXNEG_A::PIN1),
+            2 => Val(MUXNEG_A::PIN2),
+            3 => Val(MUXNEG_A::PIN3),
+            4 => Val(MUXNEG_A::PIN4),
+            5 => Val(MUXNEG_A::PIN5),
+            6 => Val(MUXNEG_A::PIN6),
+            7 => Val(MUXNEG_A::PIN7),
+            24 => Val(MUXNEG_A::GND),
+            25 => Val(MUXNEG_A::IOGND),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `PIN0`"]
+    #[inline(always)]
+    pub fn is_pin0(&self) -> bool {
+        *self == MUXNEG_A::PIN0
+    }
+    #[doc = "Checks if the value of the field is `PIN1`"]
+    #[inline(always)]
+    pub fn is_pin1(&self) -> bool {
+        *self == MUXNEG_A::PIN1
+    }
+    #[doc = "Checks if the value of the field is `PIN2`"]
+    #[inline(always)]
+    pub fn is_pin2(&self) -> bool {
+        *self == MUXNEG_A::PIN2
+    }
+    #[doc = "Checks if the value of the field is `PIN3`"]
+    #[inline(always)]
+    pub fn is_pin3(&self) -> bool {
+        *self == MUXNEG_A::PIN3
+    }
+    #[doc = "Checks if the value of the field is `PIN4`"]
+    #[inline(always)]
+    pub fn is_pin4(&self) -> bool {
+        *self == MUXNEG_A::PIN4
+    }
+    #[doc = "Checks if the value of the field is `PIN5`"]
+    #[inline(always)]
+    pub fn is_pin5(&self) -> bool {
+        *self == MUXNEG_A::PIN5
+    }
+    #[doc = "Checks if the value of the field is `PIN6`"]
+    #[inline(always)]
+    pub fn is_pin6(&self) -> bool {
+        *self == MUXNEG_A::PIN6
+    }
+    #[doc = "Checks if the value of the field is `PIN7`"]
+    #[inline(always)]
+    pub fn is_pin7(&self) -> bool {
+        *self == MUXNEG_A::PIN7
+    }
+    #[doc = "Checks if the value of the field is `GND`"]
+    #[inline(always)]
+    pub fn is_gnd(&self) -> bool {
+        *self == MUXNEG_A::GND
+    }
+    #[doc = "Checks if the value of the field is `IOGND`"]
+    #[inline(always)]
+    pub fn is_iognd(&self) -> bool {
+        *self == MUXNEG_A::IOGND
+    }
+}
+#[doc = "Write proxy for field `MUXNEG`"]
+pub struct MUXNEG_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MUXNEG_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: MUXNEG_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "ADC AIN0 Pin"]
+    #[inline(always)]
+    pub fn pin0(self) -> &'a mut W {
+        self.variant(MUXNEG_A::PIN0)
+    }
+    #[doc = "ADC AIN1 Pin"]
+    #[inline(always)]
+    pub fn pin1(self) -> &'a mut W {
+        self.variant(MUXNEG_A::PIN1)
+    }
+    #[doc = "ADC AIN2 Pin"]
+    #[inline(always)]
+    pub fn pin2(self) -> &'a mut W {
+        self.variant(MUXNEG_A::PIN2)
+    }
+    #[doc = "ADC AIN3 Pin"]
+    #[inline(always)]
+    pub fn pin3(self) -> &'a mut W {
+        self.variant(MUXNEG_A::PIN3)
+    }
+    #[doc = "ADC AIN4 Pin"]
+    #[inline(always)]
+    pub fn pin4(self) -> &'a mut W {
+        self.variant(MUXNEG_A::PIN4)
+    }
+    #[doc = "ADC AIN5 Pin"]
+    #[inline(always)]
+    pub fn pin5(self) -> &'a mut W {
+        self.variant(MUXNEG_A::PIN5)
+    }
+    #[doc = "ADC AIN6 Pin"]
+    #[inline(always)]
+    pub fn pin6(self) -> &'a mut W {
+        self.variant(MUXNEG_A::PIN6)
+    }
+    #[doc = "ADC AIN7 Pin"]
+    #[inline(always)]
+    pub fn pin7(self) -> &'a mut W {
+        self.variant(MUXNEG_A::PIN7)
+    }
+    #[doc = "Internal Ground"]
+    #[inline(always)]
+    pub fn gnd(self) -> &'a mut W {
+        self.variant(MUXNEG_A::GND)
+    }
+    #[doc = "I/O Ground"]
+    #[inline(always)]
+    pub fn iognd(self) -> &'a mut W {
+        self.variant(MUXNEG_A::IOGND)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x1f << 8)) | (((value as u32) & 0x1f) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `INPUTSCAN`"]
+pub type INPUTSCAN_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `INPUTSCAN`"]
+pub struct INPUTSCAN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INPUTSCAN_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 16)) | (((value as u32) & 0x0f) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `INPUTOFFSET`"]
+pub type INPUTOFFSET_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `INPUTOFFSET`"]
+pub struct INPUTOFFSET_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INPUTOFFSET_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 20)) | (((value as u32) & 0x0f) << 20);
+        self.w
+    }
+}
+#[doc = "Gain Factor Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum GAIN_A {
+    #[doc = "0: 1x"]
+    _1X,
+    #[doc = "1: 2x"]
+    _2X,
+    #[doc = "2: 4x"]
+    _4X,
+    #[doc = "3: 8x"]
+    _8X,
+    #[doc = "4: 16x"]
+    _16X,
+    #[doc = "15: 1/2x"]
+    DIV2,
+}
+impl From<GAIN_A> for u8 {
+    #[inline(always)]
+    fn from(variant: GAIN_A) -> Self {
+        match variant {
+            GAIN_A::_1X => 0,
+            GAIN_A::_2X => 1,
+            GAIN_A::_4X => 2,
+            GAIN_A::_8X => 3,
+            GAIN_A::_16X => 4,
+            GAIN_A::DIV2 => 15,
+        }
+    }
+}
+#[doc = "Reader of field `GAIN`"]
+pub type GAIN_R = crate::R<u8, GAIN_A>;
+impl GAIN_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, GAIN_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(GAIN_A::_1X),
+            1 => Val(GAIN_A::_2X),
+            2 => Val(GAIN_A::_4X),
+            3 => Val(GAIN_A::_8X),
+            4 => Val(GAIN_A::_16X),
+            15 => Val(GAIN_A::DIV2),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `_1X`"]
+    #[inline(always)]
+    pub fn is_1x(&self) -> bool {
+        *self == GAIN_A::_1X
+    }
+    #[doc = "Checks if the value of the field is `_2X`"]
+    #[inline(always)]
+    pub fn is_2x(&self) -> bool {
+        *self == GAIN_A::_2X
+    }
+    #[doc = "Checks if the value of the field is `_4X`"]
+    #[inline(always)]
+    pub fn is_4x(&self) -> bool {
+        *self == GAIN_A::_4X
+    }
+    #[doc = "Checks if the value of the field is `_8X`"]
+    #[inline(always)]
+    pub fn is_8x(&self) -> bool {
+        *self == GAIN_A::_8X
+    }
+    #[doc = "Checks if the value of the field is `_16X`"]
+    #[inline(always)]
+    pub fn is_16x(&self) -> bool {
+        *self == GAIN_A::_16X
+    }
+    #[doc = "Checks if the value of the field is `DIV2`"]
+    #[inline(always)]
+    pub fn is_div2(&self) -> bool {
+        *self == GAIN_A::DIV2
+    }
+}
+#[doc = "Write proxy for field `GAIN`"]
+pub struct GAIN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> GAIN_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: GAIN_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "1x"]
+    #[inline(always)]
+    pub fn _1x(self) -> &'a mut W {
+        self.variant(GAIN_A::_1X)
+    }
+    #[doc = "2x"]
+    #[inline(always)]
+    pub fn _2x(self) -> &'a mut W {
+        self.variant(GAIN_A::_2X)
+    }
+    #[doc = "4x"]
+    #[inline(always)]
+    pub fn _4x(self) -> &'a mut W {
+        self.variant(GAIN_A::_4X)
+    }
+    #[doc = "8x"]
+    #[inline(always)]
+    pub fn _8x(self) -> &'a mut W {
+        self.variant(GAIN_A::_8X)
+    }
+    #[doc = "16x"]
+    #[inline(always)]
+    pub fn _16x(self) -> &'a mut W {
+        self.variant(GAIN_A::_16X)
+    }
+    #[doc = "1/2x"]
+    #[inline(always)]
+    pub fn div2(self) -> &'a mut W {
+        self.variant(GAIN_A::DIV2)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 24)) | (((value as u32) & 0x0f) << 24);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:4 - Positive Mux Input Selection"]
+    #[inline(always)]
+    pub fn muxpos(&self) -> MUXPOS_R {
+        MUXPOS_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bits 8:12 - Negative Mux Input Selection"]
+    #[inline(always)]
+    pub fn muxneg(&self) -> MUXNEG_R {
+        MUXNEG_R::new(((self.bits >> 8) & 0x1f) as u8)
+    }
+    #[doc = "Bits 16:19 - Number of Input Channels Included in Scan"]
+    #[inline(always)]
+    pub fn inputscan(&self) -> INPUTSCAN_R {
+        INPUTSCAN_R::new(((self.bits >> 16) & 0x0f) as u8)
+    }
+    #[doc = "Bits 20:23 - Positive Mux Setting Offset"]
+    #[inline(always)]
+    pub fn inputoffset(&self) -> INPUTOFFSET_R {
+        INPUTOFFSET_R::new(((self.bits >> 20) & 0x0f) as u8)
+    }
+    #[doc = "Bits 24:27 - Gain Factor Selection"]
+    #[inline(always)]
+    pub fn gain(&self) -> GAIN_R {
+        GAIN_R::new(((self.bits >> 24) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - Positive Mux Input Selection"]
+    #[inline(always)]
+    pub fn muxpos(&mut self) -> MUXPOS_W {
+        MUXPOS_W { w: self }
+    }
+    #[doc = "Bits 8:12 - Negative Mux Input Selection"]
+    #[inline(always)]
+    pub fn muxneg(&mut self) -> MUXNEG_W {
+        MUXNEG_W { w: self }
+    }
+    #[doc = "Bits 16:19 - Number of Input Channels Included in Scan"]
+    #[inline(always)]
+    pub fn inputscan(&mut self) -> INPUTSCAN_W {
+        INPUTSCAN_W { w: self }
+    }
+    #[doc = "Bits 20:23 - Positive Mux Setting Offset"]
+    #[inline(always)]
+    pub fn inputoffset(&mut self) -> INPUTOFFSET_W {
+        INPUTOFFSET_W { w: self }
+    }
+    #[doc = "Bits 24:27 - Gain Factor Selection"]
+    #[inline(always)]
+    pub fn gain(&mut self) -> GAIN_W {
+        GAIN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/intenclr.rs
+++ b/pac/atsamd11c14a/src/adc/intenclr.rs
@@ -1,0 +1,152 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `RESRDY`"]
+pub type RESRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RESRDY`"]
+pub struct RESRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RESRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVERRUN`"]
+pub type OVERRUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVERRUN`"]
+pub struct OVERRUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVERRUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `WINMON`"]
+pub type WINMON_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WINMON`"]
+pub struct WINMON_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WINMON_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Result Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn resrdy(&self) -> RESRDY_R {
+        RESRDY_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn overrun(&self) -> OVERRUN_R {
+        OVERRUN_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Window Monitor Interrupt Enable"]
+    #[inline(always)]
+    pub fn winmon(&self) -> WINMON_R {
+        WINMON_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Result Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn resrdy(&mut self) -> RESRDY_W {
+        RESRDY_W { w: self }
+    }
+    #[doc = "Bit 1 - Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn overrun(&mut self) -> OVERRUN_W {
+        OVERRUN_W { w: self }
+    }
+    #[doc = "Bit 2 - Window Monitor Interrupt Enable"]
+    #[inline(always)]
+    pub fn winmon(&mut self) -> WINMON_W {
+        WINMON_W { w: self }
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/intenset.rs
+++ b/pac/atsamd11c14a/src/adc/intenset.rs
@@ -1,0 +1,152 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `RESRDY`"]
+pub type RESRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RESRDY`"]
+pub struct RESRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RESRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVERRUN`"]
+pub type OVERRUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVERRUN`"]
+pub struct OVERRUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVERRUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `WINMON`"]
+pub type WINMON_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WINMON`"]
+pub struct WINMON_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WINMON_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Result Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn resrdy(&self) -> RESRDY_R {
+        RESRDY_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn overrun(&self) -> OVERRUN_R {
+        OVERRUN_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Window Monitor Interrupt Enable"]
+    #[inline(always)]
+    pub fn winmon(&self) -> WINMON_R {
+        WINMON_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Result Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn resrdy(&mut self) -> RESRDY_W {
+        RESRDY_W { w: self }
+    }
+    #[doc = "Bit 1 - Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn overrun(&mut self) -> OVERRUN_W {
+        OVERRUN_W { w: self }
+    }
+    #[doc = "Bit 2 - Window Monitor Interrupt Enable"]
+    #[inline(always)]
+    pub fn winmon(&mut self) -> WINMON_W {
+        WINMON_W { w: self }
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/intflag.rs
+++ b/pac/atsamd11c14a/src/adc/intflag.rs
@@ -1,0 +1,152 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `RESRDY`"]
+pub type RESRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RESRDY`"]
+pub struct RESRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RESRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVERRUN`"]
+pub type OVERRUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVERRUN`"]
+pub struct OVERRUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVERRUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `WINMON`"]
+pub type WINMON_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WINMON`"]
+pub struct WINMON_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WINMON_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Result Ready"]
+    #[inline(always)]
+    pub fn resrdy(&self) -> RESRDY_R {
+        RESRDY_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Overrun"]
+    #[inline(always)]
+    pub fn overrun(&self) -> OVERRUN_R {
+        OVERRUN_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Window Monitor"]
+    #[inline(always)]
+    pub fn winmon(&self) -> WINMON_R {
+        WINMON_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Result Ready"]
+    #[inline(always)]
+    pub fn resrdy(&mut self) -> RESRDY_W {
+        RESRDY_W { w: self }
+    }
+    #[doc = "Bit 1 - Overrun"]
+    #[inline(always)]
+    pub fn overrun(&mut self) -> OVERRUN_W {
+        OVERRUN_W { w: self }
+    }
+    #[doc = "Bit 2 - Window Monitor"]
+    #[inline(always)]
+    pub fn winmon(&mut self) -> WINMON_W {
+        WINMON_W { w: self }
+    }
+    #[doc = "Bit 3 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/offsetcorr.rs
+++ b/pac/atsamd11c14a/src/adc/offsetcorr.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register OFFSETCORR"]
+pub type R = crate::R<u16, super::OFFSETCORR>;
+#[doc = "Writer for register OFFSETCORR"]
+pub type W = crate::W<u16, super::OFFSETCORR>;
+#[doc = "Register OFFSETCORR `reset()`'s with value 0"]
+impl crate::ResetValue for super::OFFSETCORR {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OFFSETCORR`"]
+pub type OFFSETCORR_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `OFFSETCORR`"]
+pub struct OFFSETCORR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OFFSETCORR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0fff) | ((value as u16) & 0x0fff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:11 - Offset Correction Value"]
+    #[inline(always)]
+    pub fn offsetcorr(&self) -> OFFSETCORR_R {
+        OFFSETCORR_R::new((self.bits & 0x0fff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:11 - Offset Correction Value"]
+    #[inline(always)]
+    pub fn offsetcorr(&mut self) -> OFFSETCORR_W {
+        OFFSETCORR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/refctrl.rs
+++ b/pac/atsamd11c14a/src/adc/refctrl.rs
@@ -1,0 +1,170 @@
+#[doc = "Reader of register REFCTRL"]
+pub type R = crate::R<u8, super::REFCTRL>;
+#[doc = "Writer for register REFCTRL"]
+pub type W = crate::W<u8, super::REFCTRL>;
+#[doc = "Register REFCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::REFCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reference Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum REFSEL_A {
+    #[doc = "0: 1.0V voltage reference"]
+    INT1V,
+    #[doc = "1: 1/1.48 VDDANA"]
+    INTVCC0,
+    #[doc = "2: 1/2 VDDANA (only for VDDANA > 2.0V)"]
+    INTVCC1,
+    #[doc = "3: External reference"]
+    AREFA,
+    #[doc = "4: External reference"]
+    AREFB,
+}
+impl From<REFSEL_A> for u8 {
+    #[inline(always)]
+    fn from(variant: REFSEL_A) -> Self {
+        match variant {
+            REFSEL_A::INT1V => 0,
+            REFSEL_A::INTVCC0 => 1,
+            REFSEL_A::INTVCC1 => 2,
+            REFSEL_A::AREFA => 3,
+            REFSEL_A::AREFB => 4,
+        }
+    }
+}
+#[doc = "Reader of field `REFSEL`"]
+pub type REFSEL_R = crate::R<u8, REFSEL_A>;
+impl REFSEL_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, REFSEL_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(REFSEL_A::INT1V),
+            1 => Val(REFSEL_A::INTVCC0),
+            2 => Val(REFSEL_A::INTVCC1),
+            3 => Val(REFSEL_A::AREFA),
+            4 => Val(REFSEL_A::AREFB),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `INT1V`"]
+    #[inline(always)]
+    pub fn is_int1v(&self) -> bool {
+        *self == REFSEL_A::INT1V
+    }
+    #[doc = "Checks if the value of the field is `INTVCC0`"]
+    #[inline(always)]
+    pub fn is_intvcc0(&self) -> bool {
+        *self == REFSEL_A::INTVCC0
+    }
+    #[doc = "Checks if the value of the field is `INTVCC1`"]
+    #[inline(always)]
+    pub fn is_intvcc1(&self) -> bool {
+        *self == REFSEL_A::INTVCC1
+    }
+    #[doc = "Checks if the value of the field is `AREFA`"]
+    #[inline(always)]
+    pub fn is_arefa(&self) -> bool {
+        *self == REFSEL_A::AREFA
+    }
+    #[doc = "Checks if the value of the field is `AREFB`"]
+    #[inline(always)]
+    pub fn is_arefb(&self) -> bool {
+        *self == REFSEL_A::AREFB
+    }
+}
+#[doc = "Write proxy for field `REFSEL`"]
+pub struct REFSEL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> REFSEL_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: REFSEL_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "1.0V voltage reference"]
+    #[inline(always)]
+    pub fn int1v(self) -> &'a mut W {
+        self.variant(REFSEL_A::INT1V)
+    }
+    #[doc = "1/1.48 VDDANA"]
+    #[inline(always)]
+    pub fn intvcc0(self) -> &'a mut W {
+        self.variant(REFSEL_A::INTVCC0)
+    }
+    #[doc = "1/2 VDDANA (only for VDDANA > 2.0V)"]
+    #[inline(always)]
+    pub fn intvcc1(self) -> &'a mut W {
+        self.variant(REFSEL_A::INTVCC1)
+    }
+    #[doc = "External reference"]
+    #[inline(always)]
+    pub fn arefa(self) -> &'a mut W {
+        self.variant(REFSEL_A::AREFA)
+    }
+    #[doc = "External reference"]
+    #[inline(always)]
+    pub fn arefb(self) -> &'a mut W {
+        self.variant(REFSEL_A::AREFB)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0f) | ((value as u8) & 0x0f);
+        self.w
+    }
+}
+#[doc = "Reader of field `REFCOMP`"]
+pub type REFCOMP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `REFCOMP`"]
+pub struct REFCOMP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> REFCOMP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:3 - Reference Selection"]
+    #[inline(always)]
+    pub fn refsel(&self) -> REFSEL_R {
+        REFSEL_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bit 7 - Reference Buffer Offset Compensation Enable"]
+    #[inline(always)]
+    pub fn refcomp(&self) -> REFCOMP_R {
+        REFCOMP_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Reference Selection"]
+    #[inline(always)]
+    pub fn refsel(&mut self) -> REFSEL_W {
+        REFSEL_W { w: self }
+    }
+    #[doc = "Bit 7 - Reference Buffer Offset Compensation Enable"]
+    #[inline(always)]
+    pub fn refcomp(&mut self) -> REFCOMP_W {
+        REFCOMP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/result.rs
+++ b/pac/atsamd11c14a/src/adc/result.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register RESULT"]
+pub type R = crate::R<u16, super::RESULT>;
+#[doc = "Reader of field `RESULT`"]
+pub type RESULT_R = crate::R<u16, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Result Conversion Value"]
+    #[inline(always)]
+    pub fn result(&self) -> RESULT_R {
+        RESULT_R::new((self.bits & 0xffff) as u16)
+    }
+}

--- a/pac/atsamd11c14a/src/adc/sampctrl.rs
+++ b/pac/atsamd11c14a/src/adc/sampctrl.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register SAMPCTRL"]
+pub type R = crate::R<u8, super::SAMPCTRL>;
+#[doc = "Writer for register SAMPCTRL"]
+pub type W = crate::W<u8, super::SAMPCTRL>;
+#[doc = "Register SAMPCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::SAMPCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SAMPLEN`"]
+pub type SAMPLEN_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `SAMPLEN`"]
+pub struct SAMPLEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SAMPLEN_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x3f) | ((value as u8) & 0x3f);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:5 - Sampling Time Length"]
+    #[inline(always)]
+    pub fn samplen(&self) -> SAMPLEN_R {
+        SAMPLEN_R::new((self.bits & 0x3f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:5 - Sampling Time Length"]
+    #[inline(always)]
+    pub fn samplen(&mut self) -> SAMPLEN_W {
+        SAMPLEN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/status.rs
+++ b/pac/atsamd11c14a/src/adc/status.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u8, super::STATUS>;
+#[doc = "Reader of field `SYNCBUSY`"]
+pub type SYNCBUSY_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 7 - Synchronization Busy"]
+    #[inline(always)]
+    pub fn syncbusy(&self) -> SYNCBUSY_R {
+        SYNCBUSY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/adc/swtrig.rs
+++ b/pac/atsamd11c14a/src/adc/swtrig.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register SWTRIG"]
+pub type R = crate::R<u8, super::SWTRIG>;
+#[doc = "Writer for register SWTRIG"]
+pub type W = crate::W<u8, super::SWTRIG>;
+#[doc = "Register SWTRIG `reset()`'s with value 0"]
+impl crate::ResetValue for super::SWTRIG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `FLUSH`"]
+pub type FLUSH_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FLUSH`"]
+pub struct FLUSH_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FLUSH_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `START`"]
+pub type START_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `START`"]
+pub struct START_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> START_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - ADC Conversion Flush"]
+    #[inline(always)]
+    pub fn flush(&self) -> FLUSH_R {
+        FLUSH_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - ADC Start Conversion"]
+    #[inline(always)]
+    pub fn start(&self) -> START_R {
+        START_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - ADC Conversion Flush"]
+    #[inline(always)]
+    pub fn flush(&mut self) -> FLUSH_W {
+        FLUSH_W { w: self }
+    }
+    #[doc = "Bit 1 - ADC Start Conversion"]
+    #[inline(always)]
+    pub fn start(&mut self) -> START_W {
+        START_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/winctrl.rs
+++ b/pac/atsamd11c14a/src/adc/winctrl.rs
@@ -1,0 +1,136 @@
+#[doc = "Reader of register WINCTRL"]
+pub type R = crate::R<u8, super::WINCTRL>;
+#[doc = "Writer for register WINCTRL"]
+pub type W = crate::W<u8, super::WINCTRL>;
+#[doc = "Register WINCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::WINCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Window Monitor Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum WINMODE_A {
+    #[doc = "0: No window mode (default)"]
+    DISABLE,
+    #[doc = "1: Mode 1: RESULT > WINLT"]
+    MODE1,
+    #[doc = "2: Mode 2: RESULT < WINUT"]
+    MODE2,
+    #[doc = "3: Mode 3: WINLT < RESULT < WINUT"]
+    MODE3,
+    #[doc = "4: Mode 4: !(WINLT < RESULT < WINUT)"]
+    MODE4,
+}
+impl From<WINMODE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: WINMODE_A) -> Self {
+        match variant {
+            WINMODE_A::DISABLE => 0,
+            WINMODE_A::MODE1 => 1,
+            WINMODE_A::MODE2 => 2,
+            WINMODE_A::MODE3 => 3,
+            WINMODE_A::MODE4 => 4,
+        }
+    }
+}
+#[doc = "Reader of field `WINMODE`"]
+pub type WINMODE_R = crate::R<u8, WINMODE_A>;
+impl WINMODE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, WINMODE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(WINMODE_A::DISABLE),
+            1 => Val(WINMODE_A::MODE1),
+            2 => Val(WINMODE_A::MODE2),
+            3 => Val(WINMODE_A::MODE3),
+            4 => Val(WINMODE_A::MODE4),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[inline(always)]
+    pub fn is_disable(&self) -> bool {
+        *self == WINMODE_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `MODE1`"]
+    #[inline(always)]
+    pub fn is_mode1(&self) -> bool {
+        *self == WINMODE_A::MODE1
+    }
+    #[doc = "Checks if the value of the field is `MODE2`"]
+    #[inline(always)]
+    pub fn is_mode2(&self) -> bool {
+        *self == WINMODE_A::MODE2
+    }
+    #[doc = "Checks if the value of the field is `MODE3`"]
+    #[inline(always)]
+    pub fn is_mode3(&self) -> bool {
+        *self == WINMODE_A::MODE3
+    }
+    #[doc = "Checks if the value of the field is `MODE4`"]
+    #[inline(always)]
+    pub fn is_mode4(&self) -> bool {
+        *self == WINMODE_A::MODE4
+    }
+}
+#[doc = "Write proxy for field `WINMODE`"]
+pub struct WINMODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WINMODE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: WINMODE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No window mode (default)"]
+    #[inline(always)]
+    pub fn disable(self) -> &'a mut W {
+        self.variant(WINMODE_A::DISABLE)
+    }
+    #[doc = "Mode 1: RESULT > WINLT"]
+    #[inline(always)]
+    pub fn mode1(self) -> &'a mut W {
+        self.variant(WINMODE_A::MODE1)
+    }
+    #[doc = "Mode 2: RESULT < WINUT"]
+    #[inline(always)]
+    pub fn mode2(self) -> &'a mut W {
+        self.variant(WINMODE_A::MODE2)
+    }
+    #[doc = "Mode 3: WINLT < RESULT < WINUT"]
+    #[inline(always)]
+    pub fn mode3(self) -> &'a mut W {
+        self.variant(WINMODE_A::MODE3)
+    }
+    #[doc = "Mode 4: !(WINLT < RESULT < WINUT)"]
+    #[inline(always)]
+    pub fn mode4(self) -> &'a mut W {
+        self.variant(WINMODE_A::MODE4)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u8) & 0x07);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Window Monitor Mode"]
+    #[inline(always)]
+    pub fn winmode(&self) -> WINMODE_R {
+        WINMODE_R::new((self.bits & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Window Monitor Mode"]
+    #[inline(always)]
+    pub fn winmode(&mut self) -> WINMODE_W {
+        WINMODE_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/winlt.rs
+++ b/pac/atsamd11c14a/src/adc/winlt.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register WINLT"]
+pub type R = crate::R<u16, super::WINLT>;
+#[doc = "Writer for register WINLT"]
+pub type W = crate::W<u16, super::WINLT>;
+#[doc = "Register WINLT `reset()`'s with value 0"]
+impl crate::ResetValue for super::WINLT {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `WINLT`"]
+pub type WINLT_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `WINLT`"]
+pub struct WINLT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WINLT_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff) | ((value as u16) & 0xffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:15 - Window Lower Threshold"]
+    #[inline(always)]
+    pub fn winlt(&self) -> WINLT_R {
+        WINLT_R::new((self.bits & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Window Lower Threshold"]
+    #[inline(always)]
+    pub fn winlt(&mut self) -> WINLT_W {
+        WINLT_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/adc/winut.rs
+++ b/pac/atsamd11c14a/src/adc/winut.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register WINUT"]
+pub type R = crate::R<u16, super::WINUT>;
+#[doc = "Writer for register WINUT"]
+pub type W = crate::W<u16, super::WINUT>;
+#[doc = "Register WINUT `reset()`'s with value 0"]
+impl crate::ResetValue for super::WINUT {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `WINUT`"]
+pub type WINUT_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `WINUT`"]
+pub struct WINUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WINUT_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff) | ((value as u16) & 0xffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:15 - Window Upper Threshold"]
+    #[inline(always)]
+    pub fn winut(&self) -> WINUT_R {
+        WINUT_R::new((self.bits & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Window Upper Threshold"]
+    #[inline(always)]
+    pub fn winut(&mut self) -> WINUT_W {
+        WINUT_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dac.rs
+++ b/pac/atsamd11c14a/src/dac.rs
@@ -1,0 +1,121 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Control A"]
+    pub ctrla: CTRLA,
+    #[doc = "0x01 - Control B"]
+    pub ctrlb: CTRLB,
+    #[doc = "0x02 - Event Control"]
+    pub evctrl: EVCTRL,
+    _reserved3: [u8; 1usize],
+    #[doc = "0x04 - Interrupt Enable Clear"]
+    pub intenclr: INTENCLR,
+    #[doc = "0x05 - Interrupt Enable Set"]
+    pub intenset: INTENSET,
+    #[doc = "0x06 - Interrupt Flag Status and Clear"]
+    pub intflag: INTFLAG,
+    #[doc = "0x07 - Status"]
+    pub status: STATUS,
+    #[doc = "0x08 - Data"]
+    pub data: DATA,
+    _reserved8: [u8; 2usize],
+    #[doc = "0x0c - Data Buffer"]
+    pub databuf: DATABUF,
+}
+#[doc = "Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrla](ctrla) module"]
+pub type CTRLA = crate::Reg<u8, _CTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLA;
+#[doc = "`read()` method returns [ctrla::R](ctrla::R) reader structure"]
+impl crate::Readable for CTRLA {}
+#[doc = "`write(|w| ..)` method takes [ctrla::W](ctrla::W) writer structure"]
+impl crate::Writable for CTRLA {}
+#[doc = "Control A"]
+pub mod ctrla;
+#[doc = "Control B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlb](ctrlb) module"]
+pub type CTRLB = crate::Reg<u8, _CTRLB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLB;
+#[doc = "`read()` method returns [ctrlb::R](ctrlb::R) reader structure"]
+impl crate::Readable for CTRLB {}
+#[doc = "`write(|w| ..)` method takes [ctrlb::W](ctrlb::W) writer structure"]
+impl crate::Writable for CTRLB {}
+#[doc = "Control B"]
+pub mod ctrlb;
+#[doc = "Event Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [evctrl](evctrl) module"]
+pub type EVCTRL = crate::Reg<u8, _EVCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EVCTRL;
+#[doc = "`read()` method returns [evctrl::R](evctrl::R) reader structure"]
+impl crate::Readable for EVCTRL {}
+#[doc = "`write(|w| ..)` method takes [evctrl::W](evctrl::W) writer structure"]
+impl crate::Writable for EVCTRL {}
+#[doc = "Event Control"]
+pub mod evctrl;
+#[doc = "Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u8, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "Status"]
+pub mod status;
+#[doc = "Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [data](data) module"]
+pub type DATA = crate::Reg<u16, _DATA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DATA;
+#[doc = "`read()` method returns [data::R](data::R) reader structure"]
+impl crate::Readable for DATA {}
+#[doc = "`write(|w| ..)` method takes [data::W](data::W) writer structure"]
+impl crate::Writable for DATA {}
+#[doc = "Data"]
+pub mod data;
+#[doc = "Data Buffer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [databuf](databuf) module"]
+pub type DATABUF = crate::Reg<u16, _DATABUF>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DATABUF;
+#[doc = "`read()` method returns [databuf::R](databuf::R) reader structure"]
+impl crate::Readable for DATABUF {}
+#[doc = "`write(|w| ..)` method takes [databuf::W](databuf::W) writer structure"]
+impl crate::Writable for DATABUF {}
+#[doc = "Data Buffer"]
+pub mod databuf;

--- a/pac/atsamd11c14a/src/dac/ctrla.rs
+++ b/pac/atsamd11c14a/src/dac/ctrla.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register CTRLA"]
+pub type R = crate::R<u8, super::CTRLA>;
+#[doc = "Writer for register CTRLA"]
+pub type W = crate::W<u8, super::CTRLA>;
+#[doc = "Register CTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLA {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bit 2 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dac/ctrlb.rs
+++ b/pac/atsamd11c14a/src/dac/ctrlb.rs
@@ -1,0 +1,278 @@
+#[doc = "Reader of register CTRLB"]
+pub type R = crate::R<u8, super::CTRLB>;
+#[doc = "Writer for register CTRLB"]
+pub type W = crate::W<u8, super::CTRLB>;
+#[doc = "Register CTRLB `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLB {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `EOEN`"]
+pub type EOEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EOEN`"]
+pub struct EOEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EOEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `IOEN`"]
+pub type IOEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `IOEN`"]
+pub struct IOEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> IOEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `LEFTADJ`"]
+pub type LEFTADJ_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LEFTADJ`"]
+pub struct LEFTADJ_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LEFTADJ_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `VPD`"]
+pub type VPD_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `VPD`"]
+pub struct VPD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> VPD_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `BDWP`"]
+pub type BDWP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BDWP`"]
+pub struct BDWP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BDWP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reference Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum REFSEL_A {
+    #[doc = "0: Internal 1.0V reference"]
+    INT1V,
+    #[doc = "1: AVCC"]
+    AVCC,
+    #[doc = "2: External reference"]
+    VREFP,
+}
+impl From<REFSEL_A> for u8 {
+    #[inline(always)]
+    fn from(variant: REFSEL_A) -> Self {
+        match variant {
+            REFSEL_A::INT1V => 0,
+            REFSEL_A::AVCC => 1,
+            REFSEL_A::VREFP => 2,
+        }
+    }
+}
+#[doc = "Reader of field `REFSEL`"]
+pub type REFSEL_R = crate::R<u8, REFSEL_A>;
+impl REFSEL_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, REFSEL_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(REFSEL_A::INT1V),
+            1 => Val(REFSEL_A::AVCC),
+            2 => Val(REFSEL_A::VREFP),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `INT1V`"]
+    #[inline(always)]
+    pub fn is_int1v(&self) -> bool {
+        *self == REFSEL_A::INT1V
+    }
+    #[doc = "Checks if the value of the field is `AVCC`"]
+    #[inline(always)]
+    pub fn is_avcc(&self) -> bool {
+        *self == REFSEL_A::AVCC
+    }
+    #[doc = "Checks if the value of the field is `VREFP`"]
+    #[inline(always)]
+    pub fn is_vrefp(&self) -> bool {
+        *self == REFSEL_A::VREFP
+    }
+}
+#[doc = "Write proxy for field `REFSEL`"]
+pub struct REFSEL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> REFSEL_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: REFSEL_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Internal 1.0V reference"]
+    #[inline(always)]
+    pub fn int1v(self) -> &'a mut W {
+        self.variant(REFSEL_A::INT1V)
+    }
+    #[doc = "AVCC"]
+    #[inline(always)]
+    pub fn avcc(self) -> &'a mut W {
+        self.variant(REFSEL_A::AVCC)
+    }
+    #[doc = "External reference"]
+    #[inline(always)]
+    pub fn vrefp(self) -> &'a mut W {
+        self.variant(REFSEL_A::VREFP)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 6)) | (((value as u8) & 0x03) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - External Output Enable"]
+    #[inline(always)]
+    pub fn eoen(&self) -> EOEN_R {
+        EOEN_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Internal Output Enable"]
+    #[inline(always)]
+    pub fn ioen(&self) -> IOEN_R {
+        IOEN_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Left Adjusted Data"]
+    #[inline(always)]
+    pub fn leftadj(&self) -> LEFTADJ_R {
+        LEFTADJ_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Voltage Pump Disable"]
+    #[inline(always)]
+    pub fn vpd(&self) -> VPD_R {
+        VPD_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Bypass DATABUF Write Protection"]
+    #[inline(always)]
+    pub fn bdwp(&self) -> BDWP_R {
+        BDWP_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bits 6:7 - Reference Selection"]
+    #[inline(always)]
+    pub fn refsel(&self) -> REFSEL_R {
+        REFSEL_R::new(((self.bits >> 6) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - External Output Enable"]
+    #[inline(always)]
+    pub fn eoen(&mut self) -> EOEN_W {
+        EOEN_W { w: self }
+    }
+    #[doc = "Bit 1 - Internal Output Enable"]
+    #[inline(always)]
+    pub fn ioen(&mut self) -> IOEN_W {
+        IOEN_W { w: self }
+    }
+    #[doc = "Bit 2 - Left Adjusted Data"]
+    #[inline(always)]
+    pub fn leftadj(&mut self) -> LEFTADJ_W {
+        LEFTADJ_W { w: self }
+    }
+    #[doc = "Bit 3 - Voltage Pump Disable"]
+    #[inline(always)]
+    pub fn vpd(&mut self) -> VPD_W {
+        VPD_W { w: self }
+    }
+    #[doc = "Bit 4 - Bypass DATABUF Write Protection"]
+    #[inline(always)]
+    pub fn bdwp(&mut self) -> BDWP_W {
+        BDWP_W { w: self }
+    }
+    #[doc = "Bits 6:7 - Reference Selection"]
+    #[inline(always)]
+    pub fn refsel(&mut self) -> REFSEL_W {
+        REFSEL_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dac/data.rs
+++ b/pac/atsamd11c14a/src/dac/data.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register DATA"]
+pub type R = crate::R<u16, super::DATA>;
+#[doc = "Writer for register DATA"]
+pub type W = crate::W<u16, super::DATA>;
+#[doc = "Register DATA `reset()`'s with value 0"]
+impl crate::ResetValue for super::DATA {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DATA`"]
+pub type DATA_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `DATA`"]
+pub struct DATA_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DATA_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff) | ((value as u16) & 0xffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:15 - Data value to be converted"]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new((self.bits & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Data value to be converted"]
+    #[inline(always)]
+    pub fn data(&mut self) -> DATA_W {
+        DATA_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dac/databuf.rs
+++ b/pac/atsamd11c14a/src/dac/databuf.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register DATABUF"]
+pub type R = crate::R<u16, super::DATABUF>;
+#[doc = "Writer for register DATABUF"]
+pub type W = crate::W<u16, super::DATABUF>;
+#[doc = "Register DATABUF `reset()`'s with value 0"]
+impl crate::ResetValue for super::DATABUF {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DATABUF`"]
+pub type DATABUF_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `DATABUF`"]
+pub struct DATABUF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DATABUF_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff) | ((value as u16) & 0xffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:15 - Data Buffer"]
+    #[inline(always)]
+    pub fn databuf(&self) -> DATABUF_R {
+        DATABUF_R::new((self.bits & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Data Buffer"]
+    #[inline(always)]
+    pub fn databuf(&mut self) -> DATABUF_W {
+        DATABUF_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dac/evctrl.rs
+++ b/pac/atsamd11c14a/src/dac/evctrl.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register EVCTRL"]
+pub type R = crate::R<u8, super::EVCTRL>;
+#[doc = "Writer for register EVCTRL"]
+pub type W = crate::W<u8, super::EVCTRL>;
+#[doc = "Register EVCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::EVCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `STARTEI`"]
+pub type STARTEI_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `STARTEI`"]
+pub struct STARTEI_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STARTEI_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `EMPTYEO`"]
+pub type EMPTYEO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EMPTYEO`"]
+pub struct EMPTYEO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EMPTYEO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Start Conversion Event Input"]
+    #[inline(always)]
+    pub fn startei(&self) -> STARTEI_R {
+        STARTEI_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Data Buffer Empty Event Output"]
+    #[inline(always)]
+    pub fn emptyeo(&self) -> EMPTYEO_R {
+        EMPTYEO_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Start Conversion Event Input"]
+    #[inline(always)]
+    pub fn startei(&mut self) -> STARTEI_W {
+        STARTEI_W { w: self }
+    }
+    #[doc = "Bit 1 - Data Buffer Empty Event Output"]
+    #[inline(always)]
+    pub fn emptyeo(&mut self) -> EMPTYEO_W {
+        EMPTYEO_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dac/intenclr.rs
+++ b/pac/atsamd11c14a/src/dac/intenclr.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `UNDERRUN`"]
+pub type UNDERRUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `UNDERRUN`"]
+pub struct UNDERRUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> UNDERRUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `EMPTY`"]
+pub type EMPTY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EMPTY`"]
+pub struct EMPTY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EMPTY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Underrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn underrun(&self) -> UNDERRUN_R {
+        UNDERRUN_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Data Buffer Empty Interrupt Enable"]
+    #[inline(always)]
+    pub fn empty(&self) -> EMPTY_R {
+        EMPTY_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Underrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn underrun(&mut self) -> UNDERRUN_W {
+        UNDERRUN_W { w: self }
+    }
+    #[doc = "Bit 1 - Data Buffer Empty Interrupt Enable"]
+    #[inline(always)]
+    pub fn empty(&mut self) -> EMPTY_W {
+        EMPTY_W { w: self }
+    }
+    #[doc = "Bit 2 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dac/intenset.rs
+++ b/pac/atsamd11c14a/src/dac/intenset.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `UNDERRUN`"]
+pub type UNDERRUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `UNDERRUN`"]
+pub struct UNDERRUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> UNDERRUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `EMPTY`"]
+pub type EMPTY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EMPTY`"]
+pub struct EMPTY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EMPTY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Underrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn underrun(&self) -> UNDERRUN_R {
+        UNDERRUN_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Data Buffer Empty Interrupt Enable"]
+    #[inline(always)]
+    pub fn empty(&self) -> EMPTY_R {
+        EMPTY_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Underrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn underrun(&mut self) -> UNDERRUN_W {
+        UNDERRUN_W { w: self }
+    }
+    #[doc = "Bit 1 - Data Buffer Empty Interrupt Enable"]
+    #[inline(always)]
+    pub fn empty(&mut self) -> EMPTY_W {
+        EMPTY_W { w: self }
+    }
+    #[doc = "Bit 2 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dac/intflag.rs
+++ b/pac/atsamd11c14a/src/dac/intflag.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `UNDERRUN`"]
+pub type UNDERRUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `UNDERRUN`"]
+pub struct UNDERRUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> UNDERRUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `EMPTY`"]
+pub type EMPTY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EMPTY`"]
+pub struct EMPTY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EMPTY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Underrun"]
+    #[inline(always)]
+    pub fn underrun(&self) -> UNDERRUN_R {
+        UNDERRUN_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Data Buffer Empty"]
+    #[inline(always)]
+    pub fn empty(&self) -> EMPTY_R {
+        EMPTY_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Underrun"]
+    #[inline(always)]
+    pub fn underrun(&mut self) -> UNDERRUN_W {
+        UNDERRUN_W { w: self }
+    }
+    #[doc = "Bit 1 - Data Buffer Empty"]
+    #[inline(always)]
+    pub fn empty(&mut self) -> EMPTY_W {
+        EMPTY_W { w: self }
+    }
+    #[doc = "Bit 2 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dac/status.rs
+++ b/pac/atsamd11c14a/src/dac/status.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u8, super::STATUS>;
+#[doc = "Reader of field `SYNCBUSY`"]
+pub type SYNCBUSY_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 7 - Synchronization Busy Status"]
+    #[inline(always)]
+    pub fn syncbusy(&self) -> SYNCBUSY_R {
+        SYNCBUSY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/dmac.rs
+++ b/pac/atsamd11c14a/src/dmac.rs
@@ -1,0 +1,299 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Control"]
+    pub ctrl: CTRL,
+    #[doc = "0x02 - CRC Control"]
+    pub crcctrl: CRCCTRL,
+    #[doc = "0x04 - CRC Data Input"]
+    pub crcdatain: CRCDATAIN,
+    #[doc = "0x08 - CRC Checksum"]
+    pub crcchksum: CRCCHKSUM,
+    #[doc = "0x0c - CRC Status"]
+    pub crcstatus: CRCSTATUS,
+    #[doc = "0x0d - Debug Control"]
+    pub dbgctrl: DBGCTRL,
+    #[doc = "0x0e - QOS Control"]
+    pub qosctrl: QOSCTRL,
+    _reserved7: [u8; 1usize],
+    #[doc = "0x10 - Software Trigger Control"]
+    pub swtrigctrl: SWTRIGCTRL,
+    #[doc = "0x14 - Priority Control 0"]
+    pub prictrl0: PRICTRL0,
+    _reserved9: [u8; 8usize],
+    #[doc = "0x20 - Interrupt Pending"]
+    pub intpend: INTPEND,
+    _reserved10: [u8; 2usize],
+    #[doc = "0x24 - Interrupt Status"]
+    pub intstatus: INTSTATUS,
+    #[doc = "0x28 - Busy Channels"]
+    pub busych: BUSYCH,
+    #[doc = "0x2c - Pending Channels"]
+    pub pendch: PENDCH,
+    #[doc = "0x30 - Active Channel and Levels"]
+    pub active: ACTIVE,
+    #[doc = "0x34 - Descriptor Memory Section Base Address"]
+    pub baseaddr: BASEADDR,
+    #[doc = "0x38 - Write-Back Memory Section Base Address"]
+    pub wrbaddr: WRBADDR,
+    _reserved16: [u8; 3usize],
+    #[doc = "0x3f - Channel ID"]
+    pub chid: CHID,
+    #[doc = "0x40 - Channel Control A"]
+    pub chctrla: CHCTRLA,
+    _reserved18: [u8; 3usize],
+    #[doc = "0x44 - Channel Control B"]
+    pub chctrlb: CHCTRLB,
+    _reserved19: [u8; 4usize],
+    #[doc = "0x4c - Channel Interrupt Enable Clear"]
+    pub chintenclr: CHINTENCLR,
+    #[doc = "0x4d - Channel Interrupt Enable Set"]
+    pub chintenset: CHINTENSET,
+    #[doc = "0x4e - Channel Interrupt Flag Status and Clear"]
+    pub chintflag: CHINTFLAG,
+    #[doc = "0x4f - Channel Status"]
+    pub chstatus: CHSTATUS,
+}
+#[doc = "Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrl](ctrl) module"]
+pub type CTRL = crate::Reg<u16, _CTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRL;
+#[doc = "`read()` method returns [ctrl::R](ctrl::R) reader structure"]
+impl crate::Readable for CTRL {}
+#[doc = "`write(|w| ..)` method takes [ctrl::W](ctrl::W) writer structure"]
+impl crate::Writable for CTRL {}
+#[doc = "Control"]
+pub mod ctrl;
+#[doc = "CRC Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [crcctrl](crcctrl) module"]
+pub type CRCCTRL = crate::Reg<u16, _CRCCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CRCCTRL;
+#[doc = "`read()` method returns [crcctrl::R](crcctrl::R) reader structure"]
+impl crate::Readable for CRCCTRL {}
+#[doc = "`write(|w| ..)` method takes [crcctrl::W](crcctrl::W) writer structure"]
+impl crate::Writable for CRCCTRL {}
+#[doc = "CRC Control"]
+pub mod crcctrl;
+#[doc = "CRC Data Input\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [crcdatain](crcdatain) module"]
+pub type CRCDATAIN = crate::Reg<u32, _CRCDATAIN>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CRCDATAIN;
+#[doc = "`read()` method returns [crcdatain::R](crcdatain::R) reader structure"]
+impl crate::Readable for CRCDATAIN {}
+#[doc = "`write(|w| ..)` method takes [crcdatain::W](crcdatain::W) writer structure"]
+impl crate::Writable for CRCDATAIN {}
+#[doc = "CRC Data Input"]
+pub mod crcdatain;
+#[doc = "CRC Checksum\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [crcchksum](crcchksum) module"]
+pub type CRCCHKSUM = crate::Reg<u32, _CRCCHKSUM>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CRCCHKSUM;
+#[doc = "`read()` method returns [crcchksum::R](crcchksum::R) reader structure"]
+impl crate::Readable for CRCCHKSUM {}
+#[doc = "`write(|w| ..)` method takes [crcchksum::W](crcchksum::W) writer structure"]
+impl crate::Writable for CRCCHKSUM {}
+#[doc = "CRC Checksum"]
+pub mod crcchksum;
+#[doc = "CRC Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [crcstatus](crcstatus) module"]
+pub type CRCSTATUS = crate::Reg<u8, _CRCSTATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CRCSTATUS;
+#[doc = "`read()` method returns [crcstatus::R](crcstatus::R) reader structure"]
+impl crate::Readable for CRCSTATUS {}
+#[doc = "`write(|w| ..)` method takes [crcstatus::W](crcstatus::W) writer structure"]
+impl crate::Writable for CRCSTATUS {}
+#[doc = "CRC Status"]
+pub mod crcstatus;
+#[doc = "Debug Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dbgctrl](dbgctrl) module"]
+pub type DBGCTRL = crate::Reg<u8, _DBGCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DBGCTRL;
+#[doc = "`read()` method returns [dbgctrl::R](dbgctrl::R) reader structure"]
+impl crate::Readable for DBGCTRL {}
+#[doc = "`write(|w| ..)` method takes [dbgctrl::W](dbgctrl::W) writer structure"]
+impl crate::Writable for DBGCTRL {}
+#[doc = "Debug Control"]
+pub mod dbgctrl;
+#[doc = "QOS Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [qosctrl](qosctrl) module"]
+pub type QOSCTRL = crate::Reg<u8, _QOSCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _QOSCTRL;
+#[doc = "`read()` method returns [qosctrl::R](qosctrl::R) reader structure"]
+impl crate::Readable for QOSCTRL {}
+#[doc = "`write(|w| ..)` method takes [qosctrl::W](qosctrl::W) writer structure"]
+impl crate::Writable for QOSCTRL {}
+#[doc = "QOS Control"]
+pub mod qosctrl;
+#[doc = "Software Trigger Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [swtrigctrl](swtrigctrl) module"]
+pub type SWTRIGCTRL = crate::Reg<u32, _SWTRIGCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _SWTRIGCTRL;
+#[doc = "`read()` method returns [swtrigctrl::R](swtrigctrl::R) reader structure"]
+impl crate::Readable for SWTRIGCTRL {}
+#[doc = "`write(|w| ..)` method takes [swtrigctrl::W](swtrigctrl::W) writer structure"]
+impl crate::Writable for SWTRIGCTRL {}
+#[doc = "Software Trigger Control"]
+pub mod swtrigctrl;
+#[doc = "Priority Control 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prictrl0](prictrl0) module"]
+pub type PRICTRL0 = crate::Reg<u32, _PRICTRL0>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PRICTRL0;
+#[doc = "`read()` method returns [prictrl0::R](prictrl0::R) reader structure"]
+impl crate::Readable for PRICTRL0 {}
+#[doc = "`write(|w| ..)` method takes [prictrl0::W](prictrl0::W) writer structure"]
+impl crate::Writable for PRICTRL0 {}
+#[doc = "Priority Control 0"]
+pub mod prictrl0;
+#[doc = "Interrupt Pending\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intpend](intpend) module"]
+pub type INTPEND = crate::Reg<u16, _INTPEND>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTPEND;
+#[doc = "`read()` method returns [intpend::R](intpend::R) reader structure"]
+impl crate::Readable for INTPEND {}
+#[doc = "`write(|w| ..)` method takes [intpend::W](intpend::W) writer structure"]
+impl crate::Writable for INTPEND {}
+#[doc = "Interrupt Pending"]
+pub mod intpend;
+#[doc = "Interrupt Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intstatus](intstatus) module"]
+pub type INTSTATUS = crate::Reg<u32, _INTSTATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTSTATUS;
+#[doc = "`read()` method returns [intstatus::R](intstatus::R) reader structure"]
+impl crate::Readable for INTSTATUS {}
+#[doc = "Interrupt Status"]
+pub mod intstatus;
+#[doc = "Busy Channels\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [busych](busych) module"]
+pub type BUSYCH = crate::Reg<u32, _BUSYCH>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _BUSYCH;
+#[doc = "`read()` method returns [busych::R](busych::R) reader structure"]
+impl crate::Readable for BUSYCH {}
+#[doc = "Busy Channels"]
+pub mod busych;
+#[doc = "Pending Channels\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pendch](pendch) module"]
+pub type PENDCH = crate::Reg<u32, _PENDCH>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PENDCH;
+#[doc = "`read()` method returns [pendch::R](pendch::R) reader structure"]
+impl crate::Readable for PENDCH {}
+#[doc = "Pending Channels"]
+pub mod pendch;
+#[doc = "Active Channel and Levels\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [active](active) module"]
+pub type ACTIVE = crate::Reg<u32, _ACTIVE>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _ACTIVE;
+#[doc = "`read()` method returns [active::R](active::R) reader structure"]
+impl crate::Readable for ACTIVE {}
+#[doc = "Active Channel and Levels"]
+pub mod active;
+#[doc = "Descriptor Memory Section Base Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [baseaddr](baseaddr) module"]
+pub type BASEADDR = crate::Reg<u32, _BASEADDR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _BASEADDR;
+#[doc = "`read()` method returns [baseaddr::R](baseaddr::R) reader structure"]
+impl crate::Readable for BASEADDR {}
+#[doc = "`write(|w| ..)` method takes [baseaddr::W](baseaddr::W) writer structure"]
+impl crate::Writable for BASEADDR {}
+#[doc = "Descriptor Memory Section Base Address"]
+pub mod baseaddr;
+#[doc = "Write-Back Memory Section Base Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [wrbaddr](wrbaddr) module"]
+pub type WRBADDR = crate::Reg<u32, _WRBADDR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WRBADDR;
+#[doc = "`read()` method returns [wrbaddr::R](wrbaddr::R) reader structure"]
+impl crate::Readable for WRBADDR {}
+#[doc = "`write(|w| ..)` method takes [wrbaddr::W](wrbaddr::W) writer structure"]
+impl crate::Writable for WRBADDR {}
+#[doc = "Write-Back Memory Section Base Address"]
+pub mod wrbaddr;
+#[doc = "Channel ID\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chid](chid) module"]
+pub type CHID = crate::Reg<u8, _CHID>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CHID;
+#[doc = "`read()` method returns [chid::R](chid::R) reader structure"]
+impl crate::Readable for CHID {}
+#[doc = "`write(|w| ..)` method takes [chid::W](chid::W) writer structure"]
+impl crate::Writable for CHID {}
+#[doc = "Channel ID"]
+pub mod chid;
+#[doc = "Channel Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chctrla](chctrla) module"]
+pub type CHCTRLA = crate::Reg<u8, _CHCTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CHCTRLA;
+#[doc = "`read()` method returns [chctrla::R](chctrla::R) reader structure"]
+impl crate::Readable for CHCTRLA {}
+#[doc = "`write(|w| ..)` method takes [chctrla::W](chctrla::W) writer structure"]
+impl crate::Writable for CHCTRLA {}
+#[doc = "Channel Control A"]
+pub mod chctrla;
+#[doc = "Channel Control B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chctrlb](chctrlb) module"]
+pub type CHCTRLB = crate::Reg<u32, _CHCTRLB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CHCTRLB;
+#[doc = "`read()` method returns [chctrlb::R](chctrlb::R) reader structure"]
+impl crate::Readable for CHCTRLB {}
+#[doc = "`write(|w| ..)` method takes [chctrlb::W](chctrlb::W) writer structure"]
+impl crate::Writable for CHCTRLB {}
+#[doc = "Channel Control B"]
+pub mod chctrlb;
+#[doc = "Channel Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chintenclr](chintenclr) module"]
+pub type CHINTENCLR = crate::Reg<u8, _CHINTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CHINTENCLR;
+#[doc = "`read()` method returns [chintenclr::R](chintenclr::R) reader structure"]
+impl crate::Readable for CHINTENCLR {}
+#[doc = "`write(|w| ..)` method takes [chintenclr::W](chintenclr::W) writer structure"]
+impl crate::Writable for CHINTENCLR {}
+#[doc = "Channel Interrupt Enable Clear"]
+pub mod chintenclr;
+#[doc = "Channel Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chintenset](chintenset) module"]
+pub type CHINTENSET = crate::Reg<u8, _CHINTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CHINTENSET;
+#[doc = "`read()` method returns [chintenset::R](chintenset::R) reader structure"]
+impl crate::Readable for CHINTENSET {}
+#[doc = "`write(|w| ..)` method takes [chintenset::W](chintenset::W) writer structure"]
+impl crate::Writable for CHINTENSET {}
+#[doc = "Channel Interrupt Enable Set"]
+pub mod chintenset;
+#[doc = "Channel Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chintflag](chintflag) module"]
+pub type CHINTFLAG = crate::Reg<u8, _CHINTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CHINTFLAG;
+#[doc = "`read()` method returns [chintflag::R](chintflag::R) reader structure"]
+impl crate::Readable for CHINTFLAG {}
+#[doc = "`write(|w| ..)` method takes [chintflag::W](chintflag::W) writer structure"]
+impl crate::Writable for CHINTFLAG {}
+#[doc = "Channel Interrupt Flag Status and Clear"]
+pub mod chintflag;
+#[doc = "Channel Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chstatus](chstatus) module"]
+pub type CHSTATUS = crate::Reg<u8, _CHSTATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CHSTATUS;
+#[doc = "`read()` method returns [chstatus::R](chstatus::R) reader structure"]
+impl crate::Readable for CHSTATUS {}
+#[doc = "Channel Status"]
+pub mod chstatus;

--- a/pac/atsamd11c14a/src/dmac/active.rs
+++ b/pac/atsamd11c14a/src/dmac/active.rs
@@ -1,0 +1,53 @@
+#[doc = "Reader of register ACTIVE"]
+pub type R = crate::R<u32, super::ACTIVE>;
+#[doc = "Reader of field `LVLEX0`"]
+pub type LVLEX0_R = crate::R<bool, bool>;
+#[doc = "Reader of field `LVLEX1`"]
+pub type LVLEX1_R = crate::R<bool, bool>;
+#[doc = "Reader of field `LVLEX2`"]
+pub type LVLEX2_R = crate::R<bool, bool>;
+#[doc = "Reader of field `LVLEX3`"]
+pub type LVLEX3_R = crate::R<bool, bool>;
+#[doc = "Reader of field `ID`"]
+pub type ID_R = crate::R<u8, u8>;
+#[doc = "Reader of field `ABUSY`"]
+pub type ABUSY_R = crate::R<bool, bool>;
+#[doc = "Reader of field `BTCNT`"]
+pub type BTCNT_R = crate::R<u16, u16>;
+impl R {
+    #[doc = "Bit 0 - Level 0 Channel Trigger Request Executing"]
+    #[inline(always)]
+    pub fn lvlex0(&self) -> LVLEX0_R {
+        LVLEX0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Level 1 Channel Trigger Request Executing"]
+    #[inline(always)]
+    pub fn lvlex1(&self) -> LVLEX1_R {
+        LVLEX1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Level 2 Channel Trigger Request Executing"]
+    #[inline(always)]
+    pub fn lvlex2(&self) -> LVLEX2_R {
+        LVLEX2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Level 3 Channel Trigger Request Executing"]
+    #[inline(always)]
+    pub fn lvlex3(&self) -> LVLEX3_R {
+        LVLEX3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bits 8:12 - Active Channel ID"]
+    #[inline(always)]
+    pub fn id(&self) -> ID_R {
+        ID_R::new(((self.bits >> 8) & 0x1f) as u8)
+    }
+    #[doc = "Bit 15 - Active Channel Busy"]
+    #[inline(always)]
+    pub fn abusy(&self) -> ABUSY_R {
+        ABUSY_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bits 16:31 - Active Channel Block Transfer Count"]
+    #[inline(always)]
+    pub fn btcnt(&self) -> BTCNT_R {
+        BTCNT_R::new(((self.bits >> 16) & 0xffff) as u16)
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/baseaddr.rs
+++ b/pac/atsamd11c14a/src/dmac/baseaddr.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register BASEADDR"]
+pub type R = crate::R<u32, super::BASEADDR>;
+#[doc = "Writer for register BASEADDR"]
+pub type W = crate::W<u32, super::BASEADDR>;
+#[doc = "Register BASEADDR `reset()`'s with value 0"]
+impl crate::ResetValue for super::BASEADDR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `BASEADDR`"]
+pub type BASEADDR_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `BASEADDR`"]
+pub struct BASEADDR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BASEADDR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Descriptor Memory Base Address"]
+    #[inline(always)]
+    pub fn baseaddr(&self) -> BASEADDR_R {
+        BASEADDR_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Descriptor Memory Base Address"]
+    #[inline(always)]
+    pub fn baseaddr(&mut self) -> BASEADDR_W {
+        BASEADDR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/busych.rs
+++ b/pac/atsamd11c14a/src/dmac/busych.rs
@@ -1,0 +1,46 @@
+#[doc = "Reader of register BUSYCH"]
+pub type R = crate::R<u32, super::BUSYCH>;
+#[doc = "Reader of field `BUSYCH0`"]
+pub type BUSYCH0_R = crate::R<bool, bool>;
+#[doc = "Reader of field `BUSYCH1`"]
+pub type BUSYCH1_R = crate::R<bool, bool>;
+#[doc = "Reader of field `BUSYCH2`"]
+pub type BUSYCH2_R = crate::R<bool, bool>;
+#[doc = "Reader of field `BUSYCH3`"]
+pub type BUSYCH3_R = crate::R<bool, bool>;
+#[doc = "Reader of field `BUSYCH4`"]
+pub type BUSYCH4_R = crate::R<bool, bool>;
+#[doc = "Reader of field `BUSYCH5`"]
+pub type BUSYCH5_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Busy Channel 0"]
+    #[inline(always)]
+    pub fn busych0(&self) -> BUSYCH0_R {
+        BUSYCH0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Busy Channel 1"]
+    #[inline(always)]
+    pub fn busych1(&self) -> BUSYCH1_R {
+        BUSYCH1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Busy Channel 2"]
+    #[inline(always)]
+    pub fn busych2(&self) -> BUSYCH2_R {
+        BUSYCH2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Busy Channel 3"]
+    #[inline(always)]
+    pub fn busych3(&self) -> BUSYCH3_R {
+        BUSYCH3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Busy Channel 4"]
+    #[inline(always)]
+    pub fn busych4(&self) -> BUSYCH4_R {
+        BUSYCH4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Busy Channel 5"]
+    #[inline(always)]
+    pub fn busych5(&self) -> BUSYCH5_R {
+        BUSYCH5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/chctrla.rs
+++ b/pac/atsamd11c14a/src/dmac/chctrla.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register CHCTRLA"]
+pub type R = crate::R<u8, super::CHCTRLA>;
+#[doc = "Writer for register CHCTRLA"]
+pub type W = crate::W<u8, super::CHCTRLA>;
+#[doc = "Register CHCTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::CHCTRLA {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Channel Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Channel Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Channel Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Channel Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/chctrlb.rs
+++ b/pac/atsamd11c14a/src/dmac/chctrlb.rs
@@ -1,0 +1,587 @@
+#[doc = "Reader of register CHCTRLB"]
+pub type R = crate::R<u32, super::CHCTRLB>;
+#[doc = "Writer for register CHCTRLB"]
+pub type W = crate::W<u32, super::CHCTRLB>;
+#[doc = "Register CHCTRLB `reset()`'s with value 0"]
+impl crate::ResetValue for super::CHCTRLB {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Event Input Action\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum EVACT_A {
+    #[doc = "0: No action"]
+    NOACT,
+    #[doc = "1: Transfer and periodic transfer trigger"]
+    TRIG,
+    #[doc = "2: Conditional transfer trigger"]
+    CTRIG,
+    #[doc = "3: Conditional block transfer"]
+    CBLOCK,
+    #[doc = "4: Channel suspend operation"]
+    SUSPEND,
+    #[doc = "5: Channel resume operation"]
+    RESUME,
+    #[doc = "6: Skip next block suspend action"]
+    SSKIP,
+}
+impl From<EVACT_A> for u8 {
+    #[inline(always)]
+    fn from(variant: EVACT_A) -> Self {
+        match variant {
+            EVACT_A::NOACT => 0,
+            EVACT_A::TRIG => 1,
+            EVACT_A::CTRIG => 2,
+            EVACT_A::CBLOCK => 3,
+            EVACT_A::SUSPEND => 4,
+            EVACT_A::RESUME => 5,
+            EVACT_A::SSKIP => 6,
+        }
+    }
+}
+#[doc = "Reader of field `EVACT`"]
+pub type EVACT_R = crate::R<u8, EVACT_A>;
+impl EVACT_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, EVACT_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(EVACT_A::NOACT),
+            1 => Val(EVACT_A::TRIG),
+            2 => Val(EVACT_A::CTRIG),
+            3 => Val(EVACT_A::CBLOCK),
+            4 => Val(EVACT_A::SUSPEND),
+            5 => Val(EVACT_A::RESUME),
+            6 => Val(EVACT_A::SSKIP),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NOACT`"]
+    #[inline(always)]
+    pub fn is_noact(&self) -> bool {
+        *self == EVACT_A::NOACT
+    }
+    #[doc = "Checks if the value of the field is `TRIG`"]
+    #[inline(always)]
+    pub fn is_trig(&self) -> bool {
+        *self == EVACT_A::TRIG
+    }
+    #[doc = "Checks if the value of the field is `CTRIG`"]
+    #[inline(always)]
+    pub fn is_ctrig(&self) -> bool {
+        *self == EVACT_A::CTRIG
+    }
+    #[doc = "Checks if the value of the field is `CBLOCK`"]
+    #[inline(always)]
+    pub fn is_cblock(&self) -> bool {
+        *self == EVACT_A::CBLOCK
+    }
+    #[doc = "Checks if the value of the field is `SUSPEND`"]
+    #[inline(always)]
+    pub fn is_suspend(&self) -> bool {
+        *self == EVACT_A::SUSPEND
+    }
+    #[doc = "Checks if the value of the field is `RESUME`"]
+    #[inline(always)]
+    pub fn is_resume(&self) -> bool {
+        *self == EVACT_A::RESUME
+    }
+    #[doc = "Checks if the value of the field is `SSKIP`"]
+    #[inline(always)]
+    pub fn is_sskip(&self) -> bool {
+        *self == EVACT_A::SSKIP
+    }
+}
+#[doc = "Write proxy for field `EVACT`"]
+pub struct EVACT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVACT_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: EVACT_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No action"]
+    #[inline(always)]
+    pub fn noact(self) -> &'a mut W {
+        self.variant(EVACT_A::NOACT)
+    }
+    #[doc = "Transfer and periodic transfer trigger"]
+    #[inline(always)]
+    pub fn trig(self) -> &'a mut W {
+        self.variant(EVACT_A::TRIG)
+    }
+    #[doc = "Conditional transfer trigger"]
+    #[inline(always)]
+    pub fn ctrig(self) -> &'a mut W {
+        self.variant(EVACT_A::CTRIG)
+    }
+    #[doc = "Conditional block transfer"]
+    #[inline(always)]
+    pub fn cblock(self) -> &'a mut W {
+        self.variant(EVACT_A::CBLOCK)
+    }
+    #[doc = "Channel suspend operation"]
+    #[inline(always)]
+    pub fn suspend(self) -> &'a mut W {
+        self.variant(EVACT_A::SUSPEND)
+    }
+    #[doc = "Channel resume operation"]
+    #[inline(always)]
+    pub fn resume(self) -> &'a mut W {
+        self.variant(EVACT_A::RESUME)
+    }
+    #[doc = "Skip next block suspend action"]
+    #[inline(always)]
+    pub fn sskip(self) -> &'a mut W {
+        self.variant(EVACT_A::SSKIP)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u32) & 0x07);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVIE`"]
+pub type EVIE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVIE`"]
+pub struct EVIE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVIE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVOE`"]
+pub type EVOE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVOE`"]
+pub struct EVOE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVOE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Channel Arbitration Level\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LVL_A {
+    #[doc = "0: Channel Priority Level 0"]
+    LVL0,
+    #[doc = "1: Channel Priority Level 1"]
+    LVL1,
+    #[doc = "2: Channel Priority Level 2"]
+    LVL2,
+    #[doc = "3: Channel Priority Level 3"]
+    LVL3,
+}
+impl From<LVL_A> for u8 {
+    #[inline(always)]
+    fn from(variant: LVL_A) -> Self {
+        match variant {
+            LVL_A::LVL0 => 0,
+            LVL_A::LVL1 => 1,
+            LVL_A::LVL2 => 2,
+            LVL_A::LVL3 => 3,
+        }
+    }
+}
+#[doc = "Reader of field `LVL`"]
+pub type LVL_R = crate::R<u8, LVL_A>;
+impl LVL_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> LVL_A {
+        match self.bits {
+            0 => LVL_A::LVL0,
+            1 => LVL_A::LVL1,
+            2 => LVL_A::LVL2,
+            3 => LVL_A::LVL3,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `LVL0`"]
+    #[inline(always)]
+    pub fn is_lvl0(&self) -> bool {
+        *self == LVL_A::LVL0
+    }
+    #[doc = "Checks if the value of the field is `LVL1`"]
+    #[inline(always)]
+    pub fn is_lvl1(&self) -> bool {
+        *self == LVL_A::LVL1
+    }
+    #[doc = "Checks if the value of the field is `LVL2`"]
+    #[inline(always)]
+    pub fn is_lvl2(&self) -> bool {
+        *self == LVL_A::LVL2
+    }
+    #[doc = "Checks if the value of the field is `LVL3`"]
+    #[inline(always)]
+    pub fn is_lvl3(&self) -> bool {
+        *self == LVL_A::LVL3
+    }
+}
+#[doc = "Write proxy for field `LVL`"]
+pub struct LVL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LVL_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: LVL_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Channel Priority Level 0"]
+    #[inline(always)]
+    pub fn lvl0(self) -> &'a mut W {
+        self.variant(LVL_A::LVL0)
+    }
+    #[doc = "Channel Priority Level 1"]
+    #[inline(always)]
+    pub fn lvl1(self) -> &'a mut W {
+        self.variant(LVL_A::LVL1)
+    }
+    #[doc = "Channel Priority Level 2"]
+    #[inline(always)]
+    pub fn lvl2(self) -> &'a mut W {
+        self.variant(LVL_A::LVL2)
+    }
+    #[doc = "Channel Priority Level 3"]
+    #[inline(always)]
+    pub fn lvl3(self) -> &'a mut W {
+        self.variant(LVL_A::LVL3)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 5)) | (((value as u32) & 0x03) << 5);
+        self.w
+    }
+}
+#[doc = "Trigger Source\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TRIGSRC_A {
+    #[doc = "0: Only software/event triggers"]
+    DISABLE,
+}
+impl From<TRIGSRC_A> for u8 {
+    #[inline(always)]
+    fn from(variant: TRIGSRC_A) -> Self {
+        match variant {
+            TRIGSRC_A::DISABLE => 0,
+        }
+    }
+}
+#[doc = "Reader of field `TRIGSRC`"]
+pub type TRIGSRC_R = crate::R<u8, TRIGSRC_A>;
+impl TRIGSRC_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, TRIGSRC_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(TRIGSRC_A::DISABLE),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[inline(always)]
+    pub fn is_disable(&self) -> bool {
+        *self == TRIGSRC_A::DISABLE
+    }
+}
+#[doc = "Write proxy for field `TRIGSRC`"]
+pub struct TRIGSRC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRIGSRC_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: TRIGSRC_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Only software/event triggers"]
+    #[inline(always)]
+    pub fn disable(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x1f << 8)) | (((value as u32) & 0x1f) << 8);
+        self.w
+    }
+}
+#[doc = "Trigger Action\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum TRIGACT_A {
+    #[doc = "0: One trigger required for each block transfer"]
+    BLOCK,
+    #[doc = "2: One trigger required for each beat transfer"]
+    BEAT,
+    #[doc = "3: One trigger required for each transaction"]
+    TRANSACTION,
+}
+impl From<TRIGACT_A> for u8 {
+    #[inline(always)]
+    fn from(variant: TRIGACT_A) -> Self {
+        match variant {
+            TRIGACT_A::BLOCK => 0,
+            TRIGACT_A::BEAT => 2,
+            TRIGACT_A::TRANSACTION => 3,
+        }
+    }
+}
+#[doc = "Reader of field `TRIGACT`"]
+pub type TRIGACT_R = crate::R<u8, TRIGACT_A>;
+impl TRIGACT_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, TRIGACT_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(TRIGACT_A::BLOCK),
+            2 => Val(TRIGACT_A::BEAT),
+            3 => Val(TRIGACT_A::TRANSACTION),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `BLOCK`"]
+    #[inline(always)]
+    pub fn is_block(&self) -> bool {
+        *self == TRIGACT_A::BLOCK
+    }
+    #[doc = "Checks if the value of the field is `BEAT`"]
+    #[inline(always)]
+    pub fn is_beat(&self) -> bool {
+        *self == TRIGACT_A::BEAT
+    }
+    #[doc = "Checks if the value of the field is `TRANSACTION`"]
+    #[inline(always)]
+    pub fn is_transaction(&self) -> bool {
+        *self == TRIGACT_A::TRANSACTION
+    }
+}
+#[doc = "Write proxy for field `TRIGACT`"]
+pub struct TRIGACT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRIGACT_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: TRIGACT_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "One trigger required for each block transfer"]
+    #[inline(always)]
+    pub fn block(self) -> &'a mut W {
+        self.variant(TRIGACT_A::BLOCK)
+    }
+    #[doc = "One trigger required for each beat transfer"]
+    #[inline(always)]
+    pub fn beat(self) -> &'a mut W {
+        self.variant(TRIGACT_A::BEAT)
+    }
+    #[doc = "One trigger required for each transaction"]
+    #[inline(always)]
+    pub fn transaction(self) -> &'a mut W {
+        self.variant(TRIGACT_A::TRANSACTION)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 22)) | (((value as u32) & 0x03) << 22);
+        self.w
+    }
+}
+#[doc = "Software Command\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CMD_A {
+    #[doc = "0: No action"]
+    NOACT,
+    #[doc = "1: Channel suspend operation"]
+    SUSPEND,
+    #[doc = "2: Channel resume operation"]
+    RESUME,
+}
+impl From<CMD_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CMD_A) -> Self {
+        match variant {
+            CMD_A::NOACT => 0,
+            CMD_A::SUSPEND => 1,
+            CMD_A::RESUME => 2,
+        }
+    }
+}
+#[doc = "Reader of field `CMD`"]
+pub type CMD_R = crate::R<u8, CMD_A>;
+impl CMD_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, CMD_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(CMD_A::NOACT),
+            1 => Val(CMD_A::SUSPEND),
+            2 => Val(CMD_A::RESUME),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NOACT`"]
+    #[inline(always)]
+    pub fn is_noact(&self) -> bool {
+        *self == CMD_A::NOACT
+    }
+    #[doc = "Checks if the value of the field is `SUSPEND`"]
+    #[inline(always)]
+    pub fn is_suspend(&self) -> bool {
+        *self == CMD_A::SUSPEND
+    }
+    #[doc = "Checks if the value of the field is `RESUME`"]
+    #[inline(always)]
+    pub fn is_resume(&self) -> bool {
+        *self == CMD_A::RESUME
+    }
+}
+#[doc = "Write proxy for field `CMD`"]
+pub struct CMD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMD_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CMD_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No action"]
+    #[inline(always)]
+    pub fn noact(self) -> &'a mut W {
+        self.variant(CMD_A::NOACT)
+    }
+    #[doc = "Channel suspend operation"]
+    #[inline(always)]
+    pub fn suspend(self) -> &'a mut W {
+        self.variant(CMD_A::SUSPEND)
+    }
+    #[doc = "Channel resume operation"]
+    #[inline(always)]
+    pub fn resume(self) -> &'a mut W {
+        self.variant(CMD_A::RESUME)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 24)) | (((value as u32) & 0x03) << 24);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Event Input Action"]
+    #[inline(always)]
+    pub fn evact(&self) -> EVACT_R {
+        EVACT_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bit 3 - Channel Event Input Enable"]
+    #[inline(always)]
+    pub fn evie(&self) -> EVIE_R {
+        EVIE_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Channel Event Output Enable"]
+    #[inline(always)]
+    pub fn evoe(&self) -> EVOE_R {
+        EVOE_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bits 5:6 - Channel Arbitration Level"]
+    #[inline(always)]
+    pub fn lvl(&self) -> LVL_R {
+        LVL_R::new(((self.bits >> 5) & 0x03) as u8)
+    }
+    #[doc = "Bits 8:12 - Trigger Source"]
+    #[inline(always)]
+    pub fn trigsrc(&self) -> TRIGSRC_R {
+        TRIGSRC_R::new(((self.bits >> 8) & 0x1f) as u8)
+    }
+    #[doc = "Bits 22:23 - Trigger Action"]
+    #[inline(always)]
+    pub fn trigact(&self) -> TRIGACT_R {
+        TRIGACT_R::new(((self.bits >> 22) & 0x03) as u8)
+    }
+    #[doc = "Bits 24:25 - Software Command"]
+    #[inline(always)]
+    pub fn cmd(&self) -> CMD_R {
+        CMD_R::new(((self.bits >> 24) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Event Input Action"]
+    #[inline(always)]
+    pub fn evact(&mut self) -> EVACT_W {
+        EVACT_W { w: self }
+    }
+    #[doc = "Bit 3 - Channel Event Input Enable"]
+    #[inline(always)]
+    pub fn evie(&mut self) -> EVIE_W {
+        EVIE_W { w: self }
+    }
+    #[doc = "Bit 4 - Channel Event Output Enable"]
+    #[inline(always)]
+    pub fn evoe(&mut self) -> EVOE_W {
+        EVOE_W { w: self }
+    }
+    #[doc = "Bits 5:6 - Channel Arbitration Level"]
+    #[inline(always)]
+    pub fn lvl(&mut self) -> LVL_W {
+        LVL_W { w: self }
+    }
+    #[doc = "Bits 8:12 - Trigger Source"]
+    #[inline(always)]
+    pub fn trigsrc(&mut self) -> TRIGSRC_W {
+        TRIGSRC_W { w: self }
+    }
+    #[doc = "Bits 22:23 - Trigger Action"]
+    #[inline(always)]
+    pub fn trigact(&mut self) -> TRIGACT_W {
+        TRIGACT_W { w: self }
+    }
+    #[doc = "Bits 24:25 - Software Command"]
+    #[inline(always)]
+    pub fn cmd(&mut self) -> CMD_W {
+        CMD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/chid.rs
+++ b/pac/atsamd11c14a/src/dmac/chid.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register CHID"]
+pub type R = crate::R<u8, super::CHID>;
+#[doc = "Writer for register CHID"]
+pub type W = crate::W<u8, super::CHID>;
+#[doc = "Register CHID `reset()`'s with value 0"]
+impl crate::ResetValue for super::CHID {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ID`"]
+pub type ID_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `ID`"]
+pub struct ID_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ID_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u8) & 0x07);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Channel ID"]
+    #[inline(always)]
+    pub fn id(&self) -> ID_R {
+        ID_R::new((self.bits & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Channel ID"]
+    #[inline(always)]
+    pub fn id(&mut self) -> ID_W {
+        ID_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/chintenclr.rs
+++ b/pac/atsamd11c14a/src/dmac/chintenclr.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register CHINTENCLR"]
+pub type R = crate::R<u8, super::CHINTENCLR>;
+#[doc = "Writer for register CHINTENCLR"]
+pub type W = crate::W<u8, super::CHINTENCLR>;
+#[doc = "Register CHINTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::CHINTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `TERR`"]
+pub type TERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TERR`"]
+pub struct TERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `TCMPL`"]
+pub type TCMPL_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TCMPL`"]
+pub struct TCMPL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TCMPL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SUSP`"]
+pub type SUSP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SUSP`"]
+pub struct SUSP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SUSP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Channel Transfer Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn terr(&self) -> TERR_R {
+        TERR_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Channel Transfer Complete Interrupt Enable"]
+    #[inline(always)]
+    pub fn tcmpl(&self) -> TCMPL_R {
+        TCMPL_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Channel Suspend Interrupt Enable"]
+    #[inline(always)]
+    pub fn susp(&self) -> SUSP_R {
+        SUSP_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Channel Transfer Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn terr(&mut self) -> TERR_W {
+        TERR_W { w: self }
+    }
+    #[doc = "Bit 1 - Channel Transfer Complete Interrupt Enable"]
+    #[inline(always)]
+    pub fn tcmpl(&mut self) -> TCMPL_W {
+        TCMPL_W { w: self }
+    }
+    #[doc = "Bit 2 - Channel Suspend Interrupt Enable"]
+    #[inline(always)]
+    pub fn susp(&mut self) -> SUSP_W {
+        SUSP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/chintenset.rs
+++ b/pac/atsamd11c14a/src/dmac/chintenset.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register CHINTENSET"]
+pub type R = crate::R<u8, super::CHINTENSET>;
+#[doc = "Writer for register CHINTENSET"]
+pub type W = crate::W<u8, super::CHINTENSET>;
+#[doc = "Register CHINTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::CHINTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `TERR`"]
+pub type TERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TERR`"]
+pub struct TERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `TCMPL`"]
+pub type TCMPL_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TCMPL`"]
+pub struct TCMPL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TCMPL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SUSP`"]
+pub type SUSP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SUSP`"]
+pub struct SUSP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SUSP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Channel Transfer Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn terr(&self) -> TERR_R {
+        TERR_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Channel Transfer Complete Interrupt Enable"]
+    #[inline(always)]
+    pub fn tcmpl(&self) -> TCMPL_R {
+        TCMPL_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Channel Suspend Interrupt Enable"]
+    #[inline(always)]
+    pub fn susp(&self) -> SUSP_R {
+        SUSP_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Channel Transfer Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn terr(&mut self) -> TERR_W {
+        TERR_W { w: self }
+    }
+    #[doc = "Bit 1 - Channel Transfer Complete Interrupt Enable"]
+    #[inline(always)]
+    pub fn tcmpl(&mut self) -> TCMPL_W {
+        TCMPL_W { w: self }
+    }
+    #[doc = "Bit 2 - Channel Suspend Interrupt Enable"]
+    #[inline(always)]
+    pub fn susp(&mut self) -> SUSP_W {
+        SUSP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/chintflag.rs
+++ b/pac/atsamd11c14a/src/dmac/chintflag.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register CHINTFLAG"]
+pub type R = crate::R<u8, super::CHINTFLAG>;
+#[doc = "Writer for register CHINTFLAG"]
+pub type W = crate::W<u8, super::CHINTFLAG>;
+#[doc = "Register CHINTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::CHINTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `TERR`"]
+pub type TERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TERR`"]
+pub struct TERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `TCMPL`"]
+pub type TCMPL_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TCMPL`"]
+pub struct TCMPL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TCMPL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SUSP`"]
+pub type SUSP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SUSP`"]
+pub struct SUSP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SUSP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Channel Transfer Error"]
+    #[inline(always)]
+    pub fn terr(&self) -> TERR_R {
+        TERR_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Channel Transfer Complete"]
+    #[inline(always)]
+    pub fn tcmpl(&self) -> TCMPL_R {
+        TCMPL_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Channel Suspend"]
+    #[inline(always)]
+    pub fn susp(&self) -> SUSP_R {
+        SUSP_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Channel Transfer Error"]
+    #[inline(always)]
+    pub fn terr(&mut self) -> TERR_W {
+        TERR_W { w: self }
+    }
+    #[doc = "Bit 1 - Channel Transfer Complete"]
+    #[inline(always)]
+    pub fn tcmpl(&mut self) -> TCMPL_W {
+        TCMPL_W { w: self }
+    }
+    #[doc = "Bit 2 - Channel Suspend"]
+    #[inline(always)]
+    pub fn susp(&mut self) -> SUSP_W {
+        SUSP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/chstatus.rs
+++ b/pac/atsamd11c14a/src/dmac/chstatus.rs
@@ -1,0 +1,25 @@
+#[doc = "Reader of register CHSTATUS"]
+pub type R = crate::R<u8, super::CHSTATUS>;
+#[doc = "Reader of field `PEND`"]
+pub type PEND_R = crate::R<bool, bool>;
+#[doc = "Reader of field `BUSY`"]
+pub type BUSY_R = crate::R<bool, bool>;
+#[doc = "Reader of field `FERR`"]
+pub type FERR_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Channel Pending"]
+    #[inline(always)]
+    pub fn pend(&self) -> PEND_R {
+        PEND_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Channel Busy"]
+    #[inline(always)]
+    pub fn busy(&self) -> BUSY_R {
+        BUSY_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Channel Fetch Error"]
+    #[inline(always)]
+    pub fn ferr(&self) -> FERR_R {
+        FERR_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/crcchksum.rs
+++ b/pac/atsamd11c14a/src/dmac/crcchksum.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register CRCCHKSUM"]
+pub type R = crate::R<u32, super::CRCCHKSUM>;
+#[doc = "Writer for register CRCCHKSUM"]
+pub type W = crate::W<u32, super::CRCCHKSUM>;
+#[doc = "Register CRCCHKSUM `reset()`'s with value 0"]
+impl crate::ResetValue for super::CRCCHKSUM {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CRCCHKSUM`"]
+pub type CRCCHKSUM_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `CRCCHKSUM`"]
+pub struct CRCCHKSUM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CRCCHKSUM_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - CRC Checksum"]
+    #[inline(always)]
+    pub fn crcchksum(&self) -> CRCCHKSUM_R {
+        CRCCHKSUM_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - CRC Checksum"]
+    #[inline(always)]
+    pub fn crcchksum(&mut self) -> CRCCHKSUM_W {
+        CRCCHKSUM_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/crcctrl.rs
+++ b/pac/atsamd11c14a/src/dmac/crcctrl.rs
@@ -1,0 +1,264 @@
+#[doc = "Reader of register CRCCTRL"]
+pub type R = crate::R<u16, super::CRCCTRL>;
+#[doc = "Writer for register CRCCTRL"]
+pub type W = crate::W<u16, super::CRCCTRL>;
+#[doc = "Register CRCCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::CRCCTRL {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "CRC Beat Size\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CRCBEATSIZE_A {
+    #[doc = "0: 8-bit bus transfer"]
+    BYTE,
+    #[doc = "1: 16-bit bus transfer"]
+    HWORD,
+    #[doc = "2: 32-bit bus transfer"]
+    WORD,
+}
+impl From<CRCBEATSIZE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CRCBEATSIZE_A) -> Self {
+        match variant {
+            CRCBEATSIZE_A::BYTE => 0,
+            CRCBEATSIZE_A::HWORD => 1,
+            CRCBEATSIZE_A::WORD => 2,
+        }
+    }
+}
+#[doc = "Reader of field `CRCBEATSIZE`"]
+pub type CRCBEATSIZE_R = crate::R<u8, CRCBEATSIZE_A>;
+impl CRCBEATSIZE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, CRCBEATSIZE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(CRCBEATSIZE_A::BYTE),
+            1 => Val(CRCBEATSIZE_A::HWORD),
+            2 => Val(CRCBEATSIZE_A::WORD),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `BYTE`"]
+    #[inline(always)]
+    pub fn is_byte(&self) -> bool {
+        *self == CRCBEATSIZE_A::BYTE
+    }
+    #[doc = "Checks if the value of the field is `HWORD`"]
+    #[inline(always)]
+    pub fn is_hword(&self) -> bool {
+        *self == CRCBEATSIZE_A::HWORD
+    }
+    #[doc = "Checks if the value of the field is `WORD`"]
+    #[inline(always)]
+    pub fn is_word(&self) -> bool {
+        *self == CRCBEATSIZE_A::WORD
+    }
+}
+#[doc = "Write proxy for field `CRCBEATSIZE`"]
+pub struct CRCBEATSIZE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CRCBEATSIZE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CRCBEATSIZE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "8-bit bus transfer"]
+    #[inline(always)]
+    pub fn byte(self) -> &'a mut W {
+        self.variant(CRCBEATSIZE_A::BYTE)
+    }
+    #[doc = "16-bit bus transfer"]
+    #[inline(always)]
+    pub fn hword(self) -> &'a mut W {
+        self.variant(CRCBEATSIZE_A::HWORD)
+    }
+    #[doc = "32-bit bus transfer"]
+    #[inline(always)]
+    pub fn word(self) -> &'a mut W {
+        self.variant(CRCBEATSIZE_A::WORD)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x03) | ((value as u16) & 0x03);
+        self.w
+    }
+}
+#[doc = "CRC Polynomial Type\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CRCPOLY_A {
+    #[doc = "0: CRC-16 (CRC-CCITT)"]
+    CRC16,
+    #[doc = "1: CRC32 (IEEE 802.3)"]
+    CRC32,
+}
+impl From<CRCPOLY_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CRCPOLY_A) -> Self {
+        match variant {
+            CRCPOLY_A::CRC16 => 0,
+            CRCPOLY_A::CRC32 => 1,
+        }
+    }
+}
+#[doc = "Reader of field `CRCPOLY`"]
+pub type CRCPOLY_R = crate::R<u8, CRCPOLY_A>;
+impl CRCPOLY_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, CRCPOLY_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(CRCPOLY_A::CRC16),
+            1 => Val(CRCPOLY_A::CRC32),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `CRC16`"]
+    #[inline(always)]
+    pub fn is_crc16(&self) -> bool {
+        *self == CRCPOLY_A::CRC16
+    }
+    #[doc = "Checks if the value of the field is `CRC32`"]
+    #[inline(always)]
+    pub fn is_crc32(&self) -> bool {
+        *self == CRCPOLY_A::CRC32
+    }
+}
+#[doc = "Write proxy for field `CRCPOLY`"]
+pub struct CRCPOLY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CRCPOLY_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CRCPOLY_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "CRC-16 (CRC-CCITT)"]
+    #[inline(always)]
+    pub fn crc16(self) -> &'a mut W {
+        self.variant(CRCPOLY_A::CRC16)
+    }
+    #[doc = "CRC32 (IEEE 802.3)"]
+    #[inline(always)]
+    pub fn crc32(self) -> &'a mut W {
+        self.variant(CRCPOLY_A::CRC32)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 2)) | (((value as u16) & 0x03) << 2);
+        self.w
+    }
+}
+#[doc = "CRC Input Source\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CRCSRC_A {
+    #[doc = "0: No action"]
+    NOACT,
+    #[doc = "1: I/O interface"]
+    IO,
+}
+impl From<CRCSRC_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CRCSRC_A) -> Self {
+        match variant {
+            CRCSRC_A::NOACT => 0,
+            CRCSRC_A::IO => 1,
+        }
+    }
+}
+#[doc = "Reader of field `CRCSRC`"]
+pub type CRCSRC_R = crate::R<u8, CRCSRC_A>;
+impl CRCSRC_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, CRCSRC_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(CRCSRC_A::NOACT),
+            1 => Val(CRCSRC_A::IO),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NOACT`"]
+    #[inline(always)]
+    pub fn is_noact(&self) -> bool {
+        *self == CRCSRC_A::NOACT
+    }
+    #[doc = "Checks if the value of the field is `IO`"]
+    #[inline(always)]
+    pub fn is_io(&self) -> bool {
+        *self == CRCSRC_A::IO
+    }
+}
+#[doc = "Write proxy for field `CRCSRC`"]
+pub struct CRCSRC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CRCSRC_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CRCSRC_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No action"]
+    #[inline(always)]
+    pub fn noact(self) -> &'a mut W {
+        self.variant(CRCSRC_A::NOACT)
+    }
+    #[doc = "I/O interface"]
+    #[inline(always)]
+    pub fn io(self) -> &'a mut W {
+        self.variant(CRCSRC_A::IO)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x3f << 8)) | (((value as u16) & 0x3f) << 8);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:1 - CRC Beat Size"]
+    #[inline(always)]
+    pub fn crcbeatsize(&self) -> CRCBEATSIZE_R {
+        CRCBEATSIZE_R::new((self.bits & 0x03) as u8)
+    }
+    #[doc = "Bits 2:3 - CRC Polynomial Type"]
+    #[inline(always)]
+    pub fn crcpoly(&self) -> CRCPOLY_R {
+        CRCPOLY_R::new(((self.bits >> 2) & 0x03) as u8)
+    }
+    #[doc = "Bits 8:13 - CRC Input Source"]
+    #[inline(always)]
+    pub fn crcsrc(&self) -> CRCSRC_R {
+        CRCSRC_R::new(((self.bits >> 8) & 0x3f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:1 - CRC Beat Size"]
+    #[inline(always)]
+    pub fn crcbeatsize(&mut self) -> CRCBEATSIZE_W {
+        CRCBEATSIZE_W { w: self }
+    }
+    #[doc = "Bits 2:3 - CRC Polynomial Type"]
+    #[inline(always)]
+    pub fn crcpoly(&mut self) -> CRCPOLY_W {
+        CRCPOLY_W { w: self }
+    }
+    #[doc = "Bits 8:13 - CRC Input Source"]
+    #[inline(always)]
+    pub fn crcsrc(&mut self) -> CRCSRC_W {
+        CRCSRC_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/crcdatain.rs
+++ b/pac/atsamd11c14a/src/dmac/crcdatain.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register CRCDATAIN"]
+pub type R = crate::R<u32, super::CRCDATAIN>;
+#[doc = "Writer for register CRCDATAIN"]
+pub type W = crate::W<u32, super::CRCDATAIN>;
+#[doc = "Register CRCDATAIN `reset()`'s with value 0"]
+impl crate::ResetValue for super::CRCDATAIN {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CRCDATAIN`"]
+pub type CRCDATAIN_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `CRCDATAIN`"]
+pub struct CRCDATAIN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CRCDATAIN_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - CRC Data Input"]
+    #[inline(always)]
+    pub fn crcdatain(&self) -> CRCDATAIN_R {
+        CRCDATAIN_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - CRC Data Input"]
+    #[inline(always)]
+    pub fn crcdatain(&mut self) -> CRCDATAIN_W {
+        CRCDATAIN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/crcstatus.rs
+++ b/pac/atsamd11c14a/src/dmac/crcstatus.rs
@@ -1,0 +1,57 @@
+#[doc = "Reader of register CRCSTATUS"]
+pub type R = crate::R<u8, super::CRCSTATUS>;
+#[doc = "Writer for register CRCSTATUS"]
+pub type W = crate::W<u8, super::CRCSTATUS>;
+#[doc = "Register CRCSTATUS `reset()`'s with value 0"]
+impl crate::ResetValue for super::CRCSTATUS {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CRCBUSY`"]
+pub type CRCBUSY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CRCBUSY`"]
+pub struct CRCBUSY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CRCBUSY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `CRCZERO`"]
+pub type CRCZERO_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - CRC Module Busy"]
+    #[inline(always)]
+    pub fn crcbusy(&self) -> CRCBUSY_R {
+        CRCBUSY_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - CRC Zero"]
+    #[inline(always)]
+    pub fn crczero(&self) -> CRCZERO_R {
+        CRCZERO_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - CRC Module Busy"]
+    #[inline(always)]
+    pub fn crcbusy(&mut self) -> CRCBUSY_W {
+        CRCBUSY_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/ctrl.rs
+++ b/pac/atsamd11c14a/src/dmac/ctrl.rs
@@ -1,0 +1,254 @@
+#[doc = "Reader of register CTRL"]
+pub type R = crate::R<u16, super::CTRL>;
+#[doc = "Writer for register CTRL"]
+pub type W = crate::W<u16, super::CTRL>;
+#[doc = "Register CTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRL {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `DMAENABLE`"]
+pub type DMAENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DMAENABLE`"]
+pub struct DMAENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DMAENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `CRCENABLE`"]
+pub type CRCENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CRCENABLE`"]
+pub struct CRCENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CRCENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `LVLEN0`"]
+pub type LVLEN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LVLEN0`"]
+pub struct LVLEN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LVLEN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `LVLEN1`"]
+pub type LVLEN1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LVLEN1`"]
+pub struct LVLEN1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LVLEN1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u16) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `LVLEN2`"]
+pub type LVLEN2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LVLEN2`"]
+pub struct LVLEN2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LVLEN2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u16) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `LVLEN3`"]
+pub type LVLEN3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LVLEN3`"]
+pub struct LVLEN3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LVLEN3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u16) & 0x01) << 11);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - DMA Enable"]
+    #[inline(always)]
+    pub fn dmaenable(&self) -> DMAENABLE_R {
+        DMAENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - CRC Enable"]
+    #[inline(always)]
+    pub fn crcenable(&self) -> CRCENABLE_R {
+        CRCENABLE_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Priority Level 0 Enable"]
+    #[inline(always)]
+    pub fn lvlen0(&self) -> LVLEN0_R {
+        LVLEN0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Priority Level 1 Enable"]
+    #[inline(always)]
+    pub fn lvlen1(&self) -> LVLEN1_R {
+        LVLEN1_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Priority Level 2 Enable"]
+    #[inline(always)]
+    pub fn lvlen2(&self) -> LVLEN2_R {
+        LVLEN2_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Priority Level 3 Enable"]
+    #[inline(always)]
+    pub fn lvlen3(&self) -> LVLEN3_R {
+        LVLEN3_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - DMA Enable"]
+    #[inline(always)]
+    pub fn dmaenable(&mut self) -> DMAENABLE_W {
+        DMAENABLE_W { w: self }
+    }
+    #[doc = "Bit 2 - CRC Enable"]
+    #[inline(always)]
+    pub fn crcenable(&mut self) -> CRCENABLE_W {
+        CRCENABLE_W { w: self }
+    }
+    #[doc = "Bit 8 - Priority Level 0 Enable"]
+    #[inline(always)]
+    pub fn lvlen0(&mut self) -> LVLEN0_W {
+        LVLEN0_W { w: self }
+    }
+    #[doc = "Bit 9 - Priority Level 1 Enable"]
+    #[inline(always)]
+    pub fn lvlen1(&mut self) -> LVLEN1_W {
+        LVLEN1_W { w: self }
+    }
+    #[doc = "Bit 10 - Priority Level 2 Enable"]
+    #[inline(always)]
+    pub fn lvlen2(&mut self) -> LVLEN2_W {
+        LVLEN2_W { w: self }
+    }
+    #[doc = "Bit 11 - Priority Level 3 Enable"]
+    #[inline(always)]
+    pub fn lvlen3(&mut self) -> LVLEN3_W {
+        LVLEN3_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/dbgctrl.rs
+++ b/pac/atsamd11c14a/src/dmac/dbgctrl.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register DBGCTRL"]
+pub type R = crate::R<u8, super::DBGCTRL>;
+#[doc = "Writer for register DBGCTRL"]
+pub type W = crate::W<u8, super::DBGCTRL>;
+#[doc = "Register DBGCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::DBGCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DBGRUN`"]
+pub type DBGRUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DBGRUN`"]
+pub struct DBGRUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DBGRUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Debug Run"]
+    #[inline(always)]
+    pub fn dbgrun(&self) -> DBGRUN_R {
+        DBGRUN_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Debug Run"]
+    #[inline(always)]
+    pub fn dbgrun(&mut self) -> DBGRUN_W {
+        DBGRUN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/intpend.rs
+++ b/pac/atsamd11c14a/src/dmac/intpend.rs
@@ -1,0 +1,163 @@
+#[doc = "Reader of register INTPEND"]
+pub type R = crate::R<u16, super::INTPEND>;
+#[doc = "Writer for register INTPEND"]
+pub type W = crate::W<u16, super::INTPEND>;
+#[doc = "Register INTPEND `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTPEND {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ID`"]
+pub type ID_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `ID`"]
+pub struct ID_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ID_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u16) & 0x07);
+        self.w
+    }
+}
+#[doc = "Reader of field `TERR`"]
+pub type TERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TERR`"]
+pub struct TERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `TCMPL`"]
+pub type TCMPL_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TCMPL`"]
+pub struct TCMPL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TCMPL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u16) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `SUSP`"]
+pub type SUSP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SUSP`"]
+pub struct SUSP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SUSP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u16) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `FERR`"]
+pub type FERR_R = crate::R<bool, bool>;
+#[doc = "Reader of field `BUSY`"]
+pub type BUSY_R = crate::R<bool, bool>;
+#[doc = "Reader of field `PEND`"]
+pub type PEND_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bits 0:2 - Channel ID"]
+    #[inline(always)]
+    pub fn id(&self) -> ID_R {
+        ID_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bit 8 - Transfer Error"]
+    #[inline(always)]
+    pub fn terr(&self) -> TERR_R {
+        TERR_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Transfer Complete"]
+    #[inline(always)]
+    pub fn tcmpl(&self) -> TCMPL_R {
+        TCMPL_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Channel Suspend"]
+    #[inline(always)]
+    pub fn susp(&self) -> SUSP_R {
+        SUSP_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Fetch Error"]
+    #[inline(always)]
+    pub fn ferr(&self) -> FERR_R {
+        FERR_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+    #[doc = "Bit 14 - Busy"]
+    #[inline(always)]
+    pub fn busy(&self) -> BUSY_R {
+        BUSY_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Pending"]
+    #[inline(always)]
+    pub fn pend(&self) -> PEND_R {
+        PEND_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Channel ID"]
+    #[inline(always)]
+    pub fn id(&mut self) -> ID_W {
+        ID_W { w: self }
+    }
+    #[doc = "Bit 8 - Transfer Error"]
+    #[inline(always)]
+    pub fn terr(&mut self) -> TERR_W {
+        TERR_W { w: self }
+    }
+    #[doc = "Bit 9 - Transfer Complete"]
+    #[inline(always)]
+    pub fn tcmpl(&mut self) -> TCMPL_W {
+        TCMPL_W { w: self }
+    }
+    #[doc = "Bit 10 - Channel Suspend"]
+    #[inline(always)]
+    pub fn susp(&mut self) -> SUSP_W {
+        SUSP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/intstatus.rs
+++ b/pac/atsamd11c14a/src/dmac/intstatus.rs
@@ -1,0 +1,46 @@
+#[doc = "Reader of register INTSTATUS"]
+pub type R = crate::R<u32, super::INTSTATUS>;
+#[doc = "Reader of field `CHINT0`"]
+pub type CHINT0_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CHINT1`"]
+pub type CHINT1_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CHINT2`"]
+pub type CHINT2_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CHINT3`"]
+pub type CHINT3_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CHINT4`"]
+pub type CHINT4_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CHINT5`"]
+pub type CHINT5_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Channel 0 Pending Interrupt"]
+    #[inline(always)]
+    pub fn chint0(&self) -> CHINT0_R {
+        CHINT0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Channel 1 Pending Interrupt"]
+    #[inline(always)]
+    pub fn chint1(&self) -> CHINT1_R {
+        CHINT1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Channel 2 Pending Interrupt"]
+    #[inline(always)]
+    pub fn chint2(&self) -> CHINT2_R {
+        CHINT2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Channel 3 Pending Interrupt"]
+    #[inline(always)]
+    pub fn chint3(&self) -> CHINT3_R {
+        CHINT3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Channel 4 Pending Interrupt"]
+    #[inline(always)]
+    pub fn chint4(&self) -> CHINT4_R {
+        CHINT4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Channel 5 Pending Interrupt"]
+    #[inline(always)]
+    pub fn chint5(&self) -> CHINT5_R {
+        CHINT5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/pendch.rs
+++ b/pac/atsamd11c14a/src/dmac/pendch.rs
@@ -1,0 +1,46 @@
+#[doc = "Reader of register PENDCH"]
+pub type R = crate::R<u32, super::PENDCH>;
+#[doc = "Reader of field `PENDCH0`"]
+pub type PENDCH0_R = crate::R<bool, bool>;
+#[doc = "Reader of field `PENDCH1`"]
+pub type PENDCH1_R = crate::R<bool, bool>;
+#[doc = "Reader of field `PENDCH2`"]
+pub type PENDCH2_R = crate::R<bool, bool>;
+#[doc = "Reader of field `PENDCH3`"]
+pub type PENDCH3_R = crate::R<bool, bool>;
+#[doc = "Reader of field `PENDCH4`"]
+pub type PENDCH4_R = crate::R<bool, bool>;
+#[doc = "Reader of field `PENDCH5`"]
+pub type PENDCH5_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Pending Channel 0"]
+    #[inline(always)]
+    pub fn pendch0(&self) -> PENDCH0_R {
+        PENDCH0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Pending Channel 1"]
+    #[inline(always)]
+    pub fn pendch1(&self) -> PENDCH1_R {
+        PENDCH1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Pending Channel 2"]
+    #[inline(always)]
+    pub fn pendch2(&self) -> PENDCH2_R {
+        PENDCH2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Pending Channel 3"]
+    #[inline(always)]
+    pub fn pendch3(&self) -> PENDCH3_R {
+        PENDCH3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Pending Channel 4"]
+    #[inline(always)]
+    pub fn pendch4(&self) -> PENDCH4_R {
+        PENDCH4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Pending Channel 5"]
+    #[inline(always)]
+    pub fn pendch5(&self) -> PENDCH5_R {
+        PENDCH5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/prictrl0.rs
+++ b/pac/atsamd11c14a/src/dmac/prictrl0.rs
@@ -1,0 +1,248 @@
+#[doc = "Reader of register PRICTRL0"]
+pub type R = crate::R<u32, super::PRICTRL0>;
+#[doc = "Writer for register PRICTRL0"]
+pub type W = crate::W<u32, super::PRICTRL0>;
+#[doc = "Register PRICTRL0 `reset()`'s with value 0"]
+impl crate::ResetValue for super::PRICTRL0 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `LVLPRI0`"]
+pub type LVLPRI0_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `LVLPRI0`"]
+pub struct LVLPRI0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LVLPRI0_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u32) & 0x07);
+        self.w
+    }
+}
+#[doc = "Reader of field `RRLVLEN0`"]
+pub type RRLVLEN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RRLVLEN0`"]
+pub struct RRLVLEN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RRLVLEN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `LVLPRI1`"]
+pub type LVLPRI1_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `LVLPRI1`"]
+pub struct LVLPRI1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LVLPRI1_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 8)) | (((value as u32) & 0x07) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `RRLVLEN1`"]
+pub type RRLVLEN1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RRLVLEN1`"]
+pub struct RRLVLEN1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RRLVLEN1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Reader of field `LVLPRI2`"]
+pub type LVLPRI2_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `LVLPRI2`"]
+pub struct LVLPRI2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LVLPRI2_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 16)) | (((value as u32) & 0x07) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `RRLVLEN2`"]
+pub type RRLVLEN2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RRLVLEN2`"]
+pub struct RRLVLEN2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RRLVLEN2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 23)) | (((value as u32) & 0x01) << 23);
+        self.w
+    }
+}
+#[doc = "Reader of field `LVLPRI3`"]
+pub type LVLPRI3_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `LVLPRI3`"]
+pub struct LVLPRI3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LVLPRI3_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 24)) | (((value as u32) & 0x07) << 24);
+        self.w
+    }
+}
+#[doc = "Reader of field `RRLVLEN3`"]
+pub type RRLVLEN3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RRLVLEN3`"]
+pub struct RRLVLEN3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RRLVLEN3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 31)) | (((value as u32) & 0x01) << 31);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Level 0 Channel Priority Number"]
+    #[inline(always)]
+    pub fn lvlpri0(&self) -> LVLPRI0_R {
+        LVLPRI0_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bit 7 - Level 0 Round-Robin Scheduling Enable"]
+    #[inline(always)]
+    pub fn rrlvlen0(&self) -> RRLVLEN0_R {
+        RRLVLEN0_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bits 8:10 - Level 1 Channel Priority Number"]
+    #[inline(always)]
+    pub fn lvlpri1(&self) -> LVLPRI1_R {
+        LVLPRI1_R::new(((self.bits >> 8) & 0x07) as u8)
+    }
+    #[doc = "Bit 15 - Level 1 Round-Robin Scheduling Enable"]
+    #[inline(always)]
+    pub fn rrlvlen1(&self) -> RRLVLEN1_R {
+        RRLVLEN1_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bits 16:18 - Level 2 Channel Priority Number"]
+    #[inline(always)]
+    pub fn lvlpri2(&self) -> LVLPRI2_R {
+        LVLPRI2_R::new(((self.bits >> 16) & 0x07) as u8)
+    }
+    #[doc = "Bit 23 - Level 2 Round-Robin Scheduling Enable"]
+    #[inline(always)]
+    pub fn rrlvlen2(&self) -> RRLVLEN2_R {
+        RRLVLEN2_R::new(((self.bits >> 23) & 0x01) != 0)
+    }
+    #[doc = "Bits 24:26 - Level 3 Channel Priority Number"]
+    #[inline(always)]
+    pub fn lvlpri3(&self) -> LVLPRI3_R {
+        LVLPRI3_R::new(((self.bits >> 24) & 0x07) as u8)
+    }
+    #[doc = "Bit 31 - Level 3 Round-Robin Scheduling Enable"]
+    #[inline(always)]
+    pub fn rrlvlen3(&self) -> RRLVLEN3_R {
+        RRLVLEN3_R::new(((self.bits >> 31) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Level 0 Channel Priority Number"]
+    #[inline(always)]
+    pub fn lvlpri0(&mut self) -> LVLPRI0_W {
+        LVLPRI0_W { w: self }
+    }
+    #[doc = "Bit 7 - Level 0 Round-Robin Scheduling Enable"]
+    #[inline(always)]
+    pub fn rrlvlen0(&mut self) -> RRLVLEN0_W {
+        RRLVLEN0_W { w: self }
+    }
+    #[doc = "Bits 8:10 - Level 1 Channel Priority Number"]
+    #[inline(always)]
+    pub fn lvlpri1(&mut self) -> LVLPRI1_W {
+        LVLPRI1_W { w: self }
+    }
+    #[doc = "Bit 15 - Level 1 Round-Robin Scheduling Enable"]
+    #[inline(always)]
+    pub fn rrlvlen1(&mut self) -> RRLVLEN1_W {
+        RRLVLEN1_W { w: self }
+    }
+    #[doc = "Bits 16:18 - Level 2 Channel Priority Number"]
+    #[inline(always)]
+    pub fn lvlpri2(&mut self) -> LVLPRI2_W {
+        LVLPRI2_W { w: self }
+    }
+    #[doc = "Bit 23 - Level 2 Round-Robin Scheduling Enable"]
+    #[inline(always)]
+    pub fn rrlvlen2(&mut self) -> RRLVLEN2_W {
+        RRLVLEN2_W { w: self }
+    }
+    #[doc = "Bits 24:26 - Level 3 Channel Priority Number"]
+    #[inline(always)]
+    pub fn lvlpri3(&mut self) -> LVLPRI3_W {
+        LVLPRI3_W { w: self }
+    }
+    #[doc = "Bit 31 - Level 3 Round-Robin Scheduling Enable"]
+    #[inline(always)]
+    pub fn rrlvlen3(&mut self) -> RRLVLEN3_W {
+        RRLVLEN3_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/qosctrl.rs
+++ b/pac/atsamd11c14a/src/dmac/qosctrl.rs
@@ -1,0 +1,337 @@
+#[doc = "Reader of register QOSCTRL"]
+pub type R = crate::R<u8, super::QOSCTRL>;
+#[doc = "Writer for register QOSCTRL"]
+pub type W = crate::W<u8, super::QOSCTRL>;
+#[doc = "Register QOSCTRL `reset()`'s with value 0x15"]
+impl crate::ResetValue for super::QOSCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x15
+    }
+}
+#[doc = "Write-Back Quality of Service\n\nValue on reset: 1"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum WRBQOS_A {
+    #[doc = "0: Background (no sensitive operation)"]
+    DISABLE,
+    #[doc = "1: Sensitive Bandwidth"]
+    LOW,
+    #[doc = "2: Sensitive Latency"]
+    MEDIUM,
+    #[doc = "3: Critical Latency"]
+    HIGH,
+}
+impl From<WRBQOS_A> for u8 {
+    #[inline(always)]
+    fn from(variant: WRBQOS_A) -> Self {
+        match variant {
+            WRBQOS_A::DISABLE => 0,
+            WRBQOS_A::LOW => 1,
+            WRBQOS_A::MEDIUM => 2,
+            WRBQOS_A::HIGH => 3,
+        }
+    }
+}
+#[doc = "Reader of field `WRBQOS`"]
+pub type WRBQOS_R = crate::R<u8, WRBQOS_A>;
+impl WRBQOS_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> WRBQOS_A {
+        match self.bits {
+            0 => WRBQOS_A::DISABLE,
+            1 => WRBQOS_A::LOW,
+            2 => WRBQOS_A::MEDIUM,
+            3 => WRBQOS_A::HIGH,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[inline(always)]
+    pub fn is_disable(&self) -> bool {
+        *self == WRBQOS_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `LOW`"]
+    #[inline(always)]
+    pub fn is_low(&self) -> bool {
+        *self == WRBQOS_A::LOW
+    }
+    #[doc = "Checks if the value of the field is `MEDIUM`"]
+    #[inline(always)]
+    pub fn is_medium(&self) -> bool {
+        *self == WRBQOS_A::MEDIUM
+    }
+    #[doc = "Checks if the value of the field is `HIGH`"]
+    #[inline(always)]
+    pub fn is_high(&self) -> bool {
+        *self == WRBQOS_A::HIGH
+    }
+}
+#[doc = "Write proxy for field `WRBQOS`"]
+pub struct WRBQOS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WRBQOS_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: WRBQOS_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Background (no sensitive operation)"]
+    #[inline(always)]
+    pub fn disable(self) -> &'a mut W {
+        self.variant(WRBQOS_A::DISABLE)
+    }
+    #[doc = "Sensitive Bandwidth"]
+    #[inline(always)]
+    pub fn low(self) -> &'a mut W {
+        self.variant(WRBQOS_A::LOW)
+    }
+    #[doc = "Sensitive Latency"]
+    #[inline(always)]
+    pub fn medium(self) -> &'a mut W {
+        self.variant(WRBQOS_A::MEDIUM)
+    }
+    #[doc = "Critical Latency"]
+    #[inline(always)]
+    pub fn high(self) -> &'a mut W {
+        self.variant(WRBQOS_A::HIGH)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x03) | ((value as u8) & 0x03);
+        self.w
+    }
+}
+#[doc = "Fetch Quality of Service\n\nValue on reset: 1"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FQOS_A {
+    #[doc = "0: Background (no sensitive operation)"]
+    DISABLE,
+    #[doc = "1: Sensitive Bandwidth"]
+    LOW,
+    #[doc = "2: Sensitive Latency"]
+    MEDIUM,
+    #[doc = "3: Critical Latency"]
+    HIGH,
+}
+impl From<FQOS_A> for u8 {
+    #[inline(always)]
+    fn from(variant: FQOS_A) -> Self {
+        match variant {
+            FQOS_A::DISABLE => 0,
+            FQOS_A::LOW => 1,
+            FQOS_A::MEDIUM => 2,
+            FQOS_A::HIGH => 3,
+        }
+    }
+}
+#[doc = "Reader of field `FQOS`"]
+pub type FQOS_R = crate::R<u8, FQOS_A>;
+impl FQOS_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> FQOS_A {
+        match self.bits {
+            0 => FQOS_A::DISABLE,
+            1 => FQOS_A::LOW,
+            2 => FQOS_A::MEDIUM,
+            3 => FQOS_A::HIGH,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[inline(always)]
+    pub fn is_disable(&self) -> bool {
+        *self == FQOS_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `LOW`"]
+    #[inline(always)]
+    pub fn is_low(&self) -> bool {
+        *self == FQOS_A::LOW
+    }
+    #[doc = "Checks if the value of the field is `MEDIUM`"]
+    #[inline(always)]
+    pub fn is_medium(&self) -> bool {
+        *self == FQOS_A::MEDIUM
+    }
+    #[doc = "Checks if the value of the field is `HIGH`"]
+    #[inline(always)]
+    pub fn is_high(&self) -> bool {
+        *self == FQOS_A::HIGH
+    }
+}
+#[doc = "Write proxy for field `FQOS`"]
+pub struct FQOS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FQOS_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: FQOS_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Background (no sensitive operation)"]
+    #[inline(always)]
+    pub fn disable(self) -> &'a mut W {
+        self.variant(FQOS_A::DISABLE)
+    }
+    #[doc = "Sensitive Bandwidth"]
+    #[inline(always)]
+    pub fn low(self) -> &'a mut W {
+        self.variant(FQOS_A::LOW)
+    }
+    #[doc = "Sensitive Latency"]
+    #[inline(always)]
+    pub fn medium(self) -> &'a mut W {
+        self.variant(FQOS_A::MEDIUM)
+    }
+    #[doc = "Critical Latency"]
+    #[inline(always)]
+    pub fn high(self) -> &'a mut W {
+        self.variant(FQOS_A::HIGH)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 2)) | (((value as u8) & 0x03) << 2);
+        self.w
+    }
+}
+#[doc = "Data Transfer Quality of Service\n\nValue on reset: 1"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum DQOS_A {
+    #[doc = "0: Background (no sensitive operation)"]
+    DISABLE,
+    #[doc = "1: Sensitive Bandwidth"]
+    LOW,
+    #[doc = "2: Sensitive Latency"]
+    MEDIUM,
+    #[doc = "3: Critical Latency"]
+    HIGH,
+}
+impl From<DQOS_A> for u8 {
+    #[inline(always)]
+    fn from(variant: DQOS_A) -> Self {
+        match variant {
+            DQOS_A::DISABLE => 0,
+            DQOS_A::LOW => 1,
+            DQOS_A::MEDIUM => 2,
+            DQOS_A::HIGH => 3,
+        }
+    }
+}
+#[doc = "Reader of field `DQOS`"]
+pub type DQOS_R = crate::R<u8, DQOS_A>;
+impl DQOS_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> DQOS_A {
+        match self.bits {
+            0 => DQOS_A::DISABLE,
+            1 => DQOS_A::LOW,
+            2 => DQOS_A::MEDIUM,
+            3 => DQOS_A::HIGH,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[inline(always)]
+    pub fn is_disable(&self) -> bool {
+        *self == DQOS_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `LOW`"]
+    #[inline(always)]
+    pub fn is_low(&self) -> bool {
+        *self == DQOS_A::LOW
+    }
+    #[doc = "Checks if the value of the field is `MEDIUM`"]
+    #[inline(always)]
+    pub fn is_medium(&self) -> bool {
+        *self == DQOS_A::MEDIUM
+    }
+    #[doc = "Checks if the value of the field is `HIGH`"]
+    #[inline(always)]
+    pub fn is_high(&self) -> bool {
+        *self == DQOS_A::HIGH
+    }
+}
+#[doc = "Write proxy for field `DQOS`"]
+pub struct DQOS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DQOS_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: DQOS_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Background (no sensitive operation)"]
+    #[inline(always)]
+    pub fn disable(self) -> &'a mut W {
+        self.variant(DQOS_A::DISABLE)
+    }
+    #[doc = "Sensitive Bandwidth"]
+    #[inline(always)]
+    pub fn low(self) -> &'a mut W {
+        self.variant(DQOS_A::LOW)
+    }
+    #[doc = "Sensitive Latency"]
+    #[inline(always)]
+    pub fn medium(self) -> &'a mut W {
+        self.variant(DQOS_A::MEDIUM)
+    }
+    #[doc = "Critical Latency"]
+    #[inline(always)]
+    pub fn high(self) -> &'a mut W {
+        self.variant(DQOS_A::HIGH)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 4)) | (((value as u8) & 0x03) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:1 - Write-Back Quality of Service"]
+    #[inline(always)]
+    pub fn wrbqos(&self) -> WRBQOS_R {
+        WRBQOS_R::new((self.bits & 0x03) as u8)
+    }
+    #[doc = "Bits 2:3 - Fetch Quality of Service"]
+    #[inline(always)]
+    pub fn fqos(&self) -> FQOS_R {
+        FQOS_R::new(((self.bits >> 2) & 0x03) as u8)
+    }
+    #[doc = "Bits 4:5 - Data Transfer Quality of Service"]
+    #[inline(always)]
+    pub fn dqos(&self) -> DQOS_R {
+        DQOS_R::new(((self.bits >> 4) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:1 - Write-Back Quality of Service"]
+    #[inline(always)]
+    pub fn wrbqos(&mut self) -> WRBQOS_W {
+        WRBQOS_W { w: self }
+    }
+    #[doc = "Bits 2:3 - Fetch Quality of Service"]
+    #[inline(always)]
+    pub fn fqos(&mut self) -> FQOS_W {
+        FQOS_W { w: self }
+    }
+    #[doc = "Bits 4:5 - Data Transfer Quality of Service"]
+    #[inline(always)]
+    pub fn dqos(&mut self) -> DQOS_W {
+        DQOS_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/swtrigctrl.rs
+++ b/pac/atsamd11c14a/src/dmac/swtrigctrl.rs
@@ -1,0 +1,220 @@
+#[doc = "Reader of register SWTRIGCTRL"]
+pub type R = crate::R<u32, super::SWTRIGCTRL>;
+#[doc = "Writer for register SWTRIGCTRL"]
+pub type W = crate::W<u32, super::SWTRIGCTRL>;
+#[doc = "Register SWTRIGCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::SWTRIGCTRL {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SWTRIG0`"]
+pub type SWTRIG0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWTRIG0`"]
+pub struct SWTRIG0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWTRIG0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `SWTRIG1`"]
+pub type SWTRIG1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWTRIG1`"]
+pub struct SWTRIG1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWTRIG1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SWTRIG2`"]
+pub type SWTRIG2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWTRIG2`"]
+pub struct SWTRIG2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWTRIG2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `SWTRIG3`"]
+pub type SWTRIG3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWTRIG3`"]
+pub struct SWTRIG3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWTRIG3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `SWTRIG4`"]
+pub type SWTRIG4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWTRIG4`"]
+pub struct SWTRIG4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWTRIG4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `SWTRIG5`"]
+pub type SWTRIG5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWTRIG5`"]
+pub struct SWTRIG5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWTRIG5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Channel 0 Software Trigger"]
+    #[inline(always)]
+    pub fn swtrig0(&self) -> SWTRIG0_R {
+        SWTRIG0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Channel 1 Software Trigger"]
+    #[inline(always)]
+    pub fn swtrig1(&self) -> SWTRIG1_R {
+        SWTRIG1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Channel 2 Software Trigger"]
+    #[inline(always)]
+    pub fn swtrig2(&self) -> SWTRIG2_R {
+        SWTRIG2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Channel 3 Software Trigger"]
+    #[inline(always)]
+    pub fn swtrig3(&self) -> SWTRIG3_R {
+        SWTRIG3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Channel 4 Software Trigger"]
+    #[inline(always)]
+    pub fn swtrig4(&self) -> SWTRIG4_R {
+        SWTRIG4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Channel 5 Software Trigger"]
+    #[inline(always)]
+    pub fn swtrig5(&self) -> SWTRIG5_R {
+        SWTRIG5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Channel 0 Software Trigger"]
+    #[inline(always)]
+    pub fn swtrig0(&mut self) -> SWTRIG0_W {
+        SWTRIG0_W { w: self }
+    }
+    #[doc = "Bit 1 - Channel 1 Software Trigger"]
+    #[inline(always)]
+    pub fn swtrig1(&mut self) -> SWTRIG1_W {
+        SWTRIG1_W { w: self }
+    }
+    #[doc = "Bit 2 - Channel 2 Software Trigger"]
+    #[inline(always)]
+    pub fn swtrig2(&mut self) -> SWTRIG2_W {
+        SWTRIG2_W { w: self }
+    }
+    #[doc = "Bit 3 - Channel 3 Software Trigger"]
+    #[inline(always)]
+    pub fn swtrig3(&mut self) -> SWTRIG3_W {
+        SWTRIG3_W { w: self }
+    }
+    #[doc = "Bit 4 - Channel 4 Software Trigger"]
+    #[inline(always)]
+    pub fn swtrig4(&mut self) -> SWTRIG4_W {
+        SWTRIG4_W { w: self }
+    }
+    #[doc = "Bit 5 - Channel 5 Software Trigger"]
+    #[inline(always)]
+    pub fn swtrig5(&mut self) -> SWTRIG5_W {
+        SWTRIG5_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dmac/wrbaddr.rs
+++ b/pac/atsamd11c14a/src/dmac/wrbaddr.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register WRBADDR"]
+pub type R = crate::R<u32, super::WRBADDR>;
+#[doc = "Writer for register WRBADDR"]
+pub type W = crate::W<u32, super::WRBADDR>;
+#[doc = "Register WRBADDR `reset()`'s with value 0"]
+impl crate::ResetValue for super::WRBADDR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `WRBADDR`"]
+pub type WRBADDR_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `WRBADDR`"]
+pub struct WRBADDR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WRBADDR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Write-Back Memory Base Address"]
+    #[inline(always)]
+    pub fn wrbaddr(&self) -> WRBADDR_R {
+        WRBADDR_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Write-Back Memory Base Address"]
+    #[inline(always)]
+    pub fn wrbaddr(&mut self) -> WRBADDR_W {
+        WRBADDR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dsu.rs
+++ b/pac/atsamd11c14a/src/dsu.rs
@@ -1,0 +1,295 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Control"]
+    pub ctrl: CTRL,
+    #[doc = "0x01 - Status A"]
+    pub statusa: STATUSA,
+    #[doc = "0x02 - Status B"]
+    pub statusb: STATUSB,
+    _reserved3: [u8; 1usize],
+    #[doc = "0x04 - Address"]
+    pub addr: ADDR,
+    #[doc = "0x08 - Length"]
+    pub length: LENGTH,
+    #[doc = "0x0c - Data"]
+    pub data: DATA,
+    #[doc = "0x10 - Debug Communication Channel n"]
+    pub dcc: [DCC; 2],
+    #[doc = "0x18 - Device Identification"]
+    pub did: DID,
+    _reserved8: [u8; 212usize],
+    #[doc = "0xf0 - Device Configuration"]
+    pub dcfg: [DCFG; 2],
+    _reserved9: [u8; 3848usize],
+    #[doc = "0x1000 - CoreSight ROM Table Entry 0"]
+    pub entry0: ENTRY0,
+    #[doc = "0x1004 - CoreSight ROM Table Entry 1"]
+    pub entry1: ENTRY1,
+    #[doc = "0x1008 - CoreSight ROM Table End"]
+    pub end: END,
+    _reserved12: [u8; 4032usize],
+    #[doc = "0x1fcc - CoreSight ROM Table Memory Type"]
+    pub memtype: MEMTYPE,
+    #[doc = "0x1fd0 - Peripheral Identification 4"]
+    pub pid4: PID4,
+    #[doc = "0x1fd4 - Peripheral Identification 5"]
+    pub pid5: PID5,
+    #[doc = "0x1fd8 - Peripheral Identification 6"]
+    pub pid6: PID6,
+    #[doc = "0x1fdc - Peripheral Identification 7"]
+    pub pid7: PID7,
+    #[doc = "0x1fe0 - Peripheral Identification 0"]
+    pub pid0: PID0,
+    #[doc = "0x1fe4 - Peripheral Identification 1"]
+    pub pid1: PID1,
+    #[doc = "0x1fe8 - Peripheral Identification 2"]
+    pub pid2: PID2,
+    #[doc = "0x1fec - Peripheral Identification 3"]
+    pub pid3: PID3,
+    #[doc = "0x1ff0 - Component Identification 0"]
+    pub cid0: CID0,
+    #[doc = "0x1ff4 - Component Identification 1"]
+    pub cid1: CID1,
+    #[doc = "0x1ff8 - Component Identification 2"]
+    pub cid2: CID2,
+    #[doc = "0x1ffc - Component Identification 3"]
+    pub cid3: CID3,
+}
+#[doc = "Control\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrl](ctrl) module"]
+pub type CTRL = crate::Reg<u8, _CTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRL;
+#[doc = "`write(|w| ..)` method takes [ctrl::W](ctrl::W) writer structure"]
+impl crate::Writable for CTRL {}
+#[doc = "Control"]
+pub mod ctrl;
+#[doc = "Status A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [statusa](statusa) module"]
+pub type STATUSA = crate::Reg<u8, _STATUSA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUSA;
+#[doc = "`read()` method returns [statusa::R](statusa::R) reader structure"]
+impl crate::Readable for STATUSA {}
+#[doc = "`write(|w| ..)` method takes [statusa::W](statusa::W) writer structure"]
+impl crate::Writable for STATUSA {}
+#[doc = "Status A"]
+pub mod statusa;
+#[doc = "Status B\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [statusb](statusb) module"]
+pub type STATUSB = crate::Reg<u8, _STATUSB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUSB;
+#[doc = "`read()` method returns [statusb::R](statusb::R) reader structure"]
+impl crate::Readable for STATUSB {}
+#[doc = "Status B"]
+pub mod statusb;
+#[doc = "Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [addr](addr) module"]
+pub type ADDR = crate::Reg<u32, _ADDR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _ADDR;
+#[doc = "`read()` method returns [addr::R](addr::R) reader structure"]
+impl crate::Readable for ADDR {}
+#[doc = "`write(|w| ..)` method takes [addr::W](addr::W) writer structure"]
+impl crate::Writable for ADDR {}
+#[doc = "Address"]
+pub mod addr;
+#[doc = "Length\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [length](length) module"]
+pub type LENGTH = crate::Reg<u32, _LENGTH>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _LENGTH;
+#[doc = "`read()` method returns [length::R](length::R) reader structure"]
+impl crate::Readable for LENGTH {}
+#[doc = "`write(|w| ..)` method takes [length::W](length::W) writer structure"]
+impl crate::Writable for LENGTH {}
+#[doc = "Length"]
+pub mod length;
+#[doc = "Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [data](data) module"]
+pub type DATA = crate::Reg<u32, _DATA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DATA;
+#[doc = "`read()` method returns [data::R](data::R) reader structure"]
+impl crate::Readable for DATA {}
+#[doc = "`write(|w| ..)` method takes [data::W](data::W) writer structure"]
+impl crate::Writable for DATA {}
+#[doc = "Data"]
+pub mod data;
+#[doc = "Debug Communication Channel n\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcc](dcc) module"]
+pub type DCC = crate::Reg<u32, _DCC>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DCC;
+#[doc = "`read()` method returns [dcc::R](dcc::R) reader structure"]
+impl crate::Readable for DCC {}
+#[doc = "`write(|w| ..)` method takes [dcc::W](dcc::W) writer structure"]
+impl crate::Writable for DCC {}
+#[doc = "Debug Communication Channel n"]
+pub mod dcc;
+#[doc = "Device Identification\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [did](did) module"]
+pub type DID = crate::Reg<u32, _DID>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DID;
+#[doc = "`read()` method returns [did::R](did::R) reader structure"]
+impl crate::Readable for DID {}
+#[doc = "Device Identification"]
+pub mod did;
+#[doc = "Device Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dcfg](dcfg) module"]
+pub type DCFG = crate::Reg<u32, _DCFG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DCFG;
+#[doc = "`read()` method returns [dcfg::R](dcfg::R) reader structure"]
+impl crate::Readable for DCFG {}
+#[doc = "`write(|w| ..)` method takes [dcfg::W](dcfg::W) writer structure"]
+impl crate::Writable for DCFG {}
+#[doc = "Device Configuration"]
+pub mod dcfg;
+#[doc = "CoreSight ROM Table Entry 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [entry0](entry0) module"]
+pub type ENTRY0 = crate::Reg<u32, _ENTRY0>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _ENTRY0;
+#[doc = "`read()` method returns [entry0::R](entry0::R) reader structure"]
+impl crate::Readable for ENTRY0 {}
+#[doc = "CoreSight ROM Table Entry 0"]
+pub mod entry0;
+#[doc = "CoreSight ROM Table Entry 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [entry1](entry1) module"]
+pub type ENTRY1 = crate::Reg<u32, _ENTRY1>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _ENTRY1;
+#[doc = "`read()` method returns [entry1::R](entry1::R) reader structure"]
+impl crate::Readable for ENTRY1 {}
+#[doc = "CoreSight ROM Table Entry 1"]
+pub mod entry1;
+#[doc = "CoreSight ROM Table End\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [end](end) module"]
+pub type END = crate::Reg<u32, _END>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _END;
+#[doc = "`read()` method returns [end::R](end::R) reader structure"]
+impl crate::Readable for END {}
+#[doc = "CoreSight ROM Table End"]
+pub mod end;
+#[doc = "CoreSight ROM Table Memory Type\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [memtype](memtype) module"]
+pub type MEMTYPE = crate::Reg<u32, _MEMTYPE>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _MEMTYPE;
+#[doc = "`read()` method returns [memtype::R](memtype::R) reader structure"]
+impl crate::Readable for MEMTYPE {}
+#[doc = "CoreSight ROM Table Memory Type"]
+pub mod memtype;
+#[doc = "Peripheral Identification 4\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid4](pid4) module"]
+pub type PID4 = crate::Reg<u32, _PID4>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID4;
+#[doc = "`read()` method returns [pid4::R](pid4::R) reader structure"]
+impl crate::Readable for PID4 {}
+#[doc = "Peripheral Identification 4"]
+pub mod pid4;
+#[doc = "Peripheral Identification 5\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid5](pid5) module"]
+pub type PID5 = crate::Reg<u32, _PID5>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID5;
+#[doc = "`read()` method returns [pid5::R](pid5::R) reader structure"]
+impl crate::Readable for PID5 {}
+#[doc = "Peripheral Identification 5"]
+pub mod pid5;
+#[doc = "Peripheral Identification 6\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid6](pid6) module"]
+pub type PID6 = crate::Reg<u32, _PID6>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID6;
+#[doc = "`read()` method returns [pid6::R](pid6::R) reader structure"]
+impl crate::Readable for PID6 {}
+#[doc = "Peripheral Identification 6"]
+pub mod pid6;
+#[doc = "Peripheral Identification 7\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid7](pid7) module"]
+pub type PID7 = crate::Reg<u32, _PID7>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID7;
+#[doc = "`read()` method returns [pid7::R](pid7::R) reader structure"]
+impl crate::Readable for PID7 {}
+#[doc = "Peripheral Identification 7"]
+pub mod pid7;
+#[doc = "Peripheral Identification 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid0](pid0) module"]
+pub type PID0 = crate::Reg<u32, _PID0>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID0;
+#[doc = "`read()` method returns [pid0::R](pid0::R) reader structure"]
+impl crate::Readable for PID0 {}
+#[doc = "Peripheral Identification 0"]
+pub mod pid0;
+#[doc = "Peripheral Identification 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid1](pid1) module"]
+pub type PID1 = crate::Reg<u32, _PID1>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID1;
+#[doc = "`read()` method returns [pid1::R](pid1::R) reader structure"]
+impl crate::Readable for PID1 {}
+#[doc = "Peripheral Identification 1"]
+pub mod pid1;
+#[doc = "Peripheral Identification 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid2](pid2) module"]
+pub type PID2 = crate::Reg<u32, _PID2>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID2;
+#[doc = "`read()` method returns [pid2::R](pid2::R) reader structure"]
+impl crate::Readable for PID2 {}
+#[doc = "Peripheral Identification 2"]
+pub mod pid2;
+#[doc = "Peripheral Identification 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid3](pid3) module"]
+pub type PID3 = crate::Reg<u32, _PID3>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID3;
+#[doc = "`read()` method returns [pid3::R](pid3::R) reader structure"]
+impl crate::Readable for PID3 {}
+#[doc = "Peripheral Identification 3"]
+pub mod pid3;
+#[doc = "Component Identification 0\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cid0](cid0) module"]
+pub type CID0 = crate::Reg<u32, _CID0>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CID0;
+#[doc = "`read()` method returns [cid0::R](cid0::R) reader structure"]
+impl crate::Readable for CID0 {}
+#[doc = "Component Identification 0"]
+pub mod cid0;
+#[doc = "Component Identification 1\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cid1](cid1) module"]
+pub type CID1 = crate::Reg<u32, _CID1>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CID1;
+#[doc = "`read()` method returns [cid1::R](cid1::R) reader structure"]
+impl crate::Readable for CID1 {}
+#[doc = "Component Identification 1"]
+pub mod cid1;
+#[doc = "Component Identification 2\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cid2](cid2) module"]
+pub type CID2 = crate::Reg<u32, _CID2>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CID2;
+#[doc = "`read()` method returns [cid2::R](cid2::R) reader structure"]
+impl crate::Readable for CID2 {}
+#[doc = "Component Identification 2"]
+pub mod cid2;
+#[doc = "Component Identification 3\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cid3](cid3) module"]
+pub type CID3 = crate::Reg<u32, _CID3>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CID3;
+#[doc = "`read()` method returns [cid3::R](cid3::R) reader structure"]
+impl crate::Readable for CID3 {}
+#[doc = "Component Identification 3"]
+pub mod cid3;

--- a/pac/atsamd11c14a/src/dsu/addr.rs
+++ b/pac/atsamd11c14a/src/dsu/addr.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register ADDR"]
+pub type R = crate::R<u32, super::ADDR>;
+#[doc = "Writer for register ADDR"]
+pub type W = crate::W<u32, super::ADDR>;
+#[doc = "Register ADDR `reset()`'s with value 0"]
+impl crate::ResetValue for super::ADDR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `AMOD`"]
+pub type AMOD_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `AMOD`"]
+pub struct AMOD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> AMOD_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x03) | ((value as u32) & 0x03);
+        self.w
+    }
+}
+#[doc = "Reader of field `ADDR`"]
+pub type ADDR_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `ADDR`"]
+pub struct ADDR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ADDR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x3fff_ffff << 2)) | (((value as u32) & 0x3fff_ffff) << 2);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:1 - Access Mode"]
+    #[inline(always)]
+    pub fn amod(&self) -> AMOD_R {
+        AMOD_R::new((self.bits & 0x03) as u8)
+    }
+    #[doc = "Bits 2:31 - Address"]
+    #[inline(always)]
+    pub fn addr(&self) -> ADDR_R {
+        ADDR_R::new(((self.bits >> 2) & 0x3fff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:1 - Access Mode"]
+    #[inline(always)]
+    pub fn amod(&mut self) -> AMOD_W {
+        AMOD_W { w: self }
+    }
+    #[doc = "Bits 2:31 - Address"]
+    #[inline(always)]
+    pub fn addr(&mut self) -> ADDR_W {
+        ADDR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/cid0.rs
+++ b/pac/atsamd11c14a/src/dsu/cid0.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register CID0"]
+pub type R = crate::R<u32, super::CID0>;
+#[doc = "Reader of field `PREAMBLEB0`"]
+pub type PREAMBLEB0_R = crate::R<u8, u8>;
+impl R {
+    #[doc = "Bits 0:7 - Preamble Byte 0"]
+    #[inline(always)]
+    pub fn preambleb0(&self) -> PREAMBLEB0_R {
+        PREAMBLEB0_R::new((self.bits & 0xff) as u8)
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/cid1.rs
+++ b/pac/atsamd11c14a/src/dsu/cid1.rs
@@ -1,0 +1,18 @@
+#[doc = "Reader of register CID1"]
+pub type R = crate::R<u32, super::CID1>;
+#[doc = "Reader of field `PREAMBLE`"]
+pub type PREAMBLE_R = crate::R<u8, u8>;
+#[doc = "Reader of field `CCLASS`"]
+pub type CCLASS_R = crate::R<u8, u8>;
+impl R {
+    #[doc = "Bits 0:3 - Preamble"]
+    #[inline(always)]
+    pub fn preamble(&self) -> PREAMBLE_R {
+        PREAMBLE_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - Component Class"]
+    #[inline(always)]
+    pub fn cclass(&self) -> CCLASS_R {
+        CCLASS_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/cid2.rs
+++ b/pac/atsamd11c14a/src/dsu/cid2.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register CID2"]
+pub type R = crate::R<u32, super::CID2>;
+#[doc = "Reader of field `PREAMBLEB2`"]
+pub type PREAMBLEB2_R = crate::R<u8, u8>;
+impl R {
+    #[doc = "Bits 0:7 - Preamble Byte 2"]
+    #[inline(always)]
+    pub fn preambleb2(&self) -> PREAMBLEB2_R {
+        PREAMBLEB2_R::new((self.bits & 0xff) as u8)
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/cid3.rs
+++ b/pac/atsamd11c14a/src/dsu/cid3.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register CID3"]
+pub type R = crate::R<u32, super::CID3>;
+#[doc = "Reader of field `PREAMBLEB3`"]
+pub type PREAMBLEB3_R = crate::R<u8, u8>;
+impl R {
+    #[doc = "Bits 0:7 - Preamble Byte 3"]
+    #[inline(always)]
+    pub fn preambleb3(&self) -> PREAMBLEB3_R {
+        PREAMBLEB3_R::new((self.bits & 0xff) as u8)
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/ctrl.rs
+++ b/pac/atsamd11c14a/src/dsu/ctrl.rs
@@ -1,0 +1,174 @@
+#[doc = "Writer for register CTRL"]
+pub type W = crate::W<u8, super::CTRL>;
+#[doc = "Register CTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `CRC`"]
+pub struct CRC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CRC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `MBIST`"]
+pub struct MBIST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MBIST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `CE`"]
+pub struct CE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `ARR`"]
+pub struct ARR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ARR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `SMSA`"]
+pub struct SMSA_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SMSA_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 2 - 32-bit Cyclic Redundancy Code"]
+    #[inline(always)]
+    pub fn crc(&mut self) -> CRC_W {
+        CRC_W { w: self }
+    }
+    #[doc = "Bit 3 - Memory built-in self-test"]
+    #[inline(always)]
+    pub fn mbist(&mut self) -> MBIST_W {
+        MBIST_W { w: self }
+    }
+    #[doc = "Bit 4 - Chip-Erase"]
+    #[inline(always)]
+    pub fn ce(&mut self) -> CE_W {
+        CE_W { w: self }
+    }
+    #[doc = "Bit 6 - Auxiliary Row Read"]
+    #[inline(always)]
+    pub fn arr(&mut self) -> ARR_W {
+        ARR_W { w: self }
+    }
+    #[doc = "Bit 7 - Start Memory Stream Access"]
+    #[inline(always)]
+    pub fn smsa(&mut self) -> SMSA_W {
+        SMSA_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/data.rs
+++ b/pac/atsamd11c14a/src/dsu/data.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register DATA"]
+pub type R = crate::R<u32, super::DATA>;
+#[doc = "Writer for register DATA"]
+pub type W = crate::W<u32, super::DATA>;
+#[doc = "Register DATA `reset()`'s with value 0"]
+impl crate::ResetValue for super::DATA {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DATA`"]
+pub type DATA_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `DATA`"]
+pub struct DATA_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DATA_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Data"]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Data"]
+    #[inline(always)]
+    pub fn data(&mut self) -> DATA_W {
+        DATA_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/dcc.rs
+++ b/pac/atsamd11c14a/src/dsu/dcc.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register DCC%s"]
+pub type R = crate::R<u32, super::DCC>;
+#[doc = "Writer for register DCC%s"]
+pub type W = crate::W<u32, super::DCC>;
+#[doc = "Register DCC%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::DCC {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DATA`"]
+pub type DATA_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `DATA`"]
+pub struct DATA_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DATA_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Data"]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Data"]
+    #[inline(always)]
+    pub fn data(&mut self) -> DATA_W {
+        DATA_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/dcfg.rs
+++ b/pac/atsamd11c14a/src/dsu/dcfg.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register DCFG%s"]
+pub type R = crate::R<u32, super::DCFG>;
+#[doc = "Writer for register DCFG%s"]
+pub type W = crate::W<u32, super::DCFG>;
+#[doc = "Register DCFG%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::DCFG {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DCFG`"]
+pub type DCFG_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `DCFG`"]
+pub struct DCFG_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DCFG_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Device Configuration"]
+    #[inline(always)]
+    pub fn dcfg(&self) -> DCFG_R {
+        DCFG_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Device Configuration"]
+    #[inline(always)]
+    pub fn dcfg(&mut self) -> DCFG_W {
+        DCFG_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/did.rs
+++ b/pac/atsamd11c14a/src/dsu/did.rs
@@ -1,0 +1,181 @@
+#[doc = "Reader of register DID"]
+pub type R = crate::R<u32, super::DID>;
+#[doc = "Reader of field `DEVSEL`"]
+pub type DEVSEL_R = crate::R<u8, u8>;
+#[doc = "Reader of field `REVISION`"]
+pub type REVISION_R = crate::R<u8, u8>;
+#[doc = "Reader of field `DIE`"]
+pub type DIE_R = crate::R<u8, u8>;
+#[doc = "Series\n\nValue on reset: 3"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SERIES_A {
+    #[doc = "0: Cortex-M0+ processor, basic feature set"]
+    _0,
+    #[doc = "1: Cortex-M0+ processor, USB"]
+    _1,
+}
+impl From<SERIES_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SERIES_A) -> Self {
+        match variant {
+            SERIES_A::_0 => 0,
+            SERIES_A::_1 => 1,
+        }
+    }
+}
+#[doc = "Reader of field `SERIES`"]
+pub type SERIES_R = crate::R<u8, SERIES_A>;
+impl SERIES_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, SERIES_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(SERIES_A::_0),
+            1 => Val(SERIES_A::_1),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `_0`"]
+    #[inline(always)]
+    pub fn is_0(&self) -> bool {
+        *self == SERIES_A::_0
+    }
+    #[doc = "Checks if the value of the field is `_1`"]
+    #[inline(always)]
+    pub fn is_1(&self) -> bool {
+        *self == SERIES_A::_1
+    }
+}
+#[doc = "Family\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FAMILY_A {
+    #[doc = "0: General purpose microcontroller"]
+    _0,
+    #[doc = "1: PicoPower"]
+    _1,
+}
+impl From<FAMILY_A> for u8 {
+    #[inline(always)]
+    fn from(variant: FAMILY_A) -> Self {
+        match variant {
+            FAMILY_A::_0 => 0,
+            FAMILY_A::_1 => 1,
+        }
+    }
+}
+#[doc = "Reader of field `FAMILY`"]
+pub type FAMILY_R = crate::R<u8, FAMILY_A>;
+impl FAMILY_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, FAMILY_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(FAMILY_A::_0),
+            1 => Val(FAMILY_A::_1),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `_0`"]
+    #[inline(always)]
+    pub fn is_0(&self) -> bool {
+        *self == FAMILY_A::_0
+    }
+    #[doc = "Checks if the value of the field is `_1`"]
+    #[inline(always)]
+    pub fn is_1(&self) -> bool {
+        *self == FAMILY_A::_1
+    }
+}
+#[doc = "Processor\n\nValue on reset: 1"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PROCESSOR_A {
+    #[doc = "0: Cortex-M0"]
+    _0,
+    #[doc = "1: Cortex-M0+"]
+    _1,
+    #[doc = "2: Cortex-M3"]
+    _2,
+    #[doc = "3: Cortex-M4"]
+    _3,
+}
+impl From<PROCESSOR_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PROCESSOR_A) -> Self {
+        match variant {
+            PROCESSOR_A::_0 => 0,
+            PROCESSOR_A::_1 => 1,
+            PROCESSOR_A::_2 => 2,
+            PROCESSOR_A::_3 => 3,
+        }
+    }
+}
+#[doc = "Reader of field `PROCESSOR`"]
+pub type PROCESSOR_R = crate::R<u8, PROCESSOR_A>;
+impl PROCESSOR_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, PROCESSOR_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(PROCESSOR_A::_0),
+            1 => Val(PROCESSOR_A::_1),
+            2 => Val(PROCESSOR_A::_2),
+            3 => Val(PROCESSOR_A::_3),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `_0`"]
+    #[inline(always)]
+    pub fn is_0(&self) -> bool {
+        *self == PROCESSOR_A::_0
+    }
+    #[doc = "Checks if the value of the field is `_1`"]
+    #[inline(always)]
+    pub fn is_1(&self) -> bool {
+        *self == PROCESSOR_A::_1
+    }
+    #[doc = "Checks if the value of the field is `_2`"]
+    #[inline(always)]
+    pub fn is_2(&self) -> bool {
+        *self == PROCESSOR_A::_2
+    }
+    #[doc = "Checks if the value of the field is `_3`"]
+    #[inline(always)]
+    pub fn is_3(&self) -> bool {
+        *self == PROCESSOR_A::_3
+    }
+}
+impl R {
+    #[doc = "Bits 0:7 - Device Select"]
+    #[inline(always)]
+    pub fn devsel(&self) -> DEVSEL_R {
+        DEVSEL_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bits 8:11 - Revision Number"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 8) & 0x0f) as u8)
+    }
+    #[doc = "Bits 12:15 - Die Number"]
+    #[inline(always)]
+    pub fn die(&self) -> DIE_R {
+        DIE_R::new(((self.bits >> 12) & 0x0f) as u8)
+    }
+    #[doc = "Bits 16:21 - Series"]
+    #[inline(always)]
+    pub fn series(&self) -> SERIES_R {
+        SERIES_R::new(((self.bits >> 16) & 0x3f) as u8)
+    }
+    #[doc = "Bits 23:27 - Family"]
+    #[inline(always)]
+    pub fn family(&self) -> FAMILY_R {
+        FAMILY_R::new(((self.bits >> 23) & 0x1f) as u8)
+    }
+    #[doc = "Bits 28:31 - Processor"]
+    #[inline(always)]
+    pub fn processor(&self) -> PROCESSOR_R {
+        PROCESSOR_R::new(((self.bits >> 28) & 0x0f) as u8)
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/end.rs
+++ b/pac/atsamd11c14a/src/dsu/end.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register END"]
+pub type R = crate::R<u32, super::END>;
+#[doc = "Reader of field `END`"]
+pub type END_R = crate::R<u32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - End Marker"]
+    #[inline(always)]
+    pub fn end(&self) -> END_R {
+        END_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/entry0.rs
+++ b/pac/atsamd11c14a/src/dsu/entry0.rs
@@ -1,0 +1,25 @@
+#[doc = "Reader of register ENTRY0"]
+pub type R = crate::R<u32, super::ENTRY0>;
+#[doc = "Reader of field `EPRES`"]
+pub type EPRES_R = crate::R<bool, bool>;
+#[doc = "Reader of field `FMT`"]
+pub type FMT_R = crate::R<bool, bool>;
+#[doc = "Reader of field `ADDOFF`"]
+pub type ADDOFF_R = crate::R<u32, u32>;
+impl R {
+    #[doc = "Bit 0 - Entry Present"]
+    #[inline(always)]
+    pub fn epres(&self) -> EPRES_R {
+        EPRES_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Format"]
+    #[inline(always)]
+    pub fn fmt(&self) -> FMT_R {
+        FMT_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 12:31 - Address Offset"]
+    #[inline(always)]
+    pub fn addoff(&self) -> ADDOFF_R {
+        ADDOFF_R::new(((self.bits >> 12) & 0x000f_ffff) as u32)
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/entry1.rs
+++ b/pac/atsamd11c14a/src/dsu/entry1.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register ENTRY1"]
+pub type R = crate::R<u32, super::ENTRY1>;
+impl R {}

--- a/pac/atsamd11c14a/src/dsu/length.rs
+++ b/pac/atsamd11c14a/src/dsu/length.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register LENGTH"]
+pub type R = crate::R<u32, super::LENGTH>;
+#[doc = "Writer for register LENGTH"]
+pub type W = crate::W<u32, super::LENGTH>;
+#[doc = "Register LENGTH `reset()`'s with value 0"]
+impl crate::ResetValue for super::LENGTH {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `LENGTH`"]
+pub type LENGTH_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `LENGTH`"]
+pub struct LENGTH_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LENGTH_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x3fff_ffff << 2)) | (((value as u32) & 0x3fff_ffff) << 2);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 2:31 - Length"]
+    #[inline(always)]
+    pub fn length(&self) -> LENGTH_R {
+        LENGTH_R::new(((self.bits >> 2) & 0x3fff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 2:31 - Length"]
+    #[inline(always)]
+    pub fn length(&mut self) -> LENGTH_W {
+        LENGTH_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/memtype.rs
+++ b/pac/atsamd11c14a/src/dsu/memtype.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register MEMTYPE"]
+pub type R = crate::R<u32, super::MEMTYPE>;
+#[doc = "Reader of field `SMEMP`"]
+pub type SMEMP_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - System Memory Present"]
+    #[inline(always)]
+    pub fn smemp(&self) -> SMEMP_R {
+        SMEMP_R::new((self.bits & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/pid0.rs
+++ b/pac/atsamd11c14a/src/dsu/pid0.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register PID0"]
+pub type R = crate::R<u32, super::PID0>;
+#[doc = "Reader of field `PARTNBL`"]
+pub type PARTNBL_R = crate::R<u8, u8>;
+impl R {
+    #[doc = "Bits 0:7 - Part Number Low"]
+    #[inline(always)]
+    pub fn partnbl(&self) -> PARTNBL_R {
+        PARTNBL_R::new((self.bits & 0xff) as u8)
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/pid1.rs
+++ b/pac/atsamd11c14a/src/dsu/pid1.rs
@@ -1,0 +1,18 @@
+#[doc = "Reader of register PID1"]
+pub type R = crate::R<u32, super::PID1>;
+#[doc = "Reader of field `PARTNBH`"]
+pub type PARTNBH_R = crate::R<u8, u8>;
+#[doc = "Reader of field `JEPIDCL`"]
+pub type JEPIDCL_R = crate::R<u8, u8>;
+impl R {
+    #[doc = "Bits 0:3 - Part Number High"]
+    #[inline(always)]
+    pub fn partnbh(&self) -> PARTNBH_R {
+        PARTNBH_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - Low part of the JEP-106 Identity Code"]
+    #[inline(always)]
+    pub fn jepidcl(&self) -> JEPIDCL_R {
+        JEPIDCL_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/pid2.rs
+++ b/pac/atsamd11c14a/src/dsu/pid2.rs
@@ -1,0 +1,25 @@
+#[doc = "Reader of register PID2"]
+pub type R = crate::R<u32, super::PID2>;
+#[doc = "Reader of field `JEPIDCH`"]
+pub type JEPIDCH_R = crate::R<u8, u8>;
+#[doc = "Reader of field `JEPU`"]
+pub type JEPU_R = crate::R<bool, bool>;
+#[doc = "Reader of field `REVISION`"]
+pub type REVISION_R = crate::R<u8, u8>;
+impl R {
+    #[doc = "Bits 0:2 - JEP-106 Identity Code High"]
+    #[inline(always)]
+    pub fn jepidch(&self) -> JEPIDCH_R {
+        JEPIDCH_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bit 3 - JEP-106 Identity Code is used"]
+    #[inline(always)]
+    pub fn jepu(&self) -> JEPU_R {
+        JEPU_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bits 4:7 - Revision Number"]
+    #[inline(always)]
+    pub fn revision(&self) -> REVISION_R {
+        REVISION_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/pid3.rs
+++ b/pac/atsamd11c14a/src/dsu/pid3.rs
@@ -1,0 +1,18 @@
+#[doc = "Reader of register PID3"]
+pub type R = crate::R<u32, super::PID3>;
+#[doc = "Reader of field `CUSMOD`"]
+pub type CUSMOD_R = crate::R<u8, u8>;
+#[doc = "Reader of field `REVAND`"]
+pub type REVAND_R = crate::R<u8, u8>;
+impl R {
+    #[doc = "Bits 0:3 - ARM CUSMOD"]
+    #[inline(always)]
+    pub fn cusmod(&self) -> CUSMOD_R {
+        CUSMOD_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - Revision Number"]
+    #[inline(always)]
+    pub fn revand(&self) -> REVAND_R {
+        REVAND_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/pid4.rs
+++ b/pac/atsamd11c14a/src/dsu/pid4.rs
@@ -1,0 +1,18 @@
+#[doc = "Reader of register PID4"]
+pub type R = crate::R<u32, super::PID4>;
+#[doc = "Reader of field `JEPCC`"]
+pub type JEPCC_R = crate::R<u8, u8>;
+#[doc = "Reader of field `FKBC`"]
+pub type FKBC_R = crate::R<u8, u8>;
+impl R {
+    #[doc = "Bits 0:3 - JEP-106 Continuation Code"]
+    #[inline(always)]
+    pub fn jepcc(&self) -> JEPCC_R {
+        JEPCC_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - 4KB count"]
+    #[inline(always)]
+    pub fn fkbc(&self) -> FKBC_R {
+        FKBC_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/pid5.rs
+++ b/pac/atsamd11c14a/src/dsu/pid5.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register PID5"]
+pub type R = crate::R<u32, super::PID5>;
+impl R {}

--- a/pac/atsamd11c14a/src/dsu/pid6.rs
+++ b/pac/atsamd11c14a/src/dsu/pid6.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register PID6"]
+pub type R = crate::R<u32, super::PID6>;
+impl R {}

--- a/pac/atsamd11c14a/src/dsu/pid7.rs
+++ b/pac/atsamd11c14a/src/dsu/pid7.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register PID7"]
+pub type R = crate::R<u32, super::PID7>;
+impl R {}

--- a/pac/atsamd11c14a/src/dsu/statusa.rs
+++ b/pac/atsamd11c14a/src/dsu/statusa.rs
@@ -1,0 +1,186 @@
+#[doc = "Reader of register STATUSA"]
+pub type R = crate::R<u8, super::STATUSA>;
+#[doc = "Writer for register STATUSA"]
+pub type W = crate::W<u8, super::STATUSA>;
+#[doc = "Register STATUSA `reset()`'s with value 0"]
+impl crate::ResetValue for super::STATUSA {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DONE`"]
+pub type DONE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DONE`"]
+pub struct DONE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DONE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `CRSTEXT`"]
+pub type CRSTEXT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CRSTEXT`"]
+pub struct CRSTEXT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CRSTEXT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `BERR`"]
+pub type BERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BERR`"]
+pub struct BERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAIL`"]
+pub type FAIL_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAIL`"]
+pub struct FAIL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAIL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `PERR`"]
+pub type PERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PERR`"]
+pub struct PERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Done"]
+    #[inline(always)]
+    pub fn done(&self) -> DONE_R {
+        DONE_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - CPU Reset Phase Extension"]
+    #[inline(always)]
+    pub fn crstext(&self) -> CRSTEXT_R {
+        CRSTEXT_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Bus Error"]
+    #[inline(always)]
+    pub fn berr(&self) -> BERR_R {
+        BERR_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Failure"]
+    #[inline(always)]
+    pub fn fail(&self) -> FAIL_R {
+        FAIL_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Protection Error"]
+    #[inline(always)]
+    pub fn perr(&self) -> PERR_R {
+        PERR_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Done"]
+    #[inline(always)]
+    pub fn done(&mut self) -> DONE_W {
+        DONE_W { w: self }
+    }
+    #[doc = "Bit 1 - CPU Reset Phase Extension"]
+    #[inline(always)]
+    pub fn crstext(&mut self) -> CRSTEXT_W {
+        CRSTEXT_W { w: self }
+    }
+    #[doc = "Bit 2 - Bus Error"]
+    #[inline(always)]
+    pub fn berr(&mut self) -> BERR_W {
+        BERR_W { w: self }
+    }
+    #[doc = "Bit 3 - Failure"]
+    #[inline(always)]
+    pub fn fail(&mut self) -> FAIL_W {
+        FAIL_W { w: self }
+    }
+    #[doc = "Bit 4 - Protection Error"]
+    #[inline(always)]
+    pub fn perr(&mut self) -> PERR_W {
+        PERR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/dsu/statusb.rs
+++ b/pac/atsamd11c14a/src/dsu/statusb.rs
@@ -1,0 +1,39 @@
+#[doc = "Reader of register STATUSB"]
+pub type R = crate::R<u8, super::STATUSB>;
+#[doc = "Reader of field `PROT`"]
+pub type PROT_R = crate::R<bool, bool>;
+#[doc = "Reader of field `DBGPRES`"]
+pub type DBGPRES_R = crate::R<bool, bool>;
+#[doc = "Reader of field `DCCD0`"]
+pub type DCCD0_R = crate::R<bool, bool>;
+#[doc = "Reader of field `DCCD1`"]
+pub type DCCD1_R = crate::R<bool, bool>;
+#[doc = "Reader of field `HPE`"]
+pub type HPE_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Protected"]
+    #[inline(always)]
+    pub fn prot(&self) -> PROT_R {
+        PROT_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Debugger Present"]
+    #[inline(always)]
+    pub fn dbgpres(&self) -> DBGPRES_R {
+        DBGPRES_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Debug Communication Channel 0 Dirty"]
+    #[inline(always)]
+    pub fn dccd0(&self) -> DCCD0_R {
+        DCCD0_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Debug Communication Channel 1 Dirty"]
+    #[inline(always)]
+    pub fn dccd1(&self) -> DCCD1_R {
+        DCCD1_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Hot-Plugging Enable"]
+    #[inline(always)]
+    pub fn hpe(&self) -> HPE_R {
+        HPE_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/eic.rs
+++ b/pac/atsamd11c14a/src/eic.rs
@@ -1,0 +1,132 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Control"]
+    pub ctrl: CTRL,
+    #[doc = "0x01 - Status"]
+    pub status: STATUS,
+    #[doc = "0x02 - Non-Maskable Interrupt Control"]
+    pub nmictrl: NMICTRL,
+    #[doc = "0x03 - Non-Maskable Interrupt Flag Status and Clear"]
+    pub nmiflag: NMIFLAG,
+    #[doc = "0x04 - Event Control"]
+    pub evctrl: EVCTRL,
+    #[doc = "0x08 - Interrupt Enable Clear"]
+    pub intenclr: INTENCLR,
+    #[doc = "0x0c - Interrupt Enable Set"]
+    pub intenset: INTENSET,
+    #[doc = "0x10 - Interrupt Flag Status and Clear"]
+    pub intflag: INTFLAG,
+    #[doc = "0x14 - Wake-Up Enable"]
+    pub wakeup: WAKEUP,
+    #[doc = "0x18 - Configuration n"]
+    pub config: [CONFIG; 1],
+}
+#[doc = "Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrl](ctrl) module"]
+pub type CTRL = crate::Reg<u8, _CTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRL;
+#[doc = "`read()` method returns [ctrl::R](ctrl::R) reader structure"]
+impl crate::Readable for CTRL {}
+#[doc = "`write(|w| ..)` method takes [ctrl::W](ctrl::W) writer structure"]
+impl crate::Writable for CTRL {}
+#[doc = "Control"]
+pub mod ctrl;
+#[doc = "Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u8, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "Status"]
+pub mod status;
+#[doc = "Non-Maskable Interrupt Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [nmictrl](nmictrl) module"]
+pub type NMICTRL = crate::Reg<u8, _NMICTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _NMICTRL;
+#[doc = "`read()` method returns [nmictrl::R](nmictrl::R) reader structure"]
+impl crate::Readable for NMICTRL {}
+#[doc = "`write(|w| ..)` method takes [nmictrl::W](nmictrl::W) writer structure"]
+impl crate::Writable for NMICTRL {}
+#[doc = "Non-Maskable Interrupt Control"]
+pub mod nmictrl;
+#[doc = "Non-Maskable Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [nmiflag](nmiflag) module"]
+pub type NMIFLAG = crate::Reg<u8, _NMIFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _NMIFLAG;
+#[doc = "`read()` method returns [nmiflag::R](nmiflag::R) reader structure"]
+impl crate::Readable for NMIFLAG {}
+#[doc = "`write(|w| ..)` method takes [nmiflag::W](nmiflag::W) writer structure"]
+impl crate::Writable for NMIFLAG {}
+#[doc = "Non-Maskable Interrupt Flag Status and Clear"]
+pub mod nmiflag;
+#[doc = "Event Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [evctrl](evctrl) module"]
+pub type EVCTRL = crate::Reg<u32, _EVCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EVCTRL;
+#[doc = "`read()` method returns [evctrl::R](evctrl::R) reader structure"]
+impl crate::Readable for EVCTRL {}
+#[doc = "`write(|w| ..)` method takes [evctrl::W](evctrl::W) writer structure"]
+impl crate::Writable for EVCTRL {}
+#[doc = "Event Control"]
+pub mod evctrl;
+#[doc = "Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u32, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u32, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u32, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Wake-Up Enable\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [wakeup](wakeup) module"]
+pub type WAKEUP = crate::Reg<u32, _WAKEUP>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WAKEUP;
+#[doc = "`read()` method returns [wakeup::R](wakeup::R) reader structure"]
+impl crate::Readable for WAKEUP {}
+#[doc = "`write(|w| ..)` method takes [wakeup::W](wakeup::W) writer structure"]
+impl crate::Writable for WAKEUP {}
+#[doc = "Wake-Up Enable"]
+pub mod wakeup;
+#[doc = "Configuration n\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [config](config) module"]
+pub type CONFIG = crate::Reg<u32, _CONFIG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CONFIG;
+#[doc = "`read()` method returns [config::R](config::R) reader structure"]
+impl crate::Readable for CONFIG {}
+#[doc = "`write(|w| ..)` method takes [config::W](config::W) writer structure"]
+impl crate::Writable for CONFIG {}
+#[doc = "Configuration n"]
+pub mod config;

--- a/pac/atsamd11c14a/src/eic/config.rs
+++ b/pac/atsamd11c14a/src/eic/config.rs
@@ -1,0 +1,1360 @@
+#[doc = "Reader of register CONFIG%s"]
+pub type R = crate::R<u32, super::CONFIG>;
+#[doc = "Writer for register CONFIG%s"]
+pub type W = crate::W<u32, super::CONFIG>;
+#[doc = "Register CONFIG%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::CONFIG {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Input Sense 0 Configuration\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SENSE0_A {
+    #[doc = "0: No detection"]
+    NONE,
+    #[doc = "1: Rising-edge detection"]
+    RISE,
+    #[doc = "2: Falling-edge detection"]
+    FALL,
+    #[doc = "3: Both-edges detection"]
+    BOTH,
+    #[doc = "4: High-level detection"]
+    HIGH,
+    #[doc = "5: Low-level detection"]
+    LOW,
+}
+impl From<SENSE0_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SENSE0_A) -> Self {
+        match variant {
+            SENSE0_A::NONE => 0,
+            SENSE0_A::RISE => 1,
+            SENSE0_A::FALL => 2,
+            SENSE0_A::BOTH => 3,
+            SENSE0_A::HIGH => 4,
+            SENSE0_A::LOW => 5,
+        }
+    }
+}
+#[doc = "Reader of field `SENSE0`"]
+pub type SENSE0_R = crate::R<u8, SENSE0_A>;
+impl SENSE0_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, SENSE0_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(SENSE0_A::NONE),
+            1 => Val(SENSE0_A::RISE),
+            2 => Val(SENSE0_A::FALL),
+            3 => Val(SENSE0_A::BOTH),
+            4 => Val(SENSE0_A::HIGH),
+            5 => Val(SENSE0_A::LOW),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == SENSE0_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RISE`"]
+    #[inline(always)]
+    pub fn is_rise(&self) -> bool {
+        *self == SENSE0_A::RISE
+    }
+    #[doc = "Checks if the value of the field is `FALL`"]
+    #[inline(always)]
+    pub fn is_fall(&self) -> bool {
+        *self == SENSE0_A::FALL
+    }
+    #[doc = "Checks if the value of the field is `BOTH`"]
+    #[inline(always)]
+    pub fn is_both(&self) -> bool {
+        *self == SENSE0_A::BOTH
+    }
+    #[doc = "Checks if the value of the field is `HIGH`"]
+    #[inline(always)]
+    pub fn is_high(&self) -> bool {
+        *self == SENSE0_A::HIGH
+    }
+    #[doc = "Checks if the value of the field is `LOW`"]
+    #[inline(always)]
+    pub fn is_low(&self) -> bool {
+        *self == SENSE0_A::LOW
+    }
+}
+#[doc = "Write proxy for field `SENSE0`"]
+pub struct SENSE0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SENSE0_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SENSE0_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No detection"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(SENSE0_A::NONE)
+    }
+    #[doc = "Rising-edge detection"]
+    #[inline(always)]
+    pub fn rise(self) -> &'a mut W {
+        self.variant(SENSE0_A::RISE)
+    }
+    #[doc = "Falling-edge detection"]
+    #[inline(always)]
+    pub fn fall(self) -> &'a mut W {
+        self.variant(SENSE0_A::FALL)
+    }
+    #[doc = "Both-edges detection"]
+    #[inline(always)]
+    pub fn both(self) -> &'a mut W {
+        self.variant(SENSE0_A::BOTH)
+    }
+    #[doc = "High-level detection"]
+    #[inline(always)]
+    pub fn high(self) -> &'a mut W {
+        self.variant(SENSE0_A::HIGH)
+    }
+    #[doc = "Low-level detection"]
+    #[inline(always)]
+    pub fn low(self) -> &'a mut W {
+        self.variant(SENSE0_A::LOW)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u32) & 0x07);
+        self.w
+    }
+}
+#[doc = "Reader of field `FILTEN0`"]
+pub type FILTEN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FILTEN0`"]
+pub struct FILTEN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FILTEN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Input Sense 1 Configuration\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SENSE1_A {
+    #[doc = "0: No detection"]
+    NONE,
+    #[doc = "1: Rising edge detection"]
+    RISE,
+    #[doc = "2: Falling edge detection"]
+    FALL,
+    #[doc = "3: Both edges detection"]
+    BOTH,
+    #[doc = "4: High level detection"]
+    HIGH,
+    #[doc = "5: Low level detection"]
+    LOW,
+}
+impl From<SENSE1_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SENSE1_A) -> Self {
+        match variant {
+            SENSE1_A::NONE => 0,
+            SENSE1_A::RISE => 1,
+            SENSE1_A::FALL => 2,
+            SENSE1_A::BOTH => 3,
+            SENSE1_A::HIGH => 4,
+            SENSE1_A::LOW => 5,
+        }
+    }
+}
+#[doc = "Reader of field `SENSE1`"]
+pub type SENSE1_R = crate::R<u8, SENSE1_A>;
+impl SENSE1_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, SENSE1_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(SENSE1_A::NONE),
+            1 => Val(SENSE1_A::RISE),
+            2 => Val(SENSE1_A::FALL),
+            3 => Val(SENSE1_A::BOTH),
+            4 => Val(SENSE1_A::HIGH),
+            5 => Val(SENSE1_A::LOW),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == SENSE1_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RISE`"]
+    #[inline(always)]
+    pub fn is_rise(&self) -> bool {
+        *self == SENSE1_A::RISE
+    }
+    #[doc = "Checks if the value of the field is `FALL`"]
+    #[inline(always)]
+    pub fn is_fall(&self) -> bool {
+        *self == SENSE1_A::FALL
+    }
+    #[doc = "Checks if the value of the field is `BOTH`"]
+    #[inline(always)]
+    pub fn is_both(&self) -> bool {
+        *self == SENSE1_A::BOTH
+    }
+    #[doc = "Checks if the value of the field is `HIGH`"]
+    #[inline(always)]
+    pub fn is_high(&self) -> bool {
+        *self == SENSE1_A::HIGH
+    }
+    #[doc = "Checks if the value of the field is `LOW`"]
+    #[inline(always)]
+    pub fn is_low(&self) -> bool {
+        *self == SENSE1_A::LOW
+    }
+}
+#[doc = "Write proxy for field `SENSE1`"]
+pub struct SENSE1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SENSE1_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SENSE1_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No detection"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(SENSE1_A::NONE)
+    }
+    #[doc = "Rising edge detection"]
+    #[inline(always)]
+    pub fn rise(self) -> &'a mut W {
+        self.variant(SENSE1_A::RISE)
+    }
+    #[doc = "Falling edge detection"]
+    #[inline(always)]
+    pub fn fall(self) -> &'a mut W {
+        self.variant(SENSE1_A::FALL)
+    }
+    #[doc = "Both edges detection"]
+    #[inline(always)]
+    pub fn both(self) -> &'a mut W {
+        self.variant(SENSE1_A::BOTH)
+    }
+    #[doc = "High level detection"]
+    #[inline(always)]
+    pub fn high(self) -> &'a mut W {
+        self.variant(SENSE1_A::HIGH)
+    }
+    #[doc = "Low level detection"]
+    #[inline(always)]
+    pub fn low(self) -> &'a mut W {
+        self.variant(SENSE1_A::LOW)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 4)) | (((value as u32) & 0x07) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `FILTEN1`"]
+pub type FILTEN1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FILTEN1`"]
+pub struct FILTEN1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FILTEN1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Input Sense 2 Configuration\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SENSE2_A {
+    #[doc = "0: No detection"]
+    NONE,
+    #[doc = "1: Rising edge detection"]
+    RISE,
+    #[doc = "2: Falling edge detection"]
+    FALL,
+    #[doc = "3: Both edges detection"]
+    BOTH,
+    #[doc = "4: High level detection"]
+    HIGH,
+    #[doc = "5: Low level detection"]
+    LOW,
+}
+impl From<SENSE2_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SENSE2_A) -> Self {
+        match variant {
+            SENSE2_A::NONE => 0,
+            SENSE2_A::RISE => 1,
+            SENSE2_A::FALL => 2,
+            SENSE2_A::BOTH => 3,
+            SENSE2_A::HIGH => 4,
+            SENSE2_A::LOW => 5,
+        }
+    }
+}
+#[doc = "Reader of field `SENSE2`"]
+pub type SENSE2_R = crate::R<u8, SENSE2_A>;
+impl SENSE2_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, SENSE2_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(SENSE2_A::NONE),
+            1 => Val(SENSE2_A::RISE),
+            2 => Val(SENSE2_A::FALL),
+            3 => Val(SENSE2_A::BOTH),
+            4 => Val(SENSE2_A::HIGH),
+            5 => Val(SENSE2_A::LOW),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == SENSE2_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RISE`"]
+    #[inline(always)]
+    pub fn is_rise(&self) -> bool {
+        *self == SENSE2_A::RISE
+    }
+    #[doc = "Checks if the value of the field is `FALL`"]
+    #[inline(always)]
+    pub fn is_fall(&self) -> bool {
+        *self == SENSE2_A::FALL
+    }
+    #[doc = "Checks if the value of the field is `BOTH`"]
+    #[inline(always)]
+    pub fn is_both(&self) -> bool {
+        *self == SENSE2_A::BOTH
+    }
+    #[doc = "Checks if the value of the field is `HIGH`"]
+    #[inline(always)]
+    pub fn is_high(&self) -> bool {
+        *self == SENSE2_A::HIGH
+    }
+    #[doc = "Checks if the value of the field is `LOW`"]
+    #[inline(always)]
+    pub fn is_low(&self) -> bool {
+        *self == SENSE2_A::LOW
+    }
+}
+#[doc = "Write proxy for field `SENSE2`"]
+pub struct SENSE2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SENSE2_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SENSE2_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No detection"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(SENSE2_A::NONE)
+    }
+    #[doc = "Rising edge detection"]
+    #[inline(always)]
+    pub fn rise(self) -> &'a mut W {
+        self.variant(SENSE2_A::RISE)
+    }
+    #[doc = "Falling edge detection"]
+    #[inline(always)]
+    pub fn fall(self) -> &'a mut W {
+        self.variant(SENSE2_A::FALL)
+    }
+    #[doc = "Both edges detection"]
+    #[inline(always)]
+    pub fn both(self) -> &'a mut W {
+        self.variant(SENSE2_A::BOTH)
+    }
+    #[doc = "High level detection"]
+    #[inline(always)]
+    pub fn high(self) -> &'a mut W {
+        self.variant(SENSE2_A::HIGH)
+    }
+    #[doc = "Low level detection"]
+    #[inline(always)]
+    pub fn low(self) -> &'a mut W {
+        self.variant(SENSE2_A::LOW)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 8)) | (((value as u32) & 0x07) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `FILTEN2`"]
+pub type FILTEN2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FILTEN2`"]
+pub struct FILTEN2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FILTEN2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Input Sense 3 Configuration\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SENSE3_A {
+    #[doc = "0: No detection"]
+    NONE,
+    #[doc = "1: Rising edge detection"]
+    RISE,
+    #[doc = "2: Falling edge detection"]
+    FALL,
+    #[doc = "3: Both edges detection"]
+    BOTH,
+    #[doc = "4: High level detection"]
+    HIGH,
+    #[doc = "5: Low level detection"]
+    LOW,
+}
+impl From<SENSE3_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SENSE3_A) -> Self {
+        match variant {
+            SENSE3_A::NONE => 0,
+            SENSE3_A::RISE => 1,
+            SENSE3_A::FALL => 2,
+            SENSE3_A::BOTH => 3,
+            SENSE3_A::HIGH => 4,
+            SENSE3_A::LOW => 5,
+        }
+    }
+}
+#[doc = "Reader of field `SENSE3`"]
+pub type SENSE3_R = crate::R<u8, SENSE3_A>;
+impl SENSE3_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, SENSE3_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(SENSE3_A::NONE),
+            1 => Val(SENSE3_A::RISE),
+            2 => Val(SENSE3_A::FALL),
+            3 => Val(SENSE3_A::BOTH),
+            4 => Val(SENSE3_A::HIGH),
+            5 => Val(SENSE3_A::LOW),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == SENSE3_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RISE`"]
+    #[inline(always)]
+    pub fn is_rise(&self) -> bool {
+        *self == SENSE3_A::RISE
+    }
+    #[doc = "Checks if the value of the field is `FALL`"]
+    #[inline(always)]
+    pub fn is_fall(&self) -> bool {
+        *self == SENSE3_A::FALL
+    }
+    #[doc = "Checks if the value of the field is `BOTH`"]
+    #[inline(always)]
+    pub fn is_both(&self) -> bool {
+        *self == SENSE3_A::BOTH
+    }
+    #[doc = "Checks if the value of the field is `HIGH`"]
+    #[inline(always)]
+    pub fn is_high(&self) -> bool {
+        *self == SENSE3_A::HIGH
+    }
+    #[doc = "Checks if the value of the field is `LOW`"]
+    #[inline(always)]
+    pub fn is_low(&self) -> bool {
+        *self == SENSE3_A::LOW
+    }
+}
+#[doc = "Write proxy for field `SENSE3`"]
+pub struct SENSE3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SENSE3_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SENSE3_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No detection"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(SENSE3_A::NONE)
+    }
+    #[doc = "Rising edge detection"]
+    #[inline(always)]
+    pub fn rise(self) -> &'a mut W {
+        self.variant(SENSE3_A::RISE)
+    }
+    #[doc = "Falling edge detection"]
+    #[inline(always)]
+    pub fn fall(self) -> &'a mut W {
+        self.variant(SENSE3_A::FALL)
+    }
+    #[doc = "Both edges detection"]
+    #[inline(always)]
+    pub fn both(self) -> &'a mut W {
+        self.variant(SENSE3_A::BOTH)
+    }
+    #[doc = "High level detection"]
+    #[inline(always)]
+    pub fn high(self) -> &'a mut W {
+        self.variant(SENSE3_A::HIGH)
+    }
+    #[doc = "Low level detection"]
+    #[inline(always)]
+    pub fn low(self) -> &'a mut W {
+        self.variant(SENSE3_A::LOW)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 12)) | (((value as u32) & 0x07) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `FILTEN3`"]
+pub type FILTEN3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FILTEN3`"]
+pub struct FILTEN3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FILTEN3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Input Sense 4 Configuration\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SENSE4_A {
+    #[doc = "0: No detection"]
+    NONE,
+    #[doc = "1: Rising edge detection"]
+    RISE,
+    #[doc = "2: Falling edge detection"]
+    FALL,
+    #[doc = "3: Both edges detection"]
+    BOTH,
+    #[doc = "4: High level detection"]
+    HIGH,
+    #[doc = "5: Low level detection"]
+    LOW,
+}
+impl From<SENSE4_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SENSE4_A) -> Self {
+        match variant {
+            SENSE4_A::NONE => 0,
+            SENSE4_A::RISE => 1,
+            SENSE4_A::FALL => 2,
+            SENSE4_A::BOTH => 3,
+            SENSE4_A::HIGH => 4,
+            SENSE4_A::LOW => 5,
+        }
+    }
+}
+#[doc = "Reader of field `SENSE4`"]
+pub type SENSE4_R = crate::R<u8, SENSE4_A>;
+impl SENSE4_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, SENSE4_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(SENSE4_A::NONE),
+            1 => Val(SENSE4_A::RISE),
+            2 => Val(SENSE4_A::FALL),
+            3 => Val(SENSE4_A::BOTH),
+            4 => Val(SENSE4_A::HIGH),
+            5 => Val(SENSE4_A::LOW),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == SENSE4_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RISE`"]
+    #[inline(always)]
+    pub fn is_rise(&self) -> bool {
+        *self == SENSE4_A::RISE
+    }
+    #[doc = "Checks if the value of the field is `FALL`"]
+    #[inline(always)]
+    pub fn is_fall(&self) -> bool {
+        *self == SENSE4_A::FALL
+    }
+    #[doc = "Checks if the value of the field is `BOTH`"]
+    #[inline(always)]
+    pub fn is_both(&self) -> bool {
+        *self == SENSE4_A::BOTH
+    }
+    #[doc = "Checks if the value of the field is `HIGH`"]
+    #[inline(always)]
+    pub fn is_high(&self) -> bool {
+        *self == SENSE4_A::HIGH
+    }
+    #[doc = "Checks if the value of the field is `LOW`"]
+    #[inline(always)]
+    pub fn is_low(&self) -> bool {
+        *self == SENSE4_A::LOW
+    }
+}
+#[doc = "Write proxy for field `SENSE4`"]
+pub struct SENSE4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SENSE4_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SENSE4_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No detection"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(SENSE4_A::NONE)
+    }
+    #[doc = "Rising edge detection"]
+    #[inline(always)]
+    pub fn rise(self) -> &'a mut W {
+        self.variant(SENSE4_A::RISE)
+    }
+    #[doc = "Falling edge detection"]
+    #[inline(always)]
+    pub fn fall(self) -> &'a mut W {
+        self.variant(SENSE4_A::FALL)
+    }
+    #[doc = "Both edges detection"]
+    #[inline(always)]
+    pub fn both(self) -> &'a mut W {
+        self.variant(SENSE4_A::BOTH)
+    }
+    #[doc = "High level detection"]
+    #[inline(always)]
+    pub fn high(self) -> &'a mut W {
+        self.variant(SENSE4_A::HIGH)
+    }
+    #[doc = "Low level detection"]
+    #[inline(always)]
+    pub fn low(self) -> &'a mut W {
+        self.variant(SENSE4_A::LOW)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 16)) | (((value as u32) & 0x07) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `FILTEN4`"]
+pub type FILTEN4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FILTEN4`"]
+pub struct FILTEN4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FILTEN4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 19)) | (((value as u32) & 0x01) << 19);
+        self.w
+    }
+}
+#[doc = "Input Sense 5 Configuration\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SENSE5_A {
+    #[doc = "0: No detection"]
+    NONE,
+    #[doc = "1: Rising edge detection"]
+    RISE,
+    #[doc = "2: Falling edge detection"]
+    FALL,
+    #[doc = "3: Both edges detection"]
+    BOTH,
+    #[doc = "4: High level detection"]
+    HIGH,
+    #[doc = "5: Low level detection"]
+    LOW,
+}
+impl From<SENSE5_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SENSE5_A) -> Self {
+        match variant {
+            SENSE5_A::NONE => 0,
+            SENSE5_A::RISE => 1,
+            SENSE5_A::FALL => 2,
+            SENSE5_A::BOTH => 3,
+            SENSE5_A::HIGH => 4,
+            SENSE5_A::LOW => 5,
+        }
+    }
+}
+#[doc = "Reader of field `SENSE5`"]
+pub type SENSE5_R = crate::R<u8, SENSE5_A>;
+impl SENSE5_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, SENSE5_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(SENSE5_A::NONE),
+            1 => Val(SENSE5_A::RISE),
+            2 => Val(SENSE5_A::FALL),
+            3 => Val(SENSE5_A::BOTH),
+            4 => Val(SENSE5_A::HIGH),
+            5 => Val(SENSE5_A::LOW),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == SENSE5_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RISE`"]
+    #[inline(always)]
+    pub fn is_rise(&self) -> bool {
+        *self == SENSE5_A::RISE
+    }
+    #[doc = "Checks if the value of the field is `FALL`"]
+    #[inline(always)]
+    pub fn is_fall(&self) -> bool {
+        *self == SENSE5_A::FALL
+    }
+    #[doc = "Checks if the value of the field is `BOTH`"]
+    #[inline(always)]
+    pub fn is_both(&self) -> bool {
+        *self == SENSE5_A::BOTH
+    }
+    #[doc = "Checks if the value of the field is `HIGH`"]
+    #[inline(always)]
+    pub fn is_high(&self) -> bool {
+        *self == SENSE5_A::HIGH
+    }
+    #[doc = "Checks if the value of the field is `LOW`"]
+    #[inline(always)]
+    pub fn is_low(&self) -> bool {
+        *self == SENSE5_A::LOW
+    }
+}
+#[doc = "Write proxy for field `SENSE5`"]
+pub struct SENSE5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SENSE5_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SENSE5_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No detection"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(SENSE5_A::NONE)
+    }
+    #[doc = "Rising edge detection"]
+    #[inline(always)]
+    pub fn rise(self) -> &'a mut W {
+        self.variant(SENSE5_A::RISE)
+    }
+    #[doc = "Falling edge detection"]
+    #[inline(always)]
+    pub fn fall(self) -> &'a mut W {
+        self.variant(SENSE5_A::FALL)
+    }
+    #[doc = "Both edges detection"]
+    #[inline(always)]
+    pub fn both(self) -> &'a mut W {
+        self.variant(SENSE5_A::BOTH)
+    }
+    #[doc = "High level detection"]
+    #[inline(always)]
+    pub fn high(self) -> &'a mut W {
+        self.variant(SENSE5_A::HIGH)
+    }
+    #[doc = "Low level detection"]
+    #[inline(always)]
+    pub fn low(self) -> &'a mut W {
+        self.variant(SENSE5_A::LOW)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 20)) | (((value as u32) & 0x07) << 20);
+        self.w
+    }
+}
+#[doc = "Reader of field `FILTEN5`"]
+pub type FILTEN5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FILTEN5`"]
+pub struct FILTEN5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FILTEN5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 23)) | (((value as u32) & 0x01) << 23);
+        self.w
+    }
+}
+#[doc = "Input Sense 6 Configuration\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SENSE6_A {
+    #[doc = "0: No detection"]
+    NONE,
+    #[doc = "1: Rising edge detection"]
+    RISE,
+    #[doc = "2: Falling edge detection"]
+    FALL,
+    #[doc = "3: Both edges detection"]
+    BOTH,
+    #[doc = "4: High level detection"]
+    HIGH,
+    #[doc = "5: Low level detection"]
+    LOW,
+}
+impl From<SENSE6_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SENSE6_A) -> Self {
+        match variant {
+            SENSE6_A::NONE => 0,
+            SENSE6_A::RISE => 1,
+            SENSE6_A::FALL => 2,
+            SENSE6_A::BOTH => 3,
+            SENSE6_A::HIGH => 4,
+            SENSE6_A::LOW => 5,
+        }
+    }
+}
+#[doc = "Reader of field `SENSE6`"]
+pub type SENSE6_R = crate::R<u8, SENSE6_A>;
+impl SENSE6_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, SENSE6_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(SENSE6_A::NONE),
+            1 => Val(SENSE6_A::RISE),
+            2 => Val(SENSE6_A::FALL),
+            3 => Val(SENSE6_A::BOTH),
+            4 => Val(SENSE6_A::HIGH),
+            5 => Val(SENSE6_A::LOW),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == SENSE6_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RISE`"]
+    #[inline(always)]
+    pub fn is_rise(&self) -> bool {
+        *self == SENSE6_A::RISE
+    }
+    #[doc = "Checks if the value of the field is `FALL`"]
+    #[inline(always)]
+    pub fn is_fall(&self) -> bool {
+        *self == SENSE6_A::FALL
+    }
+    #[doc = "Checks if the value of the field is `BOTH`"]
+    #[inline(always)]
+    pub fn is_both(&self) -> bool {
+        *self == SENSE6_A::BOTH
+    }
+    #[doc = "Checks if the value of the field is `HIGH`"]
+    #[inline(always)]
+    pub fn is_high(&self) -> bool {
+        *self == SENSE6_A::HIGH
+    }
+    #[doc = "Checks if the value of the field is `LOW`"]
+    #[inline(always)]
+    pub fn is_low(&self) -> bool {
+        *self == SENSE6_A::LOW
+    }
+}
+#[doc = "Write proxy for field `SENSE6`"]
+pub struct SENSE6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SENSE6_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SENSE6_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No detection"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(SENSE6_A::NONE)
+    }
+    #[doc = "Rising edge detection"]
+    #[inline(always)]
+    pub fn rise(self) -> &'a mut W {
+        self.variant(SENSE6_A::RISE)
+    }
+    #[doc = "Falling edge detection"]
+    #[inline(always)]
+    pub fn fall(self) -> &'a mut W {
+        self.variant(SENSE6_A::FALL)
+    }
+    #[doc = "Both edges detection"]
+    #[inline(always)]
+    pub fn both(self) -> &'a mut W {
+        self.variant(SENSE6_A::BOTH)
+    }
+    #[doc = "High level detection"]
+    #[inline(always)]
+    pub fn high(self) -> &'a mut W {
+        self.variant(SENSE6_A::HIGH)
+    }
+    #[doc = "Low level detection"]
+    #[inline(always)]
+    pub fn low(self) -> &'a mut W {
+        self.variant(SENSE6_A::LOW)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 24)) | (((value as u32) & 0x07) << 24);
+        self.w
+    }
+}
+#[doc = "Reader of field `FILTEN6`"]
+pub type FILTEN6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FILTEN6`"]
+pub struct FILTEN6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FILTEN6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 27)) | (((value as u32) & 0x01) << 27);
+        self.w
+    }
+}
+#[doc = "Input Sense 7 Configuration\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SENSE7_A {
+    #[doc = "0: No detection"]
+    NONE,
+    #[doc = "1: Rising edge detection"]
+    RISE,
+    #[doc = "2: Falling edge detection"]
+    FALL,
+    #[doc = "3: Both edges detection"]
+    BOTH,
+    #[doc = "4: High level detection"]
+    HIGH,
+    #[doc = "5: Low level detection"]
+    LOW,
+}
+impl From<SENSE7_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SENSE7_A) -> Self {
+        match variant {
+            SENSE7_A::NONE => 0,
+            SENSE7_A::RISE => 1,
+            SENSE7_A::FALL => 2,
+            SENSE7_A::BOTH => 3,
+            SENSE7_A::HIGH => 4,
+            SENSE7_A::LOW => 5,
+        }
+    }
+}
+#[doc = "Reader of field `SENSE7`"]
+pub type SENSE7_R = crate::R<u8, SENSE7_A>;
+impl SENSE7_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, SENSE7_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(SENSE7_A::NONE),
+            1 => Val(SENSE7_A::RISE),
+            2 => Val(SENSE7_A::FALL),
+            3 => Val(SENSE7_A::BOTH),
+            4 => Val(SENSE7_A::HIGH),
+            5 => Val(SENSE7_A::LOW),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == SENSE7_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RISE`"]
+    #[inline(always)]
+    pub fn is_rise(&self) -> bool {
+        *self == SENSE7_A::RISE
+    }
+    #[doc = "Checks if the value of the field is `FALL`"]
+    #[inline(always)]
+    pub fn is_fall(&self) -> bool {
+        *self == SENSE7_A::FALL
+    }
+    #[doc = "Checks if the value of the field is `BOTH`"]
+    #[inline(always)]
+    pub fn is_both(&self) -> bool {
+        *self == SENSE7_A::BOTH
+    }
+    #[doc = "Checks if the value of the field is `HIGH`"]
+    #[inline(always)]
+    pub fn is_high(&self) -> bool {
+        *self == SENSE7_A::HIGH
+    }
+    #[doc = "Checks if the value of the field is `LOW`"]
+    #[inline(always)]
+    pub fn is_low(&self) -> bool {
+        *self == SENSE7_A::LOW
+    }
+}
+#[doc = "Write proxy for field `SENSE7`"]
+pub struct SENSE7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SENSE7_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SENSE7_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No detection"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(SENSE7_A::NONE)
+    }
+    #[doc = "Rising edge detection"]
+    #[inline(always)]
+    pub fn rise(self) -> &'a mut W {
+        self.variant(SENSE7_A::RISE)
+    }
+    #[doc = "Falling edge detection"]
+    #[inline(always)]
+    pub fn fall(self) -> &'a mut W {
+        self.variant(SENSE7_A::FALL)
+    }
+    #[doc = "Both edges detection"]
+    #[inline(always)]
+    pub fn both(self) -> &'a mut W {
+        self.variant(SENSE7_A::BOTH)
+    }
+    #[doc = "High level detection"]
+    #[inline(always)]
+    pub fn high(self) -> &'a mut W {
+        self.variant(SENSE7_A::HIGH)
+    }
+    #[doc = "Low level detection"]
+    #[inline(always)]
+    pub fn low(self) -> &'a mut W {
+        self.variant(SENSE7_A::LOW)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 28)) | (((value as u32) & 0x07) << 28);
+        self.w
+    }
+}
+#[doc = "Reader of field `FILTEN7`"]
+pub type FILTEN7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FILTEN7`"]
+pub struct FILTEN7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FILTEN7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 31)) | (((value as u32) & 0x01) << 31);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Input Sense 0 Configuration"]
+    #[inline(always)]
+    pub fn sense0(&self) -> SENSE0_R {
+        SENSE0_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bit 3 - Filter 0 Enable"]
+    #[inline(always)]
+    pub fn filten0(&self) -> FILTEN0_R {
+        FILTEN0_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bits 4:6 - Input Sense 1 Configuration"]
+    #[inline(always)]
+    pub fn sense1(&self) -> SENSE1_R {
+        SENSE1_R::new(((self.bits >> 4) & 0x07) as u8)
+    }
+    #[doc = "Bit 7 - Filter 1 Enable"]
+    #[inline(always)]
+    pub fn filten1(&self) -> FILTEN1_R {
+        FILTEN1_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bits 8:10 - Input Sense 2 Configuration"]
+    #[inline(always)]
+    pub fn sense2(&self) -> SENSE2_R {
+        SENSE2_R::new(((self.bits >> 8) & 0x07) as u8)
+    }
+    #[doc = "Bit 11 - Filter 2 Enable"]
+    #[inline(always)]
+    pub fn filten2(&self) -> FILTEN2_R {
+        FILTEN2_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bits 12:14 - Input Sense 3 Configuration"]
+    #[inline(always)]
+    pub fn sense3(&self) -> SENSE3_R {
+        SENSE3_R::new(((self.bits >> 12) & 0x07) as u8)
+    }
+    #[doc = "Bit 15 - Filter 3 Enable"]
+    #[inline(always)]
+    pub fn filten3(&self) -> FILTEN3_R {
+        FILTEN3_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bits 16:18 - Input Sense 4 Configuration"]
+    #[inline(always)]
+    pub fn sense4(&self) -> SENSE4_R {
+        SENSE4_R::new(((self.bits >> 16) & 0x07) as u8)
+    }
+    #[doc = "Bit 19 - Filter 4 Enable"]
+    #[inline(always)]
+    pub fn filten4(&self) -> FILTEN4_R {
+        FILTEN4_R::new(((self.bits >> 19) & 0x01) != 0)
+    }
+    #[doc = "Bits 20:22 - Input Sense 5 Configuration"]
+    #[inline(always)]
+    pub fn sense5(&self) -> SENSE5_R {
+        SENSE5_R::new(((self.bits >> 20) & 0x07) as u8)
+    }
+    #[doc = "Bit 23 - Filter 5 Enable"]
+    #[inline(always)]
+    pub fn filten5(&self) -> FILTEN5_R {
+        FILTEN5_R::new(((self.bits >> 23) & 0x01) != 0)
+    }
+    #[doc = "Bits 24:26 - Input Sense 6 Configuration"]
+    #[inline(always)]
+    pub fn sense6(&self) -> SENSE6_R {
+        SENSE6_R::new(((self.bits >> 24) & 0x07) as u8)
+    }
+    #[doc = "Bit 27 - Filter 6 Enable"]
+    #[inline(always)]
+    pub fn filten6(&self) -> FILTEN6_R {
+        FILTEN6_R::new(((self.bits >> 27) & 0x01) != 0)
+    }
+    #[doc = "Bits 28:30 - Input Sense 7 Configuration"]
+    #[inline(always)]
+    pub fn sense7(&self) -> SENSE7_R {
+        SENSE7_R::new(((self.bits >> 28) & 0x07) as u8)
+    }
+    #[doc = "Bit 31 - Filter 7 Enable"]
+    #[inline(always)]
+    pub fn filten7(&self) -> FILTEN7_R {
+        FILTEN7_R::new(((self.bits >> 31) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Input Sense 0 Configuration"]
+    #[inline(always)]
+    pub fn sense0(&mut self) -> SENSE0_W {
+        SENSE0_W { w: self }
+    }
+    #[doc = "Bit 3 - Filter 0 Enable"]
+    #[inline(always)]
+    pub fn filten0(&mut self) -> FILTEN0_W {
+        FILTEN0_W { w: self }
+    }
+    #[doc = "Bits 4:6 - Input Sense 1 Configuration"]
+    #[inline(always)]
+    pub fn sense1(&mut self) -> SENSE1_W {
+        SENSE1_W { w: self }
+    }
+    #[doc = "Bit 7 - Filter 1 Enable"]
+    #[inline(always)]
+    pub fn filten1(&mut self) -> FILTEN1_W {
+        FILTEN1_W { w: self }
+    }
+    #[doc = "Bits 8:10 - Input Sense 2 Configuration"]
+    #[inline(always)]
+    pub fn sense2(&mut self) -> SENSE2_W {
+        SENSE2_W { w: self }
+    }
+    #[doc = "Bit 11 - Filter 2 Enable"]
+    #[inline(always)]
+    pub fn filten2(&mut self) -> FILTEN2_W {
+        FILTEN2_W { w: self }
+    }
+    #[doc = "Bits 12:14 - Input Sense 3 Configuration"]
+    #[inline(always)]
+    pub fn sense3(&mut self) -> SENSE3_W {
+        SENSE3_W { w: self }
+    }
+    #[doc = "Bit 15 - Filter 3 Enable"]
+    #[inline(always)]
+    pub fn filten3(&mut self) -> FILTEN3_W {
+        FILTEN3_W { w: self }
+    }
+    #[doc = "Bits 16:18 - Input Sense 4 Configuration"]
+    #[inline(always)]
+    pub fn sense4(&mut self) -> SENSE4_W {
+        SENSE4_W { w: self }
+    }
+    #[doc = "Bit 19 - Filter 4 Enable"]
+    #[inline(always)]
+    pub fn filten4(&mut self) -> FILTEN4_W {
+        FILTEN4_W { w: self }
+    }
+    #[doc = "Bits 20:22 - Input Sense 5 Configuration"]
+    #[inline(always)]
+    pub fn sense5(&mut self) -> SENSE5_W {
+        SENSE5_W { w: self }
+    }
+    #[doc = "Bit 23 - Filter 5 Enable"]
+    #[inline(always)]
+    pub fn filten5(&mut self) -> FILTEN5_W {
+        FILTEN5_W { w: self }
+    }
+    #[doc = "Bits 24:26 - Input Sense 6 Configuration"]
+    #[inline(always)]
+    pub fn sense6(&mut self) -> SENSE6_W {
+        SENSE6_W { w: self }
+    }
+    #[doc = "Bit 27 - Filter 6 Enable"]
+    #[inline(always)]
+    pub fn filten6(&mut self) -> FILTEN6_W {
+        FILTEN6_W { w: self }
+    }
+    #[doc = "Bits 28:30 - Input Sense 7 Configuration"]
+    #[inline(always)]
+    pub fn sense7(&mut self) -> SENSE7_W {
+        SENSE7_W { w: self }
+    }
+    #[doc = "Bit 31 - Filter 7 Enable"]
+    #[inline(always)]
+    pub fn filten7(&mut self) -> FILTEN7_W {
+        FILTEN7_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/eic/ctrl.rs
+++ b/pac/atsamd11c14a/src/eic/ctrl.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register CTRL"]
+pub type R = crate::R<u8, super::CTRL>;
+#[doc = "Writer for register CTRL"]
+pub type W = crate::W<u8, super::CTRL>;
+#[doc = "Register CTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/eic/evctrl.rs
+++ b/pac/atsamd11c14a/src/eic/evctrl.rs
@@ -1,0 +1,288 @@
+#[doc = "Reader of register EVCTRL"]
+pub type R = crate::R<u32, super::EVCTRL>;
+#[doc = "Writer for register EVCTRL"]
+pub type W = crate::W<u32, super::EVCTRL>;
+#[doc = "Register EVCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::EVCTRL {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `EXTINTEO0`"]
+pub type EXTINTEO0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINTEO0`"]
+pub struct EXTINTEO0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINTEO0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINTEO1`"]
+pub type EXTINTEO1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINTEO1`"]
+pub struct EXTINTEO1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINTEO1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINTEO2`"]
+pub type EXTINTEO2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINTEO2`"]
+pub struct EXTINTEO2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINTEO2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINTEO3`"]
+pub type EXTINTEO3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINTEO3`"]
+pub struct EXTINTEO3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINTEO3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINTEO4`"]
+pub type EXTINTEO4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINTEO4`"]
+pub struct EXTINTEO4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINTEO4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINTEO5`"]
+pub type EXTINTEO5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINTEO5`"]
+pub struct EXTINTEO5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINTEO5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINTEO6`"]
+pub type EXTINTEO6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINTEO6`"]
+pub struct EXTINTEO6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINTEO6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINTEO7`"]
+pub type EXTINTEO7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINTEO7`"]
+pub struct EXTINTEO7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINTEO7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - External Interrupt 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo0(&self) -> EXTINTEO0_R {
+        EXTINTEO0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - External Interrupt 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo1(&self) -> EXTINTEO1_R {
+        EXTINTEO1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - External Interrupt 2 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo2(&self) -> EXTINTEO2_R {
+        EXTINTEO2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - External Interrupt 3 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo3(&self) -> EXTINTEO3_R {
+        EXTINTEO3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - External Interrupt 4 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo4(&self) -> EXTINTEO4_R {
+        EXTINTEO4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - External Interrupt 5 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo5(&self) -> EXTINTEO5_R {
+        EXTINTEO5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - External Interrupt 6 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo6(&self) -> EXTINTEO6_R {
+        EXTINTEO6_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - External Interrupt 7 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo7(&self) -> EXTINTEO7_R {
+        EXTINTEO7_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - External Interrupt 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo0(&mut self) -> EXTINTEO0_W {
+        EXTINTEO0_W { w: self }
+    }
+    #[doc = "Bit 1 - External Interrupt 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo1(&mut self) -> EXTINTEO1_W {
+        EXTINTEO1_W { w: self }
+    }
+    #[doc = "Bit 2 - External Interrupt 2 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo2(&mut self) -> EXTINTEO2_W {
+        EXTINTEO2_W { w: self }
+    }
+    #[doc = "Bit 3 - External Interrupt 3 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo3(&mut self) -> EXTINTEO3_W {
+        EXTINTEO3_W { w: self }
+    }
+    #[doc = "Bit 4 - External Interrupt 4 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo4(&mut self) -> EXTINTEO4_W {
+        EXTINTEO4_W { w: self }
+    }
+    #[doc = "Bit 5 - External Interrupt 5 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo5(&mut self) -> EXTINTEO5_W {
+        EXTINTEO5_W { w: self }
+    }
+    #[doc = "Bit 6 - External Interrupt 6 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo6(&mut self) -> EXTINTEO6_W {
+        EXTINTEO6_W { w: self }
+    }
+    #[doc = "Bit 7 - External Interrupt 7 Event Output Enable"]
+    #[inline(always)]
+    pub fn extinteo7(&mut self) -> EXTINTEO7_W {
+        EXTINTEO7_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/eic/intenclr.rs
+++ b/pac/atsamd11c14a/src/eic/intenclr.rs
@@ -1,0 +1,288 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u32, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u32, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `EXTINT0`"]
+pub type EXTINT0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT0`"]
+pub struct EXTINT0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT1`"]
+pub type EXTINT1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT1`"]
+pub struct EXTINT1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT2`"]
+pub type EXTINT2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT2`"]
+pub struct EXTINT2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT3`"]
+pub type EXTINT3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT3`"]
+pub struct EXTINT3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT4`"]
+pub type EXTINT4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT4`"]
+pub struct EXTINT4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT5`"]
+pub type EXTINT5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT5`"]
+pub struct EXTINT5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT6`"]
+pub type EXTINT6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT6`"]
+pub struct EXTINT6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT7`"]
+pub type EXTINT7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT7`"]
+pub struct EXTINT7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - External Interrupt 0 Enable"]
+    #[inline(always)]
+    pub fn extint0(&self) -> EXTINT0_R {
+        EXTINT0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - External Interrupt 1 Enable"]
+    #[inline(always)]
+    pub fn extint1(&self) -> EXTINT1_R {
+        EXTINT1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - External Interrupt 2 Enable"]
+    #[inline(always)]
+    pub fn extint2(&self) -> EXTINT2_R {
+        EXTINT2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - External Interrupt 3 Enable"]
+    #[inline(always)]
+    pub fn extint3(&self) -> EXTINT3_R {
+        EXTINT3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - External Interrupt 4 Enable"]
+    #[inline(always)]
+    pub fn extint4(&self) -> EXTINT4_R {
+        EXTINT4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - External Interrupt 5 Enable"]
+    #[inline(always)]
+    pub fn extint5(&self) -> EXTINT5_R {
+        EXTINT5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - External Interrupt 6 Enable"]
+    #[inline(always)]
+    pub fn extint6(&self) -> EXTINT6_R {
+        EXTINT6_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - External Interrupt 7 Enable"]
+    #[inline(always)]
+    pub fn extint7(&self) -> EXTINT7_R {
+        EXTINT7_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - External Interrupt 0 Enable"]
+    #[inline(always)]
+    pub fn extint0(&mut self) -> EXTINT0_W {
+        EXTINT0_W { w: self }
+    }
+    #[doc = "Bit 1 - External Interrupt 1 Enable"]
+    #[inline(always)]
+    pub fn extint1(&mut self) -> EXTINT1_W {
+        EXTINT1_W { w: self }
+    }
+    #[doc = "Bit 2 - External Interrupt 2 Enable"]
+    #[inline(always)]
+    pub fn extint2(&mut self) -> EXTINT2_W {
+        EXTINT2_W { w: self }
+    }
+    #[doc = "Bit 3 - External Interrupt 3 Enable"]
+    #[inline(always)]
+    pub fn extint3(&mut self) -> EXTINT3_W {
+        EXTINT3_W { w: self }
+    }
+    #[doc = "Bit 4 - External Interrupt 4 Enable"]
+    #[inline(always)]
+    pub fn extint4(&mut self) -> EXTINT4_W {
+        EXTINT4_W { w: self }
+    }
+    #[doc = "Bit 5 - External Interrupt 5 Enable"]
+    #[inline(always)]
+    pub fn extint5(&mut self) -> EXTINT5_W {
+        EXTINT5_W { w: self }
+    }
+    #[doc = "Bit 6 - External Interrupt 6 Enable"]
+    #[inline(always)]
+    pub fn extint6(&mut self) -> EXTINT6_W {
+        EXTINT6_W { w: self }
+    }
+    #[doc = "Bit 7 - External Interrupt 7 Enable"]
+    #[inline(always)]
+    pub fn extint7(&mut self) -> EXTINT7_W {
+        EXTINT7_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/eic/intenset.rs
+++ b/pac/atsamd11c14a/src/eic/intenset.rs
@@ -1,0 +1,288 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u32, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u32, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `EXTINT0`"]
+pub type EXTINT0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT0`"]
+pub struct EXTINT0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT1`"]
+pub type EXTINT1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT1`"]
+pub struct EXTINT1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT2`"]
+pub type EXTINT2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT2`"]
+pub struct EXTINT2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT3`"]
+pub type EXTINT3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT3`"]
+pub struct EXTINT3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT4`"]
+pub type EXTINT4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT4`"]
+pub struct EXTINT4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT5`"]
+pub type EXTINT5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT5`"]
+pub struct EXTINT5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT6`"]
+pub type EXTINT6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT6`"]
+pub struct EXTINT6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT7`"]
+pub type EXTINT7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT7`"]
+pub struct EXTINT7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - External Interrupt 0 Enable"]
+    #[inline(always)]
+    pub fn extint0(&self) -> EXTINT0_R {
+        EXTINT0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - External Interrupt 1 Enable"]
+    #[inline(always)]
+    pub fn extint1(&self) -> EXTINT1_R {
+        EXTINT1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - External Interrupt 2 Enable"]
+    #[inline(always)]
+    pub fn extint2(&self) -> EXTINT2_R {
+        EXTINT2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - External Interrupt 3 Enable"]
+    #[inline(always)]
+    pub fn extint3(&self) -> EXTINT3_R {
+        EXTINT3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - External Interrupt 4 Enable"]
+    #[inline(always)]
+    pub fn extint4(&self) -> EXTINT4_R {
+        EXTINT4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - External Interrupt 5 Enable"]
+    #[inline(always)]
+    pub fn extint5(&self) -> EXTINT5_R {
+        EXTINT5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - External Interrupt 6 Enable"]
+    #[inline(always)]
+    pub fn extint6(&self) -> EXTINT6_R {
+        EXTINT6_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - External Interrupt 7 Enable"]
+    #[inline(always)]
+    pub fn extint7(&self) -> EXTINT7_R {
+        EXTINT7_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - External Interrupt 0 Enable"]
+    #[inline(always)]
+    pub fn extint0(&mut self) -> EXTINT0_W {
+        EXTINT0_W { w: self }
+    }
+    #[doc = "Bit 1 - External Interrupt 1 Enable"]
+    #[inline(always)]
+    pub fn extint1(&mut self) -> EXTINT1_W {
+        EXTINT1_W { w: self }
+    }
+    #[doc = "Bit 2 - External Interrupt 2 Enable"]
+    #[inline(always)]
+    pub fn extint2(&mut self) -> EXTINT2_W {
+        EXTINT2_W { w: self }
+    }
+    #[doc = "Bit 3 - External Interrupt 3 Enable"]
+    #[inline(always)]
+    pub fn extint3(&mut self) -> EXTINT3_W {
+        EXTINT3_W { w: self }
+    }
+    #[doc = "Bit 4 - External Interrupt 4 Enable"]
+    #[inline(always)]
+    pub fn extint4(&mut self) -> EXTINT4_W {
+        EXTINT4_W { w: self }
+    }
+    #[doc = "Bit 5 - External Interrupt 5 Enable"]
+    #[inline(always)]
+    pub fn extint5(&mut self) -> EXTINT5_W {
+        EXTINT5_W { w: self }
+    }
+    #[doc = "Bit 6 - External Interrupt 6 Enable"]
+    #[inline(always)]
+    pub fn extint6(&mut self) -> EXTINT6_W {
+        EXTINT6_W { w: self }
+    }
+    #[doc = "Bit 7 - External Interrupt 7 Enable"]
+    #[inline(always)]
+    pub fn extint7(&mut self) -> EXTINT7_W {
+        EXTINT7_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/eic/intflag.rs
+++ b/pac/atsamd11c14a/src/eic/intflag.rs
@@ -1,0 +1,288 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u32, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u32, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `EXTINT0`"]
+pub type EXTINT0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT0`"]
+pub struct EXTINT0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT1`"]
+pub type EXTINT1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT1`"]
+pub struct EXTINT1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT2`"]
+pub type EXTINT2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT2`"]
+pub struct EXTINT2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT3`"]
+pub type EXTINT3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT3`"]
+pub struct EXTINT3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT4`"]
+pub type EXTINT4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT4`"]
+pub struct EXTINT4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT5`"]
+pub type EXTINT5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT5`"]
+pub struct EXTINT5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT6`"]
+pub type EXTINT6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT6`"]
+pub struct EXTINT6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `EXTINT7`"]
+pub type EXTINT7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EXTINT7`"]
+pub struct EXTINT7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EXTINT7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - External Interrupt 0"]
+    #[inline(always)]
+    pub fn extint0(&self) -> EXTINT0_R {
+        EXTINT0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - External Interrupt 1"]
+    #[inline(always)]
+    pub fn extint1(&self) -> EXTINT1_R {
+        EXTINT1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - External Interrupt 2"]
+    #[inline(always)]
+    pub fn extint2(&self) -> EXTINT2_R {
+        EXTINT2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - External Interrupt 3"]
+    #[inline(always)]
+    pub fn extint3(&self) -> EXTINT3_R {
+        EXTINT3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - External Interrupt 4"]
+    #[inline(always)]
+    pub fn extint4(&self) -> EXTINT4_R {
+        EXTINT4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - External Interrupt 5"]
+    #[inline(always)]
+    pub fn extint5(&self) -> EXTINT5_R {
+        EXTINT5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - External Interrupt 6"]
+    #[inline(always)]
+    pub fn extint6(&self) -> EXTINT6_R {
+        EXTINT6_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - External Interrupt 7"]
+    #[inline(always)]
+    pub fn extint7(&self) -> EXTINT7_R {
+        EXTINT7_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - External Interrupt 0"]
+    #[inline(always)]
+    pub fn extint0(&mut self) -> EXTINT0_W {
+        EXTINT0_W { w: self }
+    }
+    #[doc = "Bit 1 - External Interrupt 1"]
+    #[inline(always)]
+    pub fn extint1(&mut self) -> EXTINT1_W {
+        EXTINT1_W { w: self }
+    }
+    #[doc = "Bit 2 - External Interrupt 2"]
+    #[inline(always)]
+    pub fn extint2(&mut self) -> EXTINT2_W {
+        EXTINT2_W { w: self }
+    }
+    #[doc = "Bit 3 - External Interrupt 3"]
+    #[inline(always)]
+    pub fn extint3(&mut self) -> EXTINT3_W {
+        EXTINT3_W { w: self }
+    }
+    #[doc = "Bit 4 - External Interrupt 4"]
+    #[inline(always)]
+    pub fn extint4(&mut self) -> EXTINT4_W {
+        EXTINT4_W { w: self }
+    }
+    #[doc = "Bit 5 - External Interrupt 5"]
+    #[inline(always)]
+    pub fn extint5(&mut self) -> EXTINT5_W {
+        EXTINT5_W { w: self }
+    }
+    #[doc = "Bit 6 - External Interrupt 6"]
+    #[inline(always)]
+    pub fn extint6(&mut self) -> EXTINT6_W {
+        EXTINT6_W { w: self }
+    }
+    #[doc = "Bit 7 - External Interrupt 7"]
+    #[inline(always)]
+    pub fn extint7(&mut self) -> EXTINT7_W {
+        EXTINT7_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/eic/nmictrl.rs
+++ b/pac/atsamd11c14a/src/eic/nmictrl.rs
@@ -1,0 +1,184 @@
+#[doc = "Reader of register NMICTRL"]
+pub type R = crate::R<u8, super::NMICTRL>;
+#[doc = "Writer for register NMICTRL"]
+pub type W = crate::W<u8, super::NMICTRL>;
+#[doc = "Register NMICTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::NMICTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Non-Maskable Interrupt Sense\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum NMISENSE_A {
+    #[doc = "0: No detection"]
+    NONE,
+    #[doc = "1: Rising-edge detection"]
+    RISE,
+    #[doc = "2: Falling-edge detection"]
+    FALL,
+    #[doc = "3: Both-edges detection"]
+    BOTH,
+    #[doc = "4: High-level detection"]
+    HIGH,
+    #[doc = "5: Low-level detection"]
+    LOW,
+}
+impl From<NMISENSE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: NMISENSE_A) -> Self {
+        match variant {
+            NMISENSE_A::NONE => 0,
+            NMISENSE_A::RISE => 1,
+            NMISENSE_A::FALL => 2,
+            NMISENSE_A::BOTH => 3,
+            NMISENSE_A::HIGH => 4,
+            NMISENSE_A::LOW => 5,
+        }
+    }
+}
+#[doc = "Reader of field `NMISENSE`"]
+pub type NMISENSE_R = crate::R<u8, NMISENSE_A>;
+impl NMISENSE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, NMISENSE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(NMISENSE_A::NONE),
+            1 => Val(NMISENSE_A::RISE),
+            2 => Val(NMISENSE_A::FALL),
+            3 => Val(NMISENSE_A::BOTH),
+            4 => Val(NMISENSE_A::HIGH),
+            5 => Val(NMISENSE_A::LOW),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == NMISENSE_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RISE`"]
+    #[inline(always)]
+    pub fn is_rise(&self) -> bool {
+        *self == NMISENSE_A::RISE
+    }
+    #[doc = "Checks if the value of the field is `FALL`"]
+    #[inline(always)]
+    pub fn is_fall(&self) -> bool {
+        *self == NMISENSE_A::FALL
+    }
+    #[doc = "Checks if the value of the field is `BOTH`"]
+    #[inline(always)]
+    pub fn is_both(&self) -> bool {
+        *self == NMISENSE_A::BOTH
+    }
+    #[doc = "Checks if the value of the field is `HIGH`"]
+    #[inline(always)]
+    pub fn is_high(&self) -> bool {
+        *self == NMISENSE_A::HIGH
+    }
+    #[doc = "Checks if the value of the field is `LOW`"]
+    #[inline(always)]
+    pub fn is_low(&self) -> bool {
+        *self == NMISENSE_A::LOW
+    }
+}
+#[doc = "Write proxy for field `NMISENSE`"]
+pub struct NMISENSE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NMISENSE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: NMISENSE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No detection"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(NMISENSE_A::NONE)
+    }
+    #[doc = "Rising-edge detection"]
+    #[inline(always)]
+    pub fn rise(self) -> &'a mut W {
+        self.variant(NMISENSE_A::RISE)
+    }
+    #[doc = "Falling-edge detection"]
+    #[inline(always)]
+    pub fn fall(self) -> &'a mut W {
+        self.variant(NMISENSE_A::FALL)
+    }
+    #[doc = "Both-edges detection"]
+    #[inline(always)]
+    pub fn both(self) -> &'a mut W {
+        self.variant(NMISENSE_A::BOTH)
+    }
+    #[doc = "High-level detection"]
+    #[inline(always)]
+    pub fn high(self) -> &'a mut W {
+        self.variant(NMISENSE_A::HIGH)
+    }
+    #[doc = "Low-level detection"]
+    #[inline(always)]
+    pub fn low(self) -> &'a mut W {
+        self.variant(NMISENSE_A::LOW)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u8) & 0x07);
+        self.w
+    }
+}
+#[doc = "Reader of field `NMIFILTEN`"]
+pub type NMIFILTEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NMIFILTEN`"]
+pub struct NMIFILTEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NMIFILTEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Non-Maskable Interrupt Sense"]
+    #[inline(always)]
+    pub fn nmisense(&self) -> NMISENSE_R {
+        NMISENSE_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bit 3 - Non-Maskable Interrupt Filter Enable"]
+    #[inline(always)]
+    pub fn nmifilten(&self) -> NMIFILTEN_R {
+        NMIFILTEN_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Non-Maskable Interrupt Sense"]
+    #[inline(always)]
+    pub fn nmisense(&mut self) -> NMISENSE_W {
+        NMISENSE_W { w: self }
+    }
+    #[doc = "Bit 3 - Non-Maskable Interrupt Filter Enable"]
+    #[inline(always)]
+    pub fn nmifilten(&mut self) -> NMIFILTEN_W {
+        NMIFILTEN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/eic/nmiflag.rs
+++ b/pac/atsamd11c14a/src/eic/nmiflag.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register NMIFLAG"]
+pub type R = crate::R<u8, super::NMIFLAG>;
+#[doc = "Writer for register NMIFLAG"]
+pub type W = crate::W<u8, super::NMIFLAG>;
+#[doc = "Register NMIFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::NMIFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `NMI`"]
+pub type NMI_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NMI`"]
+pub struct NMI_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NMI_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Non-Maskable Interrupt"]
+    #[inline(always)]
+    pub fn nmi(&self) -> NMI_R {
+        NMI_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Non-Maskable Interrupt"]
+    #[inline(always)]
+    pub fn nmi(&mut self) -> NMI_W {
+        NMI_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/eic/status.rs
+++ b/pac/atsamd11c14a/src/eic/status.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u8, super::STATUS>;
+#[doc = "Reader of field `SYNCBUSY`"]
+pub type SYNCBUSY_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 7 - Synchronization Busy"]
+    #[inline(always)]
+    pub fn syncbusy(&self) -> SYNCBUSY_R {
+        SYNCBUSY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/eic/wakeup.rs
+++ b/pac/atsamd11c14a/src/eic/wakeup.rs
@@ -1,0 +1,288 @@
+#[doc = "Reader of register WAKEUP"]
+pub type R = crate::R<u32, super::WAKEUP>;
+#[doc = "Writer for register WAKEUP"]
+pub type W = crate::W<u32, super::WAKEUP>;
+#[doc = "Register WAKEUP `reset()`'s with value 0"]
+impl crate::ResetValue for super::WAKEUP {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `WAKEUPEN0`"]
+pub type WAKEUPEN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WAKEUPEN0`"]
+pub struct WAKEUPEN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAKEUPEN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `WAKEUPEN1`"]
+pub type WAKEUPEN1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WAKEUPEN1`"]
+pub struct WAKEUPEN1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAKEUPEN1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `WAKEUPEN2`"]
+pub type WAKEUPEN2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WAKEUPEN2`"]
+pub struct WAKEUPEN2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAKEUPEN2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `WAKEUPEN3`"]
+pub type WAKEUPEN3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WAKEUPEN3`"]
+pub struct WAKEUPEN3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAKEUPEN3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `WAKEUPEN4`"]
+pub type WAKEUPEN4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WAKEUPEN4`"]
+pub struct WAKEUPEN4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAKEUPEN4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `WAKEUPEN5`"]
+pub type WAKEUPEN5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WAKEUPEN5`"]
+pub struct WAKEUPEN5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAKEUPEN5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `WAKEUPEN6`"]
+pub type WAKEUPEN6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WAKEUPEN6`"]
+pub struct WAKEUPEN6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAKEUPEN6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `WAKEUPEN7`"]
+pub type WAKEUPEN7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WAKEUPEN7`"]
+pub struct WAKEUPEN7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAKEUPEN7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - External Interrupt 0 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen0(&self) -> WAKEUPEN0_R {
+        WAKEUPEN0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - External Interrupt 1 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen1(&self) -> WAKEUPEN1_R {
+        WAKEUPEN1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - External Interrupt 2 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen2(&self) -> WAKEUPEN2_R {
+        WAKEUPEN2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - External Interrupt 3 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen3(&self) -> WAKEUPEN3_R {
+        WAKEUPEN3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - External Interrupt 4 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen4(&self) -> WAKEUPEN4_R {
+        WAKEUPEN4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - External Interrupt 5 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen5(&self) -> WAKEUPEN5_R {
+        WAKEUPEN5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - External Interrupt 6 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen6(&self) -> WAKEUPEN6_R {
+        WAKEUPEN6_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - External Interrupt 7 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen7(&self) -> WAKEUPEN7_R {
+        WAKEUPEN7_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - External Interrupt 0 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen0(&mut self) -> WAKEUPEN0_W {
+        WAKEUPEN0_W { w: self }
+    }
+    #[doc = "Bit 1 - External Interrupt 1 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen1(&mut self) -> WAKEUPEN1_W {
+        WAKEUPEN1_W { w: self }
+    }
+    #[doc = "Bit 2 - External Interrupt 2 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen2(&mut self) -> WAKEUPEN2_W {
+        WAKEUPEN2_W { w: self }
+    }
+    #[doc = "Bit 3 - External Interrupt 3 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen3(&mut self) -> WAKEUPEN3_W {
+        WAKEUPEN3_W { w: self }
+    }
+    #[doc = "Bit 4 - External Interrupt 4 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen4(&mut self) -> WAKEUPEN4_W {
+        WAKEUPEN4_W { w: self }
+    }
+    #[doc = "Bit 5 - External Interrupt 5 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen5(&mut self) -> WAKEUPEN5_W {
+        WAKEUPEN5_W { w: self }
+    }
+    #[doc = "Bit 6 - External Interrupt 6 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen6(&mut self) -> WAKEUPEN6_W {
+        WAKEUPEN6_W { w: self }
+    }
+    #[doc = "Bit 7 - External Interrupt 7 Wake-up Enable"]
+    #[inline(always)]
+    pub fn wakeupen7(&mut self) -> WAKEUPEN7_W {
+        WAKEUPEN7_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/evsys.rs
+++ b/pac/atsamd11c14a/src/evsys.rs
@@ -1,0 +1,93 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Control"]
+    pub ctrl: CTRL,
+    _reserved1: [u8; 3usize],
+    #[doc = "0x04 - Channel"]
+    pub channel: CHANNEL,
+    #[doc = "0x08 - User Multiplexer"]
+    pub user: USER,
+    _reserved3: [u8; 2usize],
+    #[doc = "0x0c - Channel Status"]
+    pub chstatus: CHSTATUS,
+    #[doc = "0x10 - Interrupt Enable Clear"]
+    pub intenclr: INTENCLR,
+    #[doc = "0x14 - Interrupt Enable Set"]
+    pub intenset: INTENSET,
+    #[doc = "0x18 - Interrupt Flag Status and Clear"]
+    pub intflag: INTFLAG,
+}
+#[doc = "Control\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrl](ctrl) module"]
+pub type CTRL = crate::Reg<u8, _CTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRL;
+#[doc = "`write(|w| ..)` method takes [ctrl::W](ctrl::W) writer structure"]
+impl crate::Writable for CTRL {}
+#[doc = "Control"]
+pub mod ctrl;
+#[doc = "Channel\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [channel](channel) module"]
+pub type CHANNEL = crate::Reg<u32, _CHANNEL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CHANNEL;
+#[doc = "`read()` method returns [channel::R](channel::R) reader structure"]
+impl crate::Readable for CHANNEL {}
+#[doc = "`write(|w| ..)` method takes [channel::W](channel::W) writer structure"]
+impl crate::Writable for CHANNEL {}
+#[doc = "Channel"]
+pub mod channel;
+#[doc = "User Multiplexer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [user](user) module"]
+pub type USER = crate::Reg<u16, _USER>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _USER;
+#[doc = "`read()` method returns [user::R](user::R) reader structure"]
+impl crate::Readable for USER {}
+#[doc = "`write(|w| ..)` method takes [user::W](user::W) writer structure"]
+impl crate::Writable for USER {}
+#[doc = "User Multiplexer"]
+pub mod user;
+#[doc = "Channel Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [chstatus](chstatus) module"]
+pub type CHSTATUS = crate::Reg<u32, _CHSTATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CHSTATUS;
+#[doc = "`read()` method returns [chstatus::R](chstatus::R) reader structure"]
+impl crate::Readable for CHSTATUS {}
+#[doc = "Channel Status"]
+pub mod chstatus;
+#[doc = "Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u32, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u32, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u32, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "Interrupt Flag Status and Clear"]
+pub mod intflag;

--- a/pac/atsamd11c14a/src/evsys/channel.rs
+++ b/pac/atsamd11c14a/src/evsys/channel.rs
@@ -1,0 +1,297 @@
+#[doc = "Reader of register CHANNEL"]
+pub type R = crate::R<u32, super::CHANNEL>;
+#[doc = "Writer for register CHANNEL"]
+pub type W = crate::W<u32, super::CHANNEL>;
+#[doc = "Register CHANNEL `reset()`'s with value 0"]
+impl crate::ResetValue for super::CHANNEL {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CHANNEL`"]
+pub type CHANNEL_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `CHANNEL`"]
+pub struct CHANNEL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CHANNEL_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u32) & 0x07);
+        self.w
+    }
+}
+#[doc = "Reader of field `SWEVT`"]
+pub type SWEVT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWEVT`"]
+pub struct SWEVT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWEVT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVGEN`"]
+pub type EVGEN_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `EVGEN`"]
+pub struct EVGEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVGEN_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x3f << 16)) | (((value as u32) & 0x3f) << 16);
+        self.w
+    }
+}
+#[doc = "Path Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PATH_A {
+    #[doc = "0: Synchronous path"]
+    SYNCHRONOUS,
+    #[doc = "1: Resynchronized path"]
+    RESYNCHRONIZED,
+    #[doc = "2: Asynchronous path"]
+    ASYNCHRONOUS,
+}
+impl From<PATH_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PATH_A) -> Self {
+        match variant {
+            PATH_A::SYNCHRONOUS => 0,
+            PATH_A::RESYNCHRONIZED => 1,
+            PATH_A::ASYNCHRONOUS => 2,
+        }
+    }
+}
+#[doc = "Reader of field `PATH`"]
+pub type PATH_R = crate::R<u8, PATH_A>;
+impl PATH_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, PATH_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(PATH_A::SYNCHRONOUS),
+            1 => Val(PATH_A::RESYNCHRONIZED),
+            2 => Val(PATH_A::ASYNCHRONOUS),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `SYNCHRONOUS`"]
+    #[inline(always)]
+    pub fn is_synchronous(&self) -> bool {
+        *self == PATH_A::SYNCHRONOUS
+    }
+    #[doc = "Checks if the value of the field is `RESYNCHRONIZED`"]
+    #[inline(always)]
+    pub fn is_resynchronized(&self) -> bool {
+        *self == PATH_A::RESYNCHRONIZED
+    }
+    #[doc = "Checks if the value of the field is `ASYNCHRONOUS`"]
+    #[inline(always)]
+    pub fn is_asynchronous(&self) -> bool {
+        *self == PATH_A::ASYNCHRONOUS
+    }
+}
+#[doc = "Write proxy for field `PATH`"]
+pub struct PATH_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PATH_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PATH_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Synchronous path"]
+    #[inline(always)]
+    pub fn synchronous(self) -> &'a mut W {
+        self.variant(PATH_A::SYNCHRONOUS)
+    }
+    #[doc = "Resynchronized path"]
+    #[inline(always)]
+    pub fn resynchronized(self) -> &'a mut W {
+        self.variant(PATH_A::RESYNCHRONIZED)
+    }
+    #[doc = "Asynchronous path"]
+    #[inline(always)]
+    pub fn asynchronous(self) -> &'a mut W {
+        self.variant(PATH_A::ASYNCHRONOUS)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 24)) | (((value as u32) & 0x03) << 24);
+        self.w
+    }
+}
+#[doc = "Edge Detection Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum EDGSEL_A {
+    #[doc = "0: No event output when using the resynchronized or synchronous path"]
+    NO_EVT_OUTPUT,
+    #[doc = "1: Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path"]
+    RISING_EDGE,
+    #[doc = "2: Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path"]
+    FALLING_EDGE,
+    #[doc = "3: Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path"]
+    BOTH_EDGES,
+}
+impl From<EDGSEL_A> for u8 {
+    #[inline(always)]
+    fn from(variant: EDGSEL_A) -> Self {
+        match variant {
+            EDGSEL_A::NO_EVT_OUTPUT => 0,
+            EDGSEL_A::RISING_EDGE => 1,
+            EDGSEL_A::FALLING_EDGE => 2,
+            EDGSEL_A::BOTH_EDGES => 3,
+        }
+    }
+}
+#[doc = "Reader of field `EDGSEL`"]
+pub type EDGSEL_R = crate::R<u8, EDGSEL_A>;
+impl EDGSEL_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> EDGSEL_A {
+        match self.bits {
+            0 => EDGSEL_A::NO_EVT_OUTPUT,
+            1 => EDGSEL_A::RISING_EDGE,
+            2 => EDGSEL_A::FALLING_EDGE,
+            3 => EDGSEL_A::BOTH_EDGES,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NO_EVT_OUTPUT`"]
+    #[inline(always)]
+    pub fn is_no_evt_output(&self) -> bool {
+        *self == EDGSEL_A::NO_EVT_OUTPUT
+    }
+    #[doc = "Checks if the value of the field is `RISING_EDGE`"]
+    #[inline(always)]
+    pub fn is_rising_edge(&self) -> bool {
+        *self == EDGSEL_A::RISING_EDGE
+    }
+    #[doc = "Checks if the value of the field is `FALLING_EDGE`"]
+    #[inline(always)]
+    pub fn is_falling_edge(&self) -> bool {
+        *self == EDGSEL_A::FALLING_EDGE
+    }
+    #[doc = "Checks if the value of the field is `BOTH_EDGES`"]
+    #[inline(always)]
+    pub fn is_both_edges(&self) -> bool {
+        *self == EDGSEL_A::BOTH_EDGES
+    }
+}
+#[doc = "Write proxy for field `EDGSEL`"]
+pub struct EDGSEL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EDGSEL_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: EDGSEL_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "No event output when using the resynchronized or synchronous path"]
+    #[inline(always)]
+    pub fn no_evt_output(self) -> &'a mut W {
+        self.variant(EDGSEL_A::NO_EVT_OUTPUT)
+    }
+    #[doc = "Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path"]
+    #[inline(always)]
+    pub fn rising_edge(self) -> &'a mut W {
+        self.variant(EDGSEL_A::RISING_EDGE)
+    }
+    #[doc = "Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path"]
+    #[inline(always)]
+    pub fn falling_edge(self) -> &'a mut W {
+        self.variant(EDGSEL_A::FALLING_EDGE)
+    }
+    #[doc = "Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path"]
+    #[inline(always)]
+    pub fn both_edges(self) -> &'a mut W {
+        self.variant(EDGSEL_A::BOTH_EDGES)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 26)) | (((value as u32) & 0x03) << 26);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Channel Selection"]
+    #[inline(always)]
+    pub fn channel(&self) -> CHANNEL_R {
+        CHANNEL_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bit 8 - Software Event"]
+    #[inline(always)]
+    pub fn swevt(&self) -> SWEVT_R {
+        SWEVT_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bits 16:21 - Event Generator Selection"]
+    #[inline(always)]
+    pub fn evgen(&self) -> EVGEN_R {
+        EVGEN_R::new(((self.bits >> 16) & 0x3f) as u8)
+    }
+    #[doc = "Bits 24:25 - Path Selection"]
+    #[inline(always)]
+    pub fn path(&self) -> PATH_R {
+        PATH_R::new(((self.bits >> 24) & 0x03) as u8)
+    }
+    #[doc = "Bits 26:27 - Edge Detection Selection"]
+    #[inline(always)]
+    pub fn edgsel(&self) -> EDGSEL_R {
+        EDGSEL_R::new(((self.bits >> 26) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Channel Selection"]
+    #[inline(always)]
+    pub fn channel(&mut self) -> CHANNEL_W {
+        CHANNEL_W { w: self }
+    }
+    #[doc = "Bit 8 - Software Event"]
+    #[inline(always)]
+    pub fn swevt(&mut self) -> SWEVT_W {
+        SWEVT_W { w: self }
+    }
+    #[doc = "Bits 16:21 - Event Generator Selection"]
+    #[inline(always)]
+    pub fn evgen(&mut self) -> EVGEN_W {
+        EVGEN_W { w: self }
+    }
+    #[doc = "Bits 24:25 - Path Selection"]
+    #[inline(always)]
+    pub fn path(&mut self) -> PATH_W {
+        PATH_W { w: self }
+    }
+    #[doc = "Bits 26:27 - Edge Detection Selection"]
+    #[inline(always)]
+    pub fn edgsel(&mut self) -> EDGSEL_W {
+        EDGSEL_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/evsys/chstatus.rs
+++ b/pac/atsamd11c14a/src/evsys/chstatus.rs
@@ -1,0 +1,88 @@
+#[doc = "Reader of register CHSTATUS"]
+pub type R = crate::R<u32, super::CHSTATUS>;
+#[doc = "Reader of field `USRRDY0`"]
+pub type USRRDY0_R = crate::R<bool, bool>;
+#[doc = "Reader of field `USRRDY1`"]
+pub type USRRDY1_R = crate::R<bool, bool>;
+#[doc = "Reader of field `USRRDY2`"]
+pub type USRRDY2_R = crate::R<bool, bool>;
+#[doc = "Reader of field `USRRDY3`"]
+pub type USRRDY3_R = crate::R<bool, bool>;
+#[doc = "Reader of field `USRRDY4`"]
+pub type USRRDY4_R = crate::R<bool, bool>;
+#[doc = "Reader of field `USRRDY5`"]
+pub type USRRDY5_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CHBUSY0`"]
+pub type CHBUSY0_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CHBUSY1`"]
+pub type CHBUSY1_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CHBUSY2`"]
+pub type CHBUSY2_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CHBUSY3`"]
+pub type CHBUSY3_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CHBUSY4`"]
+pub type CHBUSY4_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CHBUSY5`"]
+pub type CHBUSY5_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Channel 0 User Ready"]
+    #[inline(always)]
+    pub fn usrrdy0(&self) -> USRRDY0_R {
+        USRRDY0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Channel 1 User Ready"]
+    #[inline(always)]
+    pub fn usrrdy1(&self) -> USRRDY1_R {
+        USRRDY1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Channel 2 User Ready"]
+    #[inline(always)]
+    pub fn usrrdy2(&self) -> USRRDY2_R {
+        USRRDY2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Channel 3 User Ready"]
+    #[inline(always)]
+    pub fn usrrdy3(&self) -> USRRDY3_R {
+        USRRDY3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Channel 4 User Ready"]
+    #[inline(always)]
+    pub fn usrrdy4(&self) -> USRRDY4_R {
+        USRRDY4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Channel 5 User Ready"]
+    #[inline(always)]
+    pub fn usrrdy5(&self) -> USRRDY5_R {
+        USRRDY5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Channel 0 Busy"]
+    #[inline(always)]
+    pub fn chbusy0(&self) -> CHBUSY0_R {
+        CHBUSY0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Channel 1 Busy"]
+    #[inline(always)]
+    pub fn chbusy1(&self) -> CHBUSY1_R {
+        CHBUSY1_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Channel 2 Busy"]
+    #[inline(always)]
+    pub fn chbusy2(&self) -> CHBUSY2_R {
+        CHBUSY2_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Channel 3 Busy"]
+    #[inline(always)]
+    pub fn chbusy3(&self) -> CHBUSY3_R {
+        CHBUSY3_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - Channel 4 Busy"]
+    #[inline(always)]
+    pub fn chbusy4(&self) -> CHBUSY4_R {
+        CHBUSY4_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Channel 5 Busy"]
+    #[inline(always)]
+    pub fn chbusy5(&self) -> CHBUSY5_R {
+        CHBUSY5_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/evsys/ctrl.rs
+++ b/pac/atsamd11c14a/src/evsys/ctrl.rs
@@ -1,0 +1,66 @@
+#[doc = "Writer for register CTRL"]
+pub type W = crate::W<u8, super::CTRL>;
+#[doc = "Register CTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `GCLKREQ`"]
+pub struct GCLKREQ_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> GCLKREQ_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 4 - Generic Clock Requests"]
+    #[inline(always)]
+    pub fn gclkreq(&mut self) -> GCLKREQ_W {
+        GCLKREQ_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/evsys/intenclr.rs
+++ b/pac/atsamd11c14a/src/evsys/intenclr.rs
@@ -1,0 +1,424 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u32, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u32, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OVR0`"]
+pub type OVR0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR0`"]
+pub struct OVR0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVR1`"]
+pub type OVR1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR1`"]
+pub struct OVR1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVR2`"]
+pub type OVR2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR2`"]
+pub struct OVR2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVR3`"]
+pub type OVR3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR3`"]
+pub struct OVR3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVR4`"]
+pub type OVR4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR4`"]
+pub struct OVR4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVR5`"]
+pub type OVR5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR5`"]
+pub struct OVR5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD0`"]
+pub type EVD0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD0`"]
+pub struct EVD0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD1`"]
+pub type EVD1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD1`"]
+pub struct EVD1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD2`"]
+pub type EVD2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD2`"]
+pub struct EVD2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u32) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD3`"]
+pub type EVD3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD3`"]
+pub struct EVD3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD4`"]
+pub type EVD4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD4`"]
+pub struct EVD4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u32) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD5`"]
+pub type EVD5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD5`"]
+pub struct EVD5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u32) & 0x01) << 13);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Channel 0 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr0(&self) -> OVR0_R {
+        OVR0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Channel 1 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr1(&self) -> OVR1_R {
+        OVR1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Channel 2 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr2(&self) -> OVR2_R {
+        OVR2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Channel 3 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr3(&self) -> OVR3_R {
+        OVR3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Channel 4 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr4(&self) -> OVR4_R {
+        OVR4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Channel 5 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr5(&self) -> OVR5_R {
+        OVR5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Channel 0 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd0(&self) -> EVD0_R {
+        EVD0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Channel 1 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd1(&self) -> EVD1_R {
+        EVD1_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Channel 2 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd2(&self) -> EVD2_R {
+        EVD2_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Channel 3 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd3(&self) -> EVD3_R {
+        EVD3_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - Channel 4 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd4(&self) -> EVD4_R {
+        EVD4_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Channel 5 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd5(&self) -> EVD5_R {
+        EVD5_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Channel 0 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr0(&mut self) -> OVR0_W {
+        OVR0_W { w: self }
+    }
+    #[doc = "Bit 1 - Channel 1 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr1(&mut self) -> OVR1_W {
+        OVR1_W { w: self }
+    }
+    #[doc = "Bit 2 - Channel 2 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr2(&mut self) -> OVR2_W {
+        OVR2_W { w: self }
+    }
+    #[doc = "Bit 3 - Channel 3 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr3(&mut self) -> OVR3_W {
+        OVR3_W { w: self }
+    }
+    #[doc = "Bit 4 - Channel 4 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr4(&mut self) -> OVR4_W {
+        OVR4_W { w: self }
+    }
+    #[doc = "Bit 5 - Channel 5 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr5(&mut self) -> OVR5_W {
+        OVR5_W { w: self }
+    }
+    #[doc = "Bit 8 - Channel 0 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd0(&mut self) -> EVD0_W {
+        EVD0_W { w: self }
+    }
+    #[doc = "Bit 9 - Channel 1 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd1(&mut self) -> EVD1_W {
+        EVD1_W { w: self }
+    }
+    #[doc = "Bit 10 - Channel 2 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd2(&mut self) -> EVD2_W {
+        EVD2_W { w: self }
+    }
+    #[doc = "Bit 11 - Channel 3 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd3(&mut self) -> EVD3_W {
+        EVD3_W { w: self }
+    }
+    #[doc = "Bit 12 - Channel 4 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd4(&mut self) -> EVD4_W {
+        EVD4_W { w: self }
+    }
+    #[doc = "Bit 13 - Channel 5 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd5(&mut self) -> EVD5_W {
+        EVD5_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/evsys/intenset.rs
+++ b/pac/atsamd11c14a/src/evsys/intenset.rs
@@ -1,0 +1,424 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u32, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u32, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OVR0`"]
+pub type OVR0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR0`"]
+pub struct OVR0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVR1`"]
+pub type OVR1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR1`"]
+pub struct OVR1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVR2`"]
+pub type OVR2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR2`"]
+pub struct OVR2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVR3`"]
+pub type OVR3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR3`"]
+pub struct OVR3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVR4`"]
+pub type OVR4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR4`"]
+pub struct OVR4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVR5`"]
+pub type OVR5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR5`"]
+pub struct OVR5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD0`"]
+pub type EVD0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD0`"]
+pub struct EVD0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD1`"]
+pub type EVD1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD1`"]
+pub struct EVD1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD2`"]
+pub type EVD2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD2`"]
+pub struct EVD2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u32) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD3`"]
+pub type EVD3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD3`"]
+pub struct EVD3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD4`"]
+pub type EVD4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD4`"]
+pub struct EVD4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u32) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD5`"]
+pub type EVD5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD5`"]
+pub struct EVD5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u32) & 0x01) << 13);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Channel 0 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr0(&self) -> OVR0_R {
+        OVR0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Channel 1 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr1(&self) -> OVR1_R {
+        OVR1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Channel 2 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr2(&self) -> OVR2_R {
+        OVR2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Channel 3 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr3(&self) -> OVR3_R {
+        OVR3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Channel 4 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr4(&self) -> OVR4_R {
+        OVR4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Channel 5 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr5(&self) -> OVR5_R {
+        OVR5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Channel 0 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd0(&self) -> EVD0_R {
+        EVD0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Channel 1 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd1(&self) -> EVD1_R {
+        EVD1_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Channel 2 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd2(&self) -> EVD2_R {
+        EVD2_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Channel 3 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd3(&self) -> EVD3_R {
+        EVD3_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - Channel 4 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd4(&self) -> EVD4_R {
+        EVD4_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Channel 5 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd5(&self) -> EVD5_R {
+        EVD5_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Channel 0 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr0(&mut self) -> OVR0_W {
+        OVR0_W { w: self }
+    }
+    #[doc = "Bit 1 - Channel 1 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr1(&mut self) -> OVR1_W {
+        OVR1_W { w: self }
+    }
+    #[doc = "Bit 2 - Channel 2 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr2(&mut self) -> OVR2_W {
+        OVR2_W { w: self }
+    }
+    #[doc = "Bit 3 - Channel 3 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr3(&mut self) -> OVR3_W {
+        OVR3_W { w: self }
+    }
+    #[doc = "Bit 4 - Channel 4 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr4(&mut self) -> OVR4_W {
+        OVR4_W { w: self }
+    }
+    #[doc = "Bit 5 - Channel 5 Overrun Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovr5(&mut self) -> OVR5_W {
+        OVR5_W { w: self }
+    }
+    #[doc = "Bit 8 - Channel 0 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd0(&mut self) -> EVD0_W {
+        EVD0_W { w: self }
+    }
+    #[doc = "Bit 9 - Channel 1 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd1(&mut self) -> EVD1_W {
+        EVD1_W { w: self }
+    }
+    #[doc = "Bit 10 - Channel 2 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd2(&mut self) -> EVD2_W {
+        EVD2_W { w: self }
+    }
+    #[doc = "Bit 11 - Channel 3 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd3(&mut self) -> EVD3_W {
+        EVD3_W { w: self }
+    }
+    #[doc = "Bit 12 - Channel 4 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd4(&mut self) -> EVD4_W {
+        EVD4_W { w: self }
+    }
+    #[doc = "Bit 13 - Channel 5 Event Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn evd5(&mut self) -> EVD5_W {
+        EVD5_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/evsys/intflag.rs
+++ b/pac/atsamd11c14a/src/evsys/intflag.rs
@@ -1,0 +1,424 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u32, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u32, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OVR0`"]
+pub type OVR0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR0`"]
+pub struct OVR0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVR1`"]
+pub type OVR1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR1`"]
+pub struct OVR1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVR2`"]
+pub type OVR2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR2`"]
+pub struct OVR2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVR3`"]
+pub type OVR3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR3`"]
+pub struct OVR3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVR4`"]
+pub type OVR4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR4`"]
+pub struct OVR4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVR5`"]
+pub type OVR5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVR5`"]
+pub struct OVR5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVR5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD0`"]
+pub type EVD0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD0`"]
+pub struct EVD0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD1`"]
+pub type EVD1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD1`"]
+pub struct EVD1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD2`"]
+pub type EVD2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD2`"]
+pub struct EVD2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u32) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD3`"]
+pub type EVD3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD3`"]
+pub struct EVD3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD4`"]
+pub type EVD4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD4`"]
+pub struct EVD4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u32) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVD5`"]
+pub type EVD5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVD5`"]
+pub struct EVD5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVD5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u32) & 0x01) << 13);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Channel 0 Overrun"]
+    #[inline(always)]
+    pub fn ovr0(&self) -> OVR0_R {
+        OVR0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Channel 1 Overrun"]
+    #[inline(always)]
+    pub fn ovr1(&self) -> OVR1_R {
+        OVR1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Channel 2 Overrun"]
+    #[inline(always)]
+    pub fn ovr2(&self) -> OVR2_R {
+        OVR2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Channel 3 Overrun"]
+    #[inline(always)]
+    pub fn ovr3(&self) -> OVR3_R {
+        OVR3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Channel 4 Overrun"]
+    #[inline(always)]
+    pub fn ovr4(&self) -> OVR4_R {
+        OVR4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Channel 5 Overrun"]
+    #[inline(always)]
+    pub fn ovr5(&self) -> OVR5_R {
+        OVR5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Channel 0 Event Detection"]
+    #[inline(always)]
+    pub fn evd0(&self) -> EVD0_R {
+        EVD0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Channel 1 Event Detection"]
+    #[inline(always)]
+    pub fn evd1(&self) -> EVD1_R {
+        EVD1_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Channel 2 Event Detection"]
+    #[inline(always)]
+    pub fn evd2(&self) -> EVD2_R {
+        EVD2_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Channel 3 Event Detection"]
+    #[inline(always)]
+    pub fn evd3(&self) -> EVD3_R {
+        EVD3_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - Channel 4 Event Detection"]
+    #[inline(always)]
+    pub fn evd4(&self) -> EVD4_R {
+        EVD4_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Channel 5 Event Detection"]
+    #[inline(always)]
+    pub fn evd5(&self) -> EVD5_R {
+        EVD5_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Channel 0 Overrun"]
+    #[inline(always)]
+    pub fn ovr0(&mut self) -> OVR0_W {
+        OVR0_W { w: self }
+    }
+    #[doc = "Bit 1 - Channel 1 Overrun"]
+    #[inline(always)]
+    pub fn ovr1(&mut self) -> OVR1_W {
+        OVR1_W { w: self }
+    }
+    #[doc = "Bit 2 - Channel 2 Overrun"]
+    #[inline(always)]
+    pub fn ovr2(&mut self) -> OVR2_W {
+        OVR2_W { w: self }
+    }
+    #[doc = "Bit 3 - Channel 3 Overrun"]
+    #[inline(always)]
+    pub fn ovr3(&mut self) -> OVR3_W {
+        OVR3_W { w: self }
+    }
+    #[doc = "Bit 4 - Channel 4 Overrun"]
+    #[inline(always)]
+    pub fn ovr4(&mut self) -> OVR4_W {
+        OVR4_W { w: self }
+    }
+    #[doc = "Bit 5 - Channel 5 Overrun"]
+    #[inline(always)]
+    pub fn ovr5(&mut self) -> OVR5_W {
+        OVR5_W { w: self }
+    }
+    #[doc = "Bit 8 - Channel 0 Event Detection"]
+    #[inline(always)]
+    pub fn evd0(&mut self) -> EVD0_W {
+        EVD0_W { w: self }
+    }
+    #[doc = "Bit 9 - Channel 1 Event Detection"]
+    #[inline(always)]
+    pub fn evd1(&mut self) -> EVD1_W {
+        EVD1_W { w: self }
+    }
+    #[doc = "Bit 10 - Channel 2 Event Detection"]
+    #[inline(always)]
+    pub fn evd2(&mut self) -> EVD2_W {
+        EVD2_W { w: self }
+    }
+    #[doc = "Bit 11 - Channel 3 Event Detection"]
+    #[inline(always)]
+    pub fn evd3(&mut self) -> EVD3_W {
+        EVD3_W { w: self }
+    }
+    #[doc = "Bit 12 - Channel 4 Event Detection"]
+    #[inline(always)]
+    pub fn evd4(&mut self) -> EVD4_W {
+        EVD4_W { w: self }
+    }
+    #[doc = "Bit 13 - Channel 5 Event Detection"]
+    #[inline(always)]
+    pub fn evd5(&mut self) -> EVD5_W {
+        EVD5_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/evsys/user.rs
+++ b/pac/atsamd11c14a/src/evsys/user.rs
@@ -1,0 +1,104 @@
+#[doc = "Reader of register USER"]
+pub type R = crate::R<u16, super::USER>;
+#[doc = "Writer for register USER"]
+pub type W = crate::W<u16, super::USER>;
+#[doc = "Register USER `reset()`'s with value 0"]
+impl crate::ResetValue for super::USER {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `USER`"]
+pub type USER_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `USER`"]
+pub struct USER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> USER_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x1f) | ((value as u16) & 0x1f);
+        self.w
+    }
+}
+#[doc = "Channel Event Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CHANNEL_A {
+    #[doc = "0: No Channel Output Selected"]
+    _0,
+}
+impl From<CHANNEL_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CHANNEL_A) -> Self {
+        match variant {
+            CHANNEL_A::_0 => 0,
+        }
+    }
+}
+#[doc = "Reader of field `CHANNEL`"]
+pub type CHANNEL_R = crate::R<u8, CHANNEL_A>;
+impl CHANNEL_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, CHANNEL_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(CHANNEL_A::_0),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `_0`"]
+    #[inline(always)]
+    pub fn is_0(&self) -> bool {
+        *self == CHANNEL_A::_0
+    }
+}
+#[doc = "Write proxy for field `CHANNEL`"]
+pub struct CHANNEL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CHANNEL_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CHANNEL_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No Channel Output Selected"]
+    #[inline(always)]
+    pub fn _0(self) -> &'a mut W {
+        self.variant(CHANNEL_A::_0)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 8)) | (((value as u16) & 0x0f) << 8);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:4 - User Multiplexer Selection"]
+    #[inline(always)]
+    pub fn user(&self) -> USER_R {
+        USER_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bits 8:11 - Channel Event Selection"]
+    #[inline(always)]
+    pub fn channel(&self) -> CHANNEL_R {
+        CHANNEL_R::new(((self.bits >> 8) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - User Multiplexer Selection"]
+    #[inline(always)]
+    pub fn user(&mut self) -> USER_W {
+        USER_W { w: self }
+    }
+    #[doc = "Bits 8:11 - Channel Event Selection"]
+    #[inline(always)]
+    pub fn channel(&mut self) -> CHANNEL_W {
+        CHANNEL_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/gclk.rs
+++ b/pac/atsamd11c14a/src/gclk.rs
@@ -1,0 +1,67 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Control"]
+    pub ctrl: CTRL,
+    #[doc = "0x01 - Status"]
+    pub status: STATUS,
+    #[doc = "0x02 - Generic Clock Control"]
+    pub clkctrl: CLKCTRL,
+    #[doc = "0x04 - Generic Clock Generator Control"]
+    pub genctrl: GENCTRL,
+    #[doc = "0x08 - Generic Clock Generator Division"]
+    pub gendiv: GENDIV,
+}
+#[doc = "Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrl](ctrl) module"]
+pub type CTRL = crate::Reg<u8, _CTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRL;
+#[doc = "`read()` method returns [ctrl::R](ctrl::R) reader structure"]
+impl crate::Readable for CTRL {}
+#[doc = "`write(|w| ..)` method takes [ctrl::W](ctrl::W) writer structure"]
+impl crate::Writable for CTRL {}
+#[doc = "Control"]
+pub mod ctrl;
+#[doc = "Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u8, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "Status"]
+pub mod status;
+#[doc = "Generic Clock Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [clkctrl](clkctrl) module"]
+pub type CLKCTRL = crate::Reg<u16, _CLKCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CLKCTRL;
+#[doc = "`read()` method returns [clkctrl::R](clkctrl::R) reader structure"]
+impl crate::Readable for CLKCTRL {}
+#[doc = "`write(|w| ..)` method takes [clkctrl::W](clkctrl::W) writer structure"]
+impl crate::Writable for CLKCTRL {}
+#[doc = "Generic Clock Control"]
+pub mod clkctrl;
+#[doc = "Generic Clock Generator Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [genctrl](genctrl) module"]
+pub type GENCTRL = crate::Reg<u32, _GENCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _GENCTRL;
+#[doc = "`read()` method returns [genctrl::R](genctrl::R) reader structure"]
+impl crate::Readable for GENCTRL {}
+#[doc = "`write(|w| ..)` method takes [genctrl::W](genctrl::W) writer structure"]
+impl crate::Writable for GENCTRL {}
+#[doc = "Generic Clock Generator Control"]
+pub mod genctrl;
+#[doc = "Generic Clock Generator Division\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [gendiv](gendiv) module"]
+pub type GENDIV = crate::Reg<u32, _GENDIV>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _GENDIV;
+#[doc = "`read()` method returns [gendiv::R](gendiv::R) reader structure"]
+impl crate::Readable for GENDIV {}
+#[doc = "`write(|w| ..)` method takes [gendiv::W](gendiv::W) writer structure"]
+impl crate::Writable for GENDIV {}
+#[doc = "Generic Clock Generator Division"]
+pub mod gendiv;

--- a/pac/atsamd11c14a/src/gclk/clkctrl.rs
+++ b/pac/atsamd11c14a/src/gclk/clkctrl.rs
@@ -1,0 +1,590 @@
+#[doc = "Reader of register CLKCTRL"]
+pub type R = crate::R<u16, super::CLKCTRL>;
+#[doc = "Writer for register CLKCTRL"]
+pub type W = crate::W<u16, super::CLKCTRL>;
+#[doc = "Register CLKCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::CLKCTRL {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Generic Clock Selection ID\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ID_A {
+    #[doc = "0: DFLL48"]
+    DFLL48,
+    #[doc = "1: FDPLL"]
+    FDPLL,
+    #[doc = "2: FDPLL32K"]
+    FDPLL32K,
+    #[doc = "3: WDT"]
+    WDT,
+    #[doc = "4: RTC"]
+    RTC,
+    #[doc = "5: EIC"]
+    EIC,
+    #[doc = "6: USB"]
+    USB,
+    #[doc = "7: EVSYS_0"]
+    EVSYS_0,
+    #[doc = "8: EVSYS_1"]
+    EVSYS_1,
+    #[doc = "9: EVSYS_2"]
+    EVSYS_2,
+    #[doc = "10: EVSYS_3"]
+    EVSYS_3,
+    #[doc = "11: EVSYS_4"]
+    EVSYS_4,
+    #[doc = "12: EVSYS_5"]
+    EVSYS_5,
+    #[doc = "13: SERCOMX_SLOW"]
+    SERCOMX_SLOW,
+    #[doc = "14: SERCOM0_CORE"]
+    SERCOM0_CORE,
+    #[doc = "15: SERCOM1_CORE"]
+    SERCOM1_CORE,
+    #[doc = "16: SERCOM2_CORE"]
+    SERCOM2_CORE,
+    #[doc = "17: TCC0"]
+    TCC0,
+    #[doc = "18: TC1_TC2"]
+    TC1_TC2,
+    #[doc = "19: ADC"]
+    ADC,
+    #[doc = "20: AC_DIG"]
+    AC_DIG,
+    #[doc = "21: AC_ANA"]
+    AC_ANA,
+    #[doc = "22: DAC"]
+    DAC,
+}
+impl From<ID_A> for u8 {
+    #[inline(always)]
+    fn from(variant: ID_A) -> Self {
+        match variant {
+            ID_A::DFLL48 => 0,
+            ID_A::FDPLL => 1,
+            ID_A::FDPLL32K => 2,
+            ID_A::WDT => 3,
+            ID_A::RTC => 4,
+            ID_A::EIC => 5,
+            ID_A::USB => 6,
+            ID_A::EVSYS_0 => 7,
+            ID_A::EVSYS_1 => 8,
+            ID_A::EVSYS_2 => 9,
+            ID_A::EVSYS_3 => 10,
+            ID_A::EVSYS_4 => 11,
+            ID_A::EVSYS_5 => 12,
+            ID_A::SERCOMX_SLOW => 13,
+            ID_A::SERCOM0_CORE => 14,
+            ID_A::SERCOM1_CORE => 15,
+            ID_A::SERCOM2_CORE => 16,
+            ID_A::TCC0 => 17,
+            ID_A::TC1_TC2 => 18,
+            ID_A::ADC => 19,
+            ID_A::AC_DIG => 20,
+            ID_A::AC_ANA => 21,
+            ID_A::DAC => 22,
+        }
+    }
+}
+#[doc = "Reader of field `ID`"]
+pub type ID_R = crate::R<u8, ID_A>;
+impl ID_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, ID_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(ID_A::DFLL48),
+            1 => Val(ID_A::FDPLL),
+            2 => Val(ID_A::FDPLL32K),
+            3 => Val(ID_A::WDT),
+            4 => Val(ID_A::RTC),
+            5 => Val(ID_A::EIC),
+            6 => Val(ID_A::USB),
+            7 => Val(ID_A::EVSYS_0),
+            8 => Val(ID_A::EVSYS_1),
+            9 => Val(ID_A::EVSYS_2),
+            10 => Val(ID_A::EVSYS_3),
+            11 => Val(ID_A::EVSYS_4),
+            12 => Val(ID_A::EVSYS_5),
+            13 => Val(ID_A::SERCOMX_SLOW),
+            14 => Val(ID_A::SERCOM0_CORE),
+            15 => Val(ID_A::SERCOM1_CORE),
+            16 => Val(ID_A::SERCOM2_CORE),
+            17 => Val(ID_A::TCC0),
+            18 => Val(ID_A::TC1_TC2),
+            19 => Val(ID_A::ADC),
+            20 => Val(ID_A::AC_DIG),
+            21 => Val(ID_A::AC_ANA),
+            22 => Val(ID_A::DAC),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DFLL48`"]
+    #[inline(always)]
+    pub fn is_dfll48(&self) -> bool {
+        *self == ID_A::DFLL48
+    }
+    #[doc = "Checks if the value of the field is `FDPLL`"]
+    #[inline(always)]
+    pub fn is_fdpll(&self) -> bool {
+        *self == ID_A::FDPLL
+    }
+    #[doc = "Checks if the value of the field is `FDPLL32K`"]
+    #[inline(always)]
+    pub fn is_fdpll32k(&self) -> bool {
+        *self == ID_A::FDPLL32K
+    }
+    #[doc = "Checks if the value of the field is `WDT`"]
+    #[inline(always)]
+    pub fn is_wdt(&self) -> bool {
+        *self == ID_A::WDT
+    }
+    #[doc = "Checks if the value of the field is `RTC`"]
+    #[inline(always)]
+    pub fn is_rtc(&self) -> bool {
+        *self == ID_A::RTC
+    }
+    #[doc = "Checks if the value of the field is `EIC`"]
+    #[inline(always)]
+    pub fn is_eic(&self) -> bool {
+        *self == ID_A::EIC
+    }
+    #[doc = "Checks if the value of the field is `USB`"]
+    #[inline(always)]
+    pub fn is_usb(&self) -> bool {
+        *self == ID_A::USB
+    }
+    #[doc = "Checks if the value of the field is `EVSYS_0`"]
+    #[inline(always)]
+    pub fn is_evsys_0(&self) -> bool {
+        *self == ID_A::EVSYS_0
+    }
+    #[doc = "Checks if the value of the field is `EVSYS_1`"]
+    #[inline(always)]
+    pub fn is_evsys_1(&self) -> bool {
+        *self == ID_A::EVSYS_1
+    }
+    #[doc = "Checks if the value of the field is `EVSYS_2`"]
+    #[inline(always)]
+    pub fn is_evsys_2(&self) -> bool {
+        *self == ID_A::EVSYS_2
+    }
+    #[doc = "Checks if the value of the field is `EVSYS_3`"]
+    #[inline(always)]
+    pub fn is_evsys_3(&self) -> bool {
+        *self == ID_A::EVSYS_3
+    }
+    #[doc = "Checks if the value of the field is `EVSYS_4`"]
+    #[inline(always)]
+    pub fn is_evsys_4(&self) -> bool {
+        *self == ID_A::EVSYS_4
+    }
+    #[doc = "Checks if the value of the field is `EVSYS_5`"]
+    #[inline(always)]
+    pub fn is_evsys_5(&self) -> bool {
+        *self == ID_A::EVSYS_5
+    }
+    #[doc = "Checks if the value of the field is `SERCOMX_SLOW`"]
+    #[inline(always)]
+    pub fn is_sercomx_slow(&self) -> bool {
+        *self == ID_A::SERCOMX_SLOW
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_CORE`"]
+    #[inline(always)]
+    pub fn is_sercom0_core(&self) -> bool {
+        *self == ID_A::SERCOM0_CORE
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_CORE`"]
+    #[inline(always)]
+    pub fn is_sercom1_core(&self) -> bool {
+        *self == ID_A::SERCOM1_CORE
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_CORE`"]
+    #[inline(always)]
+    pub fn is_sercom2_core(&self) -> bool {
+        *self == ID_A::SERCOM2_CORE
+    }
+    #[doc = "Checks if the value of the field is `TCC0`"]
+    #[inline(always)]
+    pub fn is_tcc0(&self) -> bool {
+        *self == ID_A::TCC0
+    }
+    #[doc = "Checks if the value of the field is `TC1_TC2`"]
+    #[inline(always)]
+    pub fn is_tc1_tc2(&self) -> bool {
+        *self == ID_A::TC1_TC2
+    }
+    #[doc = "Checks if the value of the field is `ADC`"]
+    #[inline(always)]
+    pub fn is_adc(&self) -> bool {
+        *self == ID_A::ADC
+    }
+    #[doc = "Checks if the value of the field is `AC_DIG`"]
+    #[inline(always)]
+    pub fn is_ac_dig(&self) -> bool {
+        *self == ID_A::AC_DIG
+    }
+    #[doc = "Checks if the value of the field is `AC_ANA`"]
+    #[inline(always)]
+    pub fn is_ac_ana(&self) -> bool {
+        *self == ID_A::AC_ANA
+    }
+    #[doc = "Checks if the value of the field is `DAC`"]
+    #[inline(always)]
+    pub fn is_dac(&self) -> bool {
+        *self == ID_A::DAC
+    }
+}
+#[doc = "Write proxy for field `ID`"]
+pub struct ID_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ID_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: ID_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "DFLL48"]
+    #[inline(always)]
+    pub fn dfll48(self) -> &'a mut W {
+        self.variant(ID_A::DFLL48)
+    }
+    #[doc = "FDPLL"]
+    #[inline(always)]
+    pub fn fdpll(self) -> &'a mut W {
+        self.variant(ID_A::FDPLL)
+    }
+    #[doc = "FDPLL32K"]
+    #[inline(always)]
+    pub fn fdpll32k(self) -> &'a mut W {
+        self.variant(ID_A::FDPLL32K)
+    }
+    #[doc = "WDT"]
+    #[inline(always)]
+    pub fn wdt(self) -> &'a mut W {
+        self.variant(ID_A::WDT)
+    }
+    #[doc = "RTC"]
+    #[inline(always)]
+    pub fn rtc(self) -> &'a mut W {
+        self.variant(ID_A::RTC)
+    }
+    #[doc = "EIC"]
+    #[inline(always)]
+    pub fn eic(self) -> &'a mut W {
+        self.variant(ID_A::EIC)
+    }
+    #[doc = "USB"]
+    #[inline(always)]
+    pub fn usb(self) -> &'a mut W {
+        self.variant(ID_A::USB)
+    }
+    #[doc = "EVSYS_0"]
+    #[inline(always)]
+    pub fn evsys_0(self) -> &'a mut W {
+        self.variant(ID_A::EVSYS_0)
+    }
+    #[doc = "EVSYS_1"]
+    #[inline(always)]
+    pub fn evsys_1(self) -> &'a mut W {
+        self.variant(ID_A::EVSYS_1)
+    }
+    #[doc = "EVSYS_2"]
+    #[inline(always)]
+    pub fn evsys_2(self) -> &'a mut W {
+        self.variant(ID_A::EVSYS_2)
+    }
+    #[doc = "EVSYS_3"]
+    #[inline(always)]
+    pub fn evsys_3(self) -> &'a mut W {
+        self.variant(ID_A::EVSYS_3)
+    }
+    #[doc = "EVSYS_4"]
+    #[inline(always)]
+    pub fn evsys_4(self) -> &'a mut W {
+        self.variant(ID_A::EVSYS_4)
+    }
+    #[doc = "EVSYS_5"]
+    #[inline(always)]
+    pub fn evsys_5(self) -> &'a mut W {
+        self.variant(ID_A::EVSYS_5)
+    }
+    #[doc = "SERCOMX_SLOW"]
+    #[inline(always)]
+    pub fn sercomx_slow(self) -> &'a mut W {
+        self.variant(ID_A::SERCOMX_SLOW)
+    }
+    #[doc = "SERCOM0_CORE"]
+    #[inline(always)]
+    pub fn sercom0_core(self) -> &'a mut W {
+        self.variant(ID_A::SERCOM0_CORE)
+    }
+    #[doc = "SERCOM1_CORE"]
+    #[inline(always)]
+    pub fn sercom1_core(self) -> &'a mut W {
+        self.variant(ID_A::SERCOM1_CORE)
+    }
+    #[doc = "SERCOM2_CORE"]
+    #[inline(always)]
+    pub fn sercom2_core(self) -> &'a mut W {
+        self.variant(ID_A::SERCOM2_CORE)
+    }
+    #[doc = "TCC0"]
+    #[inline(always)]
+    pub fn tcc0(self) -> &'a mut W {
+        self.variant(ID_A::TCC0)
+    }
+    #[doc = "TC1_TC2"]
+    #[inline(always)]
+    pub fn tc1_tc2(self) -> &'a mut W {
+        self.variant(ID_A::TC1_TC2)
+    }
+    #[doc = "ADC"]
+    #[inline(always)]
+    pub fn adc(self) -> &'a mut W {
+        self.variant(ID_A::ADC)
+    }
+    #[doc = "AC_DIG"]
+    #[inline(always)]
+    pub fn ac_dig(self) -> &'a mut W {
+        self.variant(ID_A::AC_DIG)
+    }
+    #[doc = "AC_ANA"]
+    #[inline(always)]
+    pub fn ac_ana(self) -> &'a mut W {
+        self.variant(ID_A::AC_ANA)
+    }
+    #[doc = "DAC"]
+    #[inline(always)]
+    pub fn dac(self) -> &'a mut W {
+        self.variant(ID_A::DAC)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x3f) | ((value as u16) & 0x3f);
+        self.w
+    }
+}
+#[doc = "Generic Clock Generator\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum GEN_A {
+    #[doc = "0: Generic clock generator 0"]
+    GCLK0,
+    #[doc = "1: Generic clock generator 1"]
+    GCLK1,
+    #[doc = "2: Generic clock generator 2"]
+    GCLK2,
+    #[doc = "3: Generic clock generator 3"]
+    GCLK3,
+    #[doc = "4: Generic clock generator 4"]
+    GCLK4,
+    #[doc = "5: Generic clock generator 5"]
+    GCLK5,
+}
+impl From<GEN_A> for u8 {
+    #[inline(always)]
+    fn from(variant: GEN_A) -> Self {
+        match variant {
+            GEN_A::GCLK0 => 0,
+            GEN_A::GCLK1 => 1,
+            GEN_A::GCLK2 => 2,
+            GEN_A::GCLK3 => 3,
+            GEN_A::GCLK4 => 4,
+            GEN_A::GCLK5 => 5,
+        }
+    }
+}
+#[doc = "Reader of field `GEN`"]
+pub type GEN_R = crate::R<u8, GEN_A>;
+impl GEN_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, GEN_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(GEN_A::GCLK0),
+            1 => Val(GEN_A::GCLK1),
+            2 => Val(GEN_A::GCLK2),
+            3 => Val(GEN_A::GCLK3),
+            4 => Val(GEN_A::GCLK4),
+            5 => Val(GEN_A::GCLK5),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `GCLK0`"]
+    #[inline(always)]
+    pub fn is_gclk0(&self) -> bool {
+        *self == GEN_A::GCLK0
+    }
+    #[doc = "Checks if the value of the field is `GCLK1`"]
+    #[inline(always)]
+    pub fn is_gclk1(&self) -> bool {
+        *self == GEN_A::GCLK1
+    }
+    #[doc = "Checks if the value of the field is `GCLK2`"]
+    #[inline(always)]
+    pub fn is_gclk2(&self) -> bool {
+        *self == GEN_A::GCLK2
+    }
+    #[doc = "Checks if the value of the field is `GCLK3`"]
+    #[inline(always)]
+    pub fn is_gclk3(&self) -> bool {
+        *self == GEN_A::GCLK3
+    }
+    #[doc = "Checks if the value of the field is `GCLK4`"]
+    #[inline(always)]
+    pub fn is_gclk4(&self) -> bool {
+        *self == GEN_A::GCLK4
+    }
+    #[doc = "Checks if the value of the field is `GCLK5`"]
+    #[inline(always)]
+    pub fn is_gclk5(&self) -> bool {
+        *self == GEN_A::GCLK5
+    }
+}
+#[doc = "Write proxy for field `GEN`"]
+pub struct GEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> GEN_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: GEN_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Generic clock generator 0"]
+    #[inline(always)]
+    pub fn gclk0(self) -> &'a mut W {
+        self.variant(GEN_A::GCLK0)
+    }
+    #[doc = "Generic clock generator 1"]
+    #[inline(always)]
+    pub fn gclk1(self) -> &'a mut W {
+        self.variant(GEN_A::GCLK1)
+    }
+    #[doc = "Generic clock generator 2"]
+    #[inline(always)]
+    pub fn gclk2(self) -> &'a mut W {
+        self.variant(GEN_A::GCLK2)
+    }
+    #[doc = "Generic clock generator 3"]
+    #[inline(always)]
+    pub fn gclk3(self) -> &'a mut W {
+        self.variant(GEN_A::GCLK3)
+    }
+    #[doc = "Generic clock generator 4"]
+    #[inline(always)]
+    pub fn gclk4(self) -> &'a mut W {
+        self.variant(GEN_A::GCLK4)
+    }
+    #[doc = "Generic clock generator 5"]
+    #[inline(always)]
+    pub fn gclk5(self) -> &'a mut W {
+        self.variant(GEN_A::GCLK5)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 8)) | (((value as u16) & 0x0f) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `CLKEN`"]
+pub type CLKEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CLKEN`"]
+pub struct CLKEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CLKEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u16) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `WRTLOCK`"]
+pub type WRTLOCK_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WRTLOCK`"]
+pub struct WRTLOCK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WRTLOCK_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u16) & 0x01) << 15);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:5 - Generic Clock Selection ID"]
+    #[inline(always)]
+    pub fn id(&self) -> ID_R {
+        ID_R::new((self.bits & 0x3f) as u8)
+    }
+    #[doc = "Bits 8:11 - Generic Clock Generator"]
+    #[inline(always)]
+    pub fn gen(&self) -> GEN_R {
+        GEN_R::new(((self.bits >> 8) & 0x0f) as u8)
+    }
+    #[doc = "Bit 14 - Clock Enable"]
+    #[inline(always)]
+    pub fn clken(&self) -> CLKEN_R {
+        CLKEN_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Write Lock"]
+    #[inline(always)]
+    pub fn wrtlock(&self) -> WRTLOCK_R {
+        WRTLOCK_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:5 - Generic Clock Selection ID"]
+    #[inline(always)]
+    pub fn id(&mut self) -> ID_W {
+        ID_W { w: self }
+    }
+    #[doc = "Bits 8:11 - Generic Clock Generator"]
+    #[inline(always)]
+    pub fn gen(&mut self) -> GEN_W {
+        GEN_W { w: self }
+    }
+    #[doc = "Bit 14 - Clock Enable"]
+    #[inline(always)]
+    pub fn clken(&mut self) -> CLKEN_W {
+        CLKEN_W { w: self }
+    }
+    #[doc = "Bit 15 - Write Lock"]
+    #[inline(always)]
+    pub fn wrtlock(&mut self) -> WRTLOCK_W {
+        WRTLOCK_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/gclk/ctrl.rs
+++ b/pac/atsamd11c14a/src/gclk/ctrl.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register CTRL"]
+pub type R = crate::R<u8, super::CTRL>;
+#[doc = "Writer for register CTRL"]
+pub type W = crate::W<u8, super::CTRL>;
+#[doc = "Register CTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/gclk/genctrl.rs
+++ b/pac/atsamd11c14a/src/gclk/genctrl.rs
@@ -1,0 +1,420 @@
+#[doc = "Reader of register GENCTRL"]
+pub type R = crate::R<u32, super::GENCTRL>;
+#[doc = "Writer for register GENCTRL"]
+pub type W = crate::W<u32, super::GENCTRL>;
+#[doc = "Register GENCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::GENCTRL {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ID`"]
+pub type ID_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `ID`"]
+pub struct ID_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ID_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0f) | ((value as u32) & 0x0f);
+        self.w
+    }
+}
+#[doc = "Source Select\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SRC_A {
+    #[doc = "0: XOSC oscillator output"]
+    XOSC,
+    #[doc = "1: Generator input pad"]
+    GCLKIN,
+    #[doc = "2: Generic clock generator 1 output"]
+    GCLKGEN1,
+    #[doc = "3: OSCULP32K oscillator output"]
+    OSCULP32K,
+    #[doc = "4: OSC32K oscillator output"]
+    OSC32K,
+    #[doc = "5: XOSC32K oscillator output"]
+    XOSC32K,
+    #[doc = "6: OSC8M oscillator output"]
+    OSC8M,
+    #[doc = "7: DFLL48M output"]
+    DFLL48M,
+    #[doc = "8: DPLL96M output"]
+    DPLL96M,
+}
+impl From<SRC_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SRC_A) -> Self {
+        match variant {
+            SRC_A::XOSC => 0,
+            SRC_A::GCLKIN => 1,
+            SRC_A::GCLKGEN1 => 2,
+            SRC_A::OSCULP32K => 3,
+            SRC_A::OSC32K => 4,
+            SRC_A::XOSC32K => 5,
+            SRC_A::OSC8M => 6,
+            SRC_A::DFLL48M => 7,
+            SRC_A::DPLL96M => 8,
+        }
+    }
+}
+#[doc = "Reader of field `SRC`"]
+pub type SRC_R = crate::R<u8, SRC_A>;
+impl SRC_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, SRC_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(SRC_A::XOSC),
+            1 => Val(SRC_A::GCLKIN),
+            2 => Val(SRC_A::GCLKGEN1),
+            3 => Val(SRC_A::OSCULP32K),
+            4 => Val(SRC_A::OSC32K),
+            5 => Val(SRC_A::XOSC32K),
+            6 => Val(SRC_A::OSC8M),
+            7 => Val(SRC_A::DFLL48M),
+            8 => Val(SRC_A::DPLL96M),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `XOSC`"]
+    #[inline(always)]
+    pub fn is_xosc(&self) -> bool {
+        *self == SRC_A::XOSC
+    }
+    #[doc = "Checks if the value of the field is `GCLKIN`"]
+    #[inline(always)]
+    pub fn is_gclkin(&self) -> bool {
+        *self == SRC_A::GCLKIN
+    }
+    #[doc = "Checks if the value of the field is `GCLKGEN1`"]
+    #[inline(always)]
+    pub fn is_gclkgen1(&self) -> bool {
+        *self == SRC_A::GCLKGEN1
+    }
+    #[doc = "Checks if the value of the field is `OSCULP32K`"]
+    #[inline(always)]
+    pub fn is_osculp32k(&self) -> bool {
+        *self == SRC_A::OSCULP32K
+    }
+    #[doc = "Checks if the value of the field is `OSC32K`"]
+    #[inline(always)]
+    pub fn is_osc32k(&self) -> bool {
+        *self == SRC_A::OSC32K
+    }
+    #[doc = "Checks if the value of the field is `XOSC32K`"]
+    #[inline(always)]
+    pub fn is_xosc32k(&self) -> bool {
+        *self == SRC_A::XOSC32K
+    }
+    #[doc = "Checks if the value of the field is `OSC8M`"]
+    #[inline(always)]
+    pub fn is_osc8m(&self) -> bool {
+        *self == SRC_A::OSC8M
+    }
+    #[doc = "Checks if the value of the field is `DFLL48M`"]
+    #[inline(always)]
+    pub fn is_dfll48m(&self) -> bool {
+        *self == SRC_A::DFLL48M
+    }
+    #[doc = "Checks if the value of the field is `DPLL96M`"]
+    #[inline(always)]
+    pub fn is_dpll96m(&self) -> bool {
+        *self == SRC_A::DPLL96M
+    }
+}
+#[doc = "Write proxy for field `SRC`"]
+pub struct SRC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SRC_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SRC_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "XOSC oscillator output"]
+    #[inline(always)]
+    pub fn xosc(self) -> &'a mut W {
+        self.variant(SRC_A::XOSC)
+    }
+    #[doc = "Generator input pad"]
+    #[inline(always)]
+    pub fn gclkin(self) -> &'a mut W {
+        self.variant(SRC_A::GCLKIN)
+    }
+    #[doc = "Generic clock generator 1 output"]
+    #[inline(always)]
+    pub fn gclkgen1(self) -> &'a mut W {
+        self.variant(SRC_A::GCLKGEN1)
+    }
+    #[doc = "OSCULP32K oscillator output"]
+    #[inline(always)]
+    pub fn osculp32k(self) -> &'a mut W {
+        self.variant(SRC_A::OSCULP32K)
+    }
+    #[doc = "OSC32K oscillator output"]
+    #[inline(always)]
+    pub fn osc32k(self) -> &'a mut W {
+        self.variant(SRC_A::OSC32K)
+    }
+    #[doc = "XOSC32K oscillator output"]
+    #[inline(always)]
+    pub fn xosc32k(self) -> &'a mut W {
+        self.variant(SRC_A::XOSC32K)
+    }
+    #[doc = "OSC8M oscillator output"]
+    #[inline(always)]
+    pub fn osc8m(self) -> &'a mut W {
+        self.variant(SRC_A::OSC8M)
+    }
+    #[doc = "DFLL48M output"]
+    #[inline(always)]
+    pub fn dfll48m(self) -> &'a mut W {
+        self.variant(SRC_A::DFLL48M)
+    }
+    #[doc = "DPLL96M output"]
+    #[inline(always)]
+    pub fn dpll96m(self) -> &'a mut W {
+        self.variant(SRC_A::DPLL96M)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x1f << 8)) | (((value as u32) & 0x1f) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `GENEN`"]
+pub type GENEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `GENEN`"]
+pub struct GENEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> GENEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `IDC`"]
+pub type IDC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `IDC`"]
+pub struct IDC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> IDC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
+#[doc = "Reader of field `OOV`"]
+pub type OOV_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OOV`"]
+pub struct OOV_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OOV_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 18)) | (((value as u32) & 0x01) << 18);
+        self.w
+    }
+}
+#[doc = "Reader of field `OE`"]
+pub type OE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OE`"]
+pub struct OE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 19)) | (((value as u32) & 0x01) << 19);
+        self.w
+    }
+}
+#[doc = "Reader of field `DIVSEL`"]
+pub type DIVSEL_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DIVSEL`"]
+pub struct DIVSEL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIVSEL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 20)) | (((value as u32) & 0x01) << 20);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 21)) | (((value as u32) & 0x01) << 21);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:3 - Generic Clock Generator Selection"]
+    #[inline(always)]
+    pub fn id(&self) -> ID_R {
+        ID_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 8:12 - Source Select"]
+    #[inline(always)]
+    pub fn src(&self) -> SRC_R {
+        SRC_R::new(((self.bits >> 8) & 0x1f) as u8)
+    }
+    #[doc = "Bit 16 - Generic Clock Generator Enable"]
+    #[inline(always)]
+    pub fn genen(&self) -> GENEN_R {
+        GENEN_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bit 17 - Improve Duty Cycle"]
+    #[inline(always)]
+    pub fn idc(&self) -> IDC_R {
+        IDC_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+    #[doc = "Bit 18 - Output Off Value"]
+    #[inline(always)]
+    pub fn oov(&self) -> OOV_R {
+        OOV_R::new(((self.bits >> 18) & 0x01) != 0)
+    }
+    #[doc = "Bit 19 - Output Enable"]
+    #[inline(always)]
+    pub fn oe(&self) -> OE_R {
+        OE_R::new(((self.bits >> 19) & 0x01) != 0)
+    }
+    #[doc = "Bit 20 - Divide Selection"]
+    #[inline(always)]
+    pub fn divsel(&self) -> DIVSEL_R {
+        DIVSEL_R::new(((self.bits >> 20) & 0x01) != 0)
+    }
+    #[doc = "Bit 21 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 21) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Generic Clock Generator Selection"]
+    #[inline(always)]
+    pub fn id(&mut self) -> ID_W {
+        ID_W { w: self }
+    }
+    #[doc = "Bits 8:12 - Source Select"]
+    #[inline(always)]
+    pub fn src(&mut self) -> SRC_W {
+        SRC_W { w: self }
+    }
+    #[doc = "Bit 16 - Generic Clock Generator Enable"]
+    #[inline(always)]
+    pub fn genen(&mut self) -> GENEN_W {
+        GENEN_W { w: self }
+    }
+    #[doc = "Bit 17 - Improve Duty Cycle"]
+    #[inline(always)]
+    pub fn idc(&mut self) -> IDC_W {
+        IDC_W { w: self }
+    }
+    #[doc = "Bit 18 - Output Off Value"]
+    #[inline(always)]
+    pub fn oov(&mut self) -> OOV_W {
+        OOV_W { w: self }
+    }
+    #[doc = "Bit 19 - Output Enable"]
+    #[inline(always)]
+    pub fn oe(&mut self) -> OE_W {
+        OE_W { w: self }
+    }
+    #[doc = "Bit 20 - Divide Selection"]
+    #[inline(always)]
+    pub fn divsel(&mut self) -> DIVSEL_W {
+        DIVSEL_W { w: self }
+    }
+    #[doc = "Bit 21 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/gclk/gendiv.rs
+++ b/pac/atsamd11c14a/src/gclk/gendiv.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register GENDIV"]
+pub type R = crate::R<u32, super::GENDIV>;
+#[doc = "Writer for register GENDIV"]
+pub type W = crate::W<u32, super::GENDIV>;
+#[doc = "Register GENDIV `reset()`'s with value 0"]
+impl crate::ResetValue for super::GENDIV {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ID`"]
+pub type ID_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `ID`"]
+pub struct ID_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ID_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0f) | ((value as u32) & 0x0f);
+        self.w
+    }
+}
+#[doc = "Reader of field `DIV`"]
+pub type DIV_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `DIV`"]
+pub struct DIV_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIV_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0xffff << 8)) | (((value as u32) & 0xffff) << 8);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:3 - Generic Clock Generator Selection"]
+    #[inline(always)]
+    pub fn id(&self) -> ID_R {
+        ID_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 8:23 - Division Factor"]
+    #[inline(always)]
+    pub fn div(&self) -> DIV_R {
+        DIV_R::new(((self.bits >> 8) & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Generic Clock Generator Selection"]
+    #[inline(always)]
+    pub fn id(&mut self) -> ID_W {
+        ID_W { w: self }
+    }
+    #[doc = "Bits 8:23 - Division Factor"]
+    #[inline(always)]
+    pub fn div(&mut self) -> DIV_W {
+        DIV_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/gclk/status.rs
+++ b/pac/atsamd11c14a/src/gclk/status.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u8, super::STATUS>;
+#[doc = "Reader of field `SYNCBUSY`"]
+pub type SYNCBUSY_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 7 - Synchronization Busy Status"]
+    #[inline(always)]
+    pub fn syncbusy(&self) -> SYNCBUSY_R {
+        SYNCBUSY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/generic.rs
+++ b/pac/atsamd11c14a/src/generic.rs
@@ -1,0 +1,239 @@
+use core::marker;
+#[doc = "This trait shows that register has `read` method"]
+#[doc = ""]
+#[doc = "Registers marked with `Writable` can be also `modify`'ed"]
+pub trait Readable {}
+#[doc = "This trait shows that register has `write`, `write_with_zero` and `reset` method"]
+#[doc = ""]
+#[doc = "Registers marked with `Readable` can be also `modify`'ed"]
+pub trait Writable {}
+#[doc = "Reset value of the register"]
+#[doc = ""]
+#[doc = "This value is initial value for `write` method."]
+#[doc = "It can be also directly writed to register by `reset` method."]
+pub trait ResetValue {
+    #[doc = "Register size"]
+    type Type;
+    #[doc = "Reset value of the register"]
+    fn reset_value() -> Self::Type;
+}
+#[doc = "This structure provides volatile access to register"]
+pub struct Reg<U, REG> {
+    register: vcell::VolatileCell<U>,
+    _marker: marker::PhantomData<REG>,
+}
+unsafe impl<U: Send, REG> Send for Reg<U, REG> {}
+impl<U, REG> Reg<U, REG>
+where
+    Self: Readable,
+    U: Copy,
+{
+    #[doc = "Reads the contents of `Readable` register"]
+    #[doc = ""]
+    #[doc = "You can read the contents of a register in such way:"]
+    #[doc = "```ignore"]
+    #[doc = "let bits = periph.reg.read().bits();"]
+    #[doc = "```"]
+    #[doc = "or get the content of a particular field of a register."]
+    #[doc = "```ignore"]
+    #[doc = "let reader = periph.reg.read();"]
+    #[doc = "let bits = reader.field1().bits();"]
+    #[doc = "let flag = reader.field2().bit_is_set();"]
+    #[doc = "```"]
+    #[inline(always)]
+    pub fn read(&self) -> R<U, Self> {
+        R {
+            bits: self.register.get(),
+            _reg: marker::PhantomData,
+        }
+    }
+}
+impl<U, REG> Reg<U, REG>
+where
+    Self: ResetValue<Type = U> + Writable,
+    U: Copy,
+{
+    #[doc = "Writes the reset value to `Writable` register"]
+    #[doc = ""]
+    #[doc = "Resets the register to its initial state"]
+    #[inline(always)]
+    pub fn reset(&self) {
+        self.register.set(Self::reset_value())
+    }
+}
+impl<U, REG> Reg<U, REG>
+where
+    Self: ResetValue<Type = U> + Writable,
+    U: Copy,
+{
+    #[doc = "Writes bits to `Writable` register"]
+    #[doc = ""]
+    #[doc = "You can write raw bits into a register:"]
+    #[doc = "```ignore"]
+    #[doc = "periph.reg.write(|w| unsafe { w.bits(rawbits) });"]
+    #[doc = "```"]
+    #[doc = "or write only the fields you need:"]
+    #[doc = "```ignore"]
+    #[doc = "periph.reg.write(|w| w"]
+    #[doc = "    .field1().bits(newfield1bits)"]
+    #[doc = "    .field2().set_bit()"]
+    #[doc = "    .field3().variant(VARIANT)"]
+    #[doc = ");"]
+    #[doc = "```"]
+    #[doc = "Other fields will have reset value."]
+    #[inline(always)]
+    pub fn write<F>(&self, f: F)
+    where
+        F: FnOnce(&mut W<U, Self>) -> &mut W<U, Self>,
+    {
+        self.register.set(
+            f(&mut W {
+                bits: Self::reset_value(),
+                _reg: marker::PhantomData,
+            })
+            .bits,
+        );
+    }
+}
+impl<U, REG> Reg<U, REG>
+where
+    Self: Writable,
+    U: Copy + Default,
+{
+    #[doc = "Writes Zero to `Writable` register"]
+    #[doc = ""]
+    #[doc = "Similar to `write`, but unused bits will contain 0."]
+    #[inline(always)]
+    pub fn write_with_zero<F>(&self, f: F)
+    where
+        F: FnOnce(&mut W<U, Self>) -> &mut W<U, Self>,
+    {
+        self.register.set(
+            f(&mut W {
+                bits: U::default(),
+                _reg: marker::PhantomData,
+            })
+            .bits,
+        );
+    }
+}
+impl<U, REG> Reg<U, REG>
+where
+    Self: Readable + Writable,
+    U: Copy,
+{
+    #[doc = "Modifies the contents of the register"]
+    #[doc = ""]
+    #[doc = "E.g. to do a read-modify-write sequence to change parts of a register:"]
+    #[doc = "```ignore"]
+    #[doc = "periph.reg.modify(|r, w| unsafe { w.bits("]
+    #[doc = "   r.bits() | 3"]
+    #[doc = ") });"]
+    #[doc = "```"]
+    #[doc = "or"]
+    #[doc = "```ignore"]
+    #[doc = "periph.reg.modify(|_, w| w"]
+    #[doc = "    .field1().bits(newfield1bits)"]
+    #[doc = "    .field2().set_bit()"]
+    #[doc = "    .field3().variant(VARIANT)"]
+    #[doc = ");"]
+    #[doc = "```"]
+    #[doc = "Other fields will have value they had before call `modify`."]
+    #[inline(always)]
+    pub fn modify<F>(&self, f: F)
+    where
+        for<'w> F: FnOnce(&R<U, Self>, &'w mut W<U, Self>) -> &'w mut W<U, Self>,
+    {
+        let bits = self.register.get();
+        self.register.set(
+            f(
+                &R {
+                    bits,
+                    _reg: marker::PhantomData,
+                },
+                &mut W {
+                    bits,
+                    _reg: marker::PhantomData,
+                },
+            )
+            .bits,
+        );
+    }
+}
+#[doc = "Register/field reader"]
+#[doc = ""]
+#[doc = "Result of the [`read`](Reg::read) method of a register."]
+#[doc = "Also it can be used in the [`modify`](Reg::read) method"]
+pub struct R<U, T> {
+    pub(crate) bits: U,
+    _reg: marker::PhantomData<T>,
+}
+impl<U, T> R<U, T>
+where
+    U: Copy,
+{
+    #[doc = "Create new instance of reader"]
+    #[inline(always)]
+    pub(crate) fn new(bits: U) -> Self {
+        Self {
+            bits,
+            _reg: marker::PhantomData,
+        }
+    }
+    #[doc = "Read raw bits from register/field"]
+    #[inline(always)]
+    pub fn bits(&self) -> U {
+        self.bits
+    }
+}
+impl<U, T, FI> PartialEq<FI> for R<U, T>
+where
+    U: PartialEq,
+    FI: Copy + Into<U>,
+{
+    #[inline(always)]
+    fn eq(&self, other: &FI) -> bool {
+        self.bits.eq(&(*other).into())
+    }
+}
+impl<FI> R<bool, FI> {
+    #[doc = "Value of the field as raw bits"]
+    #[inline(always)]
+    pub fn bit(&self) -> bool {
+        self.bits
+    }
+    #[doc = "Returns `true` if the bit is clear (0)"]
+    #[inline(always)]
+    pub fn bit_is_clear(&self) -> bool {
+        !self.bit()
+    }
+    #[doc = "Returns `true` if the bit is set (1)"]
+    #[inline(always)]
+    pub fn bit_is_set(&self) -> bool {
+        self.bit()
+    }
+}
+#[doc = "Register writer"]
+#[doc = ""]
+#[doc = "Used as an argument to the closures in the [`write`](Reg::write) and [`modify`](Reg::modify) methods of the register"]
+pub struct W<U, REG> {
+    #[doc = "Writable bits"]
+    pub(crate) bits: U,
+    _reg: marker::PhantomData<REG>,
+}
+impl<U, REG> W<U, REG> {
+    #[doc = "Writes raw bits to the register"]
+    #[inline(always)]
+    pub unsafe fn bits(&mut self, bits: U) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
+#[doc = "Used if enumerated values cover not the whole range"]
+#[derive(Clone, Copy, PartialEq)]
+pub enum Variant<U, T> {
+    #[doc = "Expected variant"]
+    Val(T),
+    #[doc = "Raw bits"]
+    Res(U),
+}

--- a/pac/atsamd11c14a/src/hmatrix.rs
+++ b/pac/atsamd11c14a/src/hmatrix.rs
@@ -1,0 +1,105 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    _reserved0: [u8; 128usize],
+    #[doc = "0x80 - Priority A for Slave"]
+    pub pras0: PRAS,
+    #[doc = "0x84 - Priority B for Slave"]
+    pub prbs0: PRBS,
+    #[doc = "0x88 - Priority A for Slave"]
+    pub pras1: PRAS,
+    #[doc = "0x8c - Priority B for Slave"]
+    pub prbs1: PRBS,
+    #[doc = "0x90 - Priority A for Slave"]
+    pub pras2: PRAS,
+    #[doc = "0x94 - Priority B for Slave"]
+    pub prbs2: PRBS,
+    #[doc = "0x98 - Priority A for Slave"]
+    pub pras3: PRAS,
+    #[doc = "0x9c - Priority B for Slave"]
+    pub prbs3: PRBS,
+    #[doc = "0xa0 - Priority A for Slave"]
+    pub pras4: PRAS,
+    #[doc = "0xa4 - Priority B for Slave"]
+    pub prbs4: PRBS,
+    #[doc = "0xa8 - Priority A for Slave"]
+    pub pras5: PRAS,
+    #[doc = "0xac - Priority B for Slave"]
+    pub prbs5: PRBS,
+    #[doc = "0xb0 - Priority A for Slave"]
+    pub pras6: PRAS,
+    #[doc = "0xb4 - Priority B for Slave"]
+    pub prbs6: PRBS,
+    #[doc = "0xb8 - Priority A for Slave"]
+    pub pras7: PRAS,
+    #[doc = "0xbc - Priority B for Slave"]
+    pub prbs7: PRBS,
+    #[doc = "0xc0 - Priority A for Slave"]
+    pub pras8: PRAS,
+    #[doc = "0xc4 - Priority B for Slave"]
+    pub prbs8: PRBS,
+    #[doc = "0xc8 - Priority A for Slave"]
+    pub pras9: PRAS,
+    #[doc = "0xcc - Priority B for Slave"]
+    pub prbs9: PRBS,
+    #[doc = "0xd0 - Priority A for Slave"]
+    pub pras10: PRAS,
+    #[doc = "0xd4 - Priority B for Slave"]
+    pub prbs10: PRBS,
+    #[doc = "0xd8 - Priority A for Slave"]
+    pub pras11: PRAS,
+    #[doc = "0xdc - Priority B for Slave"]
+    pub prbs11: PRBS,
+    #[doc = "0xe0 - Priority A for Slave"]
+    pub pras12: PRAS,
+    #[doc = "0xe4 - Priority B for Slave"]
+    pub prbs12: PRBS,
+    #[doc = "0xe8 - Priority A for Slave"]
+    pub pras13: PRAS,
+    #[doc = "0xec - Priority B for Slave"]
+    pub prbs13: PRBS,
+    #[doc = "0xf0 - Priority A for Slave"]
+    pub pras14: PRAS,
+    #[doc = "0xf4 - Priority B for Slave"]
+    pub prbs14: PRBS,
+    #[doc = "0xf8 - Priority A for Slave"]
+    pub pras15: PRAS,
+    #[doc = "0xfc - Priority B for Slave"]
+    pub prbs15: PRBS,
+    _reserved32: [u8; 16usize],
+    #[doc = "0x110 - Special Function"]
+    pub sfr: [SFR; 16],
+}
+#[doc = "Priority A for Slave\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pras](pras) module"]
+pub type PRAS = crate::Reg<u32, _PRAS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PRAS;
+#[doc = "`read()` method returns [pras::R](pras::R) reader structure"]
+impl crate::Readable for PRAS {}
+#[doc = "`write(|w| ..)` method takes [pras::W](pras::W) writer structure"]
+impl crate::Writable for PRAS {}
+#[doc = "Priority A for Slave"]
+pub mod pras;
+#[doc = "Priority B for Slave\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [prbs](prbs) module"]
+pub type PRBS = crate::Reg<u32, _PRBS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PRBS;
+#[doc = "`read()` method returns [prbs::R](prbs::R) reader structure"]
+impl crate::Readable for PRBS {}
+#[doc = "`write(|w| ..)` method takes [prbs::W](prbs::W) writer structure"]
+impl crate::Writable for PRBS {}
+#[doc = "Priority B for Slave"]
+pub mod prbs;
+#[doc = "Special Function\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sfr](sfr) module"]
+pub type SFR = crate::Reg<u32, _SFR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _SFR;
+#[doc = "`read()` method returns [sfr::R](sfr::R) reader structure"]
+impl crate::Readable for SFR {}
+#[doc = "`write(|w| ..)` method takes [sfr::W](sfr::W) writer structure"]
+impl crate::Writable for SFR {}
+#[doc = "Special Function"]
+pub mod sfr;

--- a/pac/atsamd11c14a/src/hmatrix/pras.rs
+++ b/pac/atsamd11c14a/src/hmatrix/pras.rs
@@ -1,0 +1,208 @@
+#[doc = "Reader of register PRAS%s"]
+pub type R = crate::R<u32, super::PRAS>;
+#[doc = "Writer for register PRAS%s"]
+pub type W = crate::W<u32, super::PRAS>;
+#[doc = "Register PRAS%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::PRAS {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `M0PR`"]
+pub type M0PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M0PR`"]
+pub struct M0PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M0PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0f) | ((value as u32) & 0x0f);
+        self.w
+    }
+}
+#[doc = "Reader of field `M1PR`"]
+pub type M1PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M1PR`"]
+pub struct M1PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M1PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 4)) | (((value as u32) & 0x0f) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `M2PR`"]
+pub type M2PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M2PR`"]
+pub struct M2PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M2PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 8)) | (((value as u32) & 0x0f) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `M3PR`"]
+pub type M3PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M3PR`"]
+pub struct M3PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M3PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 12)) | (((value as u32) & 0x0f) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `M4PR`"]
+pub type M4PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M4PR`"]
+pub struct M4PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M4PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 16)) | (((value as u32) & 0x0f) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `M5PR`"]
+pub type M5PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M5PR`"]
+pub struct M5PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M5PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 20)) | (((value as u32) & 0x0f) << 20);
+        self.w
+    }
+}
+#[doc = "Reader of field `M6PR`"]
+pub type M6PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M6PR`"]
+pub struct M6PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M6PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 24)) | (((value as u32) & 0x0f) << 24);
+        self.w
+    }
+}
+#[doc = "Reader of field `M7PR`"]
+pub type M7PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M7PR`"]
+pub struct M7PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M7PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 28)) | (((value as u32) & 0x0f) << 28);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:3 - Master 0 Priority"]
+    #[inline(always)]
+    pub fn m0pr(&self) -> M0PR_R {
+        M0PR_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - Master 1 Priority"]
+    #[inline(always)]
+    pub fn m1pr(&self) -> M1PR_R {
+        M1PR_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+    #[doc = "Bits 8:11 - Master 2 Priority"]
+    #[inline(always)]
+    pub fn m2pr(&self) -> M2PR_R {
+        M2PR_R::new(((self.bits >> 8) & 0x0f) as u8)
+    }
+    #[doc = "Bits 12:15 - Master 3 Priority"]
+    #[inline(always)]
+    pub fn m3pr(&self) -> M3PR_R {
+        M3PR_R::new(((self.bits >> 12) & 0x0f) as u8)
+    }
+    #[doc = "Bits 16:19 - Master 4 Priority"]
+    #[inline(always)]
+    pub fn m4pr(&self) -> M4PR_R {
+        M4PR_R::new(((self.bits >> 16) & 0x0f) as u8)
+    }
+    #[doc = "Bits 20:23 - Master 5 Priority"]
+    #[inline(always)]
+    pub fn m5pr(&self) -> M5PR_R {
+        M5PR_R::new(((self.bits >> 20) & 0x0f) as u8)
+    }
+    #[doc = "Bits 24:27 - Master 6 Priority"]
+    #[inline(always)]
+    pub fn m6pr(&self) -> M6PR_R {
+        M6PR_R::new(((self.bits >> 24) & 0x0f) as u8)
+    }
+    #[doc = "Bits 28:31 - Master 7 Priority"]
+    #[inline(always)]
+    pub fn m7pr(&self) -> M7PR_R {
+        M7PR_R::new(((self.bits >> 28) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Master 0 Priority"]
+    #[inline(always)]
+    pub fn m0pr(&mut self) -> M0PR_W {
+        M0PR_W { w: self }
+    }
+    #[doc = "Bits 4:7 - Master 1 Priority"]
+    #[inline(always)]
+    pub fn m1pr(&mut self) -> M1PR_W {
+        M1PR_W { w: self }
+    }
+    #[doc = "Bits 8:11 - Master 2 Priority"]
+    #[inline(always)]
+    pub fn m2pr(&mut self) -> M2PR_W {
+        M2PR_W { w: self }
+    }
+    #[doc = "Bits 12:15 - Master 3 Priority"]
+    #[inline(always)]
+    pub fn m3pr(&mut self) -> M3PR_W {
+        M3PR_W { w: self }
+    }
+    #[doc = "Bits 16:19 - Master 4 Priority"]
+    #[inline(always)]
+    pub fn m4pr(&mut self) -> M4PR_W {
+        M4PR_W { w: self }
+    }
+    #[doc = "Bits 20:23 - Master 5 Priority"]
+    #[inline(always)]
+    pub fn m5pr(&mut self) -> M5PR_W {
+        M5PR_W { w: self }
+    }
+    #[doc = "Bits 24:27 - Master 6 Priority"]
+    #[inline(always)]
+    pub fn m6pr(&mut self) -> M6PR_W {
+        M6PR_W { w: self }
+    }
+    #[doc = "Bits 28:31 - Master 7 Priority"]
+    #[inline(always)]
+    pub fn m7pr(&mut self) -> M7PR_W {
+        M7PR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/hmatrix/prbs.rs
+++ b/pac/atsamd11c14a/src/hmatrix/prbs.rs
@@ -1,0 +1,208 @@
+#[doc = "Reader of register PRBS%s"]
+pub type R = crate::R<u32, super::PRBS>;
+#[doc = "Writer for register PRBS%s"]
+pub type W = crate::W<u32, super::PRBS>;
+#[doc = "Register PRBS%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::PRBS {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `M8PR`"]
+pub type M8PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M8PR`"]
+pub struct M8PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M8PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0f) | ((value as u32) & 0x0f);
+        self.w
+    }
+}
+#[doc = "Reader of field `M9PR`"]
+pub type M9PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M9PR`"]
+pub struct M9PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M9PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 4)) | (((value as u32) & 0x0f) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `M10PR`"]
+pub type M10PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M10PR`"]
+pub struct M10PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M10PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 8)) | (((value as u32) & 0x0f) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `M11PR`"]
+pub type M11PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M11PR`"]
+pub struct M11PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M11PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 12)) | (((value as u32) & 0x0f) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `M12PR`"]
+pub type M12PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M12PR`"]
+pub struct M12PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M12PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 16)) | (((value as u32) & 0x0f) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `M13PR`"]
+pub type M13PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M13PR`"]
+pub struct M13PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M13PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 20)) | (((value as u32) & 0x0f) << 20);
+        self.w
+    }
+}
+#[doc = "Reader of field `M14PR`"]
+pub type M14PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M14PR`"]
+pub struct M14PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M14PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 24)) | (((value as u32) & 0x0f) << 24);
+        self.w
+    }
+}
+#[doc = "Reader of field `M15PR`"]
+pub type M15PR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `M15PR`"]
+pub struct M15PR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> M15PR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 28)) | (((value as u32) & 0x0f) << 28);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:3 - Master 8 Priority"]
+    #[inline(always)]
+    pub fn m8pr(&self) -> M8PR_R {
+        M8PR_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - Master 9 Priority"]
+    #[inline(always)]
+    pub fn m9pr(&self) -> M9PR_R {
+        M9PR_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+    #[doc = "Bits 8:11 - Master 10 Priority"]
+    #[inline(always)]
+    pub fn m10pr(&self) -> M10PR_R {
+        M10PR_R::new(((self.bits >> 8) & 0x0f) as u8)
+    }
+    #[doc = "Bits 12:15 - Master 11 Priority"]
+    #[inline(always)]
+    pub fn m11pr(&self) -> M11PR_R {
+        M11PR_R::new(((self.bits >> 12) & 0x0f) as u8)
+    }
+    #[doc = "Bits 16:19 - Master 12 Priority"]
+    #[inline(always)]
+    pub fn m12pr(&self) -> M12PR_R {
+        M12PR_R::new(((self.bits >> 16) & 0x0f) as u8)
+    }
+    #[doc = "Bits 20:23 - Master 13 Priority"]
+    #[inline(always)]
+    pub fn m13pr(&self) -> M13PR_R {
+        M13PR_R::new(((self.bits >> 20) & 0x0f) as u8)
+    }
+    #[doc = "Bits 24:27 - Master 14 Priority"]
+    #[inline(always)]
+    pub fn m14pr(&self) -> M14PR_R {
+        M14PR_R::new(((self.bits >> 24) & 0x0f) as u8)
+    }
+    #[doc = "Bits 28:31 - Master 15 Priority"]
+    #[inline(always)]
+    pub fn m15pr(&self) -> M15PR_R {
+        M15PR_R::new(((self.bits >> 28) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Master 8 Priority"]
+    #[inline(always)]
+    pub fn m8pr(&mut self) -> M8PR_W {
+        M8PR_W { w: self }
+    }
+    #[doc = "Bits 4:7 - Master 9 Priority"]
+    #[inline(always)]
+    pub fn m9pr(&mut self) -> M9PR_W {
+        M9PR_W { w: self }
+    }
+    #[doc = "Bits 8:11 - Master 10 Priority"]
+    #[inline(always)]
+    pub fn m10pr(&mut self) -> M10PR_W {
+        M10PR_W { w: self }
+    }
+    #[doc = "Bits 12:15 - Master 11 Priority"]
+    #[inline(always)]
+    pub fn m11pr(&mut self) -> M11PR_W {
+        M11PR_W { w: self }
+    }
+    #[doc = "Bits 16:19 - Master 12 Priority"]
+    #[inline(always)]
+    pub fn m12pr(&mut self) -> M12PR_W {
+        M12PR_W { w: self }
+    }
+    #[doc = "Bits 20:23 - Master 13 Priority"]
+    #[inline(always)]
+    pub fn m13pr(&mut self) -> M13PR_W {
+        M13PR_W { w: self }
+    }
+    #[doc = "Bits 24:27 - Master 14 Priority"]
+    #[inline(always)]
+    pub fn m14pr(&mut self) -> M14PR_W {
+        M14PR_W { w: self }
+    }
+    #[doc = "Bits 28:31 - Master 15 Priority"]
+    #[inline(always)]
+    pub fn m15pr(&mut self) -> M15PR_W {
+        M15PR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/hmatrix/sfr.rs
+++ b/pac/atsamd11c14a/src/hmatrix/sfr.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register SFR%s"]
+pub type R = crate::R<u32, super::SFR>;
+#[doc = "Writer for register SFR%s"]
+pub type W = crate::W<u32, super::SFR>;
+#[doc = "Register SFR%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::SFR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SFR`"]
+pub type SFR_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `SFR`"]
+pub struct SFR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SFR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Special Function Register"]
+    #[inline(always)]
+    pub fn sfr(&self) -> SFR_R {
+        SFR_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Special Function Register"]
+    #[inline(always)]
+    pub fn sfr(&mut self) -> SFR_W {
+        SFR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/lib.rs
+++ b/pac/atsamd11c14a/src/lib.rs
@@ -1,0 +1,800 @@
+#![doc = "Peripheral access API for ATSAMD11C14A microcontrollers (generated using svd2rust v0.16.1)\n\nYou can find an overview of the API [here].\n\n[here]: https://docs.rs/svd2rust/0.16.1/svd2rust/#peripheral-api"]
+#![deny(missing_docs)]
+#![deny(warnings)]
+#![allow(non_camel_case_types)]
+#![no_std]
+extern crate bare_metal;
+extern crate cortex_m;
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+extern crate vcell;
+use core::marker::PhantomData;
+use core::ops::Deref;
+#[doc = r"Number available in the NVIC for configuring priority"]
+pub const NVIC_PRIO_BITS: u8 = 2;
+#[cfg(feature = "rt")]
+extern "C" {
+    fn PM();
+    fn SYSCTRL();
+    fn WDT();
+    fn RTC();
+    fn EIC();
+    fn NVMCTRL();
+    fn DMAC();
+    fn USB();
+    fn EVSYS();
+    fn SERCOM0();
+    fn SERCOM1();
+    fn TCC0();
+    fn TC1();
+    fn TC2();
+    fn ADC();
+    fn AC();
+    fn DAC();
+}
+#[doc(hidden)]
+pub union Vector {
+    _handler: unsafe extern "C" fn(),
+    _reserved: u32,
+}
+#[cfg(feature = "rt")]
+#[doc(hidden)]
+#[link_section = ".vector_table.interrupts"]
+#[no_mangle]
+pub static __INTERRUPTS: [Vector; 18] = [
+    Vector { _handler: PM },
+    Vector { _handler: SYSCTRL },
+    Vector { _handler: WDT },
+    Vector { _handler: RTC },
+    Vector { _handler: EIC },
+    Vector { _handler: NVMCTRL },
+    Vector { _handler: DMAC },
+    Vector { _handler: USB },
+    Vector { _handler: EVSYS },
+    Vector { _handler: SERCOM0 },
+    Vector { _handler: SERCOM1 },
+    Vector { _reserved: 0 },
+    Vector { _handler: TCC0 },
+    Vector { _handler: TC1 },
+    Vector { _handler: TC2 },
+    Vector { _handler: ADC },
+    Vector { _handler: AC },
+    Vector { _handler: DAC },
+];
+#[doc = r"Enumeration of all the interrupts"]
+#[derive(Copy, Clone, Debug)]
+pub enum Interrupt {
+    #[doc = "0 - PM"]
+    PM,
+    #[doc = "1 - SYSCTRL"]
+    SYSCTRL,
+    #[doc = "2 - WDT"]
+    WDT,
+    #[doc = "3 - RTC"]
+    RTC,
+    #[doc = "4 - EIC"]
+    EIC,
+    #[doc = "5 - NVMCTRL"]
+    NVMCTRL,
+    #[doc = "6 - DMAC"]
+    DMAC,
+    #[doc = "7 - USB"]
+    USB,
+    #[doc = "8 - EVSYS"]
+    EVSYS,
+    #[doc = "9 - SERCOM0"]
+    SERCOM0,
+    #[doc = "10 - SERCOM1"]
+    SERCOM1,
+    #[doc = "12 - TCC0"]
+    TCC0,
+    #[doc = "13 - TC1"]
+    TC1,
+    #[doc = "14 - TC2"]
+    TC2,
+    #[doc = "15 - ADC"]
+    ADC,
+    #[doc = "16 - AC"]
+    AC,
+    #[doc = "17 - DAC"]
+    DAC,
+}
+unsafe impl bare_metal::Nr for Interrupt {
+    #[inline]
+    fn nr(&self) -> u8 {
+        match *self {
+            Interrupt::PM => 0,
+            Interrupt::SYSCTRL => 1,
+            Interrupt::WDT => 2,
+            Interrupt::RTC => 3,
+            Interrupt::EIC => 4,
+            Interrupt::NVMCTRL => 5,
+            Interrupt::DMAC => 6,
+            Interrupt::USB => 7,
+            Interrupt::EVSYS => 8,
+            Interrupt::SERCOM0 => 9,
+            Interrupt::SERCOM1 => 10,
+            Interrupt::TCC0 => 12,
+            Interrupt::TC1 => 13,
+            Interrupt::TC2 => 14,
+            Interrupt::ADC => 15,
+            Interrupt::AC => 16,
+            Interrupt::DAC => 17,
+        }
+    }
+}
+#[cfg(feature = "rt")]
+pub use self::Interrupt as interrupt;
+pub use cortex_m::peripheral::Peripherals as CorePeripherals;
+pub use cortex_m::peripheral::{CBP, CPUID, DCB, DWT, FPB, ITM, MPU, NVIC, SCB, SYST, TPIU};
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::interrupt;
+#[allow(unused_imports)]
+use generic::*;
+#[doc = r"Common register and bit access and modify traits"]
+pub mod generic;
+#[doc = "Analog Comparators"]
+pub struct AC {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for AC {}
+impl AC {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const ac::RegisterBlock {
+        0x4200_2400 as *const _
+    }
+}
+impl Deref for AC {
+    type Target = ac::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*AC::ptr() }
+    }
+}
+#[doc = "Analog Comparators"]
+pub mod ac;
+#[doc = "Analog Digital Converter"]
+pub struct ADC {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for ADC {}
+impl ADC {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const adc::RegisterBlock {
+        0x4200_2000 as *const _
+    }
+}
+impl Deref for ADC {
+    type Target = adc::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*ADC::ptr() }
+    }
+}
+#[doc = "Analog Digital Converter"]
+pub mod adc;
+#[doc = "Digital Analog Converter"]
+pub struct DAC {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for DAC {}
+impl DAC {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const dac::RegisterBlock {
+        0x4200_2800 as *const _
+    }
+}
+impl Deref for DAC {
+    type Target = dac::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*DAC::ptr() }
+    }
+}
+#[doc = "Digital Analog Converter"]
+pub mod dac;
+#[doc = "Direct Memory Access Controller"]
+pub struct DMAC {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for DMAC {}
+impl DMAC {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const dmac::RegisterBlock {
+        0x4100_4800 as *const _
+    }
+}
+impl Deref for DMAC {
+    type Target = dmac::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*DMAC::ptr() }
+    }
+}
+#[doc = "Direct Memory Access Controller"]
+pub mod dmac;
+#[doc = "Device Service Unit"]
+pub struct DSU {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for DSU {}
+impl DSU {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const dsu::RegisterBlock {
+        0x4100_2000 as *const _
+    }
+}
+impl Deref for DSU {
+    type Target = dsu::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*DSU::ptr() }
+    }
+}
+#[doc = "Device Service Unit"]
+pub mod dsu;
+#[doc = "External Interrupt Controller"]
+pub struct EIC {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for EIC {}
+impl EIC {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const eic::RegisterBlock {
+        0x4000_1800 as *const _
+    }
+}
+impl Deref for EIC {
+    type Target = eic::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*EIC::ptr() }
+    }
+}
+#[doc = "External Interrupt Controller"]
+pub mod eic;
+#[doc = "Event System Interface"]
+pub struct EVSYS {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for EVSYS {}
+impl EVSYS {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const evsys::RegisterBlock {
+        0x4200_0400 as *const _
+    }
+}
+impl Deref for EVSYS {
+    type Target = evsys::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*EVSYS::ptr() }
+    }
+}
+#[doc = "Event System Interface"]
+pub mod evsys;
+#[doc = "Generic Clock Generator"]
+pub struct GCLK {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for GCLK {}
+impl GCLK {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const gclk::RegisterBlock {
+        0x4000_0c00 as *const _
+    }
+}
+impl Deref for GCLK {
+    type Target = gclk::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*GCLK::ptr() }
+    }
+}
+#[doc = "Generic Clock Generator"]
+pub mod gclk;
+#[doc = "HSB Matrix"]
+pub struct HMATRIX {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for HMATRIX {}
+impl HMATRIX {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const hmatrix::RegisterBlock {
+        0x4100_7000 as *const _
+    }
+}
+impl Deref for HMATRIX {
+    type Target = hmatrix::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*HMATRIX::ptr() }
+    }
+}
+#[doc = "HSB Matrix"]
+pub mod hmatrix;
+#[doc = "Cortex-M0+ Micro-Trace Buffer"]
+pub struct MTB {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for MTB {}
+impl MTB {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const mtb::RegisterBlock {
+        0x4100_6000 as *const _
+    }
+}
+impl Deref for MTB {
+    type Target = mtb::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*MTB::ptr() }
+    }
+}
+#[doc = "Cortex-M0+ Micro-Trace Buffer"]
+pub mod mtb;
+#[doc = "Non-Volatile Memory Controller"]
+pub struct NVMCTRL {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for NVMCTRL {}
+impl NVMCTRL {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const nvmctrl::RegisterBlock {
+        0x4100_4000 as *const _
+    }
+}
+impl Deref for NVMCTRL {
+    type Target = nvmctrl::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*NVMCTRL::ptr() }
+    }
+}
+#[doc = "Non-Volatile Memory Controller"]
+pub mod nvmctrl;
+#[doc = "Peripheral Access Controller 0"]
+pub struct PAC0 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for PAC0 {}
+impl PAC0 {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const pac0::RegisterBlock {
+        0x4000_0000 as *const _
+    }
+}
+impl Deref for PAC0 {
+    type Target = pac0::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*PAC0::ptr() }
+    }
+}
+#[doc = "Peripheral Access Controller 0"]
+pub mod pac0;
+#[doc = "Peripheral Access Controller 1"]
+pub struct PAC1 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for PAC1 {}
+impl PAC1 {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const pac0::RegisterBlock {
+        0x4100_0000 as *const _
+    }
+}
+impl Deref for PAC1 {
+    type Target = pac0::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*PAC1::ptr() }
+    }
+}
+#[doc = "Peripheral Access Controller 2"]
+pub struct PAC2 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for PAC2 {}
+impl PAC2 {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const pac0::RegisterBlock {
+        0x4200_0000 as *const _
+    }
+}
+impl Deref for PAC2 {
+    type Target = pac0::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*PAC2::ptr() }
+    }
+}
+#[doc = "Power Manager"]
+pub struct PM {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for PM {}
+impl PM {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const pm::RegisterBlock {
+        0x4000_0400 as *const _
+    }
+}
+impl Deref for PM {
+    type Target = pm::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*PM::ptr() }
+    }
+}
+#[doc = "Power Manager"]
+pub mod pm;
+#[doc = "Port Module"]
+pub struct PORT {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for PORT {}
+impl PORT {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const port::RegisterBlock {
+        0x4100_4400 as *const _
+    }
+}
+impl Deref for PORT {
+    type Target = port::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*PORT::ptr() }
+    }
+}
+#[doc = "Port Module"]
+pub mod port;
+#[doc = "Port Module (IOBUS)"]
+pub struct PORT_IOBUS {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for PORT_IOBUS {}
+impl PORT_IOBUS {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const port::RegisterBlock {
+        0x6000_0000 as *const _
+    }
+}
+impl Deref for PORT_IOBUS {
+    type Target = port::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*PORT_IOBUS::ptr() }
+    }
+}
+#[doc = "Real-Time Counter"]
+pub struct RTC {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for RTC {}
+impl RTC {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const rtc::RegisterBlock {
+        0x4000_1400 as *const _
+    }
+}
+impl Deref for RTC {
+    type Target = rtc::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*RTC::ptr() }
+    }
+}
+#[doc = "Real-Time Counter"]
+pub mod rtc;
+#[doc = "Serial Communication Interface 0"]
+pub struct SERCOM0 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for SERCOM0 {}
+impl SERCOM0 {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const sercom0::RegisterBlock {
+        0x4200_0800 as *const _
+    }
+}
+impl Deref for SERCOM0 {
+    type Target = sercom0::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*SERCOM0::ptr() }
+    }
+}
+#[doc = "Serial Communication Interface 0"]
+pub mod sercom0;
+#[doc = "Serial Communication Interface 1"]
+pub struct SERCOM1 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for SERCOM1 {}
+impl SERCOM1 {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const sercom0::RegisterBlock {
+        0x4200_0c00 as *const _
+    }
+}
+impl Deref for SERCOM1 {
+    type Target = sercom0::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*SERCOM1::ptr() }
+    }
+}
+#[doc = "System Control"]
+pub struct SYSCTRL {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for SYSCTRL {}
+impl SYSCTRL {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const sysctrl::RegisterBlock {
+        0x4000_0800 as *const _
+    }
+}
+impl Deref for SYSCTRL {
+    type Target = sysctrl::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*SYSCTRL::ptr() }
+    }
+}
+#[doc = "System Control"]
+pub mod sysctrl;
+#[doc = "Basic Timer Counter 1"]
+pub struct TC1 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for TC1 {}
+impl TC1 {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const tc1::RegisterBlock {
+        0x4200_1800 as *const _
+    }
+}
+impl Deref for TC1 {
+    type Target = tc1::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*TC1::ptr() }
+    }
+}
+#[doc = "Basic Timer Counter 1"]
+pub mod tc1;
+#[doc = "Basic Timer Counter 2"]
+pub struct TC2 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for TC2 {}
+impl TC2 {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const tc1::RegisterBlock {
+        0x4200_1c00 as *const _
+    }
+}
+impl Deref for TC2 {
+    type Target = tc1::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*TC2::ptr() }
+    }
+}
+#[doc = "Timer Counter Control"]
+pub struct TCC0 {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for TCC0 {}
+impl TCC0 {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const tcc0::RegisterBlock {
+        0x4200_1400 as *const _
+    }
+}
+impl Deref for TCC0 {
+    type Target = tcc0::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*TCC0::ptr() }
+    }
+}
+#[doc = "Timer Counter Control"]
+pub mod tcc0;
+#[doc = "Universal Serial Bus"]
+pub struct USB {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for USB {}
+impl USB {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const usb::RegisterBlock {
+        0x4100_5000 as *const _
+    }
+}
+impl Deref for USB {
+    type Target = usb::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*USB::ptr() }
+    }
+}
+#[doc = "Universal Serial Bus"]
+pub mod usb;
+#[doc = "Watchdog Timer"]
+pub struct WDT {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for WDT {}
+impl WDT {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const wdt::RegisterBlock {
+        0x4000_1000 as *const _
+    }
+}
+impl Deref for WDT {
+    type Target = wdt::RegisterBlock;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*WDT::ptr() }
+    }
+}
+#[doc = "Watchdog Timer"]
+pub mod wdt;
+#[no_mangle]
+static mut DEVICE_PERIPHERALS: bool = false;
+#[doc = r"All the peripherals"]
+#[allow(non_snake_case)]
+pub struct Peripherals {
+    #[doc = "AC"]
+    pub AC: AC,
+    #[doc = "ADC"]
+    pub ADC: ADC,
+    #[doc = "DAC"]
+    pub DAC: DAC,
+    #[doc = "DMAC"]
+    pub DMAC: DMAC,
+    #[doc = "DSU"]
+    pub DSU: DSU,
+    #[doc = "EIC"]
+    pub EIC: EIC,
+    #[doc = "EVSYS"]
+    pub EVSYS: EVSYS,
+    #[doc = "GCLK"]
+    pub GCLK: GCLK,
+    #[doc = "HMATRIX"]
+    pub HMATRIX: HMATRIX,
+    #[doc = "MTB"]
+    pub MTB: MTB,
+    #[doc = "NVMCTRL"]
+    pub NVMCTRL: NVMCTRL,
+    #[doc = "PAC0"]
+    pub PAC0: PAC0,
+    #[doc = "PAC1"]
+    pub PAC1: PAC1,
+    #[doc = "PAC2"]
+    pub PAC2: PAC2,
+    #[doc = "PM"]
+    pub PM: PM,
+    #[doc = "PORT"]
+    pub PORT: PORT,
+    #[doc = "PORT_IOBUS"]
+    pub PORT_IOBUS: PORT_IOBUS,
+    #[doc = "RTC"]
+    pub RTC: RTC,
+    #[doc = "SERCOM0"]
+    pub SERCOM0: SERCOM0,
+    #[doc = "SERCOM1"]
+    pub SERCOM1: SERCOM1,
+    #[doc = "SYSCTRL"]
+    pub SYSCTRL: SYSCTRL,
+    #[doc = "TC1"]
+    pub TC1: TC1,
+    #[doc = "TC2"]
+    pub TC2: TC2,
+    #[doc = "TCC0"]
+    pub TCC0: TCC0,
+    #[doc = "USB"]
+    pub USB: USB,
+    #[doc = "WDT"]
+    pub WDT: WDT,
+}
+impl Peripherals {
+    #[doc = r"Returns all the peripherals *once*"]
+    #[inline]
+    pub fn take() -> Option<Self> {
+        cortex_m::interrupt::free(|_| {
+            if unsafe { DEVICE_PERIPHERALS } {
+                None
+            } else {
+                Some(unsafe { Peripherals::steal() })
+            }
+        })
+    }
+    #[doc = r"Unchecked version of `Peripherals::take`"]
+    pub unsafe fn steal() -> Self {
+        DEVICE_PERIPHERALS = true;
+        Peripherals {
+            AC: AC {
+                _marker: PhantomData,
+            },
+            ADC: ADC {
+                _marker: PhantomData,
+            },
+            DAC: DAC {
+                _marker: PhantomData,
+            },
+            DMAC: DMAC {
+                _marker: PhantomData,
+            },
+            DSU: DSU {
+                _marker: PhantomData,
+            },
+            EIC: EIC {
+                _marker: PhantomData,
+            },
+            EVSYS: EVSYS {
+                _marker: PhantomData,
+            },
+            GCLK: GCLK {
+                _marker: PhantomData,
+            },
+            HMATRIX: HMATRIX {
+                _marker: PhantomData,
+            },
+            MTB: MTB {
+                _marker: PhantomData,
+            },
+            NVMCTRL: NVMCTRL {
+                _marker: PhantomData,
+            },
+            PAC0: PAC0 {
+                _marker: PhantomData,
+            },
+            PAC1: PAC1 {
+                _marker: PhantomData,
+            },
+            PAC2: PAC2 {
+                _marker: PhantomData,
+            },
+            PM: PM {
+                _marker: PhantomData,
+            },
+            PORT: PORT {
+                _marker: PhantomData,
+            },
+            PORT_IOBUS: PORT_IOBUS {
+                _marker: PhantomData,
+            },
+            RTC: RTC {
+                _marker: PhantomData,
+            },
+            SERCOM0: SERCOM0 {
+                _marker: PhantomData,
+            },
+            SERCOM1: SERCOM1 {
+                _marker: PhantomData,
+            },
+            SYSCTRL: SYSCTRL {
+                _marker: PhantomData,
+            },
+            TC1: TC1 {
+                _marker: PhantomData,
+            },
+            TC2: TC2 {
+                _marker: PhantomData,
+            },
+            TCC0: TCC0 {
+                _marker: PhantomData,
+            },
+            USB: USB {
+                _marker: PhantomData,
+            },
+            WDT: WDT {
+                _marker: PhantomData,
+            },
+        }
+    }
+}

--- a/pac/atsamd11c14a/src/mtb.rs
+++ b/pac/atsamd11c14a/src/mtb.rs
@@ -1,0 +1,297 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - MTB Position"]
+    pub position: POSITION,
+    #[doc = "0x04 - MTB Master"]
+    pub master: MASTER,
+    #[doc = "0x08 - MTB Flow"]
+    pub flow: FLOW,
+    #[doc = "0x0c - MTB Base"]
+    pub base: BASE,
+    _reserved4: [u8; 3824usize],
+    #[doc = "0xf00 - MTB Integration Mode Control"]
+    pub itctrl: ITCTRL,
+    _reserved5: [u8; 156usize],
+    #[doc = "0xfa0 - MTB Claim Set"]
+    pub claimset: CLAIMSET,
+    #[doc = "0xfa4 - MTB Claim Clear"]
+    pub claimclr: CLAIMCLR,
+    _reserved7: [u8; 8usize],
+    #[doc = "0xfb0 - MTB Lock Access"]
+    pub lockaccess: LOCKACCESS,
+    #[doc = "0xfb4 - MTB Lock Status"]
+    pub lockstatus: LOCKSTATUS,
+    #[doc = "0xfb8 - MTB Authentication Status"]
+    pub authstatus: AUTHSTATUS,
+    #[doc = "0xfbc - MTB Device Architecture"]
+    pub devarch: DEVARCH,
+    _reserved11: [u8; 8usize],
+    #[doc = "0xfc8 - MTB Device Configuration"]
+    pub devid: DEVID,
+    #[doc = "0xfcc - MTB Device Type"]
+    pub devtype: DEVTYPE,
+    #[doc = "0xfd0 - CoreSight"]
+    pub pid4: PID4,
+    #[doc = "0xfd4 - CoreSight"]
+    pub pid5: PID5,
+    #[doc = "0xfd8 - CoreSight"]
+    pub pid6: PID6,
+    #[doc = "0xfdc - CoreSight"]
+    pub pid7: PID7,
+    #[doc = "0xfe0 - CoreSight"]
+    pub pid0: PID0,
+    #[doc = "0xfe4 - CoreSight"]
+    pub pid1: PID1,
+    #[doc = "0xfe8 - CoreSight"]
+    pub pid2: PID2,
+    #[doc = "0xfec - CoreSight"]
+    pub pid3: PID3,
+    #[doc = "0xff0 - CoreSight"]
+    pub cid0: CID0,
+    #[doc = "0xff4 - CoreSight"]
+    pub cid1: CID1,
+    #[doc = "0xff8 - CoreSight"]
+    pub cid2: CID2,
+    #[doc = "0xffc - CoreSight"]
+    pub cid3: CID3,
+}
+#[doc = "MTB Position\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [position](position) module"]
+pub type POSITION = crate::Reg<u32, _POSITION>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _POSITION;
+#[doc = "`read()` method returns [position::R](position::R) reader structure"]
+impl crate::Readable for POSITION {}
+#[doc = "`write(|w| ..)` method takes [position::W](position::W) writer structure"]
+impl crate::Writable for POSITION {}
+#[doc = "MTB Position"]
+pub mod position;
+#[doc = "MTB Master\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [master](master) module"]
+pub type MASTER = crate::Reg<u32, _MASTER>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _MASTER;
+#[doc = "`read()` method returns [master::R](master::R) reader structure"]
+impl crate::Readable for MASTER {}
+#[doc = "`write(|w| ..)` method takes [master::W](master::W) writer structure"]
+impl crate::Writable for MASTER {}
+#[doc = "MTB Master"]
+pub mod master;
+#[doc = "MTB Flow\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [flow](flow) module"]
+pub type FLOW = crate::Reg<u32, _FLOW>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _FLOW;
+#[doc = "`read()` method returns [flow::R](flow::R) reader structure"]
+impl crate::Readable for FLOW {}
+#[doc = "`write(|w| ..)` method takes [flow::W](flow::W) writer structure"]
+impl crate::Writable for FLOW {}
+#[doc = "MTB Flow"]
+pub mod flow;
+#[doc = "MTB Base\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [base](base) module"]
+pub type BASE = crate::Reg<u32, _BASE>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _BASE;
+#[doc = "`read()` method returns [base::R](base::R) reader structure"]
+impl crate::Readable for BASE {}
+#[doc = "MTB Base"]
+pub mod base;
+#[doc = "MTB Integration Mode Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [itctrl](itctrl) module"]
+pub type ITCTRL = crate::Reg<u32, _ITCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _ITCTRL;
+#[doc = "`read()` method returns [itctrl::R](itctrl::R) reader structure"]
+impl crate::Readable for ITCTRL {}
+#[doc = "`write(|w| ..)` method takes [itctrl::W](itctrl::W) writer structure"]
+impl crate::Writable for ITCTRL {}
+#[doc = "MTB Integration Mode Control"]
+pub mod itctrl;
+#[doc = "MTB Claim Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [claimset](claimset) module"]
+pub type CLAIMSET = crate::Reg<u32, _CLAIMSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CLAIMSET;
+#[doc = "`read()` method returns [claimset::R](claimset::R) reader structure"]
+impl crate::Readable for CLAIMSET {}
+#[doc = "`write(|w| ..)` method takes [claimset::W](claimset::W) writer structure"]
+impl crate::Writable for CLAIMSET {}
+#[doc = "MTB Claim Set"]
+pub mod claimset;
+#[doc = "MTB Claim Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [claimclr](claimclr) module"]
+pub type CLAIMCLR = crate::Reg<u32, _CLAIMCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CLAIMCLR;
+#[doc = "`read()` method returns [claimclr::R](claimclr::R) reader structure"]
+impl crate::Readable for CLAIMCLR {}
+#[doc = "`write(|w| ..)` method takes [claimclr::W](claimclr::W) writer structure"]
+impl crate::Writable for CLAIMCLR {}
+#[doc = "MTB Claim Clear"]
+pub mod claimclr;
+#[doc = "MTB Lock Access\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lockaccess](lockaccess) module"]
+pub type LOCKACCESS = crate::Reg<u32, _LOCKACCESS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _LOCKACCESS;
+#[doc = "`read()` method returns [lockaccess::R](lockaccess::R) reader structure"]
+impl crate::Readable for LOCKACCESS {}
+#[doc = "`write(|w| ..)` method takes [lockaccess::W](lockaccess::W) writer structure"]
+impl crate::Writable for LOCKACCESS {}
+#[doc = "MTB Lock Access"]
+pub mod lockaccess;
+#[doc = "MTB Lock Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lockstatus](lockstatus) module"]
+pub type LOCKSTATUS = crate::Reg<u32, _LOCKSTATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _LOCKSTATUS;
+#[doc = "`read()` method returns [lockstatus::R](lockstatus::R) reader structure"]
+impl crate::Readable for LOCKSTATUS {}
+#[doc = "MTB Lock Status"]
+pub mod lockstatus;
+#[doc = "MTB Authentication Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [authstatus](authstatus) module"]
+pub type AUTHSTATUS = crate::Reg<u32, _AUTHSTATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _AUTHSTATUS;
+#[doc = "`read()` method returns [authstatus::R](authstatus::R) reader structure"]
+impl crate::Readable for AUTHSTATUS {}
+#[doc = "MTB Authentication Status"]
+pub mod authstatus;
+#[doc = "MTB Device Architecture\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [devarch](devarch) module"]
+pub type DEVARCH = crate::Reg<u32, _DEVARCH>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DEVARCH;
+#[doc = "`read()` method returns [devarch::R](devarch::R) reader structure"]
+impl crate::Readable for DEVARCH {}
+#[doc = "MTB Device Architecture"]
+pub mod devarch;
+#[doc = "MTB Device Configuration\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [devid](devid) module"]
+pub type DEVID = crate::Reg<u32, _DEVID>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DEVID;
+#[doc = "`read()` method returns [devid::R](devid::R) reader structure"]
+impl crate::Readable for DEVID {}
+#[doc = "MTB Device Configuration"]
+pub mod devid;
+#[doc = "MTB Device Type\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [devtype](devtype) module"]
+pub type DEVTYPE = crate::Reg<u32, _DEVTYPE>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DEVTYPE;
+#[doc = "`read()` method returns [devtype::R](devtype::R) reader structure"]
+impl crate::Readable for DEVTYPE {}
+#[doc = "MTB Device Type"]
+pub mod devtype;
+#[doc = "CoreSight\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid4](pid4) module"]
+pub type PID4 = crate::Reg<u32, _PID4>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID4;
+#[doc = "`read()` method returns [pid4::R](pid4::R) reader structure"]
+impl crate::Readable for PID4 {}
+#[doc = "CoreSight"]
+pub mod pid4;
+#[doc = "CoreSight\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid5](pid5) module"]
+pub type PID5 = crate::Reg<u32, _PID5>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID5;
+#[doc = "`read()` method returns [pid5::R](pid5::R) reader structure"]
+impl crate::Readable for PID5 {}
+#[doc = "CoreSight"]
+pub mod pid5;
+#[doc = "CoreSight\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid6](pid6) module"]
+pub type PID6 = crate::Reg<u32, _PID6>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID6;
+#[doc = "`read()` method returns [pid6::R](pid6::R) reader structure"]
+impl crate::Readable for PID6 {}
+#[doc = "CoreSight"]
+pub mod pid6;
+#[doc = "CoreSight\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid7](pid7) module"]
+pub type PID7 = crate::Reg<u32, _PID7>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID7;
+#[doc = "`read()` method returns [pid7::R](pid7::R) reader structure"]
+impl crate::Readable for PID7 {}
+#[doc = "CoreSight"]
+pub mod pid7;
+#[doc = "CoreSight\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid0](pid0) module"]
+pub type PID0 = crate::Reg<u32, _PID0>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID0;
+#[doc = "`read()` method returns [pid0::R](pid0::R) reader structure"]
+impl crate::Readable for PID0 {}
+#[doc = "CoreSight"]
+pub mod pid0;
+#[doc = "CoreSight\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid1](pid1) module"]
+pub type PID1 = crate::Reg<u32, _PID1>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID1;
+#[doc = "`read()` method returns [pid1::R](pid1::R) reader structure"]
+impl crate::Readable for PID1 {}
+#[doc = "CoreSight"]
+pub mod pid1;
+#[doc = "CoreSight\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid2](pid2) module"]
+pub type PID2 = crate::Reg<u32, _PID2>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID2;
+#[doc = "`read()` method returns [pid2::R](pid2::R) reader structure"]
+impl crate::Readable for PID2 {}
+#[doc = "CoreSight"]
+pub mod pid2;
+#[doc = "CoreSight\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pid3](pid3) module"]
+pub type PID3 = crate::Reg<u32, _PID3>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PID3;
+#[doc = "`read()` method returns [pid3::R](pid3::R) reader structure"]
+impl crate::Readable for PID3 {}
+#[doc = "CoreSight"]
+pub mod pid3;
+#[doc = "CoreSight\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cid0](cid0) module"]
+pub type CID0 = crate::Reg<u32, _CID0>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CID0;
+#[doc = "`read()` method returns [cid0::R](cid0::R) reader structure"]
+impl crate::Readable for CID0 {}
+#[doc = "CoreSight"]
+pub mod cid0;
+#[doc = "CoreSight\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cid1](cid1) module"]
+pub type CID1 = crate::Reg<u32, _CID1>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CID1;
+#[doc = "`read()` method returns [cid1::R](cid1::R) reader structure"]
+impl crate::Readable for CID1 {}
+#[doc = "CoreSight"]
+pub mod cid1;
+#[doc = "CoreSight\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cid2](cid2) module"]
+pub type CID2 = crate::Reg<u32, _CID2>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CID2;
+#[doc = "`read()` method returns [cid2::R](cid2::R) reader structure"]
+impl crate::Readable for CID2 {}
+#[doc = "CoreSight"]
+pub mod cid2;
+#[doc = "CoreSight\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cid3](cid3) module"]
+pub type CID3 = crate::Reg<u32, _CID3>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CID3;
+#[doc = "`read()` method returns [cid3::R](cid3::R) reader structure"]
+impl crate::Readable for CID3 {}
+#[doc = "CoreSight"]
+pub mod cid3;

--- a/pac/atsamd11c14a/src/mtb/authstatus.rs
+++ b/pac/atsamd11c14a/src/mtb/authstatus.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register AUTHSTATUS"]
+pub type R = crate::R<u32, super::AUTHSTATUS>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/base.rs
+++ b/pac/atsamd11c14a/src/mtb/base.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register BASE"]
+pub type R = crate::R<u32, super::BASE>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/cid0.rs
+++ b/pac/atsamd11c14a/src/mtb/cid0.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register CID0"]
+pub type R = crate::R<u32, super::CID0>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/cid1.rs
+++ b/pac/atsamd11c14a/src/mtb/cid1.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register CID1"]
+pub type R = crate::R<u32, super::CID1>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/cid2.rs
+++ b/pac/atsamd11c14a/src/mtb/cid2.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register CID2"]
+pub type R = crate::R<u32, super::CID2>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/cid3.rs
+++ b/pac/atsamd11c14a/src/mtb/cid3.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register CID3"]
+pub type R = crate::R<u32, super::CID3>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/claimclr.rs
+++ b/pac/atsamd11c14a/src/mtb/claimclr.rs
@@ -1,0 +1,14 @@
+#[doc = "Reader of register CLAIMCLR"]
+pub type R = crate::R<u32, super::CLAIMCLR>;
+#[doc = "Writer for register CLAIMCLR"]
+pub type W = crate::W<u32, super::CLAIMCLR>;
+#[doc = "Register CLAIMCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::CLAIMCLR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+impl R {}
+impl W {}

--- a/pac/atsamd11c14a/src/mtb/claimset.rs
+++ b/pac/atsamd11c14a/src/mtb/claimset.rs
@@ -1,0 +1,14 @@
+#[doc = "Reader of register CLAIMSET"]
+pub type R = crate::R<u32, super::CLAIMSET>;
+#[doc = "Writer for register CLAIMSET"]
+pub type W = crate::W<u32, super::CLAIMSET>;
+#[doc = "Register CLAIMSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::CLAIMSET {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+impl R {}
+impl W {}

--- a/pac/atsamd11c14a/src/mtb/devarch.rs
+++ b/pac/atsamd11c14a/src/mtb/devarch.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register DEVARCH"]
+pub type R = crate::R<u32, super::DEVARCH>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/devid.rs
+++ b/pac/atsamd11c14a/src/mtb/devid.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register DEVID"]
+pub type R = crate::R<u32, super::DEVID>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/devtype.rs
+++ b/pac/atsamd11c14a/src/mtb/devtype.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register DEVTYPE"]
+pub type R = crate::R<u32, super::DEVTYPE>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/flow.rs
+++ b/pac/atsamd11c14a/src/mtb/flow.rs
@@ -1,0 +1,108 @@
+#[doc = "Reader of register FLOW"]
+pub type R = crate::R<u32, super::FLOW>;
+#[doc = "Writer for register FLOW"]
+pub type W = crate::W<u32, super::FLOW>;
+#[doc = "Register FLOW `reset()`'s with value 0"]
+impl crate::ResetValue for super::FLOW {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `AUTOSTOP`"]
+pub type AUTOSTOP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `AUTOSTOP`"]
+pub struct AUTOSTOP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> AUTOSTOP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `AUTOHALT`"]
+pub type AUTOHALT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `AUTOHALT`"]
+pub struct AUTOHALT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> AUTOHALT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `WATERMARK`"]
+pub type WATERMARK_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `WATERMARK`"]
+pub struct WATERMARK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WATERMARK_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x1fff_ffff << 3)) | (((value as u32) & 0x1fff_ffff) << 3);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Auto Stop Tracing"]
+    #[inline(always)]
+    pub fn autostop(&self) -> AUTOSTOP_R {
+        AUTOSTOP_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Auto Halt Request"]
+    #[inline(always)]
+    pub fn autohalt(&self) -> AUTOHALT_R {
+        AUTOHALT_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 3:31 - Watermark value"]
+    #[inline(always)]
+    pub fn watermark(&self) -> WATERMARK_R {
+        WATERMARK_R::new(((self.bits >> 3) & 0x1fff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Auto Stop Tracing"]
+    #[inline(always)]
+    pub fn autostop(&mut self) -> AUTOSTOP_W {
+        AUTOSTOP_W { w: self }
+    }
+    #[doc = "Bit 1 - Auto Halt Request"]
+    #[inline(always)]
+    pub fn autohalt(&mut self) -> AUTOHALT_W {
+        AUTOHALT_W { w: self }
+    }
+    #[doc = "Bits 3:31 - Watermark value"]
+    #[inline(always)]
+    pub fn watermark(&mut self) -> WATERMARK_W {
+        WATERMARK_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/mtb/itctrl.rs
+++ b/pac/atsamd11c14a/src/mtb/itctrl.rs
@@ -1,0 +1,14 @@
+#[doc = "Reader of register ITCTRL"]
+pub type R = crate::R<u32, super::ITCTRL>;
+#[doc = "Writer for register ITCTRL"]
+pub type W = crate::W<u32, super::ITCTRL>;
+#[doc = "Register ITCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::ITCTRL {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+impl R {}
+impl W {}

--- a/pac/atsamd11c14a/src/mtb/lockaccess.rs
+++ b/pac/atsamd11c14a/src/mtb/lockaccess.rs
@@ -1,0 +1,14 @@
+#[doc = "Reader of register LOCKACCESS"]
+pub type R = crate::R<u32, super::LOCKACCESS>;
+#[doc = "Writer for register LOCKACCESS"]
+pub type W = crate::W<u32, super::LOCKACCESS>;
+#[doc = "Register LOCKACCESS `reset()`'s with value 0"]
+impl crate::ResetValue for super::LOCKACCESS {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+impl R {}
+impl W {}

--- a/pac/atsamd11c14a/src/mtb/lockstatus.rs
+++ b/pac/atsamd11c14a/src/mtb/lockstatus.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register LOCKSTATUS"]
+pub type R = crate::R<u32, super::LOCKSTATUS>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/master.rs
+++ b/pac/atsamd11c14a/src/mtb/master.rs
@@ -1,0 +1,244 @@
+#[doc = "Reader of register MASTER"]
+pub type R = crate::R<u32, super::MASTER>;
+#[doc = "Writer for register MASTER"]
+pub type W = crate::W<u32, super::MASTER>;
+#[doc = "Register MASTER `reset()`'s with value 0"]
+impl crate::ResetValue for super::MASTER {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `MASK`"]
+pub type MASK_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `MASK`"]
+pub struct MASK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MASK_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x1f) | ((value as u32) & 0x1f);
+        self.w
+    }
+}
+#[doc = "Reader of field `TSTARTEN`"]
+pub type TSTARTEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TSTARTEN`"]
+pub struct TSTARTEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TSTARTEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `TSTOPEN`"]
+pub type TSTOPEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TSTOPEN`"]
+pub struct TSTOPEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TSTOPEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `SFRWPRIV`"]
+pub type SFRWPRIV_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SFRWPRIV`"]
+pub struct SFRWPRIV_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SFRWPRIV_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `RAMPRIV`"]
+pub type RAMPRIV_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RAMPRIV`"]
+pub struct RAMPRIV_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RAMPRIV_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `HALTREQ`"]
+pub type HALTREQ_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `HALTREQ`"]
+pub struct HALTREQ_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HALTREQ_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `EN`"]
+pub type EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EN`"]
+pub struct EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 31)) | (((value as u32) & 0x01) << 31);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:4 - Maximum Value of the Trace Buffer in SRAM"]
+    #[inline(always)]
+    pub fn mask(&self) -> MASK_R {
+        MASK_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bit 5 - Trace Start Input Enable"]
+    #[inline(always)]
+    pub fn tstarten(&self) -> TSTARTEN_R {
+        TSTARTEN_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Trace Stop Input Enable"]
+    #[inline(always)]
+    pub fn tstopen(&self) -> TSTOPEN_R {
+        TSTOPEN_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Special Function Register Write Privilege"]
+    #[inline(always)]
+    pub fn sfrwpriv(&self) -> SFRWPRIV_R {
+        SFRWPRIV_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - SRAM Privilege"]
+    #[inline(always)]
+    pub fn rampriv(&self) -> RAMPRIV_R {
+        RAMPRIV_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Halt Request"]
+    #[inline(always)]
+    pub fn haltreq(&self) -> HALTREQ_R {
+        HALTREQ_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 31 - Main Trace Enable"]
+    #[inline(always)]
+    pub fn en(&self) -> EN_R {
+        EN_R::new(((self.bits >> 31) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - Maximum Value of the Trace Buffer in SRAM"]
+    #[inline(always)]
+    pub fn mask(&mut self) -> MASK_W {
+        MASK_W { w: self }
+    }
+    #[doc = "Bit 5 - Trace Start Input Enable"]
+    #[inline(always)]
+    pub fn tstarten(&mut self) -> TSTARTEN_W {
+        TSTARTEN_W { w: self }
+    }
+    #[doc = "Bit 6 - Trace Stop Input Enable"]
+    #[inline(always)]
+    pub fn tstopen(&mut self) -> TSTOPEN_W {
+        TSTOPEN_W { w: self }
+    }
+    #[doc = "Bit 7 - Special Function Register Write Privilege"]
+    #[inline(always)]
+    pub fn sfrwpriv(&mut self) -> SFRWPRIV_W {
+        SFRWPRIV_W { w: self }
+    }
+    #[doc = "Bit 8 - SRAM Privilege"]
+    #[inline(always)]
+    pub fn rampriv(&mut self) -> RAMPRIV_W {
+        RAMPRIV_W { w: self }
+    }
+    #[doc = "Bit 9 - Halt Request"]
+    #[inline(always)]
+    pub fn haltreq(&mut self) -> HALTREQ_W {
+        HALTREQ_W { w: self }
+    }
+    #[doc = "Bit 31 - Main Trace Enable"]
+    #[inline(always)]
+    pub fn en(&mut self) -> EN_W {
+        EN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/mtb/pid0.rs
+++ b/pac/atsamd11c14a/src/mtb/pid0.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register PID0"]
+pub type R = crate::R<u32, super::PID0>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/pid1.rs
+++ b/pac/atsamd11c14a/src/mtb/pid1.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register PID1"]
+pub type R = crate::R<u32, super::PID1>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/pid2.rs
+++ b/pac/atsamd11c14a/src/mtb/pid2.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register PID2"]
+pub type R = crate::R<u32, super::PID2>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/pid3.rs
+++ b/pac/atsamd11c14a/src/mtb/pid3.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register PID3"]
+pub type R = crate::R<u32, super::PID3>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/pid4.rs
+++ b/pac/atsamd11c14a/src/mtb/pid4.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register PID4"]
+pub type R = crate::R<u32, super::PID4>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/pid5.rs
+++ b/pac/atsamd11c14a/src/mtb/pid5.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register PID5"]
+pub type R = crate::R<u32, super::PID5>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/pid6.rs
+++ b/pac/atsamd11c14a/src/mtb/pid6.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register PID6"]
+pub type R = crate::R<u32, super::PID6>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/pid7.rs
+++ b/pac/atsamd11c14a/src/mtb/pid7.rs
@@ -1,0 +1,3 @@
+#[doc = "Reader of register PID7"]
+pub type R = crate::R<u32, super::PID7>;
+impl R {}

--- a/pac/atsamd11c14a/src/mtb/position.rs
+++ b/pac/atsamd11c14a/src/mtb/position.rs
@@ -1,0 +1,74 @@
+#[doc = "Reader of register POSITION"]
+pub type R = crate::R<u32, super::POSITION>;
+#[doc = "Writer for register POSITION"]
+pub type W = crate::W<u32, super::POSITION>;
+#[doc = "Register POSITION `reset()`'s with value 0"]
+impl crate::ResetValue for super::POSITION {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `WRAP`"]
+pub type WRAP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WRAP`"]
+pub struct WRAP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WRAP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `POINTER`"]
+pub type POINTER_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `POINTER`"]
+pub struct POINTER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> POINTER_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x1fff_ffff << 3)) | (((value as u32) & 0x1fff_ffff) << 3);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 2 - Pointer Value Wraps"]
+    #[inline(always)]
+    pub fn wrap(&self) -> WRAP_R {
+        WRAP_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bits 3:31 - Trace Packet Location Pointer"]
+    #[inline(always)]
+    pub fn pointer(&self) -> POINTER_R {
+        POINTER_R::new(((self.bits >> 3) & 0x1fff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bit 2 - Pointer Value Wraps"]
+    #[inline(always)]
+    pub fn wrap(&mut self) -> WRAP_W {
+        WRAP_W { w: self }
+    }
+    #[doc = "Bits 3:31 - Trace Packet Location Pointer"]
+    #[inline(always)]
+    pub fn pointer(&mut self) -> POINTER_W {
+        POINTER_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/nvmctrl.rs
+++ b/pac/atsamd11c14a/src/nvmctrl.rs
@@ -1,0 +1,122 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Control A"]
+    pub ctrla: CTRLA,
+    _reserved1: [u8; 2usize],
+    #[doc = "0x04 - Control B"]
+    pub ctrlb: CTRLB,
+    #[doc = "0x08 - NVM Parameter"]
+    pub param: PARAM,
+    #[doc = "0x0c - Interrupt Enable Clear"]
+    pub intenclr: INTENCLR,
+    _reserved4: [u8; 3usize],
+    #[doc = "0x10 - Interrupt Enable Set"]
+    pub intenset: INTENSET,
+    _reserved5: [u8; 3usize],
+    #[doc = "0x14 - Interrupt Flag Status and Clear"]
+    pub intflag: INTFLAG,
+    _reserved6: [u8; 3usize],
+    #[doc = "0x18 - Status"]
+    pub status: STATUS,
+    _reserved7: [u8; 2usize],
+    #[doc = "0x1c - Address"]
+    pub addr: ADDR,
+    #[doc = "0x20 - Lock Section"]
+    pub lock: LOCK,
+}
+#[doc = "Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrla](ctrla) module"]
+pub type CTRLA = crate::Reg<u16, _CTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLA;
+#[doc = "`read()` method returns [ctrla::R](ctrla::R) reader structure"]
+impl crate::Readable for CTRLA {}
+#[doc = "`write(|w| ..)` method takes [ctrla::W](ctrla::W) writer structure"]
+impl crate::Writable for CTRLA {}
+#[doc = "Control A"]
+pub mod ctrla;
+#[doc = "Control B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlb](ctrlb) module"]
+pub type CTRLB = crate::Reg<u32, _CTRLB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLB;
+#[doc = "`read()` method returns [ctrlb::R](ctrlb::R) reader structure"]
+impl crate::Readable for CTRLB {}
+#[doc = "`write(|w| ..)` method takes [ctrlb::W](ctrlb::W) writer structure"]
+impl crate::Writable for CTRLB {}
+#[doc = "Control B"]
+pub mod ctrlb;
+#[doc = "NVM Parameter\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [param](param) module"]
+pub type PARAM = crate::Reg<u32, _PARAM>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PARAM;
+#[doc = "`read()` method returns [param::R](param::R) reader structure"]
+impl crate::Readable for PARAM {}
+#[doc = "NVM Parameter"]
+pub mod param;
+#[doc = "Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u16, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "`write(|w| ..)` method takes [status::W](status::W) writer structure"]
+impl crate::Writable for STATUS {}
+#[doc = "Status"]
+pub mod status;
+#[doc = "Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [addr](addr) module"]
+pub type ADDR = crate::Reg<u32, _ADDR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _ADDR;
+#[doc = "`read()` method returns [addr::R](addr::R) reader structure"]
+impl crate::Readable for ADDR {}
+#[doc = "`write(|w| ..)` method takes [addr::W](addr::W) writer structure"]
+impl crate::Writable for ADDR {}
+#[doc = "Address"]
+pub mod addr;
+#[doc = "Lock Section\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [lock](lock) module"]
+pub type LOCK = crate::Reg<u16, _LOCK>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _LOCK;
+#[doc = "`read()` method returns [lock::R](lock::R) reader structure"]
+impl crate::Readable for LOCK {}
+#[doc = "Lock Section"]
+pub mod lock;

--- a/pac/atsamd11c14a/src/nvmctrl/addr.rs
+++ b/pac/atsamd11c14a/src/nvmctrl/addr.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register ADDR"]
+pub type R = crate::R<u32, super::ADDR>;
+#[doc = "Writer for register ADDR"]
+pub type W = crate::W<u32, super::ADDR>;
+#[doc = "Register ADDR `reset()`'s with value 0"]
+impl crate::ResetValue for super::ADDR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ADDR`"]
+pub type ADDR_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `ADDR`"]
+pub struct ADDR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ADDR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x003f_ffff) | ((value as u32) & 0x003f_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:21 - NVM Address"]
+    #[inline(always)]
+    pub fn addr(&self) -> ADDR_R {
+        ADDR_R::new((self.bits & 0x003f_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:21 - NVM Address"]
+    #[inline(always)]
+    pub fn addr(&mut self) -> ADDR_W {
+        ADDR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/nvmctrl/ctrla.rs
+++ b/pac/atsamd11c14a/src/nvmctrl/ctrla.rs
@@ -1,0 +1,312 @@
+#[doc = "Reader of register CTRLA"]
+pub type R = crate::R<u16, super::CTRLA>;
+#[doc = "Writer for register CTRLA"]
+pub type W = crate::W<u16, super::CTRLA>;
+#[doc = "Register CTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLA {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Command\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CMD_A {
+    #[doc = "2: Erase Row - Erases the row addressed by the ADDR register."]
+    ER,
+    #[doc = "4: Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register."]
+    WP,
+    #[doc = "5: Erase Auxiliary Row - Erases the auxiliary row addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row."]
+    EAR,
+    #[doc = "6: Write Auxiliary Page - Writes the contents of the page buffer to the page addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row."]
+    WAP,
+    #[doc = "10: Security Flow Command"]
+    SF,
+    #[doc = "15: Write lockbits"]
+    WL,
+    #[doc = "64: Lock Region - Locks the region containing the address location in the ADDR register."]
+    LR,
+    #[doc = "65: Unlock Region - Unlocks the region containing the address location in the ADDR register."]
+    UR,
+    #[doc = "66: Sets the power reduction mode."]
+    SPRM,
+    #[doc = "67: Clears the power reduction mode."]
+    CPRM,
+    #[doc = "68: Page Buffer Clear - Clears the page buffer."]
+    PBC,
+    #[doc = "69: Set Security Bit - Sets the security bit by writing 0x00 to the first byte in the lockbit row."]
+    SSB,
+    #[doc = "70: Invalidates all cache lines."]
+    INVALL,
+}
+impl From<CMD_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CMD_A) -> Self {
+        match variant {
+            CMD_A::ER => 2,
+            CMD_A::WP => 4,
+            CMD_A::EAR => 5,
+            CMD_A::WAP => 6,
+            CMD_A::SF => 10,
+            CMD_A::WL => 15,
+            CMD_A::LR => 64,
+            CMD_A::UR => 65,
+            CMD_A::SPRM => 66,
+            CMD_A::CPRM => 67,
+            CMD_A::PBC => 68,
+            CMD_A::SSB => 69,
+            CMD_A::INVALL => 70,
+        }
+    }
+}
+#[doc = "Reader of field `CMD`"]
+pub type CMD_R = crate::R<u8, CMD_A>;
+impl CMD_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, CMD_A> {
+        use crate::Variant::*;
+        match self.bits {
+            2 => Val(CMD_A::ER),
+            4 => Val(CMD_A::WP),
+            5 => Val(CMD_A::EAR),
+            6 => Val(CMD_A::WAP),
+            10 => Val(CMD_A::SF),
+            15 => Val(CMD_A::WL),
+            64 => Val(CMD_A::LR),
+            65 => Val(CMD_A::UR),
+            66 => Val(CMD_A::SPRM),
+            67 => Val(CMD_A::CPRM),
+            68 => Val(CMD_A::PBC),
+            69 => Val(CMD_A::SSB),
+            70 => Val(CMD_A::INVALL),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `ER`"]
+    #[inline(always)]
+    pub fn is_er(&self) -> bool {
+        *self == CMD_A::ER
+    }
+    #[doc = "Checks if the value of the field is `WP`"]
+    #[inline(always)]
+    pub fn is_wp(&self) -> bool {
+        *self == CMD_A::WP
+    }
+    #[doc = "Checks if the value of the field is `EAR`"]
+    #[inline(always)]
+    pub fn is_ear(&self) -> bool {
+        *self == CMD_A::EAR
+    }
+    #[doc = "Checks if the value of the field is `WAP`"]
+    #[inline(always)]
+    pub fn is_wap(&self) -> bool {
+        *self == CMD_A::WAP
+    }
+    #[doc = "Checks if the value of the field is `SF`"]
+    #[inline(always)]
+    pub fn is_sf(&self) -> bool {
+        *self == CMD_A::SF
+    }
+    #[doc = "Checks if the value of the field is `WL`"]
+    #[inline(always)]
+    pub fn is_wl(&self) -> bool {
+        *self == CMD_A::WL
+    }
+    #[doc = "Checks if the value of the field is `LR`"]
+    #[inline(always)]
+    pub fn is_lr(&self) -> bool {
+        *self == CMD_A::LR
+    }
+    #[doc = "Checks if the value of the field is `UR`"]
+    #[inline(always)]
+    pub fn is_ur(&self) -> bool {
+        *self == CMD_A::UR
+    }
+    #[doc = "Checks if the value of the field is `SPRM`"]
+    #[inline(always)]
+    pub fn is_sprm(&self) -> bool {
+        *self == CMD_A::SPRM
+    }
+    #[doc = "Checks if the value of the field is `CPRM`"]
+    #[inline(always)]
+    pub fn is_cprm(&self) -> bool {
+        *self == CMD_A::CPRM
+    }
+    #[doc = "Checks if the value of the field is `PBC`"]
+    #[inline(always)]
+    pub fn is_pbc(&self) -> bool {
+        *self == CMD_A::PBC
+    }
+    #[doc = "Checks if the value of the field is `SSB`"]
+    #[inline(always)]
+    pub fn is_ssb(&self) -> bool {
+        *self == CMD_A::SSB
+    }
+    #[doc = "Checks if the value of the field is `INVALL`"]
+    #[inline(always)]
+    pub fn is_invall(&self) -> bool {
+        *self == CMD_A::INVALL
+    }
+}
+#[doc = "Write proxy for field `CMD`"]
+pub struct CMD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMD_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CMD_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Erase Row - Erases the row addressed by the ADDR register."]
+    #[inline(always)]
+    pub fn er(self) -> &'a mut W {
+        self.variant(CMD_A::ER)
+    }
+    #[doc = "Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register."]
+    #[inline(always)]
+    pub fn wp(self) -> &'a mut W {
+        self.variant(CMD_A::WP)
+    }
+    #[doc = "Erase Auxiliary Row - Erases the auxiliary row addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row."]
+    #[inline(always)]
+    pub fn ear(self) -> &'a mut W {
+        self.variant(CMD_A::EAR)
+    }
+    #[doc = "Write Auxiliary Page - Writes the contents of the page buffer to the page addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row."]
+    #[inline(always)]
+    pub fn wap(self) -> &'a mut W {
+        self.variant(CMD_A::WAP)
+    }
+    #[doc = "Security Flow Command"]
+    #[inline(always)]
+    pub fn sf(self) -> &'a mut W {
+        self.variant(CMD_A::SF)
+    }
+    #[doc = "Write lockbits"]
+    #[inline(always)]
+    pub fn wl(self) -> &'a mut W {
+        self.variant(CMD_A::WL)
+    }
+    #[doc = "Lock Region - Locks the region containing the address location in the ADDR register."]
+    #[inline(always)]
+    pub fn lr(self) -> &'a mut W {
+        self.variant(CMD_A::LR)
+    }
+    #[doc = "Unlock Region - Unlocks the region containing the address location in the ADDR register."]
+    #[inline(always)]
+    pub fn ur(self) -> &'a mut W {
+        self.variant(CMD_A::UR)
+    }
+    #[doc = "Sets the power reduction mode."]
+    #[inline(always)]
+    pub fn sprm(self) -> &'a mut W {
+        self.variant(CMD_A::SPRM)
+    }
+    #[doc = "Clears the power reduction mode."]
+    #[inline(always)]
+    pub fn cprm(self) -> &'a mut W {
+        self.variant(CMD_A::CPRM)
+    }
+    #[doc = "Page Buffer Clear - Clears the page buffer."]
+    #[inline(always)]
+    pub fn pbc(self) -> &'a mut W {
+        self.variant(CMD_A::PBC)
+    }
+    #[doc = "Set Security Bit - Sets the security bit by writing 0x00 to the first byte in the lockbit row."]
+    #[inline(always)]
+    pub fn ssb(self) -> &'a mut W {
+        self.variant(CMD_A::SSB)
+    }
+    #[doc = "Invalidates all cache lines."]
+    #[inline(always)]
+    pub fn invall(self) -> &'a mut W {
+        self.variant(CMD_A::INVALL)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x7f) | ((value as u16) & 0x7f);
+        self.w
+    }
+}
+#[doc = "Command Execution\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CMDEX_A {
+    #[doc = "165: Execution Key"]
+    KEY,
+}
+impl From<CMDEX_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CMDEX_A) -> Self {
+        match variant {
+            CMDEX_A::KEY => 165,
+        }
+    }
+}
+#[doc = "Reader of field `CMDEX`"]
+pub type CMDEX_R = crate::R<u8, CMDEX_A>;
+impl CMDEX_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, CMDEX_A> {
+        use crate::Variant::*;
+        match self.bits {
+            165 => Val(CMDEX_A::KEY),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `KEY`"]
+    #[inline(always)]
+    pub fn is_key(&self) -> bool {
+        *self == CMDEX_A::KEY
+    }
+}
+#[doc = "Write proxy for field `CMDEX`"]
+pub struct CMDEX_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMDEX_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CMDEX_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Execution Key"]
+    #[inline(always)]
+    pub fn key(self) -> &'a mut W {
+        self.variant(CMDEX_A::KEY)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0xff << 8)) | (((value as u16) & 0xff) << 8);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:6 - Command"]
+    #[inline(always)]
+    pub fn cmd(&self) -> CMD_R {
+        CMD_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bits 8:15 - Command Execution"]
+    #[inline(always)]
+    pub fn cmdex(&self) -> CMDEX_R {
+        CMDEX_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - Command"]
+    #[inline(always)]
+    pub fn cmd(&mut self) -> CMD_W {
+        CMD_W { w: self }
+    }
+    #[doc = "Bits 8:15 - Command Execution"]
+    #[inline(always)]
+    pub fn cmdex(&mut self) -> CMDEX_W {
+        CMDEX_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/nvmctrl/ctrlb.rs
+++ b/pac/atsamd11c14a/src/nvmctrl/ctrlb.rs
@@ -1,0 +1,360 @@
+#[doc = "Reader of register CTRLB"]
+pub type R = crate::R<u32, super::CTRLB>;
+#[doc = "Writer for register CTRLB"]
+pub type W = crate::W<u32, super::CTRLB>;
+#[doc = "Register CTRLB `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLB {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "NVM Read Wait States\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum RWS_A {
+    #[doc = "0: Single Auto Wait State"]
+    SINGLE,
+    #[doc = "1: Half Auto Wait State"]
+    HALF,
+    #[doc = "2: Dual Auto Wait State"]
+    DUAL,
+}
+impl From<RWS_A> for u8 {
+    #[inline(always)]
+    fn from(variant: RWS_A) -> Self {
+        match variant {
+            RWS_A::SINGLE => 0,
+            RWS_A::HALF => 1,
+            RWS_A::DUAL => 2,
+        }
+    }
+}
+#[doc = "Reader of field `RWS`"]
+pub type RWS_R = crate::R<u8, RWS_A>;
+impl RWS_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, RWS_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(RWS_A::SINGLE),
+            1 => Val(RWS_A::HALF),
+            2 => Val(RWS_A::DUAL),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `SINGLE`"]
+    #[inline(always)]
+    pub fn is_single(&self) -> bool {
+        *self == RWS_A::SINGLE
+    }
+    #[doc = "Checks if the value of the field is `HALF`"]
+    #[inline(always)]
+    pub fn is_half(&self) -> bool {
+        *self == RWS_A::HALF
+    }
+    #[doc = "Checks if the value of the field is `DUAL`"]
+    #[inline(always)]
+    pub fn is_dual(&self) -> bool {
+        *self == RWS_A::DUAL
+    }
+}
+#[doc = "Write proxy for field `RWS`"]
+pub struct RWS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RWS_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: RWS_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Single Auto Wait State"]
+    #[inline(always)]
+    pub fn single(self) -> &'a mut W {
+        self.variant(RWS_A::SINGLE)
+    }
+    #[doc = "Half Auto Wait State"]
+    #[inline(always)]
+    pub fn half(self) -> &'a mut W {
+        self.variant(RWS_A::HALF)
+    }
+    #[doc = "Dual Auto Wait State"]
+    #[inline(always)]
+    pub fn dual(self) -> &'a mut W {
+        self.variant(RWS_A::DUAL)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 1)) | (((value as u32) & 0x0f) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `MANW`"]
+pub type MANW_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MANW`"]
+pub struct MANW_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MANW_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Power Reduction Mode during Sleep\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SLEEPPRM_A {
+    #[doc = "0: NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access."]
+    WAKEONACCESS,
+    #[doc = "1: NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep."]
+    WAKEUPINSTANT,
+    #[doc = "3: Auto power reduction disabled."]
+    DISABLED,
+}
+impl From<SLEEPPRM_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SLEEPPRM_A) -> Self {
+        match variant {
+            SLEEPPRM_A::WAKEONACCESS => 0,
+            SLEEPPRM_A::WAKEUPINSTANT => 1,
+            SLEEPPRM_A::DISABLED => 3,
+        }
+    }
+}
+#[doc = "Reader of field `SLEEPPRM`"]
+pub type SLEEPPRM_R = crate::R<u8, SLEEPPRM_A>;
+impl SLEEPPRM_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, SLEEPPRM_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(SLEEPPRM_A::WAKEONACCESS),
+            1 => Val(SLEEPPRM_A::WAKEUPINSTANT),
+            3 => Val(SLEEPPRM_A::DISABLED),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `WAKEONACCESS`"]
+    #[inline(always)]
+    pub fn is_wakeonaccess(&self) -> bool {
+        *self == SLEEPPRM_A::WAKEONACCESS
+    }
+    #[doc = "Checks if the value of the field is `WAKEUPINSTANT`"]
+    #[inline(always)]
+    pub fn is_wakeupinstant(&self) -> bool {
+        *self == SLEEPPRM_A::WAKEUPINSTANT
+    }
+    #[doc = "Checks if the value of the field is `DISABLED`"]
+    #[inline(always)]
+    pub fn is_disabled(&self) -> bool {
+        *self == SLEEPPRM_A::DISABLED
+    }
+}
+#[doc = "Write proxy for field `SLEEPPRM`"]
+pub struct SLEEPPRM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SLEEPPRM_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SLEEPPRM_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access."]
+    #[inline(always)]
+    pub fn wakeonaccess(self) -> &'a mut W {
+        self.variant(SLEEPPRM_A::WAKEONACCESS)
+    }
+    #[doc = "NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep."]
+    #[inline(always)]
+    pub fn wakeupinstant(self) -> &'a mut W {
+        self.variant(SLEEPPRM_A::WAKEUPINSTANT)
+    }
+    #[doc = "Auto power reduction disabled."]
+    #[inline(always)]
+    pub fn disabled(self) -> &'a mut W {
+        self.variant(SLEEPPRM_A::DISABLED)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 8)) | (((value as u32) & 0x03) << 8);
+        self.w
+    }
+}
+#[doc = "NVMCTRL Read Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum READMODE_A {
+    #[doc = "0: The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance."]
+    NO_MISS_PENALTY,
+    #[doc = "1: Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time."]
+    LOW_POWER,
+    #[doc = "2: The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings."]
+    DETERMINISTIC,
+}
+impl From<READMODE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: READMODE_A) -> Self {
+        match variant {
+            READMODE_A::NO_MISS_PENALTY => 0,
+            READMODE_A::LOW_POWER => 1,
+            READMODE_A::DETERMINISTIC => 2,
+        }
+    }
+}
+#[doc = "Reader of field `READMODE`"]
+pub type READMODE_R = crate::R<u8, READMODE_A>;
+impl READMODE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, READMODE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(READMODE_A::NO_MISS_PENALTY),
+            1 => Val(READMODE_A::LOW_POWER),
+            2 => Val(READMODE_A::DETERMINISTIC),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NO_MISS_PENALTY`"]
+    #[inline(always)]
+    pub fn is_no_miss_penalty(&self) -> bool {
+        *self == READMODE_A::NO_MISS_PENALTY
+    }
+    #[doc = "Checks if the value of the field is `LOW_POWER`"]
+    #[inline(always)]
+    pub fn is_low_power(&self) -> bool {
+        *self == READMODE_A::LOW_POWER
+    }
+    #[doc = "Checks if the value of the field is `DETERMINISTIC`"]
+    #[inline(always)]
+    pub fn is_deterministic(&self) -> bool {
+        *self == READMODE_A::DETERMINISTIC
+    }
+}
+#[doc = "Write proxy for field `READMODE`"]
+pub struct READMODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> READMODE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: READMODE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance."]
+    #[inline(always)]
+    pub fn no_miss_penalty(self) -> &'a mut W {
+        self.variant(READMODE_A::NO_MISS_PENALTY)
+    }
+    #[doc = "Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time."]
+    #[inline(always)]
+    pub fn low_power(self) -> &'a mut W {
+        self.variant(READMODE_A::LOW_POWER)
+    }
+    #[doc = "The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings."]
+    #[inline(always)]
+    pub fn deterministic(self) -> &'a mut W {
+        self.variant(READMODE_A::DETERMINISTIC)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 16)) | (((value as u32) & 0x03) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `CACHEDIS`"]
+pub type CACHEDIS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CACHEDIS`"]
+pub struct CACHEDIS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CACHEDIS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 18)) | (((value as u32) & 0x01) << 18);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 1:4 - NVM Read Wait States"]
+    #[inline(always)]
+    pub fn rws(&self) -> RWS_R {
+        RWS_R::new(((self.bits >> 1) & 0x0f) as u8)
+    }
+    #[doc = "Bit 7 - Manual Write"]
+    #[inline(always)]
+    pub fn manw(&self) -> MANW_R {
+        MANW_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bits 8:9 - Power Reduction Mode during Sleep"]
+    #[inline(always)]
+    pub fn sleepprm(&self) -> SLEEPPRM_R {
+        SLEEPPRM_R::new(((self.bits >> 8) & 0x03) as u8)
+    }
+    #[doc = "Bits 16:17 - NVMCTRL Read Mode"]
+    #[inline(always)]
+    pub fn readmode(&self) -> READMODE_R {
+        READMODE_R::new(((self.bits >> 16) & 0x03) as u8)
+    }
+    #[doc = "Bit 18 - Cache Disable"]
+    #[inline(always)]
+    pub fn cachedis(&self) -> CACHEDIS_R {
+        CACHEDIS_R::new(((self.bits >> 18) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 1:4 - NVM Read Wait States"]
+    #[inline(always)]
+    pub fn rws(&mut self) -> RWS_W {
+        RWS_W { w: self }
+    }
+    #[doc = "Bit 7 - Manual Write"]
+    #[inline(always)]
+    pub fn manw(&mut self) -> MANW_W {
+        MANW_W { w: self }
+    }
+    #[doc = "Bits 8:9 - Power Reduction Mode during Sleep"]
+    #[inline(always)]
+    pub fn sleepprm(&mut self) -> SLEEPPRM_W {
+        SLEEPPRM_W { w: self }
+    }
+    #[doc = "Bits 16:17 - NVMCTRL Read Mode"]
+    #[inline(always)]
+    pub fn readmode(&mut self) -> READMODE_W {
+        READMODE_W { w: self }
+    }
+    #[doc = "Bit 18 - Cache Disable"]
+    #[inline(always)]
+    pub fn cachedis(&mut self) -> CACHEDIS_W {
+        CACHEDIS_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/nvmctrl/intenclr.rs
+++ b/pac/atsamd11c14a/src/nvmctrl/intenclr.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `READY`"]
+pub type READY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `READY`"]
+pub struct READY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> READY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERROR`"]
+pub type ERROR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERROR`"]
+pub struct ERROR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERROR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - NVM Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn ready(&self) -> READY_R {
+        READY_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn error(&self) -> ERROR_R {
+        ERROR_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - NVM Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn ready(&mut self) -> READY_W {
+        READY_W { w: self }
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn error(&mut self) -> ERROR_W {
+        ERROR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/nvmctrl/intenset.rs
+++ b/pac/atsamd11c14a/src/nvmctrl/intenset.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `READY`"]
+pub type READY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `READY`"]
+pub struct READY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> READY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERROR`"]
+pub type ERROR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERROR`"]
+pub struct ERROR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERROR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - NVM Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn ready(&self) -> READY_R {
+        READY_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn error(&self) -> ERROR_R {
+        ERROR_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - NVM Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn ready(&mut self) -> READY_W {
+        READY_W { w: self }
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn error(&mut self) -> ERROR_W {
+        ERROR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/nvmctrl/intflag.rs
+++ b/pac/atsamd11c14a/src/nvmctrl/intflag.rs
@@ -1,0 +1,57 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `READY`"]
+pub type READY_R = crate::R<bool, bool>;
+#[doc = "Reader of field `ERROR`"]
+pub type ERROR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERROR`"]
+pub struct ERROR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERROR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - NVM Ready"]
+    #[inline(always)]
+    pub fn ready(&self) -> READY_R {
+        READY_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Error"]
+    #[inline(always)]
+    pub fn error(&self) -> ERROR_R {
+        ERROR_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 1 - Error"]
+    #[inline(always)]
+    pub fn error(&mut self) -> ERROR_W {
+        ERROR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/nvmctrl/lock.rs
+++ b/pac/atsamd11c14a/src/nvmctrl/lock.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register LOCK"]
+pub type R = crate::R<u16, super::LOCK>;
+#[doc = "Reader of field `LOCK`"]
+pub type LOCK_R = crate::R<u16, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Region Lock Bits"]
+    #[inline(always)]
+    pub fn lock(&self) -> LOCK_R {
+        LOCK_R::new((self.bits & 0xffff) as u16)
+    }
+}

--- a/pac/atsamd11c14a/src/nvmctrl/param.rs
+++ b/pac/atsamd11c14a/src/nvmctrl/param.rs
@@ -1,0 +1,110 @@
+#[doc = "Reader of register PARAM"]
+pub type R = crate::R<u32, super::PARAM>;
+#[doc = "Reader of field `NVMP`"]
+pub type NVMP_R = crate::R<u16, u16>;
+#[doc = "Page Size\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PSZ_A {
+    #[doc = "0: 8 bytes"]
+    _8,
+    #[doc = "1: 16 bytes"]
+    _16,
+    #[doc = "2: 32 bytes"]
+    _32,
+    #[doc = "3: 64 bytes"]
+    _64,
+    #[doc = "4: 128 bytes"]
+    _128,
+    #[doc = "5: 256 bytes"]
+    _256,
+    #[doc = "6: 512 bytes"]
+    _512,
+    #[doc = "7: 1024 bytes"]
+    _1024,
+}
+impl From<PSZ_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PSZ_A) -> Self {
+        match variant {
+            PSZ_A::_8 => 0,
+            PSZ_A::_16 => 1,
+            PSZ_A::_32 => 2,
+            PSZ_A::_64 => 3,
+            PSZ_A::_128 => 4,
+            PSZ_A::_256 => 5,
+            PSZ_A::_512 => 6,
+            PSZ_A::_1024 => 7,
+        }
+    }
+}
+#[doc = "Reader of field `PSZ`"]
+pub type PSZ_R = crate::R<u8, PSZ_A>;
+impl PSZ_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> PSZ_A {
+        match self.bits {
+            0 => PSZ_A::_8,
+            1 => PSZ_A::_16,
+            2 => PSZ_A::_32,
+            3 => PSZ_A::_64,
+            4 => PSZ_A::_128,
+            5 => PSZ_A::_256,
+            6 => PSZ_A::_512,
+            7 => PSZ_A::_1024,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `_8`"]
+    #[inline(always)]
+    pub fn is_8(&self) -> bool {
+        *self == PSZ_A::_8
+    }
+    #[doc = "Checks if the value of the field is `_16`"]
+    #[inline(always)]
+    pub fn is_16(&self) -> bool {
+        *self == PSZ_A::_16
+    }
+    #[doc = "Checks if the value of the field is `_32`"]
+    #[inline(always)]
+    pub fn is_32(&self) -> bool {
+        *self == PSZ_A::_32
+    }
+    #[doc = "Checks if the value of the field is `_64`"]
+    #[inline(always)]
+    pub fn is_64(&self) -> bool {
+        *self == PSZ_A::_64
+    }
+    #[doc = "Checks if the value of the field is `_128`"]
+    #[inline(always)]
+    pub fn is_128(&self) -> bool {
+        *self == PSZ_A::_128
+    }
+    #[doc = "Checks if the value of the field is `_256`"]
+    #[inline(always)]
+    pub fn is_256(&self) -> bool {
+        *self == PSZ_A::_256
+    }
+    #[doc = "Checks if the value of the field is `_512`"]
+    #[inline(always)]
+    pub fn is_512(&self) -> bool {
+        *self == PSZ_A::_512
+    }
+    #[doc = "Checks if the value of the field is `_1024`"]
+    #[inline(always)]
+    pub fn is_1024(&self) -> bool {
+        *self == PSZ_A::_1024
+    }
+}
+impl R {
+    #[doc = "Bits 0:15 - NVM Pages"]
+    #[inline(always)]
+    pub fn nvmp(&self) -> NVMP_R {
+        NVMP_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bits 16:18 - Page Size"]
+    #[inline(always)]
+    pub fn psz(&self) -> PSZ_R {
+        PSZ_R::new(((self.bits >> 16) & 0x07) as u8)
+    }
+}

--- a/pac/atsamd11c14a/src/nvmctrl/status.rs
+++ b/pac/atsamd11c14a/src/nvmctrl/status.rs
@@ -1,0 +1,166 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u16, super::STATUS>;
+#[doc = "Writer for register STATUS"]
+pub type W = crate::W<u16, super::STATUS>;
+#[doc = "Register STATUS `reset()`'s with value 0"]
+impl crate::ResetValue for super::STATUS {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `PRM`"]
+pub type PRM_R = crate::R<bool, bool>;
+#[doc = "Reader of field `LOAD`"]
+pub type LOAD_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LOAD`"]
+pub struct LOAD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LOAD_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `PROGE`"]
+pub type PROGE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PROGE`"]
+pub struct PROGE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PROGE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `LOCKE`"]
+pub type LOCKE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LOCKE`"]
+pub struct LOCKE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LOCKE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u16) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `NVME`"]
+pub type NVME_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NVME`"]
+pub struct NVME_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NVME_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `SB`"]
+pub type SB_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Power Reduction Mode"]
+    #[inline(always)]
+    pub fn prm(&self) -> PRM_R {
+        PRM_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - NVM Page Buffer Active Loading"]
+    #[inline(always)]
+    pub fn load(&self) -> LOAD_R {
+        LOAD_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Programming Error Status"]
+    #[inline(always)]
+    pub fn proge(&self) -> PROGE_R {
+        PROGE_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Lock Error Status"]
+    #[inline(always)]
+    pub fn locke(&self) -> LOCKE_R {
+        LOCKE_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - NVM Error"]
+    #[inline(always)]
+    pub fn nvme(&self) -> NVME_R {
+        NVME_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Security Bit Status"]
+    #[inline(always)]
+    pub fn sb(&self) -> SB_R {
+        SB_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 1 - NVM Page Buffer Active Loading"]
+    #[inline(always)]
+    pub fn load(&mut self) -> LOAD_W {
+        LOAD_W { w: self }
+    }
+    #[doc = "Bit 2 - Programming Error Status"]
+    #[inline(always)]
+    pub fn proge(&mut self) -> PROGE_W {
+        PROGE_W { w: self }
+    }
+    #[doc = "Bit 3 - Lock Error Status"]
+    #[inline(always)]
+    pub fn locke(&mut self) -> LOCKE_W {
+        LOCKE_W { w: self }
+    }
+    #[doc = "Bit 4 - NVM Error"]
+    #[inline(always)]
+    pub fn nvme(&mut self) -> NVME_W {
+        NVME_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pac0.rs
+++ b/pac/atsamd11c14a/src/pac0.rs
@@ -1,0 +1,30 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Write Protection Clear"]
+    pub wpclr: WPCLR,
+    #[doc = "0x04 - Write Protection Set"]
+    pub wpset: WPSET,
+}
+#[doc = "Write Protection Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [wpclr](wpclr) module"]
+pub type WPCLR = crate::Reg<u32, _WPCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WPCLR;
+#[doc = "`read()` method returns [wpclr::R](wpclr::R) reader structure"]
+impl crate::Readable for WPCLR {}
+#[doc = "`write(|w| ..)` method takes [wpclr::W](wpclr::W) writer structure"]
+impl crate::Writable for WPCLR {}
+#[doc = "Write Protection Clear"]
+pub mod wpclr;
+#[doc = "Write Protection Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [wpset](wpset) module"]
+pub type WPSET = crate::Reg<u32, _WPSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WPSET;
+#[doc = "`read()` method returns [wpset::R](wpset::R) reader structure"]
+impl crate::Readable for WPSET {}
+#[doc = "`write(|w| ..)` method takes [wpset::W](wpset::W) writer structure"]
+impl crate::Writable for WPSET {}
+#[doc = "Write Protection Set"]
+pub mod wpset;

--- a/pac/atsamd11c14a/src/pac0/wpclr.rs
+++ b/pac/atsamd11c14a/src/pac0/wpclr.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register WPCLR"]
+pub type R = crate::R<u32, super::WPCLR>;
+#[doc = "Writer for register WPCLR"]
+pub type W = crate::W<u32, super::WPCLR>;
+#[doc = "Register WPCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::WPCLR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `WP`"]
+pub type WP_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `WP`"]
+pub struct WP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WP_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x7fff_ffff << 1)) | (((value as u32) & 0x7fff_ffff) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 1:31 - Write Protection Clear"]
+    #[inline(always)]
+    pub fn wp(&self) -> WP_R {
+        WP_R::new(((self.bits >> 1) & 0x7fff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 1:31 - Write Protection Clear"]
+    #[inline(always)]
+    pub fn wp(&mut self) -> WP_W {
+        WP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pac0/wpset.rs
+++ b/pac/atsamd11c14a/src/pac0/wpset.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register WPSET"]
+pub type R = crate::R<u32, super::WPSET>;
+#[doc = "Writer for register WPSET"]
+pub type W = crate::W<u32, super::WPSET>;
+#[doc = "Register WPSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::WPSET {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `WP`"]
+pub type WP_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `WP`"]
+pub struct WP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WP_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x7fff_ffff << 1)) | (((value as u32) & 0x7fff_ffff) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 1:31 - Write Protection Set"]
+    #[inline(always)]
+    pub fn wp(&self) -> WP_R {
+        WP_R::new(((self.bits >> 1) & 0x7fff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 1:31 - Write Protection Set"]
+    #[inline(always)]
+    pub fn wp(&mut self) -> WP_W {
+        WP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pm.rs
+++ b/pac/atsamd11c14a/src/pm.rs
@@ -1,0 +1,201 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Control"]
+    pub ctrl: CTRL,
+    #[doc = "0x01 - Sleep Mode"]
+    pub sleep: SLEEP,
+    #[doc = "0x02 - External Reset Controller"]
+    pub extctrl: EXTCTRL,
+    _reserved3: [u8; 5usize],
+    #[doc = "0x08 - CPU Clock Select"]
+    pub cpusel: CPUSEL,
+    #[doc = "0x09 - APBA Clock Select"]
+    pub apbasel: APBASEL,
+    #[doc = "0x0a - APBB Clock Select"]
+    pub apbbsel: APBBSEL,
+    #[doc = "0x0b - APBC Clock Select"]
+    pub apbcsel: APBCSEL,
+    _reserved7: [u8; 8usize],
+    #[doc = "0x14 - AHB Mask"]
+    pub ahbmask: AHBMASK,
+    #[doc = "0x18 - APBA Mask"]
+    pub apbamask: APBAMASK,
+    #[doc = "0x1c - APBB Mask"]
+    pub apbbmask: APBBMASK,
+    #[doc = "0x20 - APBC Mask"]
+    pub apbcmask: APBCMASK,
+    _reserved11: [u8; 16usize],
+    #[doc = "0x34 - Interrupt Enable Clear"]
+    pub intenclr: INTENCLR,
+    #[doc = "0x35 - Interrupt Enable Set"]
+    pub intenset: INTENSET,
+    #[doc = "0x36 - Interrupt Flag Status and Clear"]
+    pub intflag: INTFLAG,
+    _reserved14: [u8; 1usize],
+    #[doc = "0x38 - Reset Cause"]
+    pub rcause: RCAUSE,
+}
+#[doc = "Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrl](ctrl) module"]
+pub type CTRL = crate::Reg<u8, _CTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRL;
+#[doc = "`read()` method returns [ctrl::R](ctrl::R) reader structure"]
+impl crate::Readable for CTRL {}
+#[doc = "`write(|w| ..)` method takes [ctrl::W](ctrl::W) writer structure"]
+impl crate::Writable for CTRL {}
+#[doc = "Control"]
+pub mod ctrl;
+#[doc = "Sleep Mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [sleep](sleep) module"]
+pub type SLEEP = crate::Reg<u8, _SLEEP>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _SLEEP;
+#[doc = "`read()` method returns [sleep::R](sleep::R) reader structure"]
+impl crate::Readable for SLEEP {}
+#[doc = "`write(|w| ..)` method takes [sleep::W](sleep::W) writer structure"]
+impl crate::Writable for SLEEP {}
+#[doc = "Sleep Mode"]
+pub mod sleep;
+#[doc = "External Reset Controller\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [extctrl](extctrl) module"]
+pub type EXTCTRL = crate::Reg<u8, _EXTCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EXTCTRL;
+#[doc = "`read()` method returns [extctrl::R](extctrl::R) reader structure"]
+impl crate::Readable for EXTCTRL {}
+#[doc = "`write(|w| ..)` method takes [extctrl::W](extctrl::W) writer structure"]
+impl crate::Writable for EXTCTRL {}
+#[doc = "External Reset Controller"]
+pub mod extctrl;
+#[doc = "CPU Clock Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cpusel](cpusel) module"]
+pub type CPUSEL = crate::Reg<u8, _CPUSEL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CPUSEL;
+#[doc = "`read()` method returns [cpusel::R](cpusel::R) reader structure"]
+impl crate::Readable for CPUSEL {}
+#[doc = "`write(|w| ..)` method takes [cpusel::W](cpusel::W) writer structure"]
+impl crate::Writable for CPUSEL {}
+#[doc = "CPU Clock Select"]
+pub mod cpusel;
+#[doc = "APBA Clock Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [apbasel](apbasel) module"]
+pub type APBASEL = crate::Reg<u8, _APBASEL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _APBASEL;
+#[doc = "`read()` method returns [apbasel::R](apbasel::R) reader structure"]
+impl crate::Readable for APBASEL {}
+#[doc = "`write(|w| ..)` method takes [apbasel::W](apbasel::W) writer structure"]
+impl crate::Writable for APBASEL {}
+#[doc = "APBA Clock Select"]
+pub mod apbasel;
+#[doc = "APBB Clock Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [apbbsel](apbbsel) module"]
+pub type APBBSEL = crate::Reg<u8, _APBBSEL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _APBBSEL;
+#[doc = "`read()` method returns [apbbsel::R](apbbsel::R) reader structure"]
+impl crate::Readable for APBBSEL {}
+#[doc = "`write(|w| ..)` method takes [apbbsel::W](apbbsel::W) writer structure"]
+impl crate::Writable for APBBSEL {}
+#[doc = "APBB Clock Select"]
+pub mod apbbsel;
+#[doc = "APBC Clock Select\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [apbcsel](apbcsel) module"]
+pub type APBCSEL = crate::Reg<u8, _APBCSEL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _APBCSEL;
+#[doc = "`read()` method returns [apbcsel::R](apbcsel::R) reader structure"]
+impl crate::Readable for APBCSEL {}
+#[doc = "`write(|w| ..)` method takes [apbcsel::W](apbcsel::W) writer structure"]
+impl crate::Writable for APBCSEL {}
+#[doc = "APBC Clock Select"]
+pub mod apbcsel;
+#[doc = "AHB Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ahbmask](ahbmask) module"]
+pub type AHBMASK = crate::Reg<u32, _AHBMASK>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _AHBMASK;
+#[doc = "`read()` method returns [ahbmask::R](ahbmask::R) reader structure"]
+impl crate::Readable for AHBMASK {}
+#[doc = "`write(|w| ..)` method takes [ahbmask::W](ahbmask::W) writer structure"]
+impl crate::Writable for AHBMASK {}
+#[doc = "AHB Mask"]
+pub mod ahbmask;
+#[doc = "APBA Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [apbamask](apbamask) module"]
+pub type APBAMASK = crate::Reg<u32, _APBAMASK>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _APBAMASK;
+#[doc = "`read()` method returns [apbamask::R](apbamask::R) reader structure"]
+impl crate::Readable for APBAMASK {}
+#[doc = "`write(|w| ..)` method takes [apbamask::W](apbamask::W) writer structure"]
+impl crate::Writable for APBAMASK {}
+#[doc = "APBA Mask"]
+pub mod apbamask;
+#[doc = "APBB Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [apbbmask](apbbmask) module"]
+pub type APBBMASK = crate::Reg<u32, _APBBMASK>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _APBBMASK;
+#[doc = "`read()` method returns [apbbmask::R](apbbmask::R) reader structure"]
+impl crate::Readable for APBBMASK {}
+#[doc = "`write(|w| ..)` method takes [apbbmask::W](apbbmask::W) writer structure"]
+impl crate::Writable for APBBMASK {}
+#[doc = "APBB Mask"]
+pub mod apbbmask;
+#[doc = "APBC Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [apbcmask](apbcmask) module"]
+pub type APBCMASK = crate::Reg<u32, _APBCMASK>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _APBCMASK;
+#[doc = "`read()` method returns [apbcmask::R](apbcmask::R) reader structure"]
+impl crate::Readable for APBCMASK {}
+#[doc = "`write(|w| ..)` method takes [apbcmask::W](apbcmask::W) writer structure"]
+impl crate::Writable for APBCMASK {}
+#[doc = "APBC Mask"]
+pub mod apbcmask;
+#[doc = "Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Reset Cause\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rcause](rcause) module"]
+pub type RCAUSE = crate::Reg<u8, _RCAUSE>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _RCAUSE;
+#[doc = "`read()` method returns [rcause::R](rcause::R) reader structure"]
+impl crate::Readable for RCAUSE {}
+#[doc = "Reset Cause"]
+pub mod rcause;

--- a/pac/atsamd11c14a/src/pm/ahbmask.rs
+++ b/pac/atsamd11c14a/src/pm/ahbmask.rs
@@ -1,0 +1,254 @@
+#[doc = "Reader of register AHBMASK"]
+pub type R = crate::R<u32, super::AHBMASK>;
+#[doc = "Writer for register AHBMASK"]
+pub type W = crate::W<u32, super::AHBMASK>;
+#[doc = "Register AHBMASK `reset()`'s with value 0x7f"]
+impl crate::ResetValue for super::AHBMASK {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x7f
+    }
+}
+#[doc = "Reader of field `HPB0_`"]
+pub type HPB0__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `HPB0_`"]
+pub struct HPB0__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HPB0__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `HPB1_`"]
+pub type HPB1__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `HPB1_`"]
+pub struct HPB1__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HPB1__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `HPB2_`"]
+pub type HPB2__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `HPB2_`"]
+pub struct HPB2__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HPB2__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `DSU_`"]
+pub type DSU__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DSU_`"]
+pub struct DSU__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DSU__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `NVMCTRL_`"]
+pub type NVMCTRL__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NVMCTRL_`"]
+pub struct NVMCTRL__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NVMCTRL__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `DMAC_`"]
+pub type DMAC__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DMAC_`"]
+pub struct DMAC__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DMAC__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `USB_`"]
+pub type USB__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `USB_`"]
+pub struct USB__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> USB__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - HPB0 AHB Clock Mask"]
+    #[inline(always)]
+    pub fn hpb0_(&self) -> HPB0__R {
+        HPB0__R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - HPB1 AHB Clock Mask"]
+    #[inline(always)]
+    pub fn hpb1_(&self) -> HPB1__R {
+        HPB1__R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - HPB2 AHB Clock Mask"]
+    #[inline(always)]
+    pub fn hpb2_(&self) -> HPB2__R {
+        HPB2__R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - DSU AHB Clock Mask"]
+    #[inline(always)]
+    pub fn dsu_(&self) -> DSU__R {
+        DSU__R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - NVMCTRL AHB Clock Mask"]
+    #[inline(always)]
+    pub fn nvmctrl_(&self) -> NVMCTRL__R {
+        NVMCTRL__R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - DMAC AHB Clock Mask"]
+    #[inline(always)]
+    pub fn dmac_(&self) -> DMAC__R {
+        DMAC__R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - USB AHB Clock Mask"]
+    #[inline(always)]
+    pub fn usb_(&self) -> USB__R {
+        USB__R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - HPB0 AHB Clock Mask"]
+    #[inline(always)]
+    pub fn hpb0_(&mut self) -> HPB0__W {
+        HPB0__W { w: self }
+    }
+    #[doc = "Bit 1 - HPB1 AHB Clock Mask"]
+    #[inline(always)]
+    pub fn hpb1_(&mut self) -> HPB1__W {
+        HPB1__W { w: self }
+    }
+    #[doc = "Bit 2 - HPB2 AHB Clock Mask"]
+    #[inline(always)]
+    pub fn hpb2_(&mut self) -> HPB2__W {
+        HPB2__W { w: self }
+    }
+    #[doc = "Bit 3 - DSU AHB Clock Mask"]
+    #[inline(always)]
+    pub fn dsu_(&mut self) -> DSU__W {
+        DSU__W { w: self }
+    }
+    #[doc = "Bit 4 - NVMCTRL AHB Clock Mask"]
+    #[inline(always)]
+    pub fn nvmctrl_(&mut self) -> NVMCTRL__W {
+        NVMCTRL__W { w: self }
+    }
+    #[doc = "Bit 5 - DMAC AHB Clock Mask"]
+    #[inline(always)]
+    pub fn dmac_(&mut self) -> DMAC__W {
+        DMAC__W { w: self }
+    }
+    #[doc = "Bit 6 - USB AHB Clock Mask"]
+    #[inline(always)]
+    pub fn usb_(&mut self) -> USB__W {
+        USB__W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pm/apbamask.rs
+++ b/pac/atsamd11c14a/src/pm/apbamask.rs
@@ -1,0 +1,254 @@
+#[doc = "Reader of register APBAMASK"]
+pub type R = crate::R<u32, super::APBAMASK>;
+#[doc = "Writer for register APBAMASK"]
+pub type W = crate::W<u32, super::APBAMASK>;
+#[doc = "Register APBAMASK `reset()`'s with value 0x7f"]
+impl crate::ResetValue for super::APBAMASK {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x7f
+    }
+}
+#[doc = "Reader of field `PAC0_`"]
+pub type PAC0__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PAC0_`"]
+pub struct PAC0__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PAC0__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `PM_`"]
+pub type PM__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PM_`"]
+pub struct PM__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PM__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYSCTRL_`"]
+pub type SYSCTRL__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYSCTRL_`"]
+pub struct SYSCTRL__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYSCTRL__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `GCLK_`"]
+pub type GCLK__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `GCLK_`"]
+pub struct GCLK__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> GCLK__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `WDT_`"]
+pub type WDT__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WDT_`"]
+pub struct WDT__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WDT__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `RTC_`"]
+pub type RTC__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RTC_`"]
+pub struct RTC__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RTC__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `EIC_`"]
+pub type EIC__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EIC_`"]
+pub struct EIC__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EIC__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - PAC0 APB Clock Enable"]
+    #[inline(always)]
+    pub fn pac0_(&self) -> PAC0__R {
+        PAC0__R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - PM APB Clock Enable"]
+    #[inline(always)]
+    pub fn pm_(&self) -> PM__R {
+        PM__R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - SYSCTRL APB Clock Enable"]
+    #[inline(always)]
+    pub fn sysctrl_(&self) -> SYSCTRL__R {
+        SYSCTRL__R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - GCLK APB Clock Enable"]
+    #[inline(always)]
+    pub fn gclk_(&self) -> GCLK__R {
+        GCLK__R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - WDT APB Clock Enable"]
+    #[inline(always)]
+    pub fn wdt_(&self) -> WDT__R {
+        WDT__R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - RTC APB Clock Enable"]
+    #[inline(always)]
+    pub fn rtc_(&self) -> RTC__R {
+        RTC__R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - EIC APB Clock Enable"]
+    #[inline(always)]
+    pub fn eic_(&self) -> EIC__R {
+        EIC__R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - PAC0 APB Clock Enable"]
+    #[inline(always)]
+    pub fn pac0_(&mut self) -> PAC0__W {
+        PAC0__W { w: self }
+    }
+    #[doc = "Bit 1 - PM APB Clock Enable"]
+    #[inline(always)]
+    pub fn pm_(&mut self) -> PM__W {
+        PM__W { w: self }
+    }
+    #[doc = "Bit 2 - SYSCTRL APB Clock Enable"]
+    #[inline(always)]
+    pub fn sysctrl_(&mut self) -> SYSCTRL__W {
+        SYSCTRL__W { w: self }
+    }
+    #[doc = "Bit 3 - GCLK APB Clock Enable"]
+    #[inline(always)]
+    pub fn gclk_(&mut self) -> GCLK__W {
+        GCLK__W { w: self }
+    }
+    #[doc = "Bit 4 - WDT APB Clock Enable"]
+    #[inline(always)]
+    pub fn wdt_(&mut self) -> WDT__W {
+        WDT__W { w: self }
+    }
+    #[doc = "Bit 5 - RTC APB Clock Enable"]
+    #[inline(always)]
+    pub fn rtc_(&mut self) -> RTC__W {
+        RTC__W { w: self }
+    }
+    #[doc = "Bit 6 - EIC APB Clock Enable"]
+    #[inline(always)]
+    pub fn eic_(&mut self) -> EIC__W {
+        EIC__W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pm/apbasel.rs
+++ b/pac/atsamd11c14a/src/pm/apbasel.rs
@@ -1,0 +1,179 @@
+#[doc = "Reader of register APBASEL"]
+pub type R = crate::R<u8, super::APBASEL>;
+#[doc = "Writer for register APBASEL"]
+pub type W = crate::W<u8, super::APBASEL>;
+#[doc = "Register APBASEL `reset()`'s with value 0"]
+impl crate::ResetValue for super::APBASEL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "APBA Prescaler Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum APBADIV_A {
+    #[doc = "0: Divide by 1"]
+    DIV1,
+    #[doc = "1: Divide by 2"]
+    DIV2,
+    #[doc = "2: Divide by 4"]
+    DIV4,
+    #[doc = "3: Divide by 8"]
+    DIV8,
+    #[doc = "4: Divide by 16"]
+    DIV16,
+    #[doc = "5: Divide by 32"]
+    DIV32,
+    #[doc = "6: Divide by 64"]
+    DIV64,
+    #[doc = "7: Divide by 128"]
+    DIV128,
+}
+impl From<APBADIV_A> for u8 {
+    #[inline(always)]
+    fn from(variant: APBADIV_A) -> Self {
+        match variant {
+            APBADIV_A::DIV1 => 0,
+            APBADIV_A::DIV2 => 1,
+            APBADIV_A::DIV4 => 2,
+            APBADIV_A::DIV8 => 3,
+            APBADIV_A::DIV16 => 4,
+            APBADIV_A::DIV32 => 5,
+            APBADIV_A::DIV64 => 6,
+            APBADIV_A::DIV128 => 7,
+        }
+    }
+}
+#[doc = "Reader of field `APBADIV`"]
+pub type APBADIV_R = crate::R<u8, APBADIV_A>;
+impl APBADIV_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> APBADIV_A {
+        match self.bits {
+            0 => APBADIV_A::DIV1,
+            1 => APBADIV_A::DIV2,
+            2 => APBADIV_A::DIV4,
+            3 => APBADIV_A::DIV8,
+            4 => APBADIV_A::DIV16,
+            5 => APBADIV_A::DIV32,
+            6 => APBADIV_A::DIV64,
+            7 => APBADIV_A::DIV128,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DIV1`"]
+    #[inline(always)]
+    pub fn is_div1(&self) -> bool {
+        *self == APBADIV_A::DIV1
+    }
+    #[doc = "Checks if the value of the field is `DIV2`"]
+    #[inline(always)]
+    pub fn is_div2(&self) -> bool {
+        *self == APBADIV_A::DIV2
+    }
+    #[doc = "Checks if the value of the field is `DIV4`"]
+    #[inline(always)]
+    pub fn is_div4(&self) -> bool {
+        *self == APBADIV_A::DIV4
+    }
+    #[doc = "Checks if the value of the field is `DIV8`"]
+    #[inline(always)]
+    pub fn is_div8(&self) -> bool {
+        *self == APBADIV_A::DIV8
+    }
+    #[doc = "Checks if the value of the field is `DIV16`"]
+    #[inline(always)]
+    pub fn is_div16(&self) -> bool {
+        *self == APBADIV_A::DIV16
+    }
+    #[doc = "Checks if the value of the field is `DIV32`"]
+    #[inline(always)]
+    pub fn is_div32(&self) -> bool {
+        *self == APBADIV_A::DIV32
+    }
+    #[doc = "Checks if the value of the field is `DIV64`"]
+    #[inline(always)]
+    pub fn is_div64(&self) -> bool {
+        *self == APBADIV_A::DIV64
+    }
+    #[doc = "Checks if the value of the field is `DIV128`"]
+    #[inline(always)]
+    pub fn is_div128(&self) -> bool {
+        *self == APBADIV_A::DIV128
+    }
+}
+#[doc = "Write proxy for field `APBADIV`"]
+pub struct APBADIV_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> APBADIV_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: APBADIV_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Divide by 1"]
+    #[inline(always)]
+    pub fn div1(self) -> &'a mut W {
+        self.variant(APBADIV_A::DIV1)
+    }
+    #[doc = "Divide by 2"]
+    #[inline(always)]
+    pub fn div2(self) -> &'a mut W {
+        self.variant(APBADIV_A::DIV2)
+    }
+    #[doc = "Divide by 4"]
+    #[inline(always)]
+    pub fn div4(self) -> &'a mut W {
+        self.variant(APBADIV_A::DIV4)
+    }
+    #[doc = "Divide by 8"]
+    #[inline(always)]
+    pub fn div8(self) -> &'a mut W {
+        self.variant(APBADIV_A::DIV8)
+    }
+    #[doc = "Divide by 16"]
+    #[inline(always)]
+    pub fn div16(self) -> &'a mut W {
+        self.variant(APBADIV_A::DIV16)
+    }
+    #[doc = "Divide by 32"]
+    #[inline(always)]
+    pub fn div32(self) -> &'a mut W {
+        self.variant(APBADIV_A::DIV32)
+    }
+    #[doc = "Divide by 64"]
+    #[inline(always)]
+    pub fn div64(self) -> &'a mut W {
+        self.variant(APBADIV_A::DIV64)
+    }
+    #[doc = "Divide by 128"]
+    #[inline(always)]
+    pub fn div128(self) -> &'a mut W {
+        self.variant(APBADIV_A::DIV128)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u8) & 0x07);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - APBA Prescaler Selection"]
+    #[inline(always)]
+    pub fn apbadiv(&self) -> APBADIV_R {
+        APBADIV_R::new((self.bits & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - APBA Prescaler Selection"]
+    #[inline(always)]
+    pub fn apbadiv(&mut self) -> APBADIV_W {
+        APBADIV_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pm/apbbmask.rs
+++ b/pac/atsamd11c14a/src/pm/apbbmask.rs
@@ -1,0 +1,254 @@
+#[doc = "Reader of register APBBMASK"]
+pub type R = crate::R<u32, super::APBBMASK>;
+#[doc = "Writer for register APBBMASK"]
+pub type W = crate::W<u32, super::APBBMASK>;
+#[doc = "Register APBBMASK `reset()`'s with value 0x7f"]
+impl crate::ResetValue for super::APBBMASK {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x7f
+    }
+}
+#[doc = "Reader of field `PAC1_`"]
+pub type PAC1__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PAC1_`"]
+pub struct PAC1__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PAC1__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `DSU_`"]
+pub type DSU__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DSU_`"]
+pub struct DSU__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DSU__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `NVMCTRL_`"]
+pub type NVMCTRL__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NVMCTRL_`"]
+pub struct NVMCTRL__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NVMCTRL__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `PORT_`"]
+pub type PORT__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PORT_`"]
+pub struct PORT__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PORT__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `DMAC_`"]
+pub type DMAC__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DMAC_`"]
+pub struct DMAC__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DMAC__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `USB_`"]
+pub type USB__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `USB_`"]
+pub struct USB__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> USB__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `HMATRIX_`"]
+pub type HMATRIX__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `HMATRIX_`"]
+pub struct HMATRIX__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HMATRIX__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - PAC1 APB Clock Enable"]
+    #[inline(always)]
+    pub fn pac1_(&self) -> PAC1__R {
+        PAC1__R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - DSU APB Clock Enable"]
+    #[inline(always)]
+    pub fn dsu_(&self) -> DSU__R {
+        DSU__R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - NVMCTRL APB Clock Enable"]
+    #[inline(always)]
+    pub fn nvmctrl_(&self) -> NVMCTRL__R {
+        NVMCTRL__R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - PORT APB Clock Enable"]
+    #[inline(always)]
+    pub fn port_(&self) -> PORT__R {
+        PORT__R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - DMAC APB Clock Enable"]
+    #[inline(always)]
+    pub fn dmac_(&self) -> DMAC__R {
+        DMAC__R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - USB APB Clock Enable"]
+    #[inline(always)]
+    pub fn usb_(&self) -> USB__R {
+        USB__R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - HMATRIX APB Clock Enable"]
+    #[inline(always)]
+    pub fn hmatrix_(&self) -> HMATRIX__R {
+        HMATRIX__R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - PAC1 APB Clock Enable"]
+    #[inline(always)]
+    pub fn pac1_(&mut self) -> PAC1__W {
+        PAC1__W { w: self }
+    }
+    #[doc = "Bit 1 - DSU APB Clock Enable"]
+    #[inline(always)]
+    pub fn dsu_(&mut self) -> DSU__W {
+        DSU__W { w: self }
+    }
+    #[doc = "Bit 2 - NVMCTRL APB Clock Enable"]
+    #[inline(always)]
+    pub fn nvmctrl_(&mut self) -> NVMCTRL__W {
+        NVMCTRL__W { w: self }
+    }
+    #[doc = "Bit 3 - PORT APB Clock Enable"]
+    #[inline(always)]
+    pub fn port_(&mut self) -> PORT__W {
+        PORT__W { w: self }
+    }
+    #[doc = "Bit 4 - DMAC APB Clock Enable"]
+    #[inline(always)]
+    pub fn dmac_(&mut self) -> DMAC__W {
+        DMAC__W { w: self }
+    }
+    #[doc = "Bit 5 - USB APB Clock Enable"]
+    #[inline(always)]
+    pub fn usb_(&mut self) -> USB__W {
+        USB__W { w: self }
+    }
+    #[doc = "Bit 6 - HMATRIX APB Clock Enable"]
+    #[inline(always)]
+    pub fn hmatrix_(&mut self) -> HMATRIX__W {
+        HMATRIX__W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pm/apbbsel.rs
+++ b/pac/atsamd11c14a/src/pm/apbbsel.rs
@@ -1,0 +1,179 @@
+#[doc = "Reader of register APBBSEL"]
+pub type R = crate::R<u8, super::APBBSEL>;
+#[doc = "Writer for register APBBSEL"]
+pub type W = crate::W<u8, super::APBBSEL>;
+#[doc = "Register APBBSEL `reset()`'s with value 0"]
+impl crate::ResetValue for super::APBBSEL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "APBB Prescaler Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum APBBDIV_A {
+    #[doc = "0: Divide by 1"]
+    DIV1,
+    #[doc = "1: Divide by 2"]
+    DIV2,
+    #[doc = "2: Divide by 4"]
+    DIV4,
+    #[doc = "3: Divide by 8"]
+    DIV8,
+    #[doc = "4: Divide by 16"]
+    DIV16,
+    #[doc = "5: Divide by 32"]
+    DIV32,
+    #[doc = "6: Divide by 64"]
+    DIV64,
+    #[doc = "7: Divide by 128"]
+    DIV128,
+}
+impl From<APBBDIV_A> for u8 {
+    #[inline(always)]
+    fn from(variant: APBBDIV_A) -> Self {
+        match variant {
+            APBBDIV_A::DIV1 => 0,
+            APBBDIV_A::DIV2 => 1,
+            APBBDIV_A::DIV4 => 2,
+            APBBDIV_A::DIV8 => 3,
+            APBBDIV_A::DIV16 => 4,
+            APBBDIV_A::DIV32 => 5,
+            APBBDIV_A::DIV64 => 6,
+            APBBDIV_A::DIV128 => 7,
+        }
+    }
+}
+#[doc = "Reader of field `APBBDIV`"]
+pub type APBBDIV_R = crate::R<u8, APBBDIV_A>;
+impl APBBDIV_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> APBBDIV_A {
+        match self.bits {
+            0 => APBBDIV_A::DIV1,
+            1 => APBBDIV_A::DIV2,
+            2 => APBBDIV_A::DIV4,
+            3 => APBBDIV_A::DIV8,
+            4 => APBBDIV_A::DIV16,
+            5 => APBBDIV_A::DIV32,
+            6 => APBBDIV_A::DIV64,
+            7 => APBBDIV_A::DIV128,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DIV1`"]
+    #[inline(always)]
+    pub fn is_div1(&self) -> bool {
+        *self == APBBDIV_A::DIV1
+    }
+    #[doc = "Checks if the value of the field is `DIV2`"]
+    #[inline(always)]
+    pub fn is_div2(&self) -> bool {
+        *self == APBBDIV_A::DIV2
+    }
+    #[doc = "Checks if the value of the field is `DIV4`"]
+    #[inline(always)]
+    pub fn is_div4(&self) -> bool {
+        *self == APBBDIV_A::DIV4
+    }
+    #[doc = "Checks if the value of the field is `DIV8`"]
+    #[inline(always)]
+    pub fn is_div8(&self) -> bool {
+        *self == APBBDIV_A::DIV8
+    }
+    #[doc = "Checks if the value of the field is `DIV16`"]
+    #[inline(always)]
+    pub fn is_div16(&self) -> bool {
+        *self == APBBDIV_A::DIV16
+    }
+    #[doc = "Checks if the value of the field is `DIV32`"]
+    #[inline(always)]
+    pub fn is_div32(&self) -> bool {
+        *self == APBBDIV_A::DIV32
+    }
+    #[doc = "Checks if the value of the field is `DIV64`"]
+    #[inline(always)]
+    pub fn is_div64(&self) -> bool {
+        *self == APBBDIV_A::DIV64
+    }
+    #[doc = "Checks if the value of the field is `DIV128`"]
+    #[inline(always)]
+    pub fn is_div128(&self) -> bool {
+        *self == APBBDIV_A::DIV128
+    }
+}
+#[doc = "Write proxy for field `APBBDIV`"]
+pub struct APBBDIV_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> APBBDIV_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: APBBDIV_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Divide by 1"]
+    #[inline(always)]
+    pub fn div1(self) -> &'a mut W {
+        self.variant(APBBDIV_A::DIV1)
+    }
+    #[doc = "Divide by 2"]
+    #[inline(always)]
+    pub fn div2(self) -> &'a mut W {
+        self.variant(APBBDIV_A::DIV2)
+    }
+    #[doc = "Divide by 4"]
+    #[inline(always)]
+    pub fn div4(self) -> &'a mut W {
+        self.variant(APBBDIV_A::DIV4)
+    }
+    #[doc = "Divide by 8"]
+    #[inline(always)]
+    pub fn div8(self) -> &'a mut W {
+        self.variant(APBBDIV_A::DIV8)
+    }
+    #[doc = "Divide by 16"]
+    #[inline(always)]
+    pub fn div16(self) -> &'a mut W {
+        self.variant(APBBDIV_A::DIV16)
+    }
+    #[doc = "Divide by 32"]
+    #[inline(always)]
+    pub fn div32(self) -> &'a mut W {
+        self.variant(APBBDIV_A::DIV32)
+    }
+    #[doc = "Divide by 64"]
+    #[inline(always)]
+    pub fn div64(self) -> &'a mut W {
+        self.variant(APBBDIV_A::DIV64)
+    }
+    #[doc = "Divide by 128"]
+    #[inline(always)]
+    pub fn div128(self) -> &'a mut W {
+        self.variant(APBBDIV_A::DIV128)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u8) & 0x07);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - APBB Prescaler Selection"]
+    #[inline(always)]
+    pub fn apbbdiv(&self) -> APBBDIV_R {
+        APBBDIV_R::new((self.bits & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - APBB Prescaler Selection"]
+    #[inline(always)]
+    pub fn apbbdiv(&mut self) -> APBBDIV_W {
+        APBBDIV_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pm/apbcmask.rs
+++ b/pac/atsamd11c14a/src/pm/apbcmask.rs
@@ -1,0 +1,390 @@
+#[doc = "Reader of register APBCMASK"]
+pub type R = crate::R<u32, super::APBCMASK>;
+#[doc = "Writer for register APBCMASK"]
+pub type W = crate::W<u32, super::APBCMASK>;
+#[doc = "Register APBCMASK `reset()`'s with value 0x0100"]
+impl crate::ResetValue for super::APBCMASK {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x0100
+    }
+}
+#[doc = "Reader of field `PAC2_`"]
+pub type PAC2__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PAC2_`"]
+pub struct PAC2__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PAC2__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `EVSYS_`"]
+pub type EVSYS__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EVSYS_`"]
+pub struct EVSYS__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVSYS__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SERCOM0_`"]
+pub type SERCOM0__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SERCOM0_`"]
+pub struct SERCOM0__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SERCOM0__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `SERCOM1_`"]
+pub type SERCOM1__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SERCOM1_`"]
+pub struct SERCOM1__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SERCOM1__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `TCC0_`"]
+pub type TCC0__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TCC0_`"]
+pub struct TCC0__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TCC0__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `TC1_`"]
+pub type TC1__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TC1_`"]
+pub struct TC1__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TC1__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `TC2_`"]
+pub type TC2__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TC2_`"]
+pub struct TC2__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TC2__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `ADC_`"]
+pub type ADC__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ADC_`"]
+pub struct ADC__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ADC__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `AC_`"]
+pub type AC__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `AC_`"]
+pub struct AC__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> AC__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `DAC_`"]
+pub type DAC__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DAC_`"]
+pub struct DAC__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DAC__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u32) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `PTC_`"]
+pub type PTC__R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PTC_`"]
+pub struct PTC__W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PTC__W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - PAC2 APB Clock Enable"]
+    #[inline(always)]
+    pub fn pac2_(&self) -> PAC2__R {
+        PAC2__R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - EVSYS APB Clock Enable"]
+    #[inline(always)]
+    pub fn evsys_(&self) -> EVSYS__R {
+        EVSYS__R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - SERCOM0 APB Clock Enable"]
+    #[inline(always)]
+    pub fn sercom0_(&self) -> SERCOM0__R {
+        SERCOM0__R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - SERCOM1 APB Clock Enable"]
+    #[inline(always)]
+    pub fn sercom1_(&self) -> SERCOM1__R {
+        SERCOM1__R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - TCC0 APB Clock Enable"]
+    #[inline(always)]
+    pub fn tcc0_(&self) -> TCC0__R {
+        TCC0__R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - TC1 APB Clock Enable"]
+    #[inline(always)]
+    pub fn tc1_(&self) -> TC1__R {
+        TC1__R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - TC2 APB Clock Enable"]
+    #[inline(always)]
+    pub fn tc2_(&self) -> TC2__R {
+        TC2__R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - ADC APB Clock Enable"]
+    #[inline(always)]
+    pub fn adc_(&self) -> ADC__R {
+        ADC__R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - AC APB Clock Enable"]
+    #[inline(always)]
+    pub fn ac_(&self) -> AC__R {
+        AC__R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - DAC APB Clock Enable"]
+    #[inline(always)]
+    pub fn dac_(&self) -> DAC__R {
+        DAC__R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - PTC APB Clock Enable"]
+    #[inline(always)]
+    pub fn ptc_(&self) -> PTC__R {
+        PTC__R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - PAC2 APB Clock Enable"]
+    #[inline(always)]
+    pub fn pac2_(&mut self) -> PAC2__W {
+        PAC2__W { w: self }
+    }
+    #[doc = "Bit 1 - EVSYS APB Clock Enable"]
+    #[inline(always)]
+    pub fn evsys_(&mut self) -> EVSYS__W {
+        EVSYS__W { w: self }
+    }
+    #[doc = "Bit 2 - SERCOM0 APB Clock Enable"]
+    #[inline(always)]
+    pub fn sercom0_(&mut self) -> SERCOM0__W {
+        SERCOM0__W { w: self }
+    }
+    #[doc = "Bit 3 - SERCOM1 APB Clock Enable"]
+    #[inline(always)]
+    pub fn sercom1_(&mut self) -> SERCOM1__W {
+        SERCOM1__W { w: self }
+    }
+    #[doc = "Bit 5 - TCC0 APB Clock Enable"]
+    #[inline(always)]
+    pub fn tcc0_(&mut self) -> TCC0__W {
+        TCC0__W { w: self }
+    }
+    #[doc = "Bit 6 - TC1 APB Clock Enable"]
+    #[inline(always)]
+    pub fn tc1_(&mut self) -> TC1__W {
+        TC1__W { w: self }
+    }
+    #[doc = "Bit 7 - TC2 APB Clock Enable"]
+    #[inline(always)]
+    pub fn tc2_(&mut self) -> TC2__W {
+        TC2__W { w: self }
+    }
+    #[doc = "Bit 8 - ADC APB Clock Enable"]
+    #[inline(always)]
+    pub fn adc_(&mut self) -> ADC__W {
+        ADC__W { w: self }
+    }
+    #[doc = "Bit 9 - AC APB Clock Enable"]
+    #[inline(always)]
+    pub fn ac_(&mut self) -> AC__W {
+        AC__W { w: self }
+    }
+    #[doc = "Bit 10 - DAC APB Clock Enable"]
+    #[inline(always)]
+    pub fn dac_(&mut self) -> DAC__W {
+        DAC__W { w: self }
+    }
+    #[doc = "Bit 11 - PTC APB Clock Enable"]
+    #[inline(always)]
+    pub fn ptc_(&mut self) -> PTC__W {
+        PTC__W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pm/apbcsel.rs
+++ b/pac/atsamd11c14a/src/pm/apbcsel.rs
@@ -1,0 +1,179 @@
+#[doc = "Reader of register APBCSEL"]
+pub type R = crate::R<u8, super::APBCSEL>;
+#[doc = "Writer for register APBCSEL"]
+pub type W = crate::W<u8, super::APBCSEL>;
+#[doc = "Register APBCSEL `reset()`'s with value 0"]
+impl crate::ResetValue for super::APBCSEL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "APBC Prescaler Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum APBCDIV_A {
+    #[doc = "0: Divide by 1"]
+    DIV1,
+    #[doc = "1: Divide by 2"]
+    DIV2,
+    #[doc = "2: Divide by 4"]
+    DIV4,
+    #[doc = "3: Divide by 8"]
+    DIV8,
+    #[doc = "4: Divide by 16"]
+    DIV16,
+    #[doc = "5: Divide by 32"]
+    DIV32,
+    #[doc = "6: Divide by 64"]
+    DIV64,
+    #[doc = "7: Divide by 128"]
+    DIV128,
+}
+impl From<APBCDIV_A> for u8 {
+    #[inline(always)]
+    fn from(variant: APBCDIV_A) -> Self {
+        match variant {
+            APBCDIV_A::DIV1 => 0,
+            APBCDIV_A::DIV2 => 1,
+            APBCDIV_A::DIV4 => 2,
+            APBCDIV_A::DIV8 => 3,
+            APBCDIV_A::DIV16 => 4,
+            APBCDIV_A::DIV32 => 5,
+            APBCDIV_A::DIV64 => 6,
+            APBCDIV_A::DIV128 => 7,
+        }
+    }
+}
+#[doc = "Reader of field `APBCDIV`"]
+pub type APBCDIV_R = crate::R<u8, APBCDIV_A>;
+impl APBCDIV_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> APBCDIV_A {
+        match self.bits {
+            0 => APBCDIV_A::DIV1,
+            1 => APBCDIV_A::DIV2,
+            2 => APBCDIV_A::DIV4,
+            3 => APBCDIV_A::DIV8,
+            4 => APBCDIV_A::DIV16,
+            5 => APBCDIV_A::DIV32,
+            6 => APBCDIV_A::DIV64,
+            7 => APBCDIV_A::DIV128,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DIV1`"]
+    #[inline(always)]
+    pub fn is_div1(&self) -> bool {
+        *self == APBCDIV_A::DIV1
+    }
+    #[doc = "Checks if the value of the field is `DIV2`"]
+    #[inline(always)]
+    pub fn is_div2(&self) -> bool {
+        *self == APBCDIV_A::DIV2
+    }
+    #[doc = "Checks if the value of the field is `DIV4`"]
+    #[inline(always)]
+    pub fn is_div4(&self) -> bool {
+        *self == APBCDIV_A::DIV4
+    }
+    #[doc = "Checks if the value of the field is `DIV8`"]
+    #[inline(always)]
+    pub fn is_div8(&self) -> bool {
+        *self == APBCDIV_A::DIV8
+    }
+    #[doc = "Checks if the value of the field is `DIV16`"]
+    #[inline(always)]
+    pub fn is_div16(&self) -> bool {
+        *self == APBCDIV_A::DIV16
+    }
+    #[doc = "Checks if the value of the field is `DIV32`"]
+    #[inline(always)]
+    pub fn is_div32(&self) -> bool {
+        *self == APBCDIV_A::DIV32
+    }
+    #[doc = "Checks if the value of the field is `DIV64`"]
+    #[inline(always)]
+    pub fn is_div64(&self) -> bool {
+        *self == APBCDIV_A::DIV64
+    }
+    #[doc = "Checks if the value of the field is `DIV128`"]
+    #[inline(always)]
+    pub fn is_div128(&self) -> bool {
+        *self == APBCDIV_A::DIV128
+    }
+}
+#[doc = "Write proxy for field `APBCDIV`"]
+pub struct APBCDIV_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> APBCDIV_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: APBCDIV_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Divide by 1"]
+    #[inline(always)]
+    pub fn div1(self) -> &'a mut W {
+        self.variant(APBCDIV_A::DIV1)
+    }
+    #[doc = "Divide by 2"]
+    #[inline(always)]
+    pub fn div2(self) -> &'a mut W {
+        self.variant(APBCDIV_A::DIV2)
+    }
+    #[doc = "Divide by 4"]
+    #[inline(always)]
+    pub fn div4(self) -> &'a mut W {
+        self.variant(APBCDIV_A::DIV4)
+    }
+    #[doc = "Divide by 8"]
+    #[inline(always)]
+    pub fn div8(self) -> &'a mut W {
+        self.variant(APBCDIV_A::DIV8)
+    }
+    #[doc = "Divide by 16"]
+    #[inline(always)]
+    pub fn div16(self) -> &'a mut W {
+        self.variant(APBCDIV_A::DIV16)
+    }
+    #[doc = "Divide by 32"]
+    #[inline(always)]
+    pub fn div32(self) -> &'a mut W {
+        self.variant(APBCDIV_A::DIV32)
+    }
+    #[doc = "Divide by 64"]
+    #[inline(always)]
+    pub fn div64(self) -> &'a mut W {
+        self.variant(APBCDIV_A::DIV64)
+    }
+    #[doc = "Divide by 128"]
+    #[inline(always)]
+    pub fn div128(self) -> &'a mut W {
+        self.variant(APBCDIV_A::DIV128)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u8) & 0x07);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - APBC Prescaler Selection"]
+    #[inline(always)]
+    pub fn apbcdiv(&self) -> APBCDIV_R {
+        APBCDIV_R::new((self.bits & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - APBC Prescaler Selection"]
+    #[inline(always)]
+    pub fn apbcdiv(&mut self) -> APBCDIV_W {
+        APBCDIV_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pm/cpusel.rs
+++ b/pac/atsamd11c14a/src/pm/cpusel.rs
@@ -1,0 +1,179 @@
+#[doc = "Reader of register CPUSEL"]
+pub type R = crate::R<u8, super::CPUSEL>;
+#[doc = "Writer for register CPUSEL"]
+pub type W = crate::W<u8, super::CPUSEL>;
+#[doc = "Register CPUSEL `reset()`'s with value 0"]
+impl crate::ResetValue for super::CPUSEL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "CPU Prescaler Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CPUDIV_A {
+    #[doc = "0: Divide by 1"]
+    DIV1,
+    #[doc = "1: Divide by 2"]
+    DIV2,
+    #[doc = "2: Divide by 4"]
+    DIV4,
+    #[doc = "3: Divide by 8"]
+    DIV8,
+    #[doc = "4: Divide by 16"]
+    DIV16,
+    #[doc = "5: Divide by 32"]
+    DIV32,
+    #[doc = "6: Divide by 64"]
+    DIV64,
+    #[doc = "7: Divide by 128"]
+    DIV128,
+}
+impl From<CPUDIV_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CPUDIV_A) -> Self {
+        match variant {
+            CPUDIV_A::DIV1 => 0,
+            CPUDIV_A::DIV2 => 1,
+            CPUDIV_A::DIV4 => 2,
+            CPUDIV_A::DIV8 => 3,
+            CPUDIV_A::DIV16 => 4,
+            CPUDIV_A::DIV32 => 5,
+            CPUDIV_A::DIV64 => 6,
+            CPUDIV_A::DIV128 => 7,
+        }
+    }
+}
+#[doc = "Reader of field `CPUDIV`"]
+pub type CPUDIV_R = crate::R<u8, CPUDIV_A>;
+impl CPUDIV_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> CPUDIV_A {
+        match self.bits {
+            0 => CPUDIV_A::DIV1,
+            1 => CPUDIV_A::DIV2,
+            2 => CPUDIV_A::DIV4,
+            3 => CPUDIV_A::DIV8,
+            4 => CPUDIV_A::DIV16,
+            5 => CPUDIV_A::DIV32,
+            6 => CPUDIV_A::DIV64,
+            7 => CPUDIV_A::DIV128,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DIV1`"]
+    #[inline(always)]
+    pub fn is_div1(&self) -> bool {
+        *self == CPUDIV_A::DIV1
+    }
+    #[doc = "Checks if the value of the field is `DIV2`"]
+    #[inline(always)]
+    pub fn is_div2(&self) -> bool {
+        *self == CPUDIV_A::DIV2
+    }
+    #[doc = "Checks if the value of the field is `DIV4`"]
+    #[inline(always)]
+    pub fn is_div4(&self) -> bool {
+        *self == CPUDIV_A::DIV4
+    }
+    #[doc = "Checks if the value of the field is `DIV8`"]
+    #[inline(always)]
+    pub fn is_div8(&self) -> bool {
+        *self == CPUDIV_A::DIV8
+    }
+    #[doc = "Checks if the value of the field is `DIV16`"]
+    #[inline(always)]
+    pub fn is_div16(&self) -> bool {
+        *self == CPUDIV_A::DIV16
+    }
+    #[doc = "Checks if the value of the field is `DIV32`"]
+    #[inline(always)]
+    pub fn is_div32(&self) -> bool {
+        *self == CPUDIV_A::DIV32
+    }
+    #[doc = "Checks if the value of the field is `DIV64`"]
+    #[inline(always)]
+    pub fn is_div64(&self) -> bool {
+        *self == CPUDIV_A::DIV64
+    }
+    #[doc = "Checks if the value of the field is `DIV128`"]
+    #[inline(always)]
+    pub fn is_div128(&self) -> bool {
+        *self == CPUDIV_A::DIV128
+    }
+}
+#[doc = "Write proxy for field `CPUDIV`"]
+pub struct CPUDIV_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CPUDIV_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CPUDIV_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Divide by 1"]
+    #[inline(always)]
+    pub fn div1(self) -> &'a mut W {
+        self.variant(CPUDIV_A::DIV1)
+    }
+    #[doc = "Divide by 2"]
+    #[inline(always)]
+    pub fn div2(self) -> &'a mut W {
+        self.variant(CPUDIV_A::DIV2)
+    }
+    #[doc = "Divide by 4"]
+    #[inline(always)]
+    pub fn div4(self) -> &'a mut W {
+        self.variant(CPUDIV_A::DIV4)
+    }
+    #[doc = "Divide by 8"]
+    #[inline(always)]
+    pub fn div8(self) -> &'a mut W {
+        self.variant(CPUDIV_A::DIV8)
+    }
+    #[doc = "Divide by 16"]
+    #[inline(always)]
+    pub fn div16(self) -> &'a mut W {
+        self.variant(CPUDIV_A::DIV16)
+    }
+    #[doc = "Divide by 32"]
+    #[inline(always)]
+    pub fn div32(self) -> &'a mut W {
+        self.variant(CPUDIV_A::DIV32)
+    }
+    #[doc = "Divide by 64"]
+    #[inline(always)]
+    pub fn div64(self) -> &'a mut W {
+        self.variant(CPUDIV_A::DIV64)
+    }
+    #[doc = "Divide by 128"]
+    #[inline(always)]
+    pub fn div128(self) -> &'a mut W {
+        self.variant(CPUDIV_A::DIV128)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u8) & 0x07);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - CPU Prescaler Selection"]
+    #[inline(always)]
+    pub fn cpudiv(&self) -> CPUDIV_R {
+        CPUDIV_R::new((self.bits & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - CPU Prescaler Selection"]
+    #[inline(always)]
+    pub fn cpudiv(&mut self) -> CPUDIV_W {
+        CPUDIV_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pm/ctrl.rs
+++ b/pac/atsamd11c14a/src/pm/ctrl.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register CTRL"]
+pub type R = crate::R<u8, super::CTRL>;
+#[doc = "Writer for register CTRL"]
+pub type W = crate::W<u8, super::CTRL>;
+#[doc = "Register CTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CFDEN`"]
+pub type CFDEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CFDEN`"]
+pub struct CFDEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CFDEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `BKUPCLK`"]
+pub type BKUPCLK_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BKUPCLK`"]
+pub struct BKUPCLK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BKUPCLK_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 2 - Clock Failure Detector Enable"]
+    #[inline(always)]
+    pub fn cfden(&self) -> CFDEN_R {
+        CFDEN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Backup Clock Select"]
+    #[inline(always)]
+    pub fn bkupclk(&self) -> BKUPCLK_R {
+        BKUPCLK_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 2 - Clock Failure Detector Enable"]
+    #[inline(always)]
+    pub fn cfden(&mut self) -> CFDEN_W {
+        CFDEN_W { w: self }
+    }
+    #[doc = "Bit 4 - Backup Clock Select"]
+    #[inline(always)]
+    pub fn bkupclk(&mut self) -> BKUPCLK_W {
+        BKUPCLK_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pm/extctrl.rs
+++ b/pac/atsamd11c14a/src/pm/extctrl.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register EXTCTRL"]
+pub type R = crate::R<u8, super::EXTCTRL>;
+#[doc = "Writer for register EXTCTRL"]
+pub type W = crate::W<u8, super::EXTCTRL>;
+#[doc = "Register EXTCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::EXTCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SETDIS`"]
+pub type SETDIS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SETDIS`"]
+pub struct SETDIS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SETDIS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - External Reset Disable"]
+    #[inline(always)]
+    pub fn setdis(&self) -> SETDIS_R {
+        SETDIS_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - External Reset Disable"]
+    #[inline(always)]
+    pub fn setdis(&mut self) -> SETDIS_W {
+        SETDIS_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pm/intenclr.rs
+++ b/pac/atsamd11c14a/src/pm/intenclr.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CKRDY`"]
+pub type CKRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CKRDY`"]
+pub struct CKRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CKRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `CFD`"]
+pub type CFD_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CFD`"]
+pub struct CFD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CFD_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Clock Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn ckrdy(&self) -> CKRDY_R {
+        CKRDY_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Clock Failure Detector Interrupt Enable"]
+    #[inline(always)]
+    pub fn cfd(&self) -> CFD_R {
+        CFD_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clock Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn ckrdy(&mut self) -> CKRDY_W {
+        CKRDY_W { w: self }
+    }
+    #[doc = "Bit 1 - Clock Failure Detector Interrupt Enable"]
+    #[inline(always)]
+    pub fn cfd(&mut self) -> CFD_W {
+        CFD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pm/intenset.rs
+++ b/pac/atsamd11c14a/src/pm/intenset.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CKRDY`"]
+pub type CKRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CKRDY`"]
+pub struct CKRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CKRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `CFD`"]
+pub type CFD_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CFD`"]
+pub struct CFD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CFD_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Clock Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn ckrdy(&self) -> CKRDY_R {
+        CKRDY_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Clock Failure Detector Interrupt Enable"]
+    #[inline(always)]
+    pub fn cfd(&self) -> CFD_R {
+        CFD_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clock Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn ckrdy(&mut self) -> CKRDY_W {
+        CKRDY_W { w: self }
+    }
+    #[doc = "Bit 1 - Clock Failure Detector Interrupt Enable"]
+    #[inline(always)]
+    pub fn cfd(&mut self) -> CFD_W {
+        CFD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pm/intflag.rs
+++ b/pac/atsamd11c14a/src/pm/intflag.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CKRDY`"]
+pub type CKRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CKRDY`"]
+pub struct CKRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CKRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `CFD`"]
+pub type CFD_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CFD`"]
+pub struct CFD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CFD_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Clock Ready"]
+    #[inline(always)]
+    pub fn ckrdy(&self) -> CKRDY_R {
+        CKRDY_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Clock Failure Detector"]
+    #[inline(always)]
+    pub fn cfd(&self) -> CFD_R {
+        CFD_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Clock Ready"]
+    #[inline(always)]
+    pub fn ckrdy(&mut self) -> CKRDY_W {
+        CKRDY_W { w: self }
+    }
+    #[doc = "Bit 1 - Clock Failure Detector"]
+    #[inline(always)]
+    pub fn cfd(&mut self) -> CFD_W {
+        CFD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/pm/rcause.rs
+++ b/pac/atsamd11c14a/src/pm/rcause.rs
@@ -1,0 +1,46 @@
+#[doc = "Reader of register RCAUSE"]
+pub type R = crate::R<u8, super::RCAUSE>;
+#[doc = "Reader of field `POR`"]
+pub type POR_R = crate::R<bool, bool>;
+#[doc = "Reader of field `BOD12`"]
+pub type BOD12_R = crate::R<bool, bool>;
+#[doc = "Reader of field `BOD33`"]
+pub type BOD33_R = crate::R<bool, bool>;
+#[doc = "Reader of field `EXT`"]
+pub type EXT_R = crate::R<bool, bool>;
+#[doc = "Reader of field `WDT`"]
+pub type WDT_R = crate::R<bool, bool>;
+#[doc = "Reader of field `SYST`"]
+pub type SYST_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Power On Reset"]
+    #[inline(always)]
+    pub fn por(&self) -> POR_R {
+        POR_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Brown Out 12 Detector Reset"]
+    #[inline(always)]
+    pub fn bod12(&self) -> BOD12_R {
+        BOD12_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Brown Out 33 Detector Reset"]
+    #[inline(always)]
+    pub fn bod33(&self) -> BOD33_R {
+        BOD33_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - External Reset"]
+    #[inline(always)]
+    pub fn ext(&self) -> EXT_R {
+        EXT_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Watchdog Reset"]
+    #[inline(always)]
+    pub fn wdt(&self) -> WDT_R {
+        WDT_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - System Reset Request"]
+    #[inline(always)]
+    pub fn syst(&self) -> SYST_R {
+        SYST_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/pm/sleep.rs
+++ b/pac/atsamd11c14a/src/pm/sleep.rs
@@ -1,0 +1,108 @@
+#[doc = "Reader of register SLEEP"]
+pub type R = crate::R<u8, super::SLEEP>;
+#[doc = "Writer for register SLEEP"]
+pub type W = crate::W<u8, super::SLEEP>;
+#[doc = "Register SLEEP `reset()`'s with value 0"]
+impl crate::ResetValue for super::SLEEP {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Idle Mode Configuration\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum IDLE_A {
+    #[doc = "0: The CPU clock domain is stopped"]
+    CPU,
+    #[doc = "1: The CPU and AHB clock domains are stopped"]
+    AHB,
+    #[doc = "2: The CPU, AHB and APB clock domains are stopped"]
+    APB,
+}
+impl From<IDLE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: IDLE_A) -> Self {
+        match variant {
+            IDLE_A::CPU => 0,
+            IDLE_A::AHB => 1,
+            IDLE_A::APB => 2,
+        }
+    }
+}
+#[doc = "Reader of field `IDLE`"]
+pub type IDLE_R = crate::R<u8, IDLE_A>;
+impl IDLE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, IDLE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(IDLE_A::CPU),
+            1 => Val(IDLE_A::AHB),
+            2 => Val(IDLE_A::APB),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `CPU`"]
+    #[inline(always)]
+    pub fn is_cpu(&self) -> bool {
+        *self == IDLE_A::CPU
+    }
+    #[doc = "Checks if the value of the field is `AHB`"]
+    #[inline(always)]
+    pub fn is_ahb(&self) -> bool {
+        *self == IDLE_A::AHB
+    }
+    #[doc = "Checks if the value of the field is `APB`"]
+    #[inline(always)]
+    pub fn is_apb(&self) -> bool {
+        *self == IDLE_A::APB
+    }
+}
+#[doc = "Write proxy for field `IDLE`"]
+pub struct IDLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> IDLE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: IDLE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "The CPU clock domain is stopped"]
+    #[inline(always)]
+    pub fn cpu(self) -> &'a mut W {
+        self.variant(IDLE_A::CPU)
+    }
+    #[doc = "The CPU and AHB clock domains are stopped"]
+    #[inline(always)]
+    pub fn ahb(self) -> &'a mut W {
+        self.variant(IDLE_A::AHB)
+    }
+    #[doc = "The CPU, AHB and APB clock domains are stopped"]
+    #[inline(always)]
+    pub fn apb(self) -> &'a mut W {
+        self.variant(IDLE_A::APB)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x03) | ((value as u8) & 0x03);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:1 - Idle Mode Configuration"]
+    #[inline(always)]
+    pub fn idle(&self) -> IDLE_R {
+        IDLE_R::new((self.bits & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:1 - Idle Mode Configuration"]
+    #[inline(always)]
+    pub fn idle(&mut self) -> IDLE_W {
+        IDLE_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/port.rs
+++ b/pac/atsamd11c14a/src/port.rs
@@ -1,0 +1,168 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Data Direction"]
+    pub dir0: DIR,
+    #[doc = "0x04 - Data Direction Clear"]
+    pub dirclr0: DIRCLR,
+    #[doc = "0x08 - Data Direction Set"]
+    pub dirset0: DIRSET,
+    #[doc = "0x0c - Data Direction Toggle"]
+    pub dirtgl0: DIRTGL,
+    #[doc = "0x10 - Data Output Value"]
+    pub out0: OUT,
+    #[doc = "0x14 - Data Output Value Clear"]
+    pub outclr0: OUTCLR,
+    #[doc = "0x18 - Data Output Value Set"]
+    pub outset0: OUTSET,
+    #[doc = "0x1c - Data Output Value Toggle"]
+    pub outtgl0: OUTTGL,
+    #[doc = "0x20 - Data Input Value"]
+    pub in0: IN,
+    #[doc = "0x24 - Control"]
+    pub ctrl0: CTRL,
+    #[doc = "0x28 - Write Configuration"]
+    pub wrconfig0: WRCONFIG,
+    _reserved11: [u8; 4usize],
+    #[doc = "0x30 - Peripheral Multiplexing n - Group 0"]
+    pub pmux0_: [PMUX0_; 16],
+    #[doc = "0x40 - Pin Configuration n - Group 0"]
+    pub pincfg0_: [PINCFG0_; 32],
+}
+#[doc = "Data Direction\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dir](dir) module"]
+pub type DIR = crate::Reg<u32, _DIR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DIR;
+#[doc = "`read()` method returns [dir::R](dir::R) reader structure"]
+impl crate::Readable for DIR {}
+#[doc = "`write(|w| ..)` method takes [dir::W](dir::W) writer structure"]
+impl crate::Writable for DIR {}
+#[doc = "Data Direction"]
+pub mod dir;
+#[doc = "Data Direction Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dirclr](dirclr) module"]
+pub type DIRCLR = crate::Reg<u32, _DIRCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DIRCLR;
+#[doc = "`read()` method returns [dirclr::R](dirclr::R) reader structure"]
+impl crate::Readable for DIRCLR {}
+#[doc = "`write(|w| ..)` method takes [dirclr::W](dirclr::W) writer structure"]
+impl crate::Writable for DIRCLR {}
+#[doc = "Data Direction Clear"]
+pub mod dirclr;
+#[doc = "Data Direction Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dirset](dirset) module"]
+pub type DIRSET = crate::Reg<u32, _DIRSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DIRSET;
+#[doc = "`read()` method returns [dirset::R](dirset::R) reader structure"]
+impl crate::Readable for DIRSET {}
+#[doc = "`write(|w| ..)` method takes [dirset::W](dirset::W) writer structure"]
+impl crate::Writable for DIRSET {}
+#[doc = "Data Direction Set"]
+pub mod dirset;
+#[doc = "Data Direction Toggle\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dirtgl](dirtgl) module"]
+pub type DIRTGL = crate::Reg<u32, _DIRTGL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DIRTGL;
+#[doc = "`read()` method returns [dirtgl::R](dirtgl::R) reader structure"]
+impl crate::Readable for DIRTGL {}
+#[doc = "`write(|w| ..)` method takes [dirtgl::W](dirtgl::W) writer structure"]
+impl crate::Writable for DIRTGL {}
+#[doc = "Data Direction Toggle"]
+pub mod dirtgl;
+#[doc = "Data Output Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [out](out) module"]
+pub type OUT = crate::Reg<u32, _OUT>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _OUT;
+#[doc = "`read()` method returns [out::R](out::R) reader structure"]
+impl crate::Readable for OUT {}
+#[doc = "`write(|w| ..)` method takes [out::W](out::W) writer structure"]
+impl crate::Writable for OUT {}
+#[doc = "Data Output Value"]
+pub mod out;
+#[doc = "Data Output Value Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [outclr](outclr) module"]
+pub type OUTCLR = crate::Reg<u32, _OUTCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _OUTCLR;
+#[doc = "`read()` method returns [outclr::R](outclr::R) reader structure"]
+impl crate::Readable for OUTCLR {}
+#[doc = "`write(|w| ..)` method takes [outclr::W](outclr::W) writer structure"]
+impl crate::Writable for OUTCLR {}
+#[doc = "Data Output Value Clear"]
+pub mod outclr;
+#[doc = "Data Output Value Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [outset](outset) module"]
+pub type OUTSET = crate::Reg<u32, _OUTSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _OUTSET;
+#[doc = "`read()` method returns [outset::R](outset::R) reader structure"]
+impl crate::Readable for OUTSET {}
+#[doc = "`write(|w| ..)` method takes [outset::W](outset::W) writer structure"]
+impl crate::Writable for OUTSET {}
+#[doc = "Data Output Value Set"]
+pub mod outset;
+#[doc = "Data Output Value Toggle\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [outtgl](outtgl) module"]
+pub type OUTTGL = crate::Reg<u32, _OUTTGL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _OUTTGL;
+#[doc = "`read()` method returns [outtgl::R](outtgl::R) reader structure"]
+impl crate::Readable for OUTTGL {}
+#[doc = "`write(|w| ..)` method takes [outtgl::W](outtgl::W) writer structure"]
+impl crate::Writable for OUTTGL {}
+#[doc = "Data Output Value Toggle"]
+pub mod outtgl;
+#[doc = "Data Input Value\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [in_](in_) module"]
+pub type IN = crate::Reg<u32, _IN>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _IN;
+#[doc = "`read()` method returns [in_::R](in_::R) reader structure"]
+impl crate::Readable for IN {}
+#[doc = "Data Input Value"]
+pub mod in_;
+#[doc = "Control\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrl](ctrl) module"]
+pub type CTRL = crate::Reg<u32, _CTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRL;
+#[doc = "`write(|w| ..)` method takes [ctrl::W](ctrl::W) writer structure"]
+impl crate::Writable for CTRL {}
+#[doc = "Control"]
+pub mod ctrl;
+#[doc = "Write Configuration\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [wrconfig](wrconfig) module"]
+pub type WRCONFIG = crate::Reg<u32, _WRCONFIG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WRCONFIG;
+#[doc = "`write(|w| ..)` method takes [wrconfig::W](wrconfig::W) writer structure"]
+impl crate::Writable for WRCONFIG {}
+#[doc = "Write Configuration"]
+pub mod wrconfig;
+#[doc = "Peripheral Multiplexing n - Group 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pmux0_](pmux0_) module"]
+pub type PMUX0_ = crate::Reg<u8, _PMUX0_>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PMUX0_;
+#[doc = "`read()` method returns [pmux0_::R](pmux0_::R) reader structure"]
+impl crate::Readable for PMUX0_ {}
+#[doc = "`write(|w| ..)` method takes [pmux0_::W](pmux0_::W) writer structure"]
+impl crate::Writable for PMUX0_ {}
+#[doc = "Peripheral Multiplexing n - Group 0"]
+pub mod pmux0_;
+#[doc = "Pin Configuration n - Group 0\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pincfg0_](pincfg0_) module"]
+pub type PINCFG0_ = crate::Reg<u8, _PINCFG0_>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PINCFG0_;
+#[doc = "`read()` method returns [pincfg0_::R](pincfg0_::R) reader structure"]
+impl crate::Readable for PINCFG0_ {}
+#[doc = "`write(|w| ..)` method takes [pincfg0_::W](pincfg0_::W) writer structure"]
+impl crate::Writable for PINCFG0_ {}
+#[doc = "Pin Configuration n - Group 0"]
+pub mod pincfg0_;

--- a/pac/atsamd11c14a/src/port/ctrl.rs
+++ b/pac/atsamd11c14a/src/port/ctrl.rs
@@ -1,0 +1,29 @@
+#[doc = "Writer for register CTRL%s"]
+pub type W = crate::W<u32, super::CTRL>;
+#[doc = "Register CTRL%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRL {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Write proxy for field `SAMPLING`"]
+pub struct SAMPLING_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SAMPLING_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Input Sampling Mode"]
+    #[inline(always)]
+    pub fn sampling(&mut self) -> SAMPLING_W {
+        SAMPLING_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/port/dir.rs
+++ b/pac/atsamd11c14a/src/port/dir.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register DIR%s"]
+pub type R = crate::R<u32, super::DIR>;
+#[doc = "Writer for register DIR%s"]
+pub type W = crate::W<u32, super::DIR>;
+#[doc = "Register DIR%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::DIR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DIR`"]
+pub type DIR_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `DIR`"]
+pub struct DIR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Port Data Direction"]
+    #[inline(always)]
+    pub fn dir(&self) -> DIR_R {
+        DIR_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Port Data Direction"]
+    #[inline(always)]
+    pub fn dir(&mut self) -> DIR_W {
+        DIR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/port/dirclr.rs
+++ b/pac/atsamd11c14a/src/port/dirclr.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register DIRCLR%s"]
+pub type R = crate::R<u32, super::DIRCLR>;
+#[doc = "Writer for register DIRCLR%s"]
+pub type W = crate::W<u32, super::DIRCLR>;
+#[doc = "Register DIRCLR%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::DIRCLR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DIRCLR`"]
+pub type DIRCLR_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `DIRCLR`"]
+pub struct DIRCLR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIRCLR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Port Data Direction Clear"]
+    #[inline(always)]
+    pub fn dirclr(&self) -> DIRCLR_R {
+        DIRCLR_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Port Data Direction Clear"]
+    #[inline(always)]
+    pub fn dirclr(&mut self) -> DIRCLR_W {
+        DIRCLR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/port/dirset.rs
+++ b/pac/atsamd11c14a/src/port/dirset.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register DIRSET%s"]
+pub type R = crate::R<u32, super::DIRSET>;
+#[doc = "Writer for register DIRSET%s"]
+pub type W = crate::W<u32, super::DIRSET>;
+#[doc = "Register DIRSET%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::DIRSET {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DIRSET`"]
+pub type DIRSET_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `DIRSET`"]
+pub struct DIRSET_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIRSET_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Port Data Direction Set"]
+    #[inline(always)]
+    pub fn dirset(&self) -> DIRSET_R {
+        DIRSET_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Port Data Direction Set"]
+    #[inline(always)]
+    pub fn dirset(&mut self) -> DIRSET_W {
+        DIRSET_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/port/dirtgl.rs
+++ b/pac/atsamd11c14a/src/port/dirtgl.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register DIRTGL%s"]
+pub type R = crate::R<u32, super::DIRTGL>;
+#[doc = "Writer for register DIRTGL%s"]
+pub type W = crate::W<u32, super::DIRTGL>;
+#[doc = "Register DIRTGL%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::DIRTGL {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DIRTGL`"]
+pub type DIRTGL_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `DIRTGL`"]
+pub struct DIRTGL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIRTGL_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Port Data Direction Toggle"]
+    #[inline(always)]
+    pub fn dirtgl(&self) -> DIRTGL_R {
+        DIRTGL_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Port Data Direction Toggle"]
+    #[inline(always)]
+    pub fn dirtgl(&mut self) -> DIRTGL_W {
+        DIRTGL_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/port/in_.rs
+++ b/pac/atsamd11c14a/src/port/in_.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register IN%s"]
+pub type R = crate::R<u32, super::IN>;
+#[doc = "Reader of field `IN`"]
+pub type IN_R = crate::R<u32, u32>;
+impl R {
+    #[doc = "Bits 0:31 - Port Data Input Value"]
+    #[inline(always)]
+    pub fn in_(&self) -> IN_R {
+        IN_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}

--- a/pac/atsamd11c14a/src/port/out.rs
+++ b/pac/atsamd11c14a/src/port/out.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register OUT%s"]
+pub type R = crate::R<u32, super::OUT>;
+#[doc = "Writer for register OUT%s"]
+pub type W = crate::W<u32, super::OUT>;
+#[doc = "Register OUT%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::OUT {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OUT`"]
+pub type OUT_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `OUT`"]
+pub struct OUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OUT_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Port Data Output Value"]
+    #[inline(always)]
+    pub fn out(&self) -> OUT_R {
+        OUT_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Port Data Output Value"]
+    #[inline(always)]
+    pub fn out(&mut self) -> OUT_W {
+        OUT_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/port/outclr.rs
+++ b/pac/atsamd11c14a/src/port/outclr.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register OUTCLR%s"]
+pub type R = crate::R<u32, super::OUTCLR>;
+#[doc = "Writer for register OUTCLR%s"]
+pub type W = crate::W<u32, super::OUTCLR>;
+#[doc = "Register OUTCLR%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::OUTCLR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OUTCLR`"]
+pub type OUTCLR_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `OUTCLR`"]
+pub struct OUTCLR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OUTCLR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Port Data Output Value Clear"]
+    #[inline(always)]
+    pub fn outclr(&self) -> OUTCLR_R {
+        OUTCLR_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Port Data Output Value Clear"]
+    #[inline(always)]
+    pub fn outclr(&mut self) -> OUTCLR_W {
+        OUTCLR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/port/outset.rs
+++ b/pac/atsamd11c14a/src/port/outset.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register OUTSET%s"]
+pub type R = crate::R<u32, super::OUTSET>;
+#[doc = "Writer for register OUTSET%s"]
+pub type W = crate::W<u32, super::OUTSET>;
+#[doc = "Register OUTSET%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::OUTSET {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OUTSET`"]
+pub type OUTSET_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `OUTSET`"]
+pub struct OUTSET_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OUTSET_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Port Data Output Value Set"]
+    #[inline(always)]
+    pub fn outset(&self) -> OUTSET_R {
+        OUTSET_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Port Data Output Value Set"]
+    #[inline(always)]
+    pub fn outset(&mut self) -> OUTSET_W {
+        OUTSET_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/port/outtgl.rs
+++ b/pac/atsamd11c14a/src/port/outtgl.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register OUTTGL%s"]
+pub type R = crate::R<u32, super::OUTTGL>;
+#[doc = "Writer for register OUTTGL%s"]
+pub type W = crate::W<u32, super::OUTTGL>;
+#[doc = "Register OUTTGL%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::OUTTGL {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OUTTGL`"]
+pub type OUTTGL_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `OUTTGL`"]
+pub struct OUTTGL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OUTTGL_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Port Data Output Value Toggle"]
+    #[inline(always)]
+    pub fn outtgl(&self) -> OUTTGL_R {
+        OUTTGL_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Port Data Output Value Toggle"]
+    #[inline(always)]
+    pub fn outtgl(&mut self) -> OUTTGL_W {
+        OUTTGL_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/port/pincfg0_.rs
+++ b/pac/atsamd11c14a/src/port/pincfg0_.rs
@@ -1,0 +1,145 @@
+#[doc = "Reader of register PINCFG0_%s"]
+pub type R = crate::R<u8, super::PINCFG0_>;
+#[doc = "Writer for register PINCFG0_%s"]
+pub type W = crate::W<u8, super::PINCFG0_>;
+#[doc = "Register PINCFG0_%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::PINCFG0_ {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `PMUXEN`"]
+pub type PMUXEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PMUXEN`"]
+pub struct PMUXEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PMUXEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `INEN`"]
+pub type INEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INEN`"]
+pub struct INEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `PULLEN`"]
+pub type PULLEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PULLEN`"]
+pub struct PULLEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PULLEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `DRVSTR`"]
+pub struct DRVSTR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DRVSTR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Peripheral Multiplexer Enable"]
+    #[inline(always)]
+    pub fn pmuxen(&self) -> PMUXEN_R {
+        PMUXEN_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Input Enable"]
+    #[inline(always)]
+    pub fn inen(&self) -> INEN_R {
+        INEN_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Pull Enable"]
+    #[inline(always)]
+    pub fn pullen(&self) -> PULLEN_R {
+        PULLEN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Peripheral Multiplexer Enable"]
+    #[inline(always)]
+    pub fn pmuxen(&mut self) -> PMUXEN_W {
+        PMUXEN_W { w: self }
+    }
+    #[doc = "Bit 1 - Input Enable"]
+    #[inline(always)]
+    pub fn inen(&mut self) -> INEN_W {
+        INEN_W { w: self }
+    }
+    #[doc = "Bit 2 - Pull Enable"]
+    #[inline(always)]
+    pub fn pullen(&mut self) -> PULLEN_W {
+        PULLEN_W { w: self }
+    }
+    #[doc = "Bit 6 - Output Driver Strength Selection"]
+    #[inline(always)]
+    pub fn drvstr(&mut self) -> DRVSTR_W {
+        DRVSTR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/port/pmux0_.rs
+++ b/pac/atsamd11c14a/src/port/pmux0_.rs
@@ -1,0 +1,340 @@
+#[doc = "Reader of register PMUX0_%s"]
+pub type R = crate::R<u8, super::PMUX0_>;
+#[doc = "Writer for register PMUX0_%s"]
+pub type W = crate::W<u8, super::PMUX0_>;
+#[doc = "Register PMUX0_%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::PMUX0_ {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Peripheral Multiplexing Even\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PMUXE_A {
+    #[doc = "0: Peripheral function A selected"]
+    A,
+    #[doc = "1: Peripheral function B selected"]
+    B,
+    #[doc = "2: Peripheral function C selected"]
+    C,
+    #[doc = "3: Peripheral function D selected"]
+    D,
+    #[doc = "4: Peripheral function E selected"]
+    E,
+    #[doc = "5: Peripheral function F selected"]
+    F,
+    #[doc = "6: Peripheral function G selected"]
+    G,
+    #[doc = "7: Peripheral function H selected"]
+    H,
+}
+impl From<PMUXE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PMUXE_A) -> Self {
+        match variant {
+            PMUXE_A::A => 0,
+            PMUXE_A::B => 1,
+            PMUXE_A::C => 2,
+            PMUXE_A::D => 3,
+            PMUXE_A::E => 4,
+            PMUXE_A::F => 5,
+            PMUXE_A::G => 6,
+            PMUXE_A::H => 7,
+        }
+    }
+}
+#[doc = "Reader of field `PMUXE`"]
+pub type PMUXE_R = crate::R<u8, PMUXE_A>;
+impl PMUXE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, PMUXE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(PMUXE_A::A),
+            1 => Val(PMUXE_A::B),
+            2 => Val(PMUXE_A::C),
+            3 => Val(PMUXE_A::D),
+            4 => Val(PMUXE_A::E),
+            5 => Val(PMUXE_A::F),
+            6 => Val(PMUXE_A::G),
+            7 => Val(PMUXE_A::H),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `A`"]
+    #[inline(always)]
+    pub fn is_a(&self) -> bool {
+        *self == PMUXE_A::A
+    }
+    #[doc = "Checks if the value of the field is `B`"]
+    #[inline(always)]
+    pub fn is_b(&self) -> bool {
+        *self == PMUXE_A::B
+    }
+    #[doc = "Checks if the value of the field is `C`"]
+    #[inline(always)]
+    pub fn is_c(&self) -> bool {
+        *self == PMUXE_A::C
+    }
+    #[doc = "Checks if the value of the field is `D`"]
+    #[inline(always)]
+    pub fn is_d(&self) -> bool {
+        *self == PMUXE_A::D
+    }
+    #[doc = "Checks if the value of the field is `E`"]
+    #[inline(always)]
+    pub fn is_e(&self) -> bool {
+        *self == PMUXE_A::E
+    }
+    #[doc = "Checks if the value of the field is `F`"]
+    #[inline(always)]
+    pub fn is_f(&self) -> bool {
+        *self == PMUXE_A::F
+    }
+    #[doc = "Checks if the value of the field is `G`"]
+    #[inline(always)]
+    pub fn is_g(&self) -> bool {
+        *self == PMUXE_A::G
+    }
+    #[doc = "Checks if the value of the field is `H`"]
+    #[inline(always)]
+    pub fn is_h(&self) -> bool {
+        *self == PMUXE_A::H
+    }
+}
+#[doc = "Write proxy for field `PMUXE`"]
+pub struct PMUXE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PMUXE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PMUXE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Peripheral function A selected"]
+    #[inline(always)]
+    pub fn a(self) -> &'a mut W {
+        self.variant(PMUXE_A::A)
+    }
+    #[doc = "Peripheral function B selected"]
+    #[inline(always)]
+    pub fn b(self) -> &'a mut W {
+        self.variant(PMUXE_A::B)
+    }
+    #[doc = "Peripheral function C selected"]
+    #[inline(always)]
+    pub fn c(self) -> &'a mut W {
+        self.variant(PMUXE_A::C)
+    }
+    #[doc = "Peripheral function D selected"]
+    #[inline(always)]
+    pub fn d(self) -> &'a mut W {
+        self.variant(PMUXE_A::D)
+    }
+    #[doc = "Peripheral function E selected"]
+    #[inline(always)]
+    pub fn e(self) -> &'a mut W {
+        self.variant(PMUXE_A::E)
+    }
+    #[doc = "Peripheral function F selected"]
+    #[inline(always)]
+    pub fn f(self) -> &'a mut W {
+        self.variant(PMUXE_A::F)
+    }
+    #[doc = "Peripheral function G selected"]
+    #[inline(always)]
+    pub fn g(self) -> &'a mut W {
+        self.variant(PMUXE_A::G)
+    }
+    #[doc = "Peripheral function H selected"]
+    #[inline(always)]
+    pub fn h(self) -> &'a mut W {
+        self.variant(PMUXE_A::H)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0f) | ((value as u8) & 0x0f);
+        self.w
+    }
+}
+#[doc = "Peripheral Multiplexing Odd\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PMUXO_A {
+    #[doc = "0: Peripheral function A selected"]
+    A,
+    #[doc = "1: Peripheral function B selected"]
+    B,
+    #[doc = "2: Peripheral function C selected"]
+    C,
+    #[doc = "3: Peripheral function D selected"]
+    D,
+    #[doc = "4: Peripheral function E selected"]
+    E,
+    #[doc = "5: Peripheral function F selected"]
+    F,
+    #[doc = "6: Peripheral function G selected"]
+    G,
+    #[doc = "7: Peripheral function H selected"]
+    H,
+}
+impl From<PMUXO_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PMUXO_A) -> Self {
+        match variant {
+            PMUXO_A::A => 0,
+            PMUXO_A::B => 1,
+            PMUXO_A::C => 2,
+            PMUXO_A::D => 3,
+            PMUXO_A::E => 4,
+            PMUXO_A::F => 5,
+            PMUXO_A::G => 6,
+            PMUXO_A::H => 7,
+        }
+    }
+}
+#[doc = "Reader of field `PMUXO`"]
+pub type PMUXO_R = crate::R<u8, PMUXO_A>;
+impl PMUXO_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, PMUXO_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(PMUXO_A::A),
+            1 => Val(PMUXO_A::B),
+            2 => Val(PMUXO_A::C),
+            3 => Val(PMUXO_A::D),
+            4 => Val(PMUXO_A::E),
+            5 => Val(PMUXO_A::F),
+            6 => Val(PMUXO_A::G),
+            7 => Val(PMUXO_A::H),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `A`"]
+    #[inline(always)]
+    pub fn is_a(&self) -> bool {
+        *self == PMUXO_A::A
+    }
+    #[doc = "Checks if the value of the field is `B`"]
+    #[inline(always)]
+    pub fn is_b(&self) -> bool {
+        *self == PMUXO_A::B
+    }
+    #[doc = "Checks if the value of the field is `C`"]
+    #[inline(always)]
+    pub fn is_c(&self) -> bool {
+        *self == PMUXO_A::C
+    }
+    #[doc = "Checks if the value of the field is `D`"]
+    #[inline(always)]
+    pub fn is_d(&self) -> bool {
+        *self == PMUXO_A::D
+    }
+    #[doc = "Checks if the value of the field is `E`"]
+    #[inline(always)]
+    pub fn is_e(&self) -> bool {
+        *self == PMUXO_A::E
+    }
+    #[doc = "Checks if the value of the field is `F`"]
+    #[inline(always)]
+    pub fn is_f(&self) -> bool {
+        *self == PMUXO_A::F
+    }
+    #[doc = "Checks if the value of the field is `G`"]
+    #[inline(always)]
+    pub fn is_g(&self) -> bool {
+        *self == PMUXO_A::G
+    }
+    #[doc = "Checks if the value of the field is `H`"]
+    #[inline(always)]
+    pub fn is_h(&self) -> bool {
+        *self == PMUXO_A::H
+    }
+}
+#[doc = "Write proxy for field `PMUXO`"]
+pub struct PMUXO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PMUXO_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PMUXO_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Peripheral function A selected"]
+    #[inline(always)]
+    pub fn a(self) -> &'a mut W {
+        self.variant(PMUXO_A::A)
+    }
+    #[doc = "Peripheral function B selected"]
+    #[inline(always)]
+    pub fn b(self) -> &'a mut W {
+        self.variant(PMUXO_A::B)
+    }
+    #[doc = "Peripheral function C selected"]
+    #[inline(always)]
+    pub fn c(self) -> &'a mut W {
+        self.variant(PMUXO_A::C)
+    }
+    #[doc = "Peripheral function D selected"]
+    #[inline(always)]
+    pub fn d(self) -> &'a mut W {
+        self.variant(PMUXO_A::D)
+    }
+    #[doc = "Peripheral function E selected"]
+    #[inline(always)]
+    pub fn e(self) -> &'a mut W {
+        self.variant(PMUXO_A::E)
+    }
+    #[doc = "Peripheral function F selected"]
+    #[inline(always)]
+    pub fn f(self) -> &'a mut W {
+        self.variant(PMUXO_A::F)
+    }
+    #[doc = "Peripheral function G selected"]
+    #[inline(always)]
+    pub fn g(self) -> &'a mut W {
+        self.variant(PMUXO_A::G)
+    }
+    #[doc = "Peripheral function H selected"]
+    #[inline(always)]
+    pub fn h(self) -> &'a mut W {
+        self.variant(PMUXO_A::H)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 4)) | (((value as u8) & 0x0f) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:3 - Peripheral Multiplexing Even"]
+    #[inline(always)]
+    pub fn pmuxe(&self) -> PMUXE_R {
+        PMUXE_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - Peripheral Multiplexing Odd"]
+    #[inline(always)]
+    pub fn pmuxo(&self) -> PMUXO_R {
+        PMUXO_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Peripheral Multiplexing Even"]
+    #[inline(always)]
+    pub fn pmuxe(&mut self) -> PMUXE_W {
+        PMUXE_W { w: self }
+    }
+    #[doc = "Bits 4:7 - Peripheral Multiplexing Odd"]
+    #[inline(always)]
+    pub fn pmuxo(&mut self) -> PMUXO_W {
+        PMUXO_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/port/wrconfig.rs
+++ b/pac/atsamd11c14a/src/port/wrconfig.rs
@@ -1,0 +1,235 @@
+#[doc = "Writer for register WRCONFIG%s"]
+pub type W = crate::W<u32, super::WRCONFIG>;
+#[doc = "Register WRCONFIG%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::WRCONFIG {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Write proxy for field `PINMASK`"]
+pub struct PINMASK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PINMASK_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff) | ((value as u32) & 0xffff);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `PMUXEN`"]
+pub struct PMUXEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PMUXEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `INEN`"]
+pub struct INEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `PULLEN`"]
+pub struct PULLEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PULLEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 18)) | (((value as u32) & 0x01) << 18);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `DRVSTR`"]
+pub struct DRVSTR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DRVSTR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 22)) | (((value as u32) & 0x01) << 22);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `PMUX`"]
+pub struct PMUX_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PMUX_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 24)) | (((value as u32) & 0x0f) << 24);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `WRPMUX`"]
+pub struct WRPMUX_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WRPMUX_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 28)) | (((value as u32) & 0x01) << 28);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `WRPINCFG`"]
+pub struct WRPINCFG_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WRPINCFG_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 30)) | (((value as u32) & 0x01) << 30);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `HWSEL`"]
+pub struct HWSEL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HWSEL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 31)) | (((value as u32) & 0x01) << 31);
+        self.w
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Pin Mask for Multiple Pin Configuration"]
+    #[inline(always)]
+    pub fn pinmask(&mut self) -> PINMASK_W {
+        PINMASK_W { w: self }
+    }
+    #[doc = "Bit 16 - Peripheral Multiplexer Enable"]
+    #[inline(always)]
+    pub fn pmuxen(&mut self) -> PMUXEN_W {
+        PMUXEN_W { w: self }
+    }
+    #[doc = "Bit 17 - Input Enable"]
+    #[inline(always)]
+    pub fn inen(&mut self) -> INEN_W {
+        INEN_W { w: self }
+    }
+    #[doc = "Bit 18 - Pull Enable"]
+    #[inline(always)]
+    pub fn pullen(&mut self) -> PULLEN_W {
+        PULLEN_W { w: self }
+    }
+    #[doc = "Bit 22 - Output Driver Strength Selection"]
+    #[inline(always)]
+    pub fn drvstr(&mut self) -> DRVSTR_W {
+        DRVSTR_W { w: self }
+    }
+    #[doc = "Bits 24:27 - Peripheral Multiplexing"]
+    #[inline(always)]
+    pub fn pmux(&mut self) -> PMUX_W {
+        PMUX_W { w: self }
+    }
+    #[doc = "Bit 28 - Write PMUX"]
+    #[inline(always)]
+    pub fn wrpmux(&mut self) -> WRPMUX_W {
+        WRPMUX_W { w: self }
+    }
+    #[doc = "Bit 30 - Write PINCFG"]
+    #[inline(always)]
+    pub fn wrpincfg(&mut self) -> WRPINCFG_W {
+        WRPINCFG_W { w: self }
+    }
+    #[doc = "Bit 31 - Half-Word Select"]
+    #[inline(always)]
+    pub fn hwsel(&mut self) -> HWSEL_W {
+        HWSEL_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc.rs
+++ b/pac/atsamd11c14a/src/rtc.rs
@@ -1,0 +1,138 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    _reserved_0_mode0: [u8; 29usize],
+}
+impl RegisterBlock {
+    #[doc = "0x00 - Clock/Calendar with Alarm"]
+    #[inline(always)]
+    pub fn mode2(&self) -> &MODE2 {
+        unsafe { &*(((self as *const Self) as *const u8).add(0usize) as *const MODE2) }
+    }
+    #[doc = "0x00 - Clock/Calendar with Alarm"]
+    #[inline(always)]
+    pub fn mode2_mut(&self) -> &mut MODE2 {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(0usize) as *mut MODE2) }
+    }
+    #[doc = "0x00 - 16-bit Counter with Two 16-bit Compares"]
+    #[inline(always)]
+    pub fn mode1(&self) -> &MODE1 {
+        unsafe { &*(((self as *const Self) as *const u8).add(0usize) as *const MODE1) }
+    }
+    #[doc = "0x00 - 16-bit Counter with Two 16-bit Compares"]
+    #[inline(always)]
+    pub fn mode1_mut(&self) -> &mut MODE1 {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(0usize) as *mut MODE1) }
+    }
+    #[doc = "0x00 - 32-bit Counter with Single 32-bit Compare"]
+    #[inline(always)]
+    pub fn mode0(&self) -> &MODE0 {
+        unsafe { &*(((self as *const Self) as *const u8).add(0usize) as *const MODE0) }
+    }
+    #[doc = "0x00 - 32-bit Counter with Single 32-bit Compare"]
+    #[inline(always)]
+    pub fn mode0_mut(&self) -> &mut MODE0 {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(0usize) as *mut MODE0) }
+    }
+}
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct MODE0 {
+    #[doc = "0x00 - MODE0 Control"]
+    pub ctrl: self::mode0::CTRL,
+    #[doc = "0x02 - Read Request"]
+    pub readreq: self::mode0::READREQ,
+    #[doc = "0x04 - MODE0 Event Control"]
+    pub evctrl: self::mode0::EVCTRL,
+    #[doc = "0x06 - MODE0 Interrupt Enable Clear"]
+    pub intenclr: self::mode0::INTENCLR,
+    #[doc = "0x07 - MODE0 Interrupt Enable Set"]
+    pub intenset: self::mode0::INTENSET,
+    #[doc = "0x08 - MODE0 Interrupt Flag Status and Clear"]
+    pub intflag: self::mode0::INTFLAG,
+    _reserved6: [u8; 1usize],
+    #[doc = "0x0a - Status"]
+    pub status: self::mode0::STATUS,
+    #[doc = "0x0b - Debug Control"]
+    pub dbgctrl: self::mode0::DBGCTRL,
+    #[doc = "0x0c - Frequency Correction"]
+    pub freqcorr: self::mode0::FREQCORR,
+    _reserved9: [u8; 3usize],
+    #[doc = "0x10 - MODE0 Counter Value"]
+    pub count: self::mode0::COUNT,
+    _reserved10: [u8; 4usize],
+    #[doc = "0x18 - MODE0 Compare n Value"]
+    pub comp: [self::mode0::COMP; 1],
+}
+#[doc = r"Register block"]
+#[doc = "32-bit Counter with Single 32-bit Compare"]
+pub mod mode0;
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct MODE1 {
+    #[doc = "0x00 - MODE1 Control"]
+    pub ctrl: self::mode1::CTRL,
+    #[doc = "0x02 - Read Request"]
+    pub readreq: self::mode1::READREQ,
+    #[doc = "0x04 - MODE1 Event Control"]
+    pub evctrl: self::mode1::EVCTRL,
+    #[doc = "0x06 - MODE1 Interrupt Enable Clear"]
+    pub intenclr: self::mode1::INTENCLR,
+    #[doc = "0x07 - MODE1 Interrupt Enable Set"]
+    pub intenset: self::mode1::INTENSET,
+    #[doc = "0x08 - MODE1 Interrupt Flag Status and Clear"]
+    pub intflag: self::mode1::INTFLAG,
+    _reserved6: [u8; 1usize],
+    #[doc = "0x0a - Status"]
+    pub status: self::mode1::STATUS,
+    #[doc = "0x0b - Debug Control"]
+    pub dbgctrl: self::mode1::DBGCTRL,
+    #[doc = "0x0c - Frequency Correction"]
+    pub freqcorr: self::mode1::FREQCORR,
+    _reserved9: [u8; 3usize],
+    #[doc = "0x10 - MODE1 Counter Value"]
+    pub count: self::mode1::COUNT,
+    _reserved10: [u8; 2usize],
+    #[doc = "0x14 - MODE1 Counter Period"]
+    pub per: self::mode1::PER,
+    _reserved11: [u8; 2usize],
+    #[doc = "0x18 - MODE1 Compare n Value"]
+    pub comp: [self::mode1::COMP; 2],
+}
+#[doc = r"Register block"]
+#[doc = "16-bit Counter with Two 16-bit Compares"]
+pub mod mode1;
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct MODE2 {
+    #[doc = "0x00 - MODE2 Control"]
+    pub ctrl: self::mode2::CTRL,
+    #[doc = "0x02 - Read Request"]
+    pub readreq: self::mode2::READREQ,
+    #[doc = "0x04 - MODE2 Event Control"]
+    pub evctrl: self::mode2::EVCTRL,
+    #[doc = "0x06 - MODE2 Interrupt Enable Clear"]
+    pub intenclr: self::mode2::INTENCLR,
+    #[doc = "0x07 - MODE2 Interrupt Enable Set"]
+    pub intenset: self::mode2::INTENSET,
+    #[doc = "0x08 - MODE2 Interrupt Flag Status and Clear"]
+    pub intflag: self::mode2::INTFLAG,
+    _reserved6: [u8; 1usize],
+    #[doc = "0x0a - Status"]
+    pub status: self::mode2::STATUS,
+    #[doc = "0x0b - Debug Control"]
+    pub dbgctrl: self::mode2::DBGCTRL,
+    #[doc = "0x0c - Frequency Correction"]
+    pub freqcorr: self::mode2::FREQCORR,
+    _reserved9: [u8; 3usize],
+    #[doc = "0x10 - MODE2 Clock Value"]
+    pub clock: self::mode2::CLOCK,
+    _reserved10: [u8; 4usize],
+    #[doc = "0x18 - MODE2 Alarm n Value"]
+    pub alarm0: self::mode2::ALARM,
+    #[doc = "0x1c - MODE2 Alarm n Mask"]
+    pub mask0: self::mode2::MASK,
+}
+#[doc = r"Register block"]
+#[doc = "Clock/Calendar with Alarm"]
+pub mod mode2;

--- a/pac/atsamd11c14a/src/rtc/mode0.rs
+++ b/pac/atsamd11c14a/src/rtc/mode0.rs
@@ -1,0 +1,119 @@
+#[doc = "MODE0 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrl](ctrl) module"]
+pub type CTRL = crate::Reg<u16, _CTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRL;
+#[doc = "`read()` method returns [ctrl::R](ctrl::R) reader structure"]
+impl crate::Readable for CTRL {}
+#[doc = "`write(|w| ..)` method takes [ctrl::W](ctrl::W) writer structure"]
+impl crate::Writable for CTRL {}
+#[doc = "MODE0 Control"]
+pub mod ctrl;
+#[doc = "Read Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [readreq](readreq) module"]
+pub type READREQ = crate::Reg<u16, _READREQ>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _READREQ;
+#[doc = "`read()` method returns [readreq::R](readreq::R) reader structure"]
+impl crate::Readable for READREQ {}
+#[doc = "`write(|w| ..)` method takes [readreq::W](readreq::W) writer structure"]
+impl crate::Writable for READREQ {}
+#[doc = "Read Request"]
+pub mod readreq;
+#[doc = "MODE0 Event Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [evctrl](evctrl) module"]
+pub type EVCTRL = crate::Reg<u16, _EVCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EVCTRL;
+#[doc = "`read()` method returns [evctrl::R](evctrl::R) reader structure"]
+impl crate::Readable for EVCTRL {}
+#[doc = "`write(|w| ..)` method takes [evctrl::W](evctrl::W) writer structure"]
+impl crate::Writable for EVCTRL {}
+#[doc = "MODE0 Event Control"]
+pub mod evctrl;
+#[doc = "MODE0 Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "MODE0 Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "MODE0 Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "MODE0 Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "MODE0 Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "MODE0 Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u8, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "Status"]
+pub mod status;
+#[doc = "Debug Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dbgctrl](dbgctrl) module"]
+pub type DBGCTRL = crate::Reg<u8, _DBGCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DBGCTRL;
+#[doc = "`read()` method returns [dbgctrl::R](dbgctrl::R) reader structure"]
+impl crate::Readable for DBGCTRL {}
+#[doc = "`write(|w| ..)` method takes [dbgctrl::W](dbgctrl::W) writer structure"]
+impl crate::Writable for DBGCTRL {}
+#[doc = "Debug Control"]
+pub mod dbgctrl;
+#[doc = "Frequency Correction\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [freqcorr](freqcorr) module"]
+pub type FREQCORR = crate::Reg<u8, _FREQCORR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _FREQCORR;
+#[doc = "`read()` method returns [freqcorr::R](freqcorr::R) reader structure"]
+impl crate::Readable for FREQCORR {}
+#[doc = "`write(|w| ..)` method takes [freqcorr::W](freqcorr::W) writer structure"]
+impl crate::Writable for FREQCORR {}
+#[doc = "Frequency Correction"]
+pub mod freqcorr;
+#[doc = "MODE0 Counter Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [count](count) module"]
+pub type COUNT = crate::Reg<u32, _COUNT>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _COUNT;
+#[doc = "`read()` method returns [count::R](count::R) reader structure"]
+impl crate::Readable for COUNT {}
+#[doc = "`write(|w| ..)` method takes [count::W](count::W) writer structure"]
+impl crate::Writable for COUNT {}
+#[doc = "MODE0 Counter Value"]
+pub mod count;
+#[doc = "MODE0 Compare n Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [comp](comp) module"]
+pub type COMP = crate::Reg<u32, _COMP>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _COMP;
+#[doc = "`read()` method returns [comp::R](comp::R) reader structure"]
+impl crate::Readable for COMP {}
+#[doc = "`write(|w| ..)` method takes [comp::W](comp::W) writer structure"]
+impl crate::Writable for COMP {}
+#[doc = "MODE0 Compare n Value"]
+pub mod comp;

--- a/pac/atsamd11c14a/src/rtc/mode0/comp.rs
+++ b/pac/atsamd11c14a/src/rtc/mode0/comp.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register COMP%s"]
+pub type R = crate::R<u32, super::COMP>;
+#[doc = "Writer for register COMP%s"]
+pub type W = crate::W<u32, super::COMP>;
+#[doc = "Register COMP%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::COMP {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `COMP`"]
+pub type COMP_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `COMP`"]
+pub struct COMP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COMP_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Compare Value"]
+    #[inline(always)]
+    pub fn comp(&self) -> COMP_R {
+        COMP_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Compare Value"]
+    #[inline(always)]
+    pub fn comp(&mut self) -> COMP_W {
+        COMP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode0/count.rs
+++ b/pac/atsamd11c14a/src/rtc/mode0/count.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register COUNT"]
+pub type R = crate::R<u32, super::COUNT>;
+#[doc = "Writer for register COUNT"]
+pub type W = crate::W<u32, super::COUNT>;
+#[doc = "Register COUNT `reset()`'s with value 0"]
+impl crate::ResetValue for super::COUNT {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `COUNT`"]
+pub type COUNT_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `COUNT`"]
+pub struct COUNT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COUNT_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Counter Value"]
+    #[inline(always)]
+    pub fn count(&self) -> COUNT_R {
+        COUNT_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Counter Value"]
+    #[inline(always)]
+    pub fn count(&mut self) -> COUNT_W {
+        COUNT_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode0/ctrl.rs
+++ b/pac/atsamd11c14a/src/rtc/mode0/ctrl.rs
@@ -1,0 +1,407 @@
+#[doc = "Reader of register CTRL"]
+pub type R = crate::R<u16, super::CTRL>;
+#[doc = "Writer for register CTRL"]
+pub type W = crate::W<u16, super::CTRL>;
+#[doc = "Register CTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRL {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Operating Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MODE_A {
+    #[doc = "0: Mode 0: 32-bit Counter"]
+    COUNT32,
+    #[doc = "1: Mode 1: 16-bit Counter"]
+    COUNT16,
+    #[doc = "2: Mode 2: Clock/Calendar"]
+    CLOCK,
+}
+impl From<MODE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: MODE_A) -> Self {
+        match variant {
+            MODE_A::COUNT32 => 0,
+            MODE_A::COUNT16 => 1,
+            MODE_A::CLOCK => 2,
+        }
+    }
+}
+#[doc = "Reader of field `MODE`"]
+pub type MODE_R = crate::R<u8, MODE_A>;
+impl MODE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, MODE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(MODE_A::COUNT32),
+            1 => Val(MODE_A::COUNT16),
+            2 => Val(MODE_A::CLOCK),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `COUNT32`"]
+    #[inline(always)]
+    pub fn is_count32(&self) -> bool {
+        *self == MODE_A::COUNT32
+    }
+    #[doc = "Checks if the value of the field is `COUNT16`"]
+    #[inline(always)]
+    pub fn is_count16(&self) -> bool {
+        *self == MODE_A::COUNT16
+    }
+    #[doc = "Checks if the value of the field is `CLOCK`"]
+    #[inline(always)]
+    pub fn is_clock(&self) -> bool {
+        *self == MODE_A::CLOCK
+    }
+}
+#[doc = "Write proxy for field `MODE`"]
+pub struct MODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MODE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: MODE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Mode 0: 32-bit Counter"]
+    #[inline(always)]
+    pub fn count32(self) -> &'a mut W {
+        self.variant(MODE_A::COUNT32)
+    }
+    #[doc = "Mode 1: 16-bit Counter"]
+    #[inline(always)]
+    pub fn count16(self) -> &'a mut W {
+        self.variant(MODE_A::COUNT16)
+    }
+    #[doc = "Mode 2: Clock/Calendar"]
+    #[inline(always)]
+    pub fn clock(self) -> &'a mut W {
+        self.variant(MODE_A::CLOCK)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 2)) | (((value as u16) & 0x03) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `MATCHCLR`"]
+pub type MATCHCLR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MATCHCLR`"]
+pub struct MATCHCLR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MATCHCLR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Prescaler\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PRESCALER_A {
+    #[doc = "0: CLK_RTC_CNT = GCLK_RTC/1"]
+    DIV1,
+    #[doc = "1: CLK_RTC_CNT = GCLK_RTC/2"]
+    DIV2,
+    #[doc = "2: CLK_RTC_CNT = GCLK_RTC/4"]
+    DIV4,
+    #[doc = "3: CLK_RTC_CNT = GCLK_RTC/8"]
+    DIV8,
+    #[doc = "4: CLK_RTC_CNT = GCLK_RTC/16"]
+    DIV16,
+    #[doc = "5: CLK_RTC_CNT = GCLK_RTC/32"]
+    DIV32,
+    #[doc = "6: CLK_RTC_CNT = GCLK_RTC/64"]
+    DIV64,
+    #[doc = "7: CLK_RTC_CNT = GCLK_RTC/128"]
+    DIV128,
+    #[doc = "8: CLK_RTC_CNT = GCLK_RTC/256"]
+    DIV256,
+    #[doc = "9: CLK_RTC_CNT = GCLK_RTC/512"]
+    DIV512,
+    #[doc = "10: CLK_RTC_CNT = GCLK_RTC/1024"]
+    DIV1024,
+}
+impl From<PRESCALER_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PRESCALER_A) -> Self {
+        match variant {
+            PRESCALER_A::DIV1 => 0,
+            PRESCALER_A::DIV2 => 1,
+            PRESCALER_A::DIV4 => 2,
+            PRESCALER_A::DIV8 => 3,
+            PRESCALER_A::DIV16 => 4,
+            PRESCALER_A::DIV32 => 5,
+            PRESCALER_A::DIV64 => 6,
+            PRESCALER_A::DIV128 => 7,
+            PRESCALER_A::DIV256 => 8,
+            PRESCALER_A::DIV512 => 9,
+            PRESCALER_A::DIV1024 => 10,
+        }
+    }
+}
+#[doc = "Reader of field `PRESCALER`"]
+pub type PRESCALER_R = crate::R<u8, PRESCALER_A>;
+impl PRESCALER_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, PRESCALER_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(PRESCALER_A::DIV1),
+            1 => Val(PRESCALER_A::DIV2),
+            2 => Val(PRESCALER_A::DIV4),
+            3 => Val(PRESCALER_A::DIV8),
+            4 => Val(PRESCALER_A::DIV16),
+            5 => Val(PRESCALER_A::DIV32),
+            6 => Val(PRESCALER_A::DIV64),
+            7 => Val(PRESCALER_A::DIV128),
+            8 => Val(PRESCALER_A::DIV256),
+            9 => Val(PRESCALER_A::DIV512),
+            10 => Val(PRESCALER_A::DIV1024),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DIV1`"]
+    #[inline(always)]
+    pub fn is_div1(&self) -> bool {
+        *self == PRESCALER_A::DIV1
+    }
+    #[doc = "Checks if the value of the field is `DIV2`"]
+    #[inline(always)]
+    pub fn is_div2(&self) -> bool {
+        *self == PRESCALER_A::DIV2
+    }
+    #[doc = "Checks if the value of the field is `DIV4`"]
+    #[inline(always)]
+    pub fn is_div4(&self) -> bool {
+        *self == PRESCALER_A::DIV4
+    }
+    #[doc = "Checks if the value of the field is `DIV8`"]
+    #[inline(always)]
+    pub fn is_div8(&self) -> bool {
+        *self == PRESCALER_A::DIV8
+    }
+    #[doc = "Checks if the value of the field is `DIV16`"]
+    #[inline(always)]
+    pub fn is_div16(&self) -> bool {
+        *self == PRESCALER_A::DIV16
+    }
+    #[doc = "Checks if the value of the field is `DIV32`"]
+    #[inline(always)]
+    pub fn is_div32(&self) -> bool {
+        *self == PRESCALER_A::DIV32
+    }
+    #[doc = "Checks if the value of the field is `DIV64`"]
+    #[inline(always)]
+    pub fn is_div64(&self) -> bool {
+        *self == PRESCALER_A::DIV64
+    }
+    #[doc = "Checks if the value of the field is `DIV128`"]
+    #[inline(always)]
+    pub fn is_div128(&self) -> bool {
+        *self == PRESCALER_A::DIV128
+    }
+    #[doc = "Checks if the value of the field is `DIV256`"]
+    #[inline(always)]
+    pub fn is_div256(&self) -> bool {
+        *self == PRESCALER_A::DIV256
+    }
+    #[doc = "Checks if the value of the field is `DIV512`"]
+    #[inline(always)]
+    pub fn is_div512(&self) -> bool {
+        *self == PRESCALER_A::DIV512
+    }
+    #[doc = "Checks if the value of the field is `DIV1024`"]
+    #[inline(always)]
+    pub fn is_div1024(&self) -> bool {
+        *self == PRESCALER_A::DIV1024
+    }
+}
+#[doc = "Write proxy for field `PRESCALER`"]
+pub struct PRESCALER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PRESCALER_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PRESCALER_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/1"]
+    #[inline(always)]
+    pub fn div1(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV1)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/2"]
+    #[inline(always)]
+    pub fn div2(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV2)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/4"]
+    #[inline(always)]
+    pub fn div4(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV4)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/8"]
+    #[inline(always)]
+    pub fn div8(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV8)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/16"]
+    #[inline(always)]
+    pub fn div16(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV16)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/32"]
+    #[inline(always)]
+    pub fn div32(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV32)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/64"]
+    #[inline(always)]
+    pub fn div64(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV64)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/128"]
+    #[inline(always)]
+    pub fn div128(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV128)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/256"]
+    #[inline(always)]
+    pub fn div256(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV256)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/512"]
+    #[inline(always)]
+    pub fn div512(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV512)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/1024"]
+    #[inline(always)]
+    pub fn div1024(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV1024)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 8)) | (((value as u16) & 0x0f) << 8);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 2:3 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 2) & 0x03) as u8)
+    }
+    #[doc = "Bit 7 - Clear on Match"]
+    #[inline(always)]
+    pub fn matchclr(&self) -> MATCHCLR_R {
+        MATCHCLR_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bits 8:11 - Prescaler"]
+    #[inline(always)]
+    pub fn prescaler(&self) -> PRESCALER_R {
+        PRESCALER_R::new(((self.bits >> 8) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bits 2:3 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&mut self) -> MODE_W {
+        MODE_W { w: self }
+    }
+    #[doc = "Bit 7 - Clear on Match"]
+    #[inline(always)]
+    pub fn matchclr(&mut self) -> MATCHCLR_W {
+        MATCHCLR_W { w: self }
+    }
+    #[doc = "Bits 8:11 - Prescaler"]
+    #[inline(always)]
+    pub fn prescaler(&mut self) -> PRESCALER_W {
+        PRESCALER_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode0/dbgctrl.rs
+++ b/pac/atsamd11c14a/src/rtc/mode0/dbgctrl.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register DBGCTRL"]
+pub type R = crate::R<u8, super::DBGCTRL>;
+#[doc = "Writer for register DBGCTRL"]
+pub type W = crate::W<u8, super::DBGCTRL>;
+#[doc = "Register DBGCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::DBGCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DBGRUN`"]
+pub type DBGRUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DBGRUN`"]
+pub struct DBGRUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DBGRUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Run During Debug"]
+    #[inline(always)]
+    pub fn dbgrun(&self) -> DBGRUN_R {
+        DBGRUN_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Run During Debug"]
+    #[inline(always)]
+    pub fn dbgrun(&mut self) -> DBGRUN_W {
+        DBGRUN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode0/evctrl.rs
+++ b/pac/atsamd11c14a/src/rtc/mode0/evctrl.rs
@@ -1,0 +1,356 @@
+#[doc = "Reader of register EVCTRL"]
+pub type R = crate::R<u16, super::EVCTRL>;
+#[doc = "Writer for register EVCTRL"]
+pub type W = crate::W<u16, super::EVCTRL>;
+#[doc = "Register EVCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::EVCTRL {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `PEREO0`"]
+pub type PEREO0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO0`"]
+pub struct PEREO0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO1`"]
+pub type PEREO1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO1`"]
+pub struct PEREO1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO2`"]
+pub type PEREO2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO2`"]
+pub struct PEREO2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO3`"]
+pub type PEREO3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO3`"]
+pub struct PEREO3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u16) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO4`"]
+pub type PEREO4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO4`"]
+pub struct PEREO4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO5`"]
+pub type PEREO5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO5`"]
+pub struct PEREO5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO6`"]
+pub type PEREO6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO6`"]
+pub struct PEREO6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO7`"]
+pub type PEREO7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO7`"]
+pub struct PEREO7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `CMPEO0`"]
+pub type CMPEO0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CMPEO0`"]
+pub struct CMPEO0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMPEO0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVFEO`"]
+pub type OVFEO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVFEO`"]
+pub struct OVFEO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVFEO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u16) & 0x01) << 15);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Periodic Interval 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo0(&self) -> PEREO0_R {
+        PEREO0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Periodic Interval 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo1(&self) -> PEREO1_R {
+        PEREO1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Periodic Interval 2 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo2(&self) -> PEREO2_R {
+        PEREO2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Periodic Interval 3 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo3(&self) -> PEREO3_R {
+        PEREO3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Periodic Interval 4 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo4(&self) -> PEREO4_R {
+        PEREO4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Periodic Interval 5 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo5(&self) -> PEREO5_R {
+        PEREO5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Periodic Interval 6 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo6(&self) -> PEREO6_R {
+        PEREO6_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Periodic Interval 7 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo7(&self) -> PEREO7_R {
+        PEREO7_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Compare 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn cmpeo0(&self) -> CMPEO0_R {
+        CMPEO0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Overflow Event Output Enable"]
+    #[inline(always)]
+    pub fn ovfeo(&self) -> OVFEO_R {
+        OVFEO_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Periodic Interval 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo0(&mut self) -> PEREO0_W {
+        PEREO0_W { w: self }
+    }
+    #[doc = "Bit 1 - Periodic Interval 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo1(&mut self) -> PEREO1_W {
+        PEREO1_W { w: self }
+    }
+    #[doc = "Bit 2 - Periodic Interval 2 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo2(&mut self) -> PEREO2_W {
+        PEREO2_W { w: self }
+    }
+    #[doc = "Bit 3 - Periodic Interval 3 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo3(&mut self) -> PEREO3_W {
+        PEREO3_W { w: self }
+    }
+    #[doc = "Bit 4 - Periodic Interval 4 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo4(&mut self) -> PEREO4_W {
+        PEREO4_W { w: self }
+    }
+    #[doc = "Bit 5 - Periodic Interval 5 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo5(&mut self) -> PEREO5_W {
+        PEREO5_W { w: self }
+    }
+    #[doc = "Bit 6 - Periodic Interval 6 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo6(&mut self) -> PEREO6_W {
+        PEREO6_W { w: self }
+    }
+    #[doc = "Bit 7 - Periodic Interval 7 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo7(&mut self) -> PEREO7_W {
+        PEREO7_W { w: self }
+    }
+    #[doc = "Bit 8 - Compare 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn cmpeo0(&mut self) -> CMPEO0_W {
+        CMPEO0_W { w: self }
+    }
+    #[doc = "Bit 15 - Overflow Event Output Enable"]
+    #[inline(always)]
+    pub fn ovfeo(&mut self) -> OVFEO_W {
+        OVFEO_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode0/freqcorr.rs
+++ b/pac/atsamd11c14a/src/rtc/mode0/freqcorr.rs
@@ -1,0 +1,74 @@
+#[doc = "Reader of register FREQCORR"]
+pub type R = crate::R<u8, super::FREQCORR>;
+#[doc = "Writer for register FREQCORR"]
+pub type W = crate::W<u8, super::FREQCORR>;
+#[doc = "Register FREQCORR `reset()`'s with value 0"]
+impl crate::ResetValue for super::FREQCORR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `VALUE`"]
+pub type VALUE_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `VALUE`"]
+pub struct VALUE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> VALUE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x7f) | ((value as u8) & 0x7f);
+        self.w
+    }
+}
+#[doc = "Reader of field `SIGN`"]
+pub type SIGN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SIGN`"]
+pub struct SIGN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SIGN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:6 - Correction Value"]
+    #[inline(always)]
+    pub fn value(&self) -> VALUE_R {
+        VALUE_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bit 7 - Correction Sign"]
+    #[inline(always)]
+    pub fn sign(&self) -> SIGN_R {
+        SIGN_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - Correction Value"]
+    #[inline(always)]
+    pub fn value(&mut self) -> VALUE_W {
+        VALUE_W { w: self }
+    }
+    #[doc = "Bit 7 - Correction Sign"]
+    #[inline(always)]
+    pub fn sign(&mut self) -> SIGN_W {
+        SIGN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode0/intenclr.rs
+++ b/pac/atsamd11c14a/src/rtc/mode0/intenclr.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CMP0`"]
+pub type CMP0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CMP0`"]
+pub struct CMP0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMP0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Compare 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn cmp0(&self) -> CMP0_R {
+        CMP0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Compare 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn cmp0(&mut self) -> CMP0_W {
+        CMP0_W { w: self }
+    }
+    #[doc = "Bit 6 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 7 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode0/intenset.rs
+++ b/pac/atsamd11c14a/src/rtc/mode0/intenset.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CMP0`"]
+pub type CMP0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CMP0`"]
+pub struct CMP0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMP0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Compare 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn cmp0(&self) -> CMP0_R {
+        CMP0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Compare 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn cmp0(&mut self) -> CMP0_W {
+        CMP0_W { w: self }
+    }
+    #[doc = "Bit 6 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 7 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode0/intflag.rs
+++ b/pac/atsamd11c14a/src/rtc/mode0/intflag.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CMP0`"]
+pub type CMP0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CMP0`"]
+pub struct CMP0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMP0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Compare 0"]
+    #[inline(always)]
+    pub fn cmp0(&self) -> CMP0_R {
+        CMP0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Overflow"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Compare 0"]
+    #[inline(always)]
+    pub fn cmp0(&mut self) -> CMP0_W {
+        CMP0_W { w: self }
+    }
+    #[doc = "Bit 6 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 7 - Overflow"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode0/readreq.rs
+++ b/pac/atsamd11c14a/src/rtc/mode0/readreq.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register READREQ"]
+pub type R = crate::R<u16, super::READREQ>;
+#[doc = "Writer for register READREQ"]
+pub type W = crate::W<u16, super::READREQ>;
+#[doc = "Register READREQ `reset()`'s with value 0x10"]
+impl crate::ResetValue for super::READREQ {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x10
+    }
+}
+#[doc = "Reader of field `ADDR`"]
+pub type ADDR_R = crate::R<u8, u8>;
+#[doc = "Reader of field `RCONT`"]
+pub type RCONT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RCONT`"]
+pub struct RCONT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RCONT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u16) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `RREQ`"]
+pub struct RREQ_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RREQ_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u16) & 0x01) << 15);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:5 - Address"]
+    #[inline(always)]
+    pub fn addr(&self) -> ADDR_R {
+        ADDR_R::new((self.bits & 0x3f) as u8)
+    }
+    #[doc = "Bit 14 - Read Continuously"]
+    #[inline(always)]
+    pub fn rcont(&self) -> RCONT_R {
+        RCONT_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 14 - Read Continuously"]
+    #[inline(always)]
+    pub fn rcont(&mut self) -> RCONT_W {
+        RCONT_W { w: self }
+    }
+    #[doc = "Bit 15 - Read Request"]
+    #[inline(always)]
+    pub fn rreq(&mut self) -> RREQ_W {
+        RREQ_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode0/status.rs
+++ b/pac/atsamd11c14a/src/rtc/mode0/status.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u8, super::STATUS>;
+#[doc = "Reader of field `SYNCBUSY`"]
+pub type SYNCBUSY_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 7 - Synchronization Busy"]
+    #[inline(always)]
+    pub fn syncbusy(&self) -> SYNCBUSY_R {
+        SYNCBUSY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode1.rs
+++ b/pac/atsamd11c14a/src/rtc/mode1.rs
@@ -1,0 +1,130 @@
+#[doc = "MODE1 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrl](ctrl) module"]
+pub type CTRL = crate::Reg<u16, _CTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRL;
+#[doc = "`read()` method returns [ctrl::R](ctrl::R) reader structure"]
+impl crate::Readable for CTRL {}
+#[doc = "`write(|w| ..)` method takes [ctrl::W](ctrl::W) writer structure"]
+impl crate::Writable for CTRL {}
+#[doc = "MODE1 Control"]
+pub mod ctrl;
+#[doc = "Read Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [readreq](readreq) module"]
+pub type READREQ = crate::Reg<u16, _READREQ>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _READREQ;
+#[doc = "`read()` method returns [readreq::R](readreq::R) reader structure"]
+impl crate::Readable for READREQ {}
+#[doc = "`write(|w| ..)` method takes [readreq::W](readreq::W) writer structure"]
+impl crate::Writable for READREQ {}
+#[doc = "Read Request"]
+pub mod readreq;
+#[doc = "MODE1 Event Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [evctrl](evctrl) module"]
+pub type EVCTRL = crate::Reg<u16, _EVCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EVCTRL;
+#[doc = "`read()` method returns [evctrl::R](evctrl::R) reader structure"]
+impl crate::Readable for EVCTRL {}
+#[doc = "`write(|w| ..)` method takes [evctrl::W](evctrl::W) writer structure"]
+impl crate::Writable for EVCTRL {}
+#[doc = "MODE1 Event Control"]
+pub mod evctrl;
+#[doc = "MODE1 Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "MODE1 Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "MODE1 Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "MODE1 Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "MODE1 Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "MODE1 Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u8, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "Status"]
+pub mod status;
+#[doc = "Debug Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dbgctrl](dbgctrl) module"]
+pub type DBGCTRL = crate::Reg<u8, _DBGCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DBGCTRL;
+#[doc = "`read()` method returns [dbgctrl::R](dbgctrl::R) reader structure"]
+impl crate::Readable for DBGCTRL {}
+#[doc = "`write(|w| ..)` method takes [dbgctrl::W](dbgctrl::W) writer structure"]
+impl crate::Writable for DBGCTRL {}
+#[doc = "Debug Control"]
+pub mod dbgctrl;
+#[doc = "Frequency Correction\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [freqcorr](freqcorr) module"]
+pub type FREQCORR = crate::Reg<u8, _FREQCORR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _FREQCORR;
+#[doc = "`read()` method returns [freqcorr::R](freqcorr::R) reader structure"]
+impl crate::Readable for FREQCORR {}
+#[doc = "`write(|w| ..)` method takes [freqcorr::W](freqcorr::W) writer structure"]
+impl crate::Writable for FREQCORR {}
+#[doc = "Frequency Correction"]
+pub mod freqcorr;
+#[doc = "MODE1 Counter Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [count](count) module"]
+pub type COUNT = crate::Reg<u16, _COUNT>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _COUNT;
+#[doc = "`read()` method returns [count::R](count::R) reader structure"]
+impl crate::Readable for COUNT {}
+#[doc = "`write(|w| ..)` method takes [count::W](count::W) writer structure"]
+impl crate::Writable for COUNT {}
+#[doc = "MODE1 Counter Value"]
+pub mod count;
+#[doc = "MODE1 Counter Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [per](per) module"]
+pub type PER = crate::Reg<u16, _PER>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PER;
+#[doc = "`read()` method returns [per::R](per::R) reader structure"]
+impl crate::Readable for PER {}
+#[doc = "`write(|w| ..)` method takes [per::W](per::W) writer structure"]
+impl crate::Writable for PER {}
+#[doc = "MODE1 Counter Period"]
+pub mod per;
+#[doc = "MODE1 Compare n Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [comp](comp) module"]
+pub type COMP = crate::Reg<u16, _COMP>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _COMP;
+#[doc = "`read()` method returns [comp::R](comp::R) reader structure"]
+impl crate::Readable for COMP {}
+#[doc = "`write(|w| ..)` method takes [comp::W](comp::W) writer structure"]
+impl crate::Writable for COMP {}
+#[doc = "MODE1 Compare n Value"]
+pub mod comp;

--- a/pac/atsamd11c14a/src/rtc/mode1/comp.rs
+++ b/pac/atsamd11c14a/src/rtc/mode1/comp.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register COMP%s"]
+pub type R = crate::R<u16, super::COMP>;
+#[doc = "Writer for register COMP%s"]
+pub type W = crate::W<u16, super::COMP>;
+#[doc = "Register COMP%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::COMP {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `COMP`"]
+pub type COMP_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `COMP`"]
+pub struct COMP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COMP_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff) | ((value as u16) & 0xffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:15 - Compare Value"]
+    #[inline(always)]
+    pub fn comp(&self) -> COMP_R {
+        COMP_R::new((self.bits & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Compare Value"]
+    #[inline(always)]
+    pub fn comp(&mut self) -> COMP_W {
+        COMP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode1/count.rs
+++ b/pac/atsamd11c14a/src/rtc/mode1/count.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register COUNT"]
+pub type R = crate::R<u16, super::COUNT>;
+#[doc = "Writer for register COUNT"]
+pub type W = crate::W<u16, super::COUNT>;
+#[doc = "Register COUNT `reset()`'s with value 0"]
+impl crate::ResetValue for super::COUNT {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `COUNT`"]
+pub type COUNT_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `COUNT`"]
+pub struct COUNT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COUNT_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff) | ((value as u16) & 0xffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:15 - Counter Value"]
+    #[inline(always)]
+    pub fn count(&self) -> COUNT_R {
+        COUNT_R::new((self.bits & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Counter Value"]
+    #[inline(always)]
+    pub fn count(&mut self) -> COUNT_W {
+        COUNT_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode1/ctrl.rs
+++ b/pac/atsamd11c14a/src/rtc/mode1/ctrl.rs
@@ -1,0 +1,373 @@
+#[doc = "Reader of register CTRL"]
+pub type R = crate::R<u16, super::CTRL>;
+#[doc = "Writer for register CTRL"]
+pub type W = crate::W<u16, super::CTRL>;
+#[doc = "Register CTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRL {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Operating Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MODE_A {
+    #[doc = "0: Mode 0: 32-bit Counter"]
+    COUNT32,
+    #[doc = "1: Mode 1: 16-bit Counter"]
+    COUNT16,
+    #[doc = "2: Mode 2: Clock/Calendar"]
+    CLOCK,
+}
+impl From<MODE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: MODE_A) -> Self {
+        match variant {
+            MODE_A::COUNT32 => 0,
+            MODE_A::COUNT16 => 1,
+            MODE_A::CLOCK => 2,
+        }
+    }
+}
+#[doc = "Reader of field `MODE`"]
+pub type MODE_R = crate::R<u8, MODE_A>;
+impl MODE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, MODE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(MODE_A::COUNT32),
+            1 => Val(MODE_A::COUNT16),
+            2 => Val(MODE_A::CLOCK),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `COUNT32`"]
+    #[inline(always)]
+    pub fn is_count32(&self) -> bool {
+        *self == MODE_A::COUNT32
+    }
+    #[doc = "Checks if the value of the field is `COUNT16`"]
+    #[inline(always)]
+    pub fn is_count16(&self) -> bool {
+        *self == MODE_A::COUNT16
+    }
+    #[doc = "Checks if the value of the field is `CLOCK`"]
+    #[inline(always)]
+    pub fn is_clock(&self) -> bool {
+        *self == MODE_A::CLOCK
+    }
+}
+#[doc = "Write proxy for field `MODE`"]
+pub struct MODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MODE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: MODE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Mode 0: 32-bit Counter"]
+    #[inline(always)]
+    pub fn count32(self) -> &'a mut W {
+        self.variant(MODE_A::COUNT32)
+    }
+    #[doc = "Mode 1: 16-bit Counter"]
+    #[inline(always)]
+    pub fn count16(self) -> &'a mut W {
+        self.variant(MODE_A::COUNT16)
+    }
+    #[doc = "Mode 2: Clock/Calendar"]
+    #[inline(always)]
+    pub fn clock(self) -> &'a mut W {
+        self.variant(MODE_A::CLOCK)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 2)) | (((value as u16) & 0x03) << 2);
+        self.w
+    }
+}
+#[doc = "Prescaler\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PRESCALER_A {
+    #[doc = "0: CLK_RTC_CNT = GCLK_RTC/1"]
+    DIV1,
+    #[doc = "1: CLK_RTC_CNT = GCLK_RTC/2"]
+    DIV2,
+    #[doc = "2: CLK_RTC_CNT = GCLK_RTC/4"]
+    DIV4,
+    #[doc = "3: CLK_RTC_CNT = GCLK_RTC/8"]
+    DIV8,
+    #[doc = "4: CLK_RTC_CNT = GCLK_RTC/16"]
+    DIV16,
+    #[doc = "5: CLK_RTC_CNT = GCLK_RTC/32"]
+    DIV32,
+    #[doc = "6: CLK_RTC_CNT = GCLK_RTC/64"]
+    DIV64,
+    #[doc = "7: CLK_RTC_CNT = GCLK_RTC/128"]
+    DIV128,
+    #[doc = "8: CLK_RTC_CNT = GCLK_RTC/256"]
+    DIV256,
+    #[doc = "9: CLK_RTC_CNT = GCLK_RTC/512"]
+    DIV512,
+    #[doc = "10: CLK_RTC_CNT = GCLK_RTC/1024"]
+    DIV1024,
+}
+impl From<PRESCALER_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PRESCALER_A) -> Self {
+        match variant {
+            PRESCALER_A::DIV1 => 0,
+            PRESCALER_A::DIV2 => 1,
+            PRESCALER_A::DIV4 => 2,
+            PRESCALER_A::DIV8 => 3,
+            PRESCALER_A::DIV16 => 4,
+            PRESCALER_A::DIV32 => 5,
+            PRESCALER_A::DIV64 => 6,
+            PRESCALER_A::DIV128 => 7,
+            PRESCALER_A::DIV256 => 8,
+            PRESCALER_A::DIV512 => 9,
+            PRESCALER_A::DIV1024 => 10,
+        }
+    }
+}
+#[doc = "Reader of field `PRESCALER`"]
+pub type PRESCALER_R = crate::R<u8, PRESCALER_A>;
+impl PRESCALER_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, PRESCALER_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(PRESCALER_A::DIV1),
+            1 => Val(PRESCALER_A::DIV2),
+            2 => Val(PRESCALER_A::DIV4),
+            3 => Val(PRESCALER_A::DIV8),
+            4 => Val(PRESCALER_A::DIV16),
+            5 => Val(PRESCALER_A::DIV32),
+            6 => Val(PRESCALER_A::DIV64),
+            7 => Val(PRESCALER_A::DIV128),
+            8 => Val(PRESCALER_A::DIV256),
+            9 => Val(PRESCALER_A::DIV512),
+            10 => Val(PRESCALER_A::DIV1024),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DIV1`"]
+    #[inline(always)]
+    pub fn is_div1(&self) -> bool {
+        *self == PRESCALER_A::DIV1
+    }
+    #[doc = "Checks if the value of the field is `DIV2`"]
+    #[inline(always)]
+    pub fn is_div2(&self) -> bool {
+        *self == PRESCALER_A::DIV2
+    }
+    #[doc = "Checks if the value of the field is `DIV4`"]
+    #[inline(always)]
+    pub fn is_div4(&self) -> bool {
+        *self == PRESCALER_A::DIV4
+    }
+    #[doc = "Checks if the value of the field is `DIV8`"]
+    #[inline(always)]
+    pub fn is_div8(&self) -> bool {
+        *self == PRESCALER_A::DIV8
+    }
+    #[doc = "Checks if the value of the field is `DIV16`"]
+    #[inline(always)]
+    pub fn is_div16(&self) -> bool {
+        *self == PRESCALER_A::DIV16
+    }
+    #[doc = "Checks if the value of the field is `DIV32`"]
+    #[inline(always)]
+    pub fn is_div32(&self) -> bool {
+        *self == PRESCALER_A::DIV32
+    }
+    #[doc = "Checks if the value of the field is `DIV64`"]
+    #[inline(always)]
+    pub fn is_div64(&self) -> bool {
+        *self == PRESCALER_A::DIV64
+    }
+    #[doc = "Checks if the value of the field is `DIV128`"]
+    #[inline(always)]
+    pub fn is_div128(&self) -> bool {
+        *self == PRESCALER_A::DIV128
+    }
+    #[doc = "Checks if the value of the field is `DIV256`"]
+    #[inline(always)]
+    pub fn is_div256(&self) -> bool {
+        *self == PRESCALER_A::DIV256
+    }
+    #[doc = "Checks if the value of the field is `DIV512`"]
+    #[inline(always)]
+    pub fn is_div512(&self) -> bool {
+        *self == PRESCALER_A::DIV512
+    }
+    #[doc = "Checks if the value of the field is `DIV1024`"]
+    #[inline(always)]
+    pub fn is_div1024(&self) -> bool {
+        *self == PRESCALER_A::DIV1024
+    }
+}
+#[doc = "Write proxy for field `PRESCALER`"]
+pub struct PRESCALER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PRESCALER_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PRESCALER_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/1"]
+    #[inline(always)]
+    pub fn div1(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV1)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/2"]
+    #[inline(always)]
+    pub fn div2(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV2)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/4"]
+    #[inline(always)]
+    pub fn div4(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV4)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/8"]
+    #[inline(always)]
+    pub fn div8(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV8)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/16"]
+    #[inline(always)]
+    pub fn div16(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV16)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/32"]
+    #[inline(always)]
+    pub fn div32(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV32)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/64"]
+    #[inline(always)]
+    pub fn div64(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV64)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/128"]
+    #[inline(always)]
+    pub fn div128(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV128)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/256"]
+    #[inline(always)]
+    pub fn div256(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV256)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/512"]
+    #[inline(always)]
+    pub fn div512(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV512)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/1024"]
+    #[inline(always)]
+    pub fn div1024(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV1024)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 8)) | (((value as u16) & 0x0f) << 8);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 2:3 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 2) & 0x03) as u8)
+    }
+    #[doc = "Bits 8:11 - Prescaler"]
+    #[inline(always)]
+    pub fn prescaler(&self) -> PRESCALER_R {
+        PRESCALER_R::new(((self.bits >> 8) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bits 2:3 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&mut self) -> MODE_W {
+        MODE_W { w: self }
+    }
+    #[doc = "Bits 8:11 - Prescaler"]
+    #[inline(always)]
+    pub fn prescaler(&mut self) -> PRESCALER_W {
+        PRESCALER_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode1/dbgctrl.rs
+++ b/pac/atsamd11c14a/src/rtc/mode1/dbgctrl.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register DBGCTRL"]
+pub type R = crate::R<u8, super::DBGCTRL>;
+#[doc = "Writer for register DBGCTRL"]
+pub type W = crate::W<u8, super::DBGCTRL>;
+#[doc = "Register DBGCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::DBGCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DBGRUN`"]
+pub type DBGRUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DBGRUN`"]
+pub struct DBGRUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DBGRUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Run During Debug"]
+    #[inline(always)]
+    pub fn dbgrun(&self) -> DBGRUN_R {
+        DBGRUN_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Run During Debug"]
+    #[inline(always)]
+    pub fn dbgrun(&mut self) -> DBGRUN_W {
+        DBGRUN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode1/evctrl.rs
+++ b/pac/atsamd11c14a/src/rtc/mode1/evctrl.rs
@@ -1,0 +1,390 @@
+#[doc = "Reader of register EVCTRL"]
+pub type R = crate::R<u16, super::EVCTRL>;
+#[doc = "Writer for register EVCTRL"]
+pub type W = crate::W<u16, super::EVCTRL>;
+#[doc = "Register EVCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::EVCTRL {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `PEREO0`"]
+pub type PEREO0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO0`"]
+pub struct PEREO0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO1`"]
+pub type PEREO1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO1`"]
+pub struct PEREO1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO2`"]
+pub type PEREO2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO2`"]
+pub struct PEREO2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO3`"]
+pub type PEREO3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO3`"]
+pub struct PEREO3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u16) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO4`"]
+pub type PEREO4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO4`"]
+pub struct PEREO4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO5`"]
+pub type PEREO5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO5`"]
+pub struct PEREO5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO6`"]
+pub type PEREO6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO6`"]
+pub struct PEREO6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO7`"]
+pub type PEREO7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO7`"]
+pub struct PEREO7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `CMPEO0`"]
+pub type CMPEO0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CMPEO0`"]
+pub struct CMPEO0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMPEO0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `CMPEO1`"]
+pub type CMPEO1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CMPEO1`"]
+pub struct CMPEO1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMPEO1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u16) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVFEO`"]
+pub type OVFEO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVFEO`"]
+pub struct OVFEO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVFEO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u16) & 0x01) << 15);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Periodic Interval 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo0(&self) -> PEREO0_R {
+        PEREO0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Periodic Interval 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo1(&self) -> PEREO1_R {
+        PEREO1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Periodic Interval 2 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo2(&self) -> PEREO2_R {
+        PEREO2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Periodic Interval 3 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo3(&self) -> PEREO3_R {
+        PEREO3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Periodic Interval 4 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo4(&self) -> PEREO4_R {
+        PEREO4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Periodic Interval 5 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo5(&self) -> PEREO5_R {
+        PEREO5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Periodic Interval 6 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo6(&self) -> PEREO6_R {
+        PEREO6_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Periodic Interval 7 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo7(&self) -> PEREO7_R {
+        PEREO7_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Compare 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn cmpeo0(&self) -> CMPEO0_R {
+        CMPEO0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Compare 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn cmpeo1(&self) -> CMPEO1_R {
+        CMPEO1_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Overflow Event Output Enable"]
+    #[inline(always)]
+    pub fn ovfeo(&self) -> OVFEO_R {
+        OVFEO_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Periodic Interval 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo0(&mut self) -> PEREO0_W {
+        PEREO0_W { w: self }
+    }
+    #[doc = "Bit 1 - Periodic Interval 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo1(&mut self) -> PEREO1_W {
+        PEREO1_W { w: self }
+    }
+    #[doc = "Bit 2 - Periodic Interval 2 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo2(&mut self) -> PEREO2_W {
+        PEREO2_W { w: self }
+    }
+    #[doc = "Bit 3 - Periodic Interval 3 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo3(&mut self) -> PEREO3_W {
+        PEREO3_W { w: self }
+    }
+    #[doc = "Bit 4 - Periodic Interval 4 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo4(&mut self) -> PEREO4_W {
+        PEREO4_W { w: self }
+    }
+    #[doc = "Bit 5 - Periodic Interval 5 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo5(&mut self) -> PEREO5_W {
+        PEREO5_W { w: self }
+    }
+    #[doc = "Bit 6 - Periodic Interval 6 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo6(&mut self) -> PEREO6_W {
+        PEREO6_W { w: self }
+    }
+    #[doc = "Bit 7 - Periodic Interval 7 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo7(&mut self) -> PEREO7_W {
+        PEREO7_W { w: self }
+    }
+    #[doc = "Bit 8 - Compare 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn cmpeo0(&mut self) -> CMPEO0_W {
+        CMPEO0_W { w: self }
+    }
+    #[doc = "Bit 9 - Compare 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn cmpeo1(&mut self) -> CMPEO1_W {
+        CMPEO1_W { w: self }
+    }
+    #[doc = "Bit 15 - Overflow Event Output Enable"]
+    #[inline(always)]
+    pub fn ovfeo(&mut self) -> OVFEO_W {
+        OVFEO_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode1/freqcorr.rs
+++ b/pac/atsamd11c14a/src/rtc/mode1/freqcorr.rs
@@ -1,0 +1,74 @@
+#[doc = "Reader of register FREQCORR"]
+pub type R = crate::R<u8, super::FREQCORR>;
+#[doc = "Writer for register FREQCORR"]
+pub type W = crate::W<u8, super::FREQCORR>;
+#[doc = "Register FREQCORR `reset()`'s with value 0"]
+impl crate::ResetValue for super::FREQCORR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `VALUE`"]
+pub type VALUE_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `VALUE`"]
+pub struct VALUE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> VALUE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x7f) | ((value as u8) & 0x7f);
+        self.w
+    }
+}
+#[doc = "Reader of field `SIGN`"]
+pub type SIGN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SIGN`"]
+pub struct SIGN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SIGN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:6 - Correction Value"]
+    #[inline(always)]
+    pub fn value(&self) -> VALUE_R {
+        VALUE_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bit 7 - Correction Sign"]
+    #[inline(always)]
+    pub fn sign(&self) -> SIGN_R {
+        SIGN_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - Correction Value"]
+    #[inline(always)]
+    pub fn value(&mut self) -> VALUE_W {
+        VALUE_W { w: self }
+    }
+    #[doc = "Bit 7 - Correction Sign"]
+    #[inline(always)]
+    pub fn sign(&mut self) -> SIGN_W {
+        SIGN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode1/intenclr.rs
+++ b/pac/atsamd11c14a/src/rtc/mode1/intenclr.rs
@@ -1,0 +1,152 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CMP0`"]
+pub type CMP0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CMP0`"]
+pub struct CMP0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMP0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `CMP1`"]
+pub type CMP1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CMP1`"]
+pub struct CMP1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMP1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Compare 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn cmp0(&self) -> CMP0_R {
+        CMP0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Compare 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn cmp1(&self) -> CMP1_R {
+        CMP1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Compare 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn cmp0(&mut self) -> CMP0_W {
+        CMP0_W { w: self }
+    }
+    #[doc = "Bit 1 - Compare 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn cmp1(&mut self) -> CMP1_W {
+        CMP1_W { w: self }
+    }
+    #[doc = "Bit 6 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 7 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode1/intenset.rs
+++ b/pac/atsamd11c14a/src/rtc/mode1/intenset.rs
@@ -1,0 +1,152 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CMP0`"]
+pub type CMP0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CMP0`"]
+pub struct CMP0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMP0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `CMP1`"]
+pub type CMP1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CMP1`"]
+pub struct CMP1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMP1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Compare 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn cmp0(&self) -> CMP0_R {
+        CMP0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Compare 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn cmp1(&self) -> CMP1_R {
+        CMP1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Compare 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn cmp0(&mut self) -> CMP0_W {
+        CMP0_W { w: self }
+    }
+    #[doc = "Bit 1 - Compare 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn cmp1(&mut self) -> CMP1_W {
+        CMP1_W { w: self }
+    }
+    #[doc = "Bit 6 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 7 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode1/intflag.rs
+++ b/pac/atsamd11c14a/src/rtc/mode1/intflag.rs
@@ -1,0 +1,152 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CMP0`"]
+pub type CMP0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CMP0`"]
+pub struct CMP0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMP0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `CMP1`"]
+pub type CMP1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CMP1`"]
+pub struct CMP1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMP1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Compare 0"]
+    #[inline(always)]
+    pub fn cmp0(&self) -> CMP0_R {
+        CMP0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Compare 1"]
+    #[inline(always)]
+    pub fn cmp1(&self) -> CMP1_R {
+        CMP1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Overflow"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Compare 0"]
+    #[inline(always)]
+    pub fn cmp0(&mut self) -> CMP0_W {
+        CMP0_W { w: self }
+    }
+    #[doc = "Bit 1 - Compare 1"]
+    #[inline(always)]
+    pub fn cmp1(&mut self) -> CMP1_W {
+        CMP1_W { w: self }
+    }
+    #[doc = "Bit 6 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 7 - Overflow"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode1/per.rs
+++ b/pac/atsamd11c14a/src/rtc/mode1/per.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register PER"]
+pub type R = crate::R<u16, super::PER>;
+#[doc = "Writer for register PER"]
+pub type W = crate::W<u16, super::PER>;
+#[doc = "Register PER `reset()`'s with value 0"]
+impl crate::ResetValue for super::PER {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `PER`"]
+pub type PER_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `PER`"]
+pub struct PER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PER_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff) | ((value as u16) & 0xffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:15 - Counter Period"]
+    #[inline(always)]
+    pub fn per(&self) -> PER_R {
+        PER_R::new((self.bits & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Counter Period"]
+    #[inline(always)]
+    pub fn per(&mut self) -> PER_W {
+        PER_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode1/readreq.rs
+++ b/pac/atsamd11c14a/src/rtc/mode1/readreq.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register READREQ"]
+pub type R = crate::R<u16, super::READREQ>;
+#[doc = "Writer for register READREQ"]
+pub type W = crate::W<u16, super::READREQ>;
+#[doc = "Register READREQ `reset()`'s with value 0x10"]
+impl crate::ResetValue for super::READREQ {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x10
+    }
+}
+#[doc = "Reader of field `ADDR`"]
+pub type ADDR_R = crate::R<u8, u8>;
+#[doc = "Reader of field `RCONT`"]
+pub type RCONT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RCONT`"]
+pub struct RCONT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RCONT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u16) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `RREQ`"]
+pub struct RREQ_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RREQ_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u16) & 0x01) << 15);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:5 - Address"]
+    #[inline(always)]
+    pub fn addr(&self) -> ADDR_R {
+        ADDR_R::new((self.bits & 0x3f) as u8)
+    }
+    #[doc = "Bit 14 - Read Continuously"]
+    #[inline(always)]
+    pub fn rcont(&self) -> RCONT_R {
+        RCONT_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 14 - Read Continuously"]
+    #[inline(always)]
+    pub fn rcont(&mut self) -> RCONT_W {
+        RCONT_W { w: self }
+    }
+    #[doc = "Bit 15 - Read Request"]
+    #[inline(always)]
+    pub fn rreq(&mut self) -> RREQ_W {
+        RREQ_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode1/status.rs
+++ b/pac/atsamd11c14a/src/rtc/mode1/status.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u8, super::STATUS>;
+#[doc = "Reader of field `SYNCBUSY`"]
+pub type SYNCBUSY_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 7 - Synchronization Busy"]
+    #[inline(always)]
+    pub fn syncbusy(&self) -> SYNCBUSY_R {
+        SYNCBUSY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode2.rs
+++ b/pac/atsamd11c14a/src/rtc/mode2.rs
@@ -1,0 +1,130 @@
+#[doc = "MODE2 Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrl](ctrl) module"]
+pub type CTRL = crate::Reg<u16, _CTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRL;
+#[doc = "`read()` method returns [ctrl::R](ctrl::R) reader structure"]
+impl crate::Readable for CTRL {}
+#[doc = "`write(|w| ..)` method takes [ctrl::W](ctrl::W) writer structure"]
+impl crate::Writable for CTRL {}
+#[doc = "MODE2 Control"]
+pub mod ctrl;
+#[doc = "Read Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [readreq](readreq) module"]
+pub type READREQ = crate::Reg<u16, _READREQ>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _READREQ;
+#[doc = "`read()` method returns [readreq::R](readreq::R) reader structure"]
+impl crate::Readable for READREQ {}
+#[doc = "`write(|w| ..)` method takes [readreq::W](readreq::W) writer structure"]
+impl crate::Writable for READREQ {}
+#[doc = "Read Request"]
+pub mod readreq;
+#[doc = "MODE2 Event Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [evctrl](evctrl) module"]
+pub type EVCTRL = crate::Reg<u16, _EVCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EVCTRL;
+#[doc = "`read()` method returns [evctrl::R](evctrl::R) reader structure"]
+impl crate::Readable for EVCTRL {}
+#[doc = "`write(|w| ..)` method takes [evctrl::W](evctrl::W) writer structure"]
+impl crate::Writable for EVCTRL {}
+#[doc = "MODE2 Event Control"]
+pub mod evctrl;
+#[doc = "MODE2 Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "MODE2 Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "MODE2 Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "MODE2 Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "MODE2 Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "MODE2 Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u8, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "Status"]
+pub mod status;
+#[doc = "Debug Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dbgctrl](dbgctrl) module"]
+pub type DBGCTRL = crate::Reg<u8, _DBGCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DBGCTRL;
+#[doc = "`read()` method returns [dbgctrl::R](dbgctrl::R) reader structure"]
+impl crate::Readable for DBGCTRL {}
+#[doc = "`write(|w| ..)` method takes [dbgctrl::W](dbgctrl::W) writer structure"]
+impl crate::Writable for DBGCTRL {}
+#[doc = "Debug Control"]
+pub mod dbgctrl;
+#[doc = "Frequency Correction\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [freqcorr](freqcorr) module"]
+pub type FREQCORR = crate::Reg<u8, _FREQCORR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _FREQCORR;
+#[doc = "`read()` method returns [freqcorr::R](freqcorr::R) reader structure"]
+impl crate::Readable for FREQCORR {}
+#[doc = "`write(|w| ..)` method takes [freqcorr::W](freqcorr::W) writer structure"]
+impl crate::Writable for FREQCORR {}
+#[doc = "Frequency Correction"]
+pub mod freqcorr;
+#[doc = "MODE2 Clock Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [clock](clock) module"]
+pub type CLOCK = crate::Reg<u32, _CLOCK>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CLOCK;
+#[doc = "`read()` method returns [clock::R](clock::R) reader structure"]
+impl crate::Readable for CLOCK {}
+#[doc = "`write(|w| ..)` method takes [clock::W](clock::W) writer structure"]
+impl crate::Writable for CLOCK {}
+#[doc = "MODE2 Clock Value"]
+pub mod clock;
+#[doc = "MODE2 Alarm n Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [alarm](alarm) module"]
+pub type ALARM = crate::Reg<u32, _ALARM>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _ALARM;
+#[doc = "`read()` method returns [alarm::R](alarm::R) reader structure"]
+impl crate::Readable for ALARM {}
+#[doc = "`write(|w| ..)` method takes [alarm::W](alarm::W) writer structure"]
+impl crate::Writable for ALARM {}
+#[doc = "MODE2 Alarm n Value"]
+pub mod alarm;
+#[doc = "MODE2 Alarm n Mask\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [mask](mask) module"]
+pub type MASK = crate::Reg<u8, _MASK>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _MASK;
+#[doc = "`read()` method returns [mask::R](mask::R) reader structure"]
+impl crate::Readable for MASK {}
+#[doc = "`write(|w| ..)` method takes [mask::W](mask::W) writer structure"]
+impl crate::Writable for MASK {}
+#[doc = "MODE2 Alarm n Mask"]
+pub mod mask;

--- a/pac/atsamd11c14a/src/rtc/mode2/alarm.rs
+++ b/pac/atsamd11c14a/src/rtc/mode2/alarm.rs
@@ -1,0 +1,214 @@
+#[doc = "Reader of register ALARM%s"]
+pub type R = crate::R<u32, super::ALARM>;
+#[doc = "Writer for register ALARM%s"]
+pub type W = crate::W<u32, super::ALARM>;
+#[doc = "Register ALARM%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::ALARM {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SECOND`"]
+pub type SECOND_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `SECOND`"]
+pub struct SECOND_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SECOND_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x3f) | ((value as u32) & 0x3f);
+        self.w
+    }
+}
+#[doc = "Reader of field `MINUTE`"]
+pub type MINUTE_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `MINUTE`"]
+pub struct MINUTE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MINUTE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x3f << 6)) | (((value as u32) & 0x3f) << 6);
+        self.w
+    }
+}
+#[doc = "Hour\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum HOUR_A {
+    #[doc = "0: Morning hour"]
+    AM,
+    #[doc = "16: Afternoon hour"]
+    PM,
+}
+impl From<HOUR_A> for u8 {
+    #[inline(always)]
+    fn from(variant: HOUR_A) -> Self {
+        match variant {
+            HOUR_A::AM => 0,
+            HOUR_A::PM => 16,
+        }
+    }
+}
+#[doc = "Reader of field `HOUR`"]
+pub type HOUR_R = crate::R<u8, HOUR_A>;
+impl HOUR_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, HOUR_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(HOUR_A::AM),
+            16 => Val(HOUR_A::PM),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `AM`"]
+    #[inline(always)]
+    pub fn is_am(&self) -> bool {
+        *self == HOUR_A::AM
+    }
+    #[doc = "Checks if the value of the field is `PM`"]
+    #[inline(always)]
+    pub fn is_pm(&self) -> bool {
+        *self == HOUR_A::PM
+    }
+}
+#[doc = "Write proxy for field `HOUR`"]
+pub struct HOUR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HOUR_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: HOUR_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Morning hour"]
+    #[inline(always)]
+    pub fn am(self) -> &'a mut W {
+        self.variant(HOUR_A::AM)
+    }
+    #[doc = "Afternoon hour"]
+    #[inline(always)]
+    pub fn pm(self) -> &'a mut W {
+        self.variant(HOUR_A::PM)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x1f << 12)) | (((value as u32) & 0x1f) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `DAY`"]
+pub type DAY_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DAY`"]
+pub struct DAY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DAY_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x1f << 17)) | (((value as u32) & 0x1f) << 17);
+        self.w
+    }
+}
+#[doc = "Reader of field `MONTH`"]
+pub type MONTH_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `MONTH`"]
+pub struct MONTH_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MONTH_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 22)) | (((value as u32) & 0x0f) << 22);
+        self.w
+    }
+}
+#[doc = "Reader of field `YEAR`"]
+pub type YEAR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `YEAR`"]
+pub struct YEAR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> YEAR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x3f << 26)) | (((value as u32) & 0x3f) << 26);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:5 - Second"]
+    #[inline(always)]
+    pub fn second(&self) -> SECOND_R {
+        SECOND_R::new((self.bits & 0x3f) as u8)
+    }
+    #[doc = "Bits 6:11 - Minute"]
+    #[inline(always)]
+    pub fn minute(&self) -> MINUTE_R {
+        MINUTE_R::new(((self.bits >> 6) & 0x3f) as u8)
+    }
+    #[doc = "Bits 12:16 - Hour"]
+    #[inline(always)]
+    pub fn hour(&self) -> HOUR_R {
+        HOUR_R::new(((self.bits >> 12) & 0x1f) as u8)
+    }
+    #[doc = "Bits 17:21 - Day"]
+    #[inline(always)]
+    pub fn day(&self) -> DAY_R {
+        DAY_R::new(((self.bits >> 17) & 0x1f) as u8)
+    }
+    #[doc = "Bits 22:25 - Month"]
+    #[inline(always)]
+    pub fn month(&self) -> MONTH_R {
+        MONTH_R::new(((self.bits >> 22) & 0x0f) as u8)
+    }
+    #[doc = "Bits 26:31 - Year"]
+    #[inline(always)]
+    pub fn year(&self) -> YEAR_R {
+        YEAR_R::new(((self.bits >> 26) & 0x3f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:5 - Second"]
+    #[inline(always)]
+    pub fn second(&mut self) -> SECOND_W {
+        SECOND_W { w: self }
+    }
+    #[doc = "Bits 6:11 - Minute"]
+    #[inline(always)]
+    pub fn minute(&mut self) -> MINUTE_W {
+        MINUTE_W { w: self }
+    }
+    #[doc = "Bits 12:16 - Hour"]
+    #[inline(always)]
+    pub fn hour(&mut self) -> HOUR_W {
+        HOUR_W { w: self }
+    }
+    #[doc = "Bits 17:21 - Day"]
+    #[inline(always)]
+    pub fn day(&mut self) -> DAY_W {
+        DAY_W { w: self }
+    }
+    #[doc = "Bits 22:25 - Month"]
+    #[inline(always)]
+    pub fn month(&mut self) -> MONTH_W {
+        MONTH_W { w: self }
+    }
+    #[doc = "Bits 26:31 - Year"]
+    #[inline(always)]
+    pub fn year(&mut self) -> YEAR_W {
+        YEAR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode2/clock.rs
+++ b/pac/atsamd11c14a/src/rtc/mode2/clock.rs
@@ -1,0 +1,214 @@
+#[doc = "Reader of register CLOCK"]
+pub type R = crate::R<u32, super::CLOCK>;
+#[doc = "Writer for register CLOCK"]
+pub type W = crate::W<u32, super::CLOCK>;
+#[doc = "Register CLOCK `reset()`'s with value 0"]
+impl crate::ResetValue for super::CLOCK {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SECOND`"]
+pub type SECOND_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `SECOND`"]
+pub struct SECOND_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SECOND_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x3f) | ((value as u32) & 0x3f);
+        self.w
+    }
+}
+#[doc = "Reader of field `MINUTE`"]
+pub type MINUTE_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `MINUTE`"]
+pub struct MINUTE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MINUTE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x3f << 6)) | (((value as u32) & 0x3f) << 6);
+        self.w
+    }
+}
+#[doc = "Hour\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum HOUR_A {
+    #[doc = "0: AM when CLKREP in 12-hour"]
+    AM,
+    #[doc = "16: PM when CLKREP in 12-hour"]
+    PM,
+}
+impl From<HOUR_A> for u8 {
+    #[inline(always)]
+    fn from(variant: HOUR_A) -> Self {
+        match variant {
+            HOUR_A::AM => 0,
+            HOUR_A::PM => 16,
+        }
+    }
+}
+#[doc = "Reader of field `HOUR`"]
+pub type HOUR_R = crate::R<u8, HOUR_A>;
+impl HOUR_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, HOUR_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(HOUR_A::AM),
+            16 => Val(HOUR_A::PM),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `AM`"]
+    #[inline(always)]
+    pub fn is_am(&self) -> bool {
+        *self == HOUR_A::AM
+    }
+    #[doc = "Checks if the value of the field is `PM`"]
+    #[inline(always)]
+    pub fn is_pm(&self) -> bool {
+        *self == HOUR_A::PM
+    }
+}
+#[doc = "Write proxy for field `HOUR`"]
+pub struct HOUR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HOUR_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: HOUR_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "AM when CLKREP in 12-hour"]
+    #[inline(always)]
+    pub fn am(self) -> &'a mut W {
+        self.variant(HOUR_A::AM)
+    }
+    #[doc = "PM when CLKREP in 12-hour"]
+    #[inline(always)]
+    pub fn pm(self) -> &'a mut W {
+        self.variant(HOUR_A::PM)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x1f << 12)) | (((value as u32) & 0x1f) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `DAY`"]
+pub type DAY_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DAY`"]
+pub struct DAY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DAY_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x1f << 17)) | (((value as u32) & 0x1f) << 17);
+        self.w
+    }
+}
+#[doc = "Reader of field `MONTH`"]
+pub type MONTH_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `MONTH`"]
+pub struct MONTH_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MONTH_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 22)) | (((value as u32) & 0x0f) << 22);
+        self.w
+    }
+}
+#[doc = "Reader of field `YEAR`"]
+pub type YEAR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `YEAR`"]
+pub struct YEAR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> YEAR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x3f << 26)) | (((value as u32) & 0x3f) << 26);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:5 - Second"]
+    #[inline(always)]
+    pub fn second(&self) -> SECOND_R {
+        SECOND_R::new((self.bits & 0x3f) as u8)
+    }
+    #[doc = "Bits 6:11 - Minute"]
+    #[inline(always)]
+    pub fn minute(&self) -> MINUTE_R {
+        MINUTE_R::new(((self.bits >> 6) & 0x3f) as u8)
+    }
+    #[doc = "Bits 12:16 - Hour"]
+    #[inline(always)]
+    pub fn hour(&self) -> HOUR_R {
+        HOUR_R::new(((self.bits >> 12) & 0x1f) as u8)
+    }
+    #[doc = "Bits 17:21 - Day"]
+    #[inline(always)]
+    pub fn day(&self) -> DAY_R {
+        DAY_R::new(((self.bits >> 17) & 0x1f) as u8)
+    }
+    #[doc = "Bits 22:25 - Month"]
+    #[inline(always)]
+    pub fn month(&self) -> MONTH_R {
+        MONTH_R::new(((self.bits >> 22) & 0x0f) as u8)
+    }
+    #[doc = "Bits 26:31 - Year"]
+    #[inline(always)]
+    pub fn year(&self) -> YEAR_R {
+        YEAR_R::new(((self.bits >> 26) & 0x3f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:5 - Second"]
+    #[inline(always)]
+    pub fn second(&mut self) -> SECOND_W {
+        SECOND_W { w: self }
+    }
+    #[doc = "Bits 6:11 - Minute"]
+    #[inline(always)]
+    pub fn minute(&mut self) -> MINUTE_W {
+        MINUTE_W { w: self }
+    }
+    #[doc = "Bits 12:16 - Hour"]
+    #[inline(always)]
+    pub fn hour(&mut self) -> HOUR_W {
+        HOUR_W { w: self }
+    }
+    #[doc = "Bits 17:21 - Day"]
+    #[inline(always)]
+    pub fn day(&mut self) -> DAY_W {
+        DAY_W { w: self }
+    }
+    #[doc = "Bits 22:25 - Month"]
+    #[inline(always)]
+    pub fn month(&mut self) -> MONTH_W {
+        MONTH_W { w: self }
+    }
+    #[doc = "Bits 26:31 - Year"]
+    #[inline(always)]
+    pub fn year(&mut self) -> YEAR_W {
+        YEAR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode2/ctrl.rs
+++ b/pac/atsamd11c14a/src/rtc/mode2/ctrl.rs
@@ -1,0 +1,441 @@
+#[doc = "Reader of register CTRL"]
+pub type R = crate::R<u16, super::CTRL>;
+#[doc = "Writer for register CTRL"]
+pub type W = crate::W<u16, super::CTRL>;
+#[doc = "Register CTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRL {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Operating Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MODE_A {
+    #[doc = "0: Mode 0: 32-bit Counter"]
+    COUNT32,
+    #[doc = "1: Mode 1: 16-bit Counter"]
+    COUNT16,
+    #[doc = "2: Mode 2: Clock/Calendar"]
+    CLOCK,
+}
+impl From<MODE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: MODE_A) -> Self {
+        match variant {
+            MODE_A::COUNT32 => 0,
+            MODE_A::COUNT16 => 1,
+            MODE_A::CLOCK => 2,
+        }
+    }
+}
+#[doc = "Reader of field `MODE`"]
+pub type MODE_R = crate::R<u8, MODE_A>;
+impl MODE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, MODE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(MODE_A::COUNT32),
+            1 => Val(MODE_A::COUNT16),
+            2 => Val(MODE_A::CLOCK),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `COUNT32`"]
+    #[inline(always)]
+    pub fn is_count32(&self) -> bool {
+        *self == MODE_A::COUNT32
+    }
+    #[doc = "Checks if the value of the field is `COUNT16`"]
+    #[inline(always)]
+    pub fn is_count16(&self) -> bool {
+        *self == MODE_A::COUNT16
+    }
+    #[doc = "Checks if the value of the field is `CLOCK`"]
+    #[inline(always)]
+    pub fn is_clock(&self) -> bool {
+        *self == MODE_A::CLOCK
+    }
+}
+#[doc = "Write proxy for field `MODE`"]
+pub struct MODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MODE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: MODE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Mode 0: 32-bit Counter"]
+    #[inline(always)]
+    pub fn count32(self) -> &'a mut W {
+        self.variant(MODE_A::COUNT32)
+    }
+    #[doc = "Mode 1: 16-bit Counter"]
+    #[inline(always)]
+    pub fn count16(self) -> &'a mut W {
+        self.variant(MODE_A::COUNT16)
+    }
+    #[doc = "Mode 2: Clock/Calendar"]
+    #[inline(always)]
+    pub fn clock(self) -> &'a mut W {
+        self.variant(MODE_A::CLOCK)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 2)) | (((value as u16) & 0x03) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `CLKREP`"]
+pub type CLKREP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CLKREP`"]
+pub struct CLKREP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CLKREP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `MATCHCLR`"]
+pub type MATCHCLR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MATCHCLR`"]
+pub struct MATCHCLR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MATCHCLR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Prescaler\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PRESCALER_A {
+    #[doc = "0: CLK_RTC_CNT = GCLK_RTC/1"]
+    DIV1,
+    #[doc = "1: CLK_RTC_CNT = GCLK_RTC/2"]
+    DIV2,
+    #[doc = "2: CLK_RTC_CNT = GCLK_RTC/4"]
+    DIV4,
+    #[doc = "3: CLK_RTC_CNT = GCLK_RTC/8"]
+    DIV8,
+    #[doc = "4: CLK_RTC_CNT = GCLK_RTC/16"]
+    DIV16,
+    #[doc = "5: CLK_RTC_CNT = GCLK_RTC/32"]
+    DIV32,
+    #[doc = "6: CLK_RTC_CNT = GCLK_RTC/64"]
+    DIV64,
+    #[doc = "7: CLK_RTC_CNT = GCLK_RTC/128"]
+    DIV128,
+    #[doc = "8: CLK_RTC_CNT = GCLK_RTC/256"]
+    DIV256,
+    #[doc = "9: CLK_RTC_CNT = GCLK_RTC/512"]
+    DIV512,
+    #[doc = "10: CLK_RTC_CNT = GCLK_RTC/1024"]
+    DIV1024,
+}
+impl From<PRESCALER_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PRESCALER_A) -> Self {
+        match variant {
+            PRESCALER_A::DIV1 => 0,
+            PRESCALER_A::DIV2 => 1,
+            PRESCALER_A::DIV4 => 2,
+            PRESCALER_A::DIV8 => 3,
+            PRESCALER_A::DIV16 => 4,
+            PRESCALER_A::DIV32 => 5,
+            PRESCALER_A::DIV64 => 6,
+            PRESCALER_A::DIV128 => 7,
+            PRESCALER_A::DIV256 => 8,
+            PRESCALER_A::DIV512 => 9,
+            PRESCALER_A::DIV1024 => 10,
+        }
+    }
+}
+#[doc = "Reader of field `PRESCALER`"]
+pub type PRESCALER_R = crate::R<u8, PRESCALER_A>;
+impl PRESCALER_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, PRESCALER_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(PRESCALER_A::DIV1),
+            1 => Val(PRESCALER_A::DIV2),
+            2 => Val(PRESCALER_A::DIV4),
+            3 => Val(PRESCALER_A::DIV8),
+            4 => Val(PRESCALER_A::DIV16),
+            5 => Val(PRESCALER_A::DIV32),
+            6 => Val(PRESCALER_A::DIV64),
+            7 => Val(PRESCALER_A::DIV128),
+            8 => Val(PRESCALER_A::DIV256),
+            9 => Val(PRESCALER_A::DIV512),
+            10 => Val(PRESCALER_A::DIV1024),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DIV1`"]
+    #[inline(always)]
+    pub fn is_div1(&self) -> bool {
+        *self == PRESCALER_A::DIV1
+    }
+    #[doc = "Checks if the value of the field is `DIV2`"]
+    #[inline(always)]
+    pub fn is_div2(&self) -> bool {
+        *self == PRESCALER_A::DIV2
+    }
+    #[doc = "Checks if the value of the field is `DIV4`"]
+    #[inline(always)]
+    pub fn is_div4(&self) -> bool {
+        *self == PRESCALER_A::DIV4
+    }
+    #[doc = "Checks if the value of the field is `DIV8`"]
+    #[inline(always)]
+    pub fn is_div8(&self) -> bool {
+        *self == PRESCALER_A::DIV8
+    }
+    #[doc = "Checks if the value of the field is `DIV16`"]
+    #[inline(always)]
+    pub fn is_div16(&self) -> bool {
+        *self == PRESCALER_A::DIV16
+    }
+    #[doc = "Checks if the value of the field is `DIV32`"]
+    #[inline(always)]
+    pub fn is_div32(&self) -> bool {
+        *self == PRESCALER_A::DIV32
+    }
+    #[doc = "Checks if the value of the field is `DIV64`"]
+    #[inline(always)]
+    pub fn is_div64(&self) -> bool {
+        *self == PRESCALER_A::DIV64
+    }
+    #[doc = "Checks if the value of the field is `DIV128`"]
+    #[inline(always)]
+    pub fn is_div128(&self) -> bool {
+        *self == PRESCALER_A::DIV128
+    }
+    #[doc = "Checks if the value of the field is `DIV256`"]
+    #[inline(always)]
+    pub fn is_div256(&self) -> bool {
+        *self == PRESCALER_A::DIV256
+    }
+    #[doc = "Checks if the value of the field is `DIV512`"]
+    #[inline(always)]
+    pub fn is_div512(&self) -> bool {
+        *self == PRESCALER_A::DIV512
+    }
+    #[doc = "Checks if the value of the field is `DIV1024`"]
+    #[inline(always)]
+    pub fn is_div1024(&self) -> bool {
+        *self == PRESCALER_A::DIV1024
+    }
+}
+#[doc = "Write proxy for field `PRESCALER`"]
+pub struct PRESCALER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PRESCALER_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PRESCALER_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/1"]
+    #[inline(always)]
+    pub fn div1(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV1)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/2"]
+    #[inline(always)]
+    pub fn div2(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV2)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/4"]
+    #[inline(always)]
+    pub fn div4(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV4)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/8"]
+    #[inline(always)]
+    pub fn div8(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV8)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/16"]
+    #[inline(always)]
+    pub fn div16(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV16)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/32"]
+    #[inline(always)]
+    pub fn div32(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV32)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/64"]
+    #[inline(always)]
+    pub fn div64(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV64)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/128"]
+    #[inline(always)]
+    pub fn div128(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV128)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/256"]
+    #[inline(always)]
+    pub fn div256(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV256)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/512"]
+    #[inline(always)]
+    pub fn div512(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV512)
+    }
+    #[doc = "CLK_RTC_CNT = GCLK_RTC/1024"]
+    #[inline(always)]
+    pub fn div1024(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV1024)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 8)) | (((value as u16) & 0x0f) << 8);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 2:3 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 2) & 0x03) as u8)
+    }
+    #[doc = "Bit 6 - Clock Representation"]
+    #[inline(always)]
+    pub fn clkrep(&self) -> CLKREP_R {
+        CLKREP_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Clear on Match"]
+    #[inline(always)]
+    pub fn matchclr(&self) -> MATCHCLR_R {
+        MATCHCLR_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bits 8:11 - Prescaler"]
+    #[inline(always)]
+    pub fn prescaler(&self) -> PRESCALER_R {
+        PRESCALER_R::new(((self.bits >> 8) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bits 2:3 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&mut self) -> MODE_W {
+        MODE_W { w: self }
+    }
+    #[doc = "Bit 6 - Clock Representation"]
+    #[inline(always)]
+    pub fn clkrep(&mut self) -> CLKREP_W {
+        CLKREP_W { w: self }
+    }
+    #[doc = "Bit 7 - Clear on Match"]
+    #[inline(always)]
+    pub fn matchclr(&mut self) -> MATCHCLR_W {
+        MATCHCLR_W { w: self }
+    }
+    #[doc = "Bits 8:11 - Prescaler"]
+    #[inline(always)]
+    pub fn prescaler(&mut self) -> PRESCALER_W {
+        PRESCALER_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode2/dbgctrl.rs
+++ b/pac/atsamd11c14a/src/rtc/mode2/dbgctrl.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register DBGCTRL"]
+pub type R = crate::R<u8, super::DBGCTRL>;
+#[doc = "Writer for register DBGCTRL"]
+pub type W = crate::W<u8, super::DBGCTRL>;
+#[doc = "Register DBGCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::DBGCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DBGRUN`"]
+pub type DBGRUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DBGRUN`"]
+pub struct DBGRUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DBGRUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Run During Debug"]
+    #[inline(always)]
+    pub fn dbgrun(&self) -> DBGRUN_R {
+        DBGRUN_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Run During Debug"]
+    #[inline(always)]
+    pub fn dbgrun(&mut self) -> DBGRUN_W {
+        DBGRUN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode2/evctrl.rs
+++ b/pac/atsamd11c14a/src/rtc/mode2/evctrl.rs
@@ -1,0 +1,356 @@
+#[doc = "Reader of register EVCTRL"]
+pub type R = crate::R<u16, super::EVCTRL>;
+#[doc = "Writer for register EVCTRL"]
+pub type W = crate::W<u16, super::EVCTRL>;
+#[doc = "Register EVCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::EVCTRL {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `PEREO0`"]
+pub type PEREO0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO0`"]
+pub struct PEREO0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO1`"]
+pub type PEREO1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO1`"]
+pub struct PEREO1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO2`"]
+pub type PEREO2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO2`"]
+pub struct PEREO2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO3`"]
+pub type PEREO3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO3`"]
+pub struct PEREO3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u16) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO4`"]
+pub type PEREO4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO4`"]
+pub struct PEREO4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO5`"]
+pub type PEREO5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO5`"]
+pub struct PEREO5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO6`"]
+pub type PEREO6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO6`"]
+pub struct PEREO6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `PEREO7`"]
+pub type PEREO7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PEREO7`"]
+pub struct PEREO7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PEREO7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `ALARMEO0`"]
+pub type ALARMEO0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ALARMEO0`"]
+pub struct ALARMEO0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ALARMEO0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVFEO`"]
+pub type OVFEO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVFEO`"]
+pub struct OVFEO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVFEO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u16) & 0x01) << 15);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Periodic Interval 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo0(&self) -> PEREO0_R {
+        PEREO0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Periodic Interval 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo1(&self) -> PEREO1_R {
+        PEREO1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Periodic Interval 2 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo2(&self) -> PEREO2_R {
+        PEREO2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Periodic Interval 3 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo3(&self) -> PEREO3_R {
+        PEREO3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Periodic Interval 4 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo4(&self) -> PEREO4_R {
+        PEREO4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Periodic Interval 5 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo5(&self) -> PEREO5_R {
+        PEREO5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Periodic Interval 6 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo6(&self) -> PEREO6_R {
+        PEREO6_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Periodic Interval 7 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo7(&self) -> PEREO7_R {
+        PEREO7_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Alarm 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn alarmeo0(&self) -> ALARMEO0_R {
+        ALARMEO0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Overflow Event Output Enable"]
+    #[inline(always)]
+    pub fn ovfeo(&self) -> OVFEO_R {
+        OVFEO_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Periodic Interval 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo0(&mut self) -> PEREO0_W {
+        PEREO0_W { w: self }
+    }
+    #[doc = "Bit 1 - Periodic Interval 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo1(&mut self) -> PEREO1_W {
+        PEREO1_W { w: self }
+    }
+    #[doc = "Bit 2 - Periodic Interval 2 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo2(&mut self) -> PEREO2_W {
+        PEREO2_W { w: self }
+    }
+    #[doc = "Bit 3 - Periodic Interval 3 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo3(&mut self) -> PEREO3_W {
+        PEREO3_W { w: self }
+    }
+    #[doc = "Bit 4 - Periodic Interval 4 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo4(&mut self) -> PEREO4_W {
+        PEREO4_W { w: self }
+    }
+    #[doc = "Bit 5 - Periodic Interval 5 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo5(&mut self) -> PEREO5_W {
+        PEREO5_W { w: self }
+    }
+    #[doc = "Bit 6 - Periodic Interval 6 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo6(&mut self) -> PEREO6_W {
+        PEREO6_W { w: self }
+    }
+    #[doc = "Bit 7 - Periodic Interval 7 Event Output Enable"]
+    #[inline(always)]
+    pub fn pereo7(&mut self) -> PEREO7_W {
+        PEREO7_W { w: self }
+    }
+    #[doc = "Bit 8 - Alarm 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn alarmeo0(&mut self) -> ALARMEO0_W {
+        ALARMEO0_W { w: self }
+    }
+    #[doc = "Bit 15 - Overflow Event Output Enable"]
+    #[inline(always)]
+    pub fn ovfeo(&mut self) -> OVFEO_W {
+        OVFEO_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode2/freqcorr.rs
+++ b/pac/atsamd11c14a/src/rtc/mode2/freqcorr.rs
@@ -1,0 +1,74 @@
+#[doc = "Reader of register FREQCORR"]
+pub type R = crate::R<u8, super::FREQCORR>;
+#[doc = "Writer for register FREQCORR"]
+pub type W = crate::W<u8, super::FREQCORR>;
+#[doc = "Register FREQCORR `reset()`'s with value 0"]
+impl crate::ResetValue for super::FREQCORR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `VALUE`"]
+pub type VALUE_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `VALUE`"]
+pub struct VALUE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> VALUE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x7f) | ((value as u8) & 0x7f);
+        self.w
+    }
+}
+#[doc = "Reader of field `SIGN`"]
+pub type SIGN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SIGN`"]
+pub struct SIGN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SIGN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:6 - Correction Value"]
+    #[inline(always)]
+    pub fn value(&self) -> VALUE_R {
+        VALUE_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bit 7 - Correction Sign"]
+    #[inline(always)]
+    pub fn sign(&self) -> SIGN_R {
+        SIGN_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - Correction Value"]
+    #[inline(always)]
+    pub fn value(&mut self) -> VALUE_W {
+        VALUE_W { w: self }
+    }
+    #[doc = "Bit 7 - Correction Sign"]
+    #[inline(always)]
+    pub fn sign(&mut self) -> SIGN_W {
+        SIGN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode2/intenclr.rs
+++ b/pac/atsamd11c14a/src/rtc/mode2/intenclr.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ALARM0`"]
+pub type ALARM0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ALARM0`"]
+pub struct ALARM0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ALARM0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Alarm 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn alarm0(&self) -> ALARM0_R {
+        ALARM0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Alarm 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn alarm0(&mut self) -> ALARM0_W {
+        ALARM0_W { w: self }
+    }
+    #[doc = "Bit 6 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 7 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode2/intenset.rs
+++ b/pac/atsamd11c14a/src/rtc/mode2/intenset.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ALARM0`"]
+pub type ALARM0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ALARM0`"]
+pub struct ALARM0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ALARM0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Alarm 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn alarm0(&self) -> ALARM0_R {
+        ALARM0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Alarm 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn alarm0(&mut self) -> ALARM0_W {
+        ALARM0_W { w: self }
+    }
+    #[doc = "Bit 6 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 7 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode2/intflag.rs
+++ b/pac/atsamd11c14a/src/rtc/mode2/intflag.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ALARM0`"]
+pub type ALARM0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ALARM0`"]
+pub struct ALARM0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ALARM0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Alarm 0"]
+    #[inline(always)]
+    pub fn alarm0(&self) -> ALARM0_R {
+        ALARM0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Overflow"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Alarm 0"]
+    #[inline(always)]
+    pub fn alarm0(&mut self) -> ALARM0_W {
+        ALARM0_W { w: self }
+    }
+    #[doc = "Bit 6 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 7 - Overflow"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode2/mask.rs
+++ b/pac/atsamd11c14a/src/rtc/mode2/mask.rs
@@ -1,0 +1,164 @@
+#[doc = "Reader of register MASK%s"]
+pub type R = crate::R<u8, super::MASK>;
+#[doc = "Writer for register MASK%s"]
+pub type W = crate::W<u8, super::MASK>;
+#[doc = "Register MASK%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::MASK {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Alarm Mask Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SEL_A {
+    #[doc = "0: Alarm Disabled"]
+    OFF,
+    #[doc = "1: Match seconds only"]
+    SS,
+    #[doc = "2: Match seconds and minutes only"]
+    MMSS,
+    #[doc = "3: Match seconds, minutes, and hours only"]
+    HHMMSS,
+    #[doc = "4: Match seconds, minutes, hours, and days only"]
+    DDHHMMSS,
+    #[doc = "5: Match seconds, minutes, hours, days, and months only"]
+    MMDDHHMMSS,
+    #[doc = "6: Match seconds, minutes, hours, days, months, and years"]
+    YYMMDDHHMMSS,
+}
+impl From<SEL_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SEL_A) -> Self {
+        match variant {
+            SEL_A::OFF => 0,
+            SEL_A::SS => 1,
+            SEL_A::MMSS => 2,
+            SEL_A::HHMMSS => 3,
+            SEL_A::DDHHMMSS => 4,
+            SEL_A::MMDDHHMMSS => 5,
+            SEL_A::YYMMDDHHMMSS => 6,
+        }
+    }
+}
+#[doc = "Reader of field `SEL`"]
+pub type SEL_R = crate::R<u8, SEL_A>;
+impl SEL_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, SEL_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(SEL_A::OFF),
+            1 => Val(SEL_A::SS),
+            2 => Val(SEL_A::MMSS),
+            3 => Val(SEL_A::HHMMSS),
+            4 => Val(SEL_A::DDHHMMSS),
+            5 => Val(SEL_A::MMDDHHMMSS),
+            6 => Val(SEL_A::YYMMDDHHMMSS),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `OFF`"]
+    #[inline(always)]
+    pub fn is_off(&self) -> bool {
+        *self == SEL_A::OFF
+    }
+    #[doc = "Checks if the value of the field is `SS`"]
+    #[inline(always)]
+    pub fn is_ss(&self) -> bool {
+        *self == SEL_A::SS
+    }
+    #[doc = "Checks if the value of the field is `MMSS`"]
+    #[inline(always)]
+    pub fn is_mmss(&self) -> bool {
+        *self == SEL_A::MMSS
+    }
+    #[doc = "Checks if the value of the field is `HHMMSS`"]
+    #[inline(always)]
+    pub fn is_hhmmss(&self) -> bool {
+        *self == SEL_A::HHMMSS
+    }
+    #[doc = "Checks if the value of the field is `DDHHMMSS`"]
+    #[inline(always)]
+    pub fn is_ddhhmmss(&self) -> bool {
+        *self == SEL_A::DDHHMMSS
+    }
+    #[doc = "Checks if the value of the field is `MMDDHHMMSS`"]
+    #[inline(always)]
+    pub fn is_mmddhhmmss(&self) -> bool {
+        *self == SEL_A::MMDDHHMMSS
+    }
+    #[doc = "Checks if the value of the field is `YYMMDDHHMMSS`"]
+    #[inline(always)]
+    pub fn is_yymmddhhmmss(&self) -> bool {
+        *self == SEL_A::YYMMDDHHMMSS
+    }
+}
+#[doc = "Write proxy for field `SEL`"]
+pub struct SEL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SEL_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SEL_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Alarm Disabled"]
+    #[inline(always)]
+    pub fn off(self) -> &'a mut W {
+        self.variant(SEL_A::OFF)
+    }
+    #[doc = "Match seconds only"]
+    #[inline(always)]
+    pub fn ss(self) -> &'a mut W {
+        self.variant(SEL_A::SS)
+    }
+    #[doc = "Match seconds and minutes only"]
+    #[inline(always)]
+    pub fn mmss(self) -> &'a mut W {
+        self.variant(SEL_A::MMSS)
+    }
+    #[doc = "Match seconds, minutes, and hours only"]
+    #[inline(always)]
+    pub fn hhmmss(self) -> &'a mut W {
+        self.variant(SEL_A::HHMMSS)
+    }
+    #[doc = "Match seconds, minutes, hours, and days only"]
+    #[inline(always)]
+    pub fn ddhhmmss(self) -> &'a mut W {
+        self.variant(SEL_A::DDHHMMSS)
+    }
+    #[doc = "Match seconds, minutes, hours, days, and months only"]
+    #[inline(always)]
+    pub fn mmddhhmmss(self) -> &'a mut W {
+        self.variant(SEL_A::MMDDHHMMSS)
+    }
+    #[doc = "Match seconds, minutes, hours, days, months, and years"]
+    #[inline(always)]
+    pub fn yymmddhhmmss(self) -> &'a mut W {
+        self.variant(SEL_A::YYMMDDHHMMSS)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u8) & 0x07);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Alarm Mask Selection"]
+    #[inline(always)]
+    pub fn sel(&self) -> SEL_R {
+        SEL_R::new((self.bits & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Alarm Mask Selection"]
+    #[inline(always)]
+    pub fn sel(&mut self) -> SEL_W {
+        SEL_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode2/readreq.rs
+++ b/pac/atsamd11c14a/src/rtc/mode2/readreq.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register READREQ"]
+pub type R = crate::R<u16, super::READREQ>;
+#[doc = "Writer for register READREQ"]
+pub type W = crate::W<u16, super::READREQ>;
+#[doc = "Register READREQ `reset()`'s with value 0x10"]
+impl crate::ResetValue for super::READREQ {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x10
+    }
+}
+#[doc = "Reader of field `ADDR`"]
+pub type ADDR_R = crate::R<u8, u8>;
+#[doc = "Reader of field `RCONT`"]
+pub type RCONT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RCONT`"]
+pub struct RCONT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RCONT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u16) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `RREQ`"]
+pub struct RREQ_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RREQ_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u16) & 0x01) << 15);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:5 - Address"]
+    #[inline(always)]
+    pub fn addr(&self) -> ADDR_R {
+        ADDR_R::new((self.bits & 0x3f) as u8)
+    }
+    #[doc = "Bit 14 - Read Continuously"]
+    #[inline(always)]
+    pub fn rcont(&self) -> RCONT_R {
+        RCONT_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 14 - Read Continuously"]
+    #[inline(always)]
+    pub fn rcont(&mut self) -> RCONT_W {
+        RCONT_W { w: self }
+    }
+    #[doc = "Bit 15 - Read Request"]
+    #[inline(always)]
+    pub fn rreq(&mut self) -> RREQ_W {
+        RREQ_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/rtc/mode2/status.rs
+++ b/pac/atsamd11c14a/src/rtc/mode2/status.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u8, super::STATUS>;
+#[doc = "Reader of field `SYNCBUSY`"]
+pub type SYNCBUSY_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 7 - Synchronization Busy"]
+    #[inline(always)]
+    pub fn syncbusy(&self) -> SYNCBUSY_R {
+        SYNCBUSY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0.rs
+++ b/pac/atsamd11c14a/src/sercom0.rs
@@ -1,0 +1,244 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    _reserved_0_spi: [u8; 49usize],
+}
+impl RegisterBlock {
+    #[doc = "0x00 - USART Mode"]
+    #[inline(always)]
+    pub fn usart(&self) -> &USART {
+        unsafe { &*(((self as *const Self) as *const u8).add(0usize) as *const USART) }
+    }
+    #[doc = "0x00 - USART Mode"]
+    #[inline(always)]
+    pub fn usart_mut(&self) -> &mut USART {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(0usize) as *mut USART) }
+    }
+    #[doc = "0x00 - SPI Mode"]
+    #[inline(always)]
+    pub fn spi(&self) -> &SPI {
+        unsafe { &*(((self as *const Self) as *const u8).add(0usize) as *const SPI) }
+    }
+    #[doc = "0x00 - SPI Mode"]
+    #[inline(always)]
+    pub fn spi_mut(&self) -> &mut SPI {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(0usize) as *mut SPI) }
+    }
+    #[doc = "0x00 - I2C Slave Mode"]
+    #[inline(always)]
+    pub fn i2cs(&self) -> &I2CS {
+        unsafe { &*(((self as *const Self) as *const u8).add(0usize) as *const I2CS) }
+    }
+    #[doc = "0x00 - I2C Slave Mode"]
+    #[inline(always)]
+    pub fn i2cs_mut(&self) -> &mut I2CS {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(0usize) as *mut I2CS) }
+    }
+    #[doc = "0x00 - I2C Master Mode"]
+    #[inline(always)]
+    pub fn i2cm(&self) -> &I2CM {
+        unsafe { &*(((self as *const Self) as *const u8).add(0usize) as *const I2CM) }
+    }
+    #[doc = "0x00 - I2C Master Mode"]
+    #[inline(always)]
+    pub fn i2cm_mut(&self) -> &mut I2CM {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(0usize) as *mut I2CM) }
+    }
+}
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct I2CM {
+    #[doc = "0x00 - I2CM Control A"]
+    pub ctrla: self::i2cm::CTRLA,
+    #[doc = "0x04 - I2CM Control B"]
+    pub ctrlb: self::i2cm::CTRLB,
+    _reserved2: [u8; 4usize],
+    #[doc = "0x0c - I2CM Baud Rate"]
+    pub baud: self::i2cm::BAUD,
+    _reserved3: [u8; 4usize],
+    #[doc = "0x14 - I2CM Interrupt Enable Clear"]
+    pub intenclr: self::i2cm::INTENCLR,
+    _reserved4: [u8; 1usize],
+    #[doc = "0x16 - I2CM Interrupt Enable Set"]
+    pub intenset: self::i2cm::INTENSET,
+    _reserved5: [u8; 1usize],
+    #[doc = "0x18 - I2CM Interrupt Flag Status and Clear"]
+    pub intflag: self::i2cm::INTFLAG,
+    _reserved6: [u8; 1usize],
+    #[doc = "0x1a - I2CM Status"]
+    pub status: self::i2cm::STATUS,
+    #[doc = "0x1c - I2CM Syncbusy"]
+    pub syncbusy: self::i2cm::SYNCBUSY,
+    _reserved8: [u8; 4usize],
+    #[doc = "0x24 - I2CM Address"]
+    pub addr: self::i2cm::ADDR,
+    #[doc = "0x28 - I2CM Data"]
+    pub data: self::i2cm::DATA,
+    _reserved10: [u8; 7usize],
+    #[doc = "0x30 - I2CM Debug Control"]
+    pub dbgctrl: self::i2cm::DBGCTRL,
+}
+#[doc = r"Register block"]
+#[doc = "I2C Master Mode"]
+pub mod i2cm;
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct I2CS {
+    #[doc = "0x00 - I2CS Control A"]
+    pub ctrla: self::i2cs::CTRLA,
+    #[doc = "0x04 - I2CS Control B"]
+    pub ctrlb: self::i2cs::CTRLB,
+    _reserved2: [u8; 12usize],
+    #[doc = "0x14 - I2CS Interrupt Enable Clear"]
+    pub intenclr: self::i2cs::INTENCLR,
+    _reserved3: [u8; 1usize],
+    #[doc = "0x16 - I2CS Interrupt Enable Set"]
+    pub intenset: self::i2cs::INTENSET,
+    _reserved4: [u8; 1usize],
+    #[doc = "0x18 - I2CS Interrupt Flag Status and Clear"]
+    pub intflag: self::i2cs::INTFLAG,
+    _reserved5: [u8; 1usize],
+    #[doc = "0x1a - I2CS Status"]
+    pub status: self::i2cs::STATUS,
+    #[doc = "0x1c - I2CS Syncbusy"]
+    pub syncbusy: self::i2cs::SYNCBUSY,
+    _reserved7: [u8; 4usize],
+    #[doc = "0x24 - I2CS Address"]
+    pub addr: self::i2cs::ADDR,
+    #[doc = "0x28 - I2CS Data"]
+    pub data: self::i2cs::DATA,
+}
+#[doc = r"Register block"]
+#[doc = "I2C Slave Mode"]
+pub mod i2cs;
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct SPI {
+    #[doc = "0x00 - SPI Control A"]
+    pub ctrla: self::spi::CTRLA,
+    #[doc = "0x04 - SPI Control B"]
+    pub ctrlb: self::spi::CTRLB,
+    _reserved2: [u8; 4usize],
+    #[doc = "0x0c - SPI Baud Rate"]
+    pub baud: self::spi::BAUD,
+    _reserved3: [u8; 7usize],
+    #[doc = "0x14 - SPI Interrupt Enable Clear"]
+    pub intenclr: self::spi::INTENCLR,
+    _reserved4: [u8; 1usize],
+    #[doc = "0x16 - SPI Interrupt Enable Set"]
+    pub intenset: self::spi::INTENSET,
+    _reserved5: [u8; 1usize],
+    #[doc = "0x18 - SPI Interrupt Flag Status and Clear"]
+    pub intflag: self::spi::INTFLAG,
+    _reserved6: [u8; 1usize],
+    #[doc = "0x1a - SPI Status"]
+    pub status: self::spi::STATUS,
+    #[doc = "0x1c - SPI Syncbusy"]
+    pub syncbusy: self::spi::SYNCBUSY,
+    _reserved8: [u8; 4usize],
+    #[doc = "0x24 - SPI Address"]
+    pub addr: self::spi::ADDR,
+    #[doc = "0x28 - SPI Data"]
+    pub data: self::spi::DATA,
+    _reserved10: [u8; 4usize],
+    #[doc = "0x30 - SPI Debug Control"]
+    pub dbgctrl: self::spi::DBGCTRL,
+}
+#[doc = r"Register block"]
+#[doc = "SPI Mode"]
+pub mod spi;
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct USART {
+    #[doc = "0x00 - USART Control A"]
+    pub ctrla: self::usart::CTRLA,
+    #[doc = "0x04 - USART Control B"]
+    pub ctrlb: self::usart::CTRLB,
+    _reserved2: [u8; 4usize],
+    _reserved_2_baud: [u8; 2usize],
+    #[doc = "0x0e - USART Receive Pulse Length"]
+    pub rxpl: self::usart::RXPL,
+    _reserved4: [u8; 5usize],
+    #[doc = "0x14 - USART Interrupt Enable Clear"]
+    pub intenclr: self::usart::INTENCLR,
+    _reserved5: [u8; 1usize],
+    #[doc = "0x16 - USART Interrupt Enable Set"]
+    pub intenset: self::usart::INTENSET,
+    _reserved6: [u8; 1usize],
+    #[doc = "0x18 - USART Interrupt Flag Status and Clear"]
+    pub intflag: self::usart::INTFLAG,
+    _reserved7: [u8; 1usize],
+    #[doc = "0x1a - USART Status"]
+    pub status: self::usart::STATUS,
+    #[doc = "0x1c - USART Syncbusy"]
+    pub syncbusy: self::usart::SYNCBUSY,
+    _reserved9: [u8; 8usize],
+    #[doc = "0x28 - USART Data"]
+    pub data: self::usart::DATA,
+    _reserved10: [u8; 6usize],
+    #[doc = "0x30 - USART Debug Control"]
+    pub dbgctrl: self::usart::DBGCTRL,
+}
+impl USART {
+    #[doc = "0x0c - USART Baud Rate"]
+    #[inline(always)]
+    pub fn baud_usartfp_mode(&self) -> &self::usart::BAUD_USARTFP_MODE {
+        unsafe {
+            &*(((self as *const Self) as *const u8).add(12usize)
+                as *const self::usart::BAUD_USARTFP_MODE)
+        }
+    }
+    #[doc = "0x0c - USART Baud Rate"]
+    #[inline(always)]
+    pub fn baud_usartfp_mode_mut(&self) -> &mut self::usart::BAUD_USARTFP_MODE {
+        unsafe {
+            &mut *(((self as *const Self) as *mut u8).add(12usize)
+                as *mut self::usart::BAUD_USARTFP_MODE)
+        }
+    }
+    #[doc = "0x0c - USART Baud Rate"]
+    #[inline(always)]
+    pub fn baud_fracfp_mode(&self) -> &self::usart::BAUD_FRACFP_MODE {
+        unsafe {
+            &*(((self as *const Self) as *const u8).add(12usize)
+                as *const self::usart::BAUD_FRACFP_MODE)
+        }
+    }
+    #[doc = "0x0c - USART Baud Rate"]
+    #[inline(always)]
+    pub fn baud_fracfp_mode_mut(&self) -> &mut self::usart::BAUD_FRACFP_MODE {
+        unsafe {
+            &mut *(((self as *const Self) as *mut u8).add(12usize)
+                as *mut self::usart::BAUD_FRACFP_MODE)
+        }
+    }
+    #[doc = "0x0c - USART Baud Rate"]
+    #[inline(always)]
+    pub fn baud_frac_mode(&self) -> &self::usart::BAUD_FRAC_MODE {
+        unsafe {
+            &*(((self as *const Self) as *const u8).add(12usize)
+                as *const self::usart::BAUD_FRAC_MODE)
+        }
+    }
+    #[doc = "0x0c - USART Baud Rate"]
+    #[inline(always)]
+    pub fn baud_frac_mode_mut(&self) -> &mut self::usart::BAUD_FRAC_MODE {
+        unsafe {
+            &mut *(((self as *const Self) as *mut u8).add(12usize)
+                as *mut self::usart::BAUD_FRAC_MODE)
+        }
+    }
+    #[doc = "0x0c - USART Baud Rate"]
+    #[inline(always)]
+    pub fn baud(&self) -> &self::usart::BAUD {
+        unsafe { &*(((self as *const Self) as *const u8).add(12usize) as *const self::usart::BAUD) }
+    }
+    #[doc = "0x0c - USART Baud Rate"]
+    #[inline(always)]
+    pub fn baud_mut(&self) -> &mut self::usart::BAUD {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(12usize) as *mut self::usart::BAUD) }
+    }
+}
+#[doc = r"Register block"]
+#[doc = "USART Mode"]
+pub mod usart;

--- a/pac/atsamd11c14a/src/sercom0/i2cm.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cm.rs
@@ -1,0 +1,119 @@
+#[doc = "I2CM Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrla](ctrla) module"]
+pub type CTRLA = crate::Reg<u32, _CTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLA;
+#[doc = "`read()` method returns [ctrla::R](ctrla::R) reader structure"]
+impl crate::Readable for CTRLA {}
+#[doc = "`write(|w| ..)` method takes [ctrla::W](ctrla::W) writer structure"]
+impl crate::Writable for CTRLA {}
+#[doc = "I2CM Control A"]
+pub mod ctrla;
+#[doc = "I2CM Control B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlb](ctrlb) module"]
+pub type CTRLB = crate::Reg<u32, _CTRLB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLB;
+#[doc = "`read()` method returns [ctrlb::R](ctrlb::R) reader structure"]
+impl crate::Readable for CTRLB {}
+#[doc = "`write(|w| ..)` method takes [ctrlb::W](ctrlb::W) writer structure"]
+impl crate::Writable for CTRLB {}
+#[doc = "I2CM Control B"]
+pub mod ctrlb;
+#[doc = "I2CM Baud Rate\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [baud](baud) module"]
+pub type BAUD = crate::Reg<u32, _BAUD>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _BAUD;
+#[doc = "`read()` method returns [baud::R](baud::R) reader structure"]
+impl crate::Readable for BAUD {}
+#[doc = "`write(|w| ..)` method takes [baud::W](baud::W) writer structure"]
+impl crate::Writable for BAUD {}
+#[doc = "I2CM Baud Rate"]
+pub mod baud;
+#[doc = "I2CM Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "I2CM Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "I2CM Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "I2CM Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "I2CM Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "I2CM Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "I2CM Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u16, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "`write(|w| ..)` method takes [status::W](status::W) writer structure"]
+impl crate::Writable for STATUS {}
+#[doc = "I2CM Status"]
+pub mod status;
+#[doc = "I2CM Syncbusy\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [syncbusy](syncbusy) module"]
+pub type SYNCBUSY = crate::Reg<u32, _SYNCBUSY>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _SYNCBUSY;
+#[doc = "`read()` method returns [syncbusy::R](syncbusy::R) reader structure"]
+impl crate::Readable for SYNCBUSY {}
+#[doc = "I2CM Syncbusy"]
+pub mod syncbusy;
+#[doc = "I2CM Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [addr](addr) module"]
+pub type ADDR = crate::Reg<u32, _ADDR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _ADDR;
+#[doc = "`read()` method returns [addr::R](addr::R) reader structure"]
+impl crate::Readable for ADDR {}
+#[doc = "`write(|w| ..)` method takes [addr::W](addr::W) writer structure"]
+impl crate::Writable for ADDR {}
+#[doc = "I2CM Address"]
+pub mod addr;
+#[doc = "I2CM Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [data](data) module"]
+pub type DATA = crate::Reg<u8, _DATA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DATA;
+#[doc = "`read()` method returns [data::R](data::R) reader structure"]
+impl crate::Readable for DATA {}
+#[doc = "`write(|w| ..)` method takes [data::W](data::W) writer structure"]
+impl crate::Writable for DATA {}
+#[doc = "I2CM Data"]
+pub mod data;
+#[doc = "I2CM Debug Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dbgctrl](dbgctrl) module"]
+pub type DBGCTRL = crate::Reg<u8, _DBGCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DBGCTRL;
+#[doc = "`read()` method returns [dbgctrl::R](dbgctrl::R) reader structure"]
+impl crate::Readable for DBGCTRL {}
+#[doc = "`write(|w| ..)` method takes [dbgctrl::W](dbgctrl::W) writer structure"]
+impl crate::Writable for DBGCTRL {}
+#[doc = "I2CM Debug Control"]
+pub mod dbgctrl;

--- a/pac/atsamd11c14a/src/sercom0/i2cm/addr.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cm/addr.rs
@@ -1,0 +1,166 @@
+#[doc = "Reader of register ADDR"]
+pub type R = crate::R<u32, super::ADDR>;
+#[doc = "Writer for register ADDR"]
+pub type W = crate::W<u32, super::ADDR>;
+#[doc = "Register ADDR `reset()`'s with value 0"]
+impl crate::ResetValue for super::ADDR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ADDR`"]
+pub type ADDR_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `ADDR`"]
+pub struct ADDR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ADDR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07ff) | ((value as u32) & 0x07ff);
+        self.w
+    }
+}
+#[doc = "Reader of field `LENEN`"]
+pub type LENEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LENEN`"]
+pub struct LENEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LENEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u32) & 0x01) << 13);
+        self.w
+    }
+}
+#[doc = "Reader of field `HS`"]
+pub type HS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `HS`"]
+pub struct HS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u32) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `TENBITEN`"]
+pub type TENBITEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TENBITEN`"]
+pub struct TENBITEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TENBITEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Reader of field `LEN`"]
+pub type LEN_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `LEN`"]
+pub struct LEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LEN_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0xff << 16)) | (((value as u32) & 0xff) << 16);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:10 - Address Value"]
+    #[inline(always)]
+    pub fn addr(&self) -> ADDR_R {
+        ADDR_R::new((self.bits & 0x07ff) as u16)
+    }
+    #[doc = "Bit 13 - Length Enable"]
+    #[inline(always)]
+    pub fn lenen(&self) -> LENEN_R {
+        LENEN_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+    #[doc = "Bit 14 - High Speed Mode"]
+    #[inline(always)]
+    pub fn hs(&self) -> HS_R {
+        HS_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Ten Bit Addressing Enable"]
+    #[inline(always)]
+    pub fn tenbiten(&self) -> TENBITEN_R {
+        TENBITEN_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bits 16:23 - Length"]
+    #[inline(always)]
+    pub fn len(&self) -> LEN_R {
+        LEN_R::new(((self.bits >> 16) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:10 - Address Value"]
+    #[inline(always)]
+    pub fn addr(&mut self) -> ADDR_W {
+        ADDR_W { w: self }
+    }
+    #[doc = "Bit 13 - Length Enable"]
+    #[inline(always)]
+    pub fn lenen(&mut self) -> LENEN_W {
+        LENEN_W { w: self }
+    }
+    #[doc = "Bit 14 - High Speed Mode"]
+    #[inline(always)]
+    pub fn hs(&mut self) -> HS_W {
+        HS_W { w: self }
+    }
+    #[doc = "Bit 15 - Ten Bit Addressing Enable"]
+    #[inline(always)]
+    pub fn tenbiten(&mut self) -> TENBITEN_W {
+        TENBITEN_W { w: self }
+    }
+    #[doc = "Bits 16:23 - Length"]
+    #[inline(always)]
+    pub fn len(&mut self) -> LEN_W {
+        LEN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cm/baud.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cm/baud.rs
@@ -1,0 +1,112 @@
+#[doc = "Reader of register BAUD"]
+pub type R = crate::R<u32, super::BAUD>;
+#[doc = "Writer for register BAUD"]
+pub type W = crate::W<u32, super::BAUD>;
+#[doc = "Register BAUD `reset()`'s with value 0"]
+impl crate::ResetValue for super::BAUD {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `BAUD`"]
+pub type BAUD_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `BAUD`"]
+pub struct BAUD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BAUD_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xff) | ((value as u32) & 0xff);
+        self.w
+    }
+}
+#[doc = "Reader of field `BAUDLOW`"]
+pub type BAUDLOW_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `BAUDLOW`"]
+pub struct BAUDLOW_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BAUDLOW_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0xff << 8)) | (((value as u32) & 0xff) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `HSBAUD`"]
+pub type HSBAUD_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `HSBAUD`"]
+pub struct HSBAUD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HSBAUD_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0xff << 16)) | (((value as u32) & 0xff) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `HSBAUDLOW`"]
+pub type HSBAUDLOW_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `HSBAUDLOW`"]
+pub struct HSBAUDLOW_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HSBAUDLOW_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0xff << 24)) | (((value as u32) & 0xff) << 24);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:7 - Baud Rate Value"]
+    #[inline(always)]
+    pub fn baud(&self) -> BAUD_R {
+        BAUD_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bits 8:15 - Baud Rate Value Low"]
+    #[inline(always)]
+    pub fn baudlow(&self) -> BAUDLOW_R {
+        BAUDLOW_R::new(((self.bits >> 8) & 0xff) as u8)
+    }
+    #[doc = "Bits 16:23 - High Speed Baud Rate Value"]
+    #[inline(always)]
+    pub fn hsbaud(&self) -> HSBAUD_R {
+        HSBAUD_R::new(((self.bits >> 16) & 0xff) as u8)
+    }
+    #[doc = "Bits 24:31 - High Speed Baud Rate Value Low"]
+    #[inline(always)]
+    pub fn hsbaudlow(&self) -> HSBAUDLOW_R {
+        HSBAUDLOW_R::new(((self.bits >> 24) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Baud Rate Value"]
+    #[inline(always)]
+    pub fn baud(&mut self) -> BAUD_W {
+        BAUD_W { w: self }
+    }
+    #[doc = "Bits 8:15 - Baud Rate Value Low"]
+    #[inline(always)]
+    pub fn baudlow(&mut self) -> BAUDLOW_W {
+        BAUDLOW_W { w: self }
+    }
+    #[doc = "Bits 16:23 - High Speed Baud Rate Value"]
+    #[inline(always)]
+    pub fn hsbaud(&mut self) -> HSBAUD_W {
+        HSBAUD_W { w: self }
+    }
+    #[doc = "Bits 24:31 - High Speed Baud Rate Value Low"]
+    #[inline(always)]
+    pub fn hsbaudlow(&mut self) -> HSBAUDLOW_W {
+        HSBAUDLOW_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cm/ctrla.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cm/ctrla.rs
@@ -1,0 +1,494 @@
+#[doc = "Reader of register CTRLA"]
+pub type R = crate::R<u32, super::CTRLA>;
+#[doc = "Writer for register CTRLA"]
+pub type W = crate::W<u32, super::CTRLA>;
+#[doc = "Register CTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLA {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Operating Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MODE_A {
+    #[doc = "0: USART mode with external clock"]
+    USART_EXT_CLK,
+    #[doc = "1: USART mode with internal clock"]
+    USART_INT_CLK,
+    #[doc = "2: SPI mode with external clock"]
+    SPI_SLAVE,
+    #[doc = "3: SPI mode with internal clock"]
+    SPI_MASTER,
+    #[doc = "4: I2C mode with external clock"]
+    I2C_SLAVE,
+    #[doc = "5: I2C mode with internal clock"]
+    I2C_MASTER,
+}
+impl From<MODE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: MODE_A) -> Self {
+        match variant {
+            MODE_A::USART_EXT_CLK => 0,
+            MODE_A::USART_INT_CLK => 1,
+            MODE_A::SPI_SLAVE => 2,
+            MODE_A::SPI_MASTER => 3,
+            MODE_A::I2C_SLAVE => 4,
+            MODE_A::I2C_MASTER => 5,
+        }
+    }
+}
+#[doc = "Reader of field `MODE`"]
+pub type MODE_R = crate::R<u8, MODE_A>;
+impl MODE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, MODE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(MODE_A::USART_EXT_CLK),
+            1 => Val(MODE_A::USART_INT_CLK),
+            2 => Val(MODE_A::SPI_SLAVE),
+            3 => Val(MODE_A::SPI_MASTER),
+            4 => Val(MODE_A::I2C_SLAVE),
+            5 => Val(MODE_A::I2C_MASTER),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `USART_EXT_CLK`"]
+    #[inline(always)]
+    pub fn is_usart_ext_clk(&self) -> bool {
+        *self == MODE_A::USART_EXT_CLK
+    }
+    #[doc = "Checks if the value of the field is `USART_INT_CLK`"]
+    #[inline(always)]
+    pub fn is_usart_int_clk(&self) -> bool {
+        *self == MODE_A::USART_INT_CLK
+    }
+    #[doc = "Checks if the value of the field is `SPI_SLAVE`"]
+    #[inline(always)]
+    pub fn is_spi_slave(&self) -> bool {
+        *self == MODE_A::SPI_SLAVE
+    }
+    #[doc = "Checks if the value of the field is `SPI_MASTER`"]
+    #[inline(always)]
+    pub fn is_spi_master(&self) -> bool {
+        *self == MODE_A::SPI_MASTER
+    }
+    #[doc = "Checks if the value of the field is `I2C_SLAVE`"]
+    #[inline(always)]
+    pub fn is_i2c_slave(&self) -> bool {
+        *self == MODE_A::I2C_SLAVE
+    }
+    #[doc = "Checks if the value of the field is `I2C_MASTER`"]
+    #[inline(always)]
+    pub fn is_i2c_master(&self) -> bool {
+        *self == MODE_A::I2C_MASTER
+    }
+}
+#[doc = "Write proxy for field `MODE`"]
+pub struct MODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MODE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: MODE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "USART mode with external clock"]
+    #[inline(always)]
+    pub fn usart_ext_clk(self) -> &'a mut W {
+        self.variant(MODE_A::USART_EXT_CLK)
+    }
+    #[doc = "USART mode with internal clock"]
+    #[inline(always)]
+    pub fn usart_int_clk(self) -> &'a mut W {
+        self.variant(MODE_A::USART_INT_CLK)
+    }
+    #[doc = "SPI mode with external clock"]
+    #[inline(always)]
+    pub fn spi_slave(self) -> &'a mut W {
+        self.variant(MODE_A::SPI_SLAVE)
+    }
+    #[doc = "SPI mode with internal clock"]
+    #[inline(always)]
+    pub fn spi_master(self) -> &'a mut W {
+        self.variant(MODE_A::SPI_MASTER)
+    }
+    #[doc = "I2C mode with external clock"]
+    #[inline(always)]
+    pub fn i2c_slave(self) -> &'a mut W {
+        self.variant(MODE_A::I2C_SLAVE)
+    }
+    #[doc = "I2C mode with internal clock"]
+    #[inline(always)]
+    pub fn i2c_master(self) -> &'a mut W {
+        self.variant(MODE_A::I2C_MASTER)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 2)) | (((value as u32) & 0x07) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `PINOUT`"]
+pub type PINOUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PINOUT`"]
+pub struct PINOUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PINOUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `SDAHOLD`"]
+pub type SDAHOLD_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `SDAHOLD`"]
+pub struct SDAHOLD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SDAHOLD_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 20)) | (((value as u32) & 0x03) << 20);
+        self.w
+    }
+}
+#[doc = "Reader of field `MEXTTOEN`"]
+pub type MEXTTOEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MEXTTOEN`"]
+pub struct MEXTTOEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MEXTTOEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 22)) | (((value as u32) & 0x01) << 22);
+        self.w
+    }
+}
+#[doc = "Reader of field `SEXTTOEN`"]
+pub type SEXTTOEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SEXTTOEN`"]
+pub struct SEXTTOEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SEXTTOEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 23)) | (((value as u32) & 0x01) << 23);
+        self.w
+    }
+}
+#[doc = "Reader of field `SPEED`"]
+pub type SPEED_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `SPEED`"]
+pub struct SPEED_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SPEED_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 24)) | (((value as u32) & 0x03) << 24);
+        self.w
+    }
+}
+#[doc = "Reader of field `SCLSM`"]
+pub type SCLSM_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SCLSM`"]
+pub struct SCLSM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SCLSM_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 27)) | (((value as u32) & 0x01) << 27);
+        self.w
+    }
+}
+#[doc = "Reader of field `INACTOUT`"]
+pub type INACTOUT_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `INACTOUT`"]
+pub struct INACTOUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INACTOUT_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 28)) | (((value as u32) & 0x03) << 28);
+        self.w
+    }
+}
+#[doc = "Reader of field `LOWTOUTEN`"]
+pub type LOWTOUTEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LOWTOUTEN`"]
+pub struct LOWTOUTEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LOWTOUTEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 30)) | (((value as u32) & 0x01) << 30);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 2:4 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 2) & 0x07) as u8)
+    }
+    #[doc = "Bit 7 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - Pin Usage"]
+    #[inline(always)]
+    pub fn pinout(&self) -> PINOUT_R {
+        PINOUT_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bits 20:21 - SDA Hold Time"]
+    #[inline(always)]
+    pub fn sdahold(&self) -> SDAHOLD_R {
+        SDAHOLD_R::new(((self.bits >> 20) & 0x03) as u8)
+    }
+    #[doc = "Bit 22 - Master SCL Low Extend Timeout"]
+    #[inline(always)]
+    pub fn mexttoen(&self) -> MEXTTOEN_R {
+        MEXTTOEN_R::new(((self.bits >> 22) & 0x01) != 0)
+    }
+    #[doc = "Bit 23 - Slave SCL Low Extend Timeout"]
+    #[inline(always)]
+    pub fn sexttoen(&self) -> SEXTTOEN_R {
+        SEXTTOEN_R::new(((self.bits >> 23) & 0x01) != 0)
+    }
+    #[doc = "Bits 24:25 - Transfer Speed"]
+    #[inline(always)]
+    pub fn speed(&self) -> SPEED_R {
+        SPEED_R::new(((self.bits >> 24) & 0x03) as u8)
+    }
+    #[doc = "Bit 27 - SCL Clock Stretch Mode"]
+    #[inline(always)]
+    pub fn sclsm(&self) -> SCLSM_R {
+        SCLSM_R::new(((self.bits >> 27) & 0x01) != 0)
+    }
+    #[doc = "Bits 28:29 - Inactive Time-Out"]
+    #[inline(always)]
+    pub fn inactout(&self) -> INACTOUT_R {
+        INACTOUT_R::new(((self.bits >> 28) & 0x03) as u8)
+    }
+    #[doc = "Bit 30 - SCL Low Timeout Enable"]
+    #[inline(always)]
+    pub fn lowtouten(&self) -> LOWTOUTEN_R {
+        LOWTOUTEN_R::new(((self.bits >> 30) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bits 2:4 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&mut self) -> MODE_W {
+        MODE_W { w: self }
+    }
+    #[doc = "Bit 7 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bit 16 - Pin Usage"]
+    #[inline(always)]
+    pub fn pinout(&mut self) -> PINOUT_W {
+        PINOUT_W { w: self }
+    }
+    #[doc = "Bits 20:21 - SDA Hold Time"]
+    #[inline(always)]
+    pub fn sdahold(&mut self) -> SDAHOLD_W {
+        SDAHOLD_W { w: self }
+    }
+    #[doc = "Bit 22 - Master SCL Low Extend Timeout"]
+    #[inline(always)]
+    pub fn mexttoen(&mut self) -> MEXTTOEN_W {
+        MEXTTOEN_W { w: self }
+    }
+    #[doc = "Bit 23 - Slave SCL Low Extend Timeout"]
+    #[inline(always)]
+    pub fn sexttoen(&mut self) -> SEXTTOEN_W {
+        SEXTTOEN_W { w: self }
+    }
+    #[doc = "Bits 24:25 - Transfer Speed"]
+    #[inline(always)]
+    pub fn speed(&mut self) -> SPEED_W {
+        SPEED_W { w: self }
+    }
+    #[doc = "Bit 27 - SCL Clock Stretch Mode"]
+    #[inline(always)]
+    pub fn sclsm(&mut self) -> SCLSM_W {
+        SCLSM_W { w: self }
+    }
+    #[doc = "Bits 28:29 - Inactive Time-Out"]
+    #[inline(always)]
+    pub fn inactout(&mut self) -> INACTOUT_W {
+        INACTOUT_W { w: self }
+    }
+    #[doc = "Bit 30 - SCL Low Timeout Enable"]
+    #[inline(always)]
+    pub fn lowtouten(&mut self) -> LOWTOUTEN_W {
+        LOWTOUTEN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cm/ctrlb.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cm/ctrlb.rs
@@ -1,0 +1,135 @@
+#[doc = "Reader of register CTRLB"]
+pub type R = crate::R<u32, super::CTRLB>;
+#[doc = "Writer for register CTRLB"]
+pub type W = crate::W<u32, super::CTRLB>;
+#[doc = "Register CTRLB `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLB {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SMEN`"]
+pub type SMEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SMEN`"]
+pub struct SMEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SMEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `QCEN`"]
+pub type QCEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `QCEN`"]
+pub struct QCEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> QCEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `CMD`"]
+pub struct CMD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMD_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 16)) | (((value as u32) & 0x03) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `ACKACT`"]
+pub type ACKACT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ACKACT`"]
+pub struct ACKACT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ACKACT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 18)) | (((value as u32) & 0x01) << 18);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 8 - Smart Mode Enable"]
+    #[inline(always)]
+    pub fn smen(&self) -> SMEN_R {
+        SMEN_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Quick Command Enable"]
+    #[inline(always)]
+    pub fn qcen(&self) -> QCEN_R {
+        QCEN_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 18 - Acknowledge Action"]
+    #[inline(always)]
+    pub fn ackact(&self) -> ACKACT_R {
+        ACKACT_R::new(((self.bits >> 18) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 8 - Smart Mode Enable"]
+    #[inline(always)]
+    pub fn smen(&mut self) -> SMEN_W {
+        SMEN_W { w: self }
+    }
+    #[doc = "Bit 9 - Quick Command Enable"]
+    #[inline(always)]
+    pub fn qcen(&mut self) -> QCEN_W {
+        QCEN_W { w: self }
+    }
+    #[doc = "Bits 16:17 - Command"]
+    #[inline(always)]
+    pub fn cmd(&mut self) -> CMD_W {
+        CMD_W { w: self }
+    }
+    #[doc = "Bit 18 - Acknowledge Action"]
+    #[inline(always)]
+    pub fn ackact(&mut self) -> ACKACT_W {
+        ACKACT_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cm/data.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cm/data.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register DATA"]
+pub type R = crate::R<u8, super::DATA>;
+#[doc = "Writer for register DATA"]
+pub type W = crate::W<u8, super::DATA>;
+#[doc = "Register DATA `reset()`'s with value 0"]
+impl crate::ResetValue for super::DATA {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DATA`"]
+pub type DATA_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DATA`"]
+pub struct DATA_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DATA_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xff) | ((value as u8) & 0xff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:7 - Data Value"]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Data Value"]
+    #[inline(always)]
+    pub fn data(&mut self) -> DATA_W {
+        DATA_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cm/dbgctrl.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cm/dbgctrl.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register DBGCTRL"]
+pub type R = crate::R<u8, super::DBGCTRL>;
+#[doc = "Writer for register DBGCTRL"]
+pub type W = crate::W<u8, super::DBGCTRL>;
+#[doc = "Register DBGCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::DBGCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DBGSTOP`"]
+pub type DBGSTOP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DBGSTOP`"]
+pub struct DBGSTOP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DBGSTOP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Debug Mode"]
+    #[inline(always)]
+    pub fn dbgstop(&self) -> DBGSTOP_R {
+        DBGSTOP_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Debug Mode"]
+    #[inline(always)]
+    pub fn dbgstop(&mut self) -> DBGSTOP_W {
+        DBGSTOP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cm/intenclr.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cm/intenclr.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `MB`"]
+pub type MB_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MB`"]
+pub struct MB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MB_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `SB`"]
+pub type SB_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SB`"]
+pub struct SB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SB_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERROR`"]
+pub type ERROR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERROR`"]
+pub struct ERROR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERROR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Master On Bus Interrupt Disable"]
+    #[inline(always)]
+    pub fn mb(&self) -> MB_R {
+        MB_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Slave On Bus Interrupt Disable"]
+    #[inline(always)]
+    pub fn sb(&self) -> SB_R {
+        SB_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Disable"]
+    #[inline(always)]
+    pub fn error(&self) -> ERROR_R {
+        ERROR_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Master On Bus Interrupt Disable"]
+    #[inline(always)]
+    pub fn mb(&mut self) -> MB_W {
+        MB_W { w: self }
+    }
+    #[doc = "Bit 1 - Slave On Bus Interrupt Disable"]
+    #[inline(always)]
+    pub fn sb(&mut self) -> SB_W {
+        SB_W { w: self }
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Disable"]
+    #[inline(always)]
+    pub fn error(&mut self) -> ERROR_W {
+        ERROR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cm/intenset.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cm/intenset.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `MB`"]
+pub type MB_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MB`"]
+pub struct MB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MB_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `SB`"]
+pub type SB_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SB`"]
+pub struct SB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SB_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERROR`"]
+pub type ERROR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERROR`"]
+pub struct ERROR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERROR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Master On Bus Interrupt Enable"]
+    #[inline(always)]
+    pub fn mb(&self) -> MB_R {
+        MB_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Slave On Bus Interrupt Enable"]
+    #[inline(always)]
+    pub fn sb(&self) -> SB_R {
+        SB_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn error(&self) -> ERROR_R {
+        ERROR_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Master On Bus Interrupt Enable"]
+    #[inline(always)]
+    pub fn mb(&mut self) -> MB_W {
+        MB_W { w: self }
+    }
+    #[doc = "Bit 1 - Slave On Bus Interrupt Enable"]
+    #[inline(always)]
+    pub fn sb(&mut self) -> SB_W {
+        SB_W { w: self }
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn error(&mut self) -> ERROR_W {
+        ERROR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cm/intflag.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cm/intflag.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `MB`"]
+pub type MB_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MB`"]
+pub struct MB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MB_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `SB`"]
+pub type SB_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SB`"]
+pub struct SB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SB_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERROR`"]
+pub type ERROR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERROR`"]
+pub struct ERROR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERROR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Master On Bus Interrupt"]
+    #[inline(always)]
+    pub fn mb(&self) -> MB_R {
+        MB_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Slave On Bus Interrupt"]
+    #[inline(always)]
+    pub fn sb(&self) -> SB_R {
+        SB_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt"]
+    #[inline(always)]
+    pub fn error(&self) -> ERROR_R {
+        ERROR_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Master On Bus Interrupt"]
+    #[inline(always)]
+    pub fn mb(&mut self) -> MB_W {
+        MB_W { w: self }
+    }
+    #[doc = "Bit 1 - Slave On Bus Interrupt"]
+    #[inline(always)]
+    pub fn sb(&mut self) -> SB_W {
+        SB_W { w: self }
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt"]
+    #[inline(always)]
+    pub fn error(&mut self) -> ERROR_W {
+        ERROR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cm/status.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cm/status.rs
@@ -1,0 +1,258 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u16, super::STATUS>;
+#[doc = "Writer for register STATUS"]
+pub type W = crate::W<u16, super::STATUS>;
+#[doc = "Register STATUS `reset()`'s with value 0"]
+impl crate::ResetValue for super::STATUS {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `BUSERR`"]
+pub type BUSERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BUSERR`"]
+pub struct BUSERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BUSERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ARBLOST`"]
+pub type ARBLOST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ARBLOST`"]
+pub struct ARBLOST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ARBLOST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXNACK`"]
+pub type RXNACK_R = crate::R<bool, bool>;
+#[doc = "Reader of field `BUSSTATE`"]
+pub type BUSSTATE_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `BUSSTATE`"]
+pub struct BUSSTATE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BUSSTATE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 4)) | (((value as u16) & 0x03) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `LOWTOUT`"]
+pub type LOWTOUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LOWTOUT`"]
+pub struct LOWTOUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LOWTOUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `CLKHOLD`"]
+pub type CLKHOLD_R = crate::R<bool, bool>;
+#[doc = "Reader of field `MEXTTOUT`"]
+pub type MEXTTOUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MEXTTOUT`"]
+pub struct MEXTTOUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MEXTTOUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `SEXTTOUT`"]
+pub type SEXTTOUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SEXTTOUT`"]
+pub struct SEXTTOUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SEXTTOUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u16) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `LENERR`"]
+pub type LENERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LENERR`"]
+pub struct LENERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LENERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u16) & 0x01) << 10);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Bus Error"]
+    #[inline(always)]
+    pub fn buserr(&self) -> BUSERR_R {
+        BUSERR_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Arbitration Lost"]
+    #[inline(always)]
+    pub fn arblost(&self) -> ARBLOST_R {
+        ARBLOST_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Received Not Acknowledge"]
+    #[inline(always)]
+    pub fn rxnack(&self) -> RXNACK_R {
+        RXNACK_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bits 4:5 - Bus State"]
+    #[inline(always)]
+    pub fn busstate(&self) -> BUSSTATE_R {
+        BUSSTATE_R::new(((self.bits >> 4) & 0x03) as u8)
+    }
+    #[doc = "Bit 6 - SCL Low Timeout"]
+    #[inline(always)]
+    pub fn lowtout(&self) -> LOWTOUT_R {
+        LOWTOUT_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Clock Hold"]
+    #[inline(always)]
+    pub fn clkhold(&self) -> CLKHOLD_R {
+        CLKHOLD_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Master SCL Low Extend Timeout"]
+    #[inline(always)]
+    pub fn mexttout(&self) -> MEXTTOUT_R {
+        MEXTTOUT_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Slave SCL Low Extend Timeout"]
+    #[inline(always)]
+    pub fn sexttout(&self) -> SEXTTOUT_R {
+        SEXTTOUT_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Length Error"]
+    #[inline(always)]
+    pub fn lenerr(&self) -> LENERR_R {
+        LENERR_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Bus Error"]
+    #[inline(always)]
+    pub fn buserr(&mut self) -> BUSERR_W {
+        BUSERR_W { w: self }
+    }
+    #[doc = "Bit 1 - Arbitration Lost"]
+    #[inline(always)]
+    pub fn arblost(&mut self) -> ARBLOST_W {
+        ARBLOST_W { w: self }
+    }
+    #[doc = "Bits 4:5 - Bus State"]
+    #[inline(always)]
+    pub fn busstate(&mut self) -> BUSSTATE_W {
+        BUSSTATE_W { w: self }
+    }
+    #[doc = "Bit 6 - SCL Low Timeout"]
+    #[inline(always)]
+    pub fn lowtout(&mut self) -> LOWTOUT_W {
+        LOWTOUT_W { w: self }
+    }
+    #[doc = "Bit 8 - Master SCL Low Extend Timeout"]
+    #[inline(always)]
+    pub fn mexttout(&mut self) -> MEXTTOUT_W {
+        MEXTTOUT_W { w: self }
+    }
+    #[doc = "Bit 9 - Slave SCL Low Extend Timeout"]
+    #[inline(always)]
+    pub fn sexttout(&mut self) -> SEXTTOUT_W {
+        SEXTTOUT_W { w: self }
+    }
+    #[doc = "Bit 10 - Length Error"]
+    #[inline(always)]
+    pub fn lenerr(&mut self) -> LENERR_W {
+        LENERR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cm/syncbusy.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cm/syncbusy.rs
@@ -1,0 +1,25 @@
+#[doc = "Reader of register SYNCBUSY"]
+pub type R = crate::R<u32, super::SYNCBUSY>;
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Reader of field `SYSOP`"]
+pub type SYSOP_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Software Reset Synchronization Busy"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - SERCOM Enable Synchronization Busy"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - System Operation Synchronization Busy"]
+    #[inline(always)]
+    pub fn sysop(&self) -> SYSOP_R {
+        SYSOP_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cs.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cs.rs
@@ -1,0 +1,97 @@
+#[doc = "I2CS Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrla](ctrla) module"]
+pub type CTRLA = crate::Reg<u32, _CTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLA;
+#[doc = "`read()` method returns [ctrla::R](ctrla::R) reader structure"]
+impl crate::Readable for CTRLA {}
+#[doc = "`write(|w| ..)` method takes [ctrla::W](ctrla::W) writer structure"]
+impl crate::Writable for CTRLA {}
+#[doc = "I2CS Control A"]
+pub mod ctrla;
+#[doc = "I2CS Control B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlb](ctrlb) module"]
+pub type CTRLB = crate::Reg<u32, _CTRLB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLB;
+#[doc = "`read()` method returns [ctrlb::R](ctrlb::R) reader structure"]
+impl crate::Readable for CTRLB {}
+#[doc = "`write(|w| ..)` method takes [ctrlb::W](ctrlb::W) writer structure"]
+impl crate::Writable for CTRLB {}
+#[doc = "I2CS Control B"]
+pub mod ctrlb;
+#[doc = "I2CS Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "I2CS Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "I2CS Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "I2CS Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "I2CS Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "I2CS Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "I2CS Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u16, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "`write(|w| ..)` method takes [status::W](status::W) writer structure"]
+impl crate::Writable for STATUS {}
+#[doc = "I2CS Status"]
+pub mod status;
+#[doc = "I2CS Syncbusy\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [syncbusy](syncbusy) module"]
+pub type SYNCBUSY = crate::Reg<u32, _SYNCBUSY>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _SYNCBUSY;
+#[doc = "`read()` method returns [syncbusy::R](syncbusy::R) reader structure"]
+impl crate::Readable for SYNCBUSY {}
+#[doc = "I2CS Syncbusy"]
+pub mod syncbusy;
+#[doc = "I2CS Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [addr](addr) module"]
+pub type ADDR = crate::Reg<u32, _ADDR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _ADDR;
+#[doc = "`read()` method returns [addr::R](addr::R) reader structure"]
+impl crate::Readable for ADDR {}
+#[doc = "`write(|w| ..)` method takes [addr::W](addr::W) writer structure"]
+impl crate::Writable for ADDR {}
+#[doc = "I2CS Address"]
+pub mod addr;
+#[doc = "I2CS Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [data](data) module"]
+pub type DATA = crate::Reg<u8, _DATA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DATA;
+#[doc = "`read()` method returns [data::R](data::R) reader structure"]
+impl crate::Readable for DATA {}
+#[doc = "`write(|w| ..)` method takes [data::W](data::W) writer structure"]
+impl crate::Writable for DATA {}
+#[doc = "I2CS Data"]
+pub mod data;

--- a/pac/atsamd11c14a/src/sercom0/i2cs/addr.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cs/addr.rs
@@ -1,0 +1,132 @@
+#[doc = "Reader of register ADDR"]
+pub type R = crate::R<u32, super::ADDR>;
+#[doc = "Writer for register ADDR"]
+pub type W = crate::W<u32, super::ADDR>;
+#[doc = "Register ADDR `reset()`'s with value 0"]
+impl crate::ResetValue for super::ADDR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `GENCEN`"]
+pub type GENCEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `GENCEN`"]
+pub struct GENCEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> GENCEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ADDR`"]
+pub type ADDR_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `ADDR`"]
+pub struct ADDR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ADDR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03ff << 1)) | (((value as u32) & 0x03ff) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `TENBITEN`"]
+pub type TENBITEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TENBITEN`"]
+pub struct TENBITEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TENBITEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Reader of field `ADDRMASK`"]
+pub type ADDRMASK_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `ADDRMASK`"]
+pub struct ADDRMASK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ADDRMASK_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03ff << 17)) | (((value as u32) & 0x03ff) << 17);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - General Call Address Enable"]
+    #[inline(always)]
+    pub fn gencen(&self) -> GENCEN_R {
+        GENCEN_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bits 1:10 - Address Value"]
+    #[inline(always)]
+    pub fn addr(&self) -> ADDR_R {
+        ADDR_R::new(((self.bits >> 1) & 0x03ff) as u16)
+    }
+    #[doc = "Bit 15 - Ten Bit Addressing Enable"]
+    #[inline(always)]
+    pub fn tenbiten(&self) -> TENBITEN_R {
+        TENBITEN_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bits 17:26 - Address Mask"]
+    #[inline(always)]
+    pub fn addrmask(&self) -> ADDRMASK_R {
+        ADDRMASK_R::new(((self.bits >> 17) & 0x03ff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - General Call Address Enable"]
+    #[inline(always)]
+    pub fn gencen(&mut self) -> GENCEN_W {
+        GENCEN_W { w: self }
+    }
+    #[doc = "Bits 1:10 - Address Value"]
+    #[inline(always)]
+    pub fn addr(&mut self) -> ADDR_W {
+        ADDR_W { w: self }
+    }
+    #[doc = "Bit 15 - Ten Bit Addressing Enable"]
+    #[inline(always)]
+    pub fn tenbiten(&mut self) -> TENBITEN_W {
+        TENBITEN_W { w: self }
+    }
+    #[doc = "Bits 17:26 - Address Mask"]
+    #[inline(always)]
+    pub fn addrmask(&mut self) -> ADDRMASK_W {
+        ADDRMASK_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cs/ctrla.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cs/ctrla.rs
@@ -1,0 +1,436 @@
+#[doc = "Reader of register CTRLA"]
+pub type R = crate::R<u32, super::CTRLA>;
+#[doc = "Writer for register CTRLA"]
+pub type W = crate::W<u32, super::CTRLA>;
+#[doc = "Register CTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLA {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Operating Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MODE_A {
+    #[doc = "0: USART mode with external clock"]
+    USART_EXT_CLK,
+    #[doc = "1: USART mode with internal clock"]
+    USART_INT_CLK,
+    #[doc = "2: SPI mode with external clock"]
+    SPI_SLAVE,
+    #[doc = "3: SPI mode with internal clock"]
+    SPI_MASTER,
+    #[doc = "4: I2C mode with external clock"]
+    I2C_SLAVE,
+    #[doc = "5: I2C mode with internal clock"]
+    I2C_MASTER,
+}
+impl From<MODE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: MODE_A) -> Self {
+        match variant {
+            MODE_A::USART_EXT_CLK => 0,
+            MODE_A::USART_INT_CLK => 1,
+            MODE_A::SPI_SLAVE => 2,
+            MODE_A::SPI_MASTER => 3,
+            MODE_A::I2C_SLAVE => 4,
+            MODE_A::I2C_MASTER => 5,
+        }
+    }
+}
+#[doc = "Reader of field `MODE`"]
+pub type MODE_R = crate::R<u8, MODE_A>;
+impl MODE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, MODE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(MODE_A::USART_EXT_CLK),
+            1 => Val(MODE_A::USART_INT_CLK),
+            2 => Val(MODE_A::SPI_SLAVE),
+            3 => Val(MODE_A::SPI_MASTER),
+            4 => Val(MODE_A::I2C_SLAVE),
+            5 => Val(MODE_A::I2C_MASTER),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `USART_EXT_CLK`"]
+    #[inline(always)]
+    pub fn is_usart_ext_clk(&self) -> bool {
+        *self == MODE_A::USART_EXT_CLK
+    }
+    #[doc = "Checks if the value of the field is `USART_INT_CLK`"]
+    #[inline(always)]
+    pub fn is_usart_int_clk(&self) -> bool {
+        *self == MODE_A::USART_INT_CLK
+    }
+    #[doc = "Checks if the value of the field is `SPI_SLAVE`"]
+    #[inline(always)]
+    pub fn is_spi_slave(&self) -> bool {
+        *self == MODE_A::SPI_SLAVE
+    }
+    #[doc = "Checks if the value of the field is `SPI_MASTER`"]
+    #[inline(always)]
+    pub fn is_spi_master(&self) -> bool {
+        *self == MODE_A::SPI_MASTER
+    }
+    #[doc = "Checks if the value of the field is `I2C_SLAVE`"]
+    #[inline(always)]
+    pub fn is_i2c_slave(&self) -> bool {
+        *self == MODE_A::I2C_SLAVE
+    }
+    #[doc = "Checks if the value of the field is `I2C_MASTER`"]
+    #[inline(always)]
+    pub fn is_i2c_master(&self) -> bool {
+        *self == MODE_A::I2C_MASTER
+    }
+}
+#[doc = "Write proxy for field `MODE`"]
+pub struct MODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MODE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: MODE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "USART mode with external clock"]
+    #[inline(always)]
+    pub fn usart_ext_clk(self) -> &'a mut W {
+        self.variant(MODE_A::USART_EXT_CLK)
+    }
+    #[doc = "USART mode with internal clock"]
+    #[inline(always)]
+    pub fn usart_int_clk(self) -> &'a mut W {
+        self.variant(MODE_A::USART_INT_CLK)
+    }
+    #[doc = "SPI mode with external clock"]
+    #[inline(always)]
+    pub fn spi_slave(self) -> &'a mut W {
+        self.variant(MODE_A::SPI_SLAVE)
+    }
+    #[doc = "SPI mode with internal clock"]
+    #[inline(always)]
+    pub fn spi_master(self) -> &'a mut W {
+        self.variant(MODE_A::SPI_MASTER)
+    }
+    #[doc = "I2C mode with external clock"]
+    #[inline(always)]
+    pub fn i2c_slave(self) -> &'a mut W {
+        self.variant(MODE_A::I2C_SLAVE)
+    }
+    #[doc = "I2C mode with internal clock"]
+    #[inline(always)]
+    pub fn i2c_master(self) -> &'a mut W {
+        self.variant(MODE_A::I2C_MASTER)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 2)) | (((value as u32) & 0x07) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `PINOUT`"]
+pub type PINOUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PINOUT`"]
+pub struct PINOUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PINOUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `SDAHOLD`"]
+pub type SDAHOLD_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `SDAHOLD`"]
+pub struct SDAHOLD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SDAHOLD_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 20)) | (((value as u32) & 0x03) << 20);
+        self.w
+    }
+}
+#[doc = "Reader of field `SEXTTOEN`"]
+pub type SEXTTOEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SEXTTOEN`"]
+pub struct SEXTTOEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SEXTTOEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 23)) | (((value as u32) & 0x01) << 23);
+        self.w
+    }
+}
+#[doc = "Reader of field `SPEED`"]
+pub type SPEED_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `SPEED`"]
+pub struct SPEED_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SPEED_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 24)) | (((value as u32) & 0x03) << 24);
+        self.w
+    }
+}
+#[doc = "Reader of field `SCLSM`"]
+pub type SCLSM_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SCLSM`"]
+pub struct SCLSM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SCLSM_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 27)) | (((value as u32) & 0x01) << 27);
+        self.w
+    }
+}
+#[doc = "Reader of field `LOWTOUTEN`"]
+pub type LOWTOUTEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LOWTOUTEN`"]
+pub struct LOWTOUTEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LOWTOUTEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 30)) | (((value as u32) & 0x01) << 30);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 2:4 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 2) & 0x07) as u8)
+    }
+    #[doc = "Bit 7 - Run during Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - Pin Usage"]
+    #[inline(always)]
+    pub fn pinout(&self) -> PINOUT_R {
+        PINOUT_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bits 20:21 - SDA Hold Time"]
+    #[inline(always)]
+    pub fn sdahold(&self) -> SDAHOLD_R {
+        SDAHOLD_R::new(((self.bits >> 20) & 0x03) as u8)
+    }
+    #[doc = "Bit 23 - Slave SCL Low Extend Timeout"]
+    #[inline(always)]
+    pub fn sexttoen(&self) -> SEXTTOEN_R {
+        SEXTTOEN_R::new(((self.bits >> 23) & 0x01) != 0)
+    }
+    #[doc = "Bits 24:25 - Transfer Speed"]
+    #[inline(always)]
+    pub fn speed(&self) -> SPEED_R {
+        SPEED_R::new(((self.bits >> 24) & 0x03) as u8)
+    }
+    #[doc = "Bit 27 - SCL Clock Stretch Mode"]
+    #[inline(always)]
+    pub fn sclsm(&self) -> SCLSM_R {
+        SCLSM_R::new(((self.bits >> 27) & 0x01) != 0)
+    }
+    #[doc = "Bit 30 - SCL Low Timeout Enable"]
+    #[inline(always)]
+    pub fn lowtouten(&self) -> LOWTOUTEN_R {
+        LOWTOUTEN_R::new(((self.bits >> 30) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bits 2:4 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&mut self) -> MODE_W {
+        MODE_W { w: self }
+    }
+    #[doc = "Bit 7 - Run during Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bit 16 - Pin Usage"]
+    #[inline(always)]
+    pub fn pinout(&mut self) -> PINOUT_W {
+        PINOUT_W { w: self }
+    }
+    #[doc = "Bits 20:21 - SDA Hold Time"]
+    #[inline(always)]
+    pub fn sdahold(&mut self) -> SDAHOLD_W {
+        SDAHOLD_W { w: self }
+    }
+    #[doc = "Bit 23 - Slave SCL Low Extend Timeout"]
+    #[inline(always)]
+    pub fn sexttoen(&mut self) -> SEXTTOEN_W {
+        SEXTTOEN_W { w: self }
+    }
+    #[doc = "Bits 24:25 - Transfer Speed"]
+    #[inline(always)]
+    pub fn speed(&mut self) -> SPEED_W {
+        SPEED_W { w: self }
+    }
+    #[doc = "Bit 27 - SCL Clock Stretch Mode"]
+    #[inline(always)]
+    pub fn sclsm(&mut self) -> SCLSM_W {
+        SCLSM_W { w: self }
+    }
+    #[doc = "Bit 30 - SCL Low Timeout Enable"]
+    #[inline(always)]
+    pub fn lowtouten(&mut self) -> LOWTOUTEN_W {
+        LOWTOUTEN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cs/ctrlb.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cs/ctrlb.rs
@@ -1,0 +1,193 @@
+#[doc = "Reader of register CTRLB"]
+pub type R = crate::R<u32, super::CTRLB>;
+#[doc = "Writer for register CTRLB"]
+pub type W = crate::W<u32, super::CTRLB>;
+#[doc = "Register CTRLB `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLB {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SMEN`"]
+pub type SMEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SMEN`"]
+pub struct SMEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SMEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `GCMD`"]
+pub type GCMD_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `GCMD`"]
+pub struct GCMD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> GCMD_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `AACKEN`"]
+pub type AACKEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `AACKEN`"]
+pub struct AACKEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> AACKEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u32) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `AMODE`"]
+pub type AMODE_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `AMODE`"]
+pub struct AMODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> AMODE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 14)) | (((value as u32) & 0x03) << 14);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `CMD`"]
+pub struct CMD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMD_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 16)) | (((value as u32) & 0x03) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `ACKACT`"]
+pub type ACKACT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ACKACT`"]
+pub struct ACKACT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ACKACT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 18)) | (((value as u32) & 0x01) << 18);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 8 - Smart Mode Enable"]
+    #[inline(always)]
+    pub fn smen(&self) -> SMEN_R {
+        SMEN_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - PMBus Group Command"]
+    #[inline(always)]
+    pub fn gcmd(&self) -> GCMD_R {
+        GCMD_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Automatic Address Acknowledge"]
+    #[inline(always)]
+    pub fn aacken(&self) -> AACKEN_R {
+        AACKEN_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bits 14:15 - Address Mode"]
+    #[inline(always)]
+    pub fn amode(&self) -> AMODE_R {
+        AMODE_R::new(((self.bits >> 14) & 0x03) as u8)
+    }
+    #[doc = "Bit 18 - Acknowledge Action"]
+    #[inline(always)]
+    pub fn ackact(&self) -> ACKACT_R {
+        ACKACT_R::new(((self.bits >> 18) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 8 - Smart Mode Enable"]
+    #[inline(always)]
+    pub fn smen(&mut self) -> SMEN_W {
+        SMEN_W { w: self }
+    }
+    #[doc = "Bit 9 - PMBus Group Command"]
+    #[inline(always)]
+    pub fn gcmd(&mut self) -> GCMD_W {
+        GCMD_W { w: self }
+    }
+    #[doc = "Bit 10 - Automatic Address Acknowledge"]
+    #[inline(always)]
+    pub fn aacken(&mut self) -> AACKEN_W {
+        AACKEN_W { w: self }
+    }
+    #[doc = "Bits 14:15 - Address Mode"]
+    #[inline(always)]
+    pub fn amode(&mut self) -> AMODE_W {
+        AMODE_W { w: self }
+    }
+    #[doc = "Bits 16:17 - Command"]
+    #[inline(always)]
+    pub fn cmd(&mut self) -> CMD_W {
+        CMD_W { w: self }
+    }
+    #[doc = "Bit 18 - Acknowledge Action"]
+    #[inline(always)]
+    pub fn ackact(&mut self) -> ACKACT_W {
+        ACKACT_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cs/data.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cs/data.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register DATA"]
+pub type R = crate::R<u8, super::DATA>;
+#[doc = "Writer for register DATA"]
+pub type W = crate::W<u8, super::DATA>;
+#[doc = "Register DATA `reset()`'s with value 0"]
+impl crate::ResetValue for super::DATA {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DATA`"]
+pub type DATA_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DATA`"]
+pub struct DATA_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DATA_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xff) | ((value as u8) & 0xff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:7 - Data Value"]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Data Value"]
+    #[inline(always)]
+    pub fn data(&mut self) -> DATA_W {
+        DATA_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cs/intenclr.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cs/intenclr.rs
@@ -1,0 +1,152 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `PREC`"]
+pub type PREC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PREC`"]
+pub struct PREC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PREC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `AMATCH`"]
+pub type AMATCH_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `AMATCH`"]
+pub struct AMATCH_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> AMATCH_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `DRDY`"]
+pub type DRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DRDY`"]
+pub struct DRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERROR`"]
+pub type ERROR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERROR`"]
+pub struct ERROR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERROR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Stop Received Interrupt Disable"]
+    #[inline(always)]
+    pub fn prec(&self) -> PREC_R {
+        PREC_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Address Match Interrupt Disable"]
+    #[inline(always)]
+    pub fn amatch(&self) -> AMATCH_R {
+        AMATCH_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Data Interrupt Disable"]
+    #[inline(always)]
+    pub fn drdy(&self) -> DRDY_R {
+        DRDY_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Disable"]
+    #[inline(always)]
+    pub fn error(&self) -> ERROR_R {
+        ERROR_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Stop Received Interrupt Disable"]
+    #[inline(always)]
+    pub fn prec(&mut self) -> PREC_W {
+        PREC_W { w: self }
+    }
+    #[doc = "Bit 1 - Address Match Interrupt Disable"]
+    #[inline(always)]
+    pub fn amatch(&mut self) -> AMATCH_W {
+        AMATCH_W { w: self }
+    }
+    #[doc = "Bit 2 - Data Interrupt Disable"]
+    #[inline(always)]
+    pub fn drdy(&mut self) -> DRDY_W {
+        DRDY_W { w: self }
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Disable"]
+    #[inline(always)]
+    pub fn error(&mut self) -> ERROR_W {
+        ERROR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cs/intenset.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cs/intenset.rs
@@ -1,0 +1,152 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `PREC`"]
+pub type PREC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PREC`"]
+pub struct PREC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PREC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `AMATCH`"]
+pub type AMATCH_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `AMATCH`"]
+pub struct AMATCH_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> AMATCH_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `DRDY`"]
+pub type DRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DRDY`"]
+pub struct DRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERROR`"]
+pub type ERROR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERROR`"]
+pub struct ERROR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERROR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Stop Received Interrupt Enable"]
+    #[inline(always)]
+    pub fn prec(&self) -> PREC_R {
+        PREC_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Address Match Interrupt Enable"]
+    #[inline(always)]
+    pub fn amatch(&self) -> AMATCH_R {
+        AMATCH_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Data Interrupt Enable"]
+    #[inline(always)]
+    pub fn drdy(&self) -> DRDY_R {
+        DRDY_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn error(&self) -> ERROR_R {
+        ERROR_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Stop Received Interrupt Enable"]
+    #[inline(always)]
+    pub fn prec(&mut self) -> PREC_W {
+        PREC_W { w: self }
+    }
+    #[doc = "Bit 1 - Address Match Interrupt Enable"]
+    #[inline(always)]
+    pub fn amatch(&mut self) -> AMATCH_W {
+        AMATCH_W { w: self }
+    }
+    #[doc = "Bit 2 - Data Interrupt Enable"]
+    #[inline(always)]
+    pub fn drdy(&mut self) -> DRDY_W {
+        DRDY_W { w: self }
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn error(&mut self) -> ERROR_W {
+        ERROR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cs/intflag.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cs/intflag.rs
@@ -1,0 +1,152 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `PREC`"]
+pub type PREC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PREC`"]
+pub struct PREC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PREC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `AMATCH`"]
+pub type AMATCH_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `AMATCH`"]
+pub struct AMATCH_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> AMATCH_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `DRDY`"]
+pub type DRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DRDY`"]
+pub struct DRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERROR`"]
+pub type ERROR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERROR`"]
+pub struct ERROR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERROR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Stop Received Interrupt"]
+    #[inline(always)]
+    pub fn prec(&self) -> PREC_R {
+        PREC_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Address Match Interrupt"]
+    #[inline(always)]
+    pub fn amatch(&self) -> AMATCH_R {
+        AMATCH_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Data Interrupt"]
+    #[inline(always)]
+    pub fn drdy(&self) -> DRDY_R {
+        DRDY_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt"]
+    #[inline(always)]
+    pub fn error(&self) -> ERROR_R {
+        ERROR_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Stop Received Interrupt"]
+    #[inline(always)]
+    pub fn prec(&mut self) -> PREC_W {
+        PREC_W { w: self }
+    }
+    #[doc = "Bit 1 - Address Match Interrupt"]
+    #[inline(always)]
+    pub fn amatch(&mut self) -> AMATCH_W {
+        AMATCH_W { w: self }
+    }
+    #[doc = "Bit 2 - Data Interrupt"]
+    #[inline(always)]
+    pub fn drdy(&mut self) -> DRDY_W {
+        DRDY_W { w: self }
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt"]
+    #[inline(always)]
+    pub fn error(&mut self) -> ERROR_W {
+        ERROR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cs/status.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cs/status.rs
@@ -1,0 +1,214 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u16, super::STATUS>;
+#[doc = "Writer for register STATUS"]
+pub type W = crate::W<u16, super::STATUS>;
+#[doc = "Register STATUS `reset()`'s with value 0"]
+impl crate::ResetValue for super::STATUS {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `BUSERR`"]
+pub type BUSERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BUSERR`"]
+pub struct BUSERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BUSERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `COLL`"]
+pub type COLL_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `COLL`"]
+pub struct COLL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COLL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXNACK`"]
+pub type RXNACK_R = crate::R<bool, bool>;
+#[doc = "Reader of field `DIR`"]
+pub type DIR_R = crate::R<bool, bool>;
+#[doc = "Reader of field `SR`"]
+pub type SR_R = crate::R<bool, bool>;
+#[doc = "Reader of field `LOWTOUT`"]
+pub type LOWTOUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LOWTOUT`"]
+pub struct LOWTOUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LOWTOUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `CLKHOLD`"]
+pub type CLKHOLD_R = crate::R<bool, bool>;
+#[doc = "Reader of field `SEXTTOUT`"]
+pub type SEXTTOUT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SEXTTOUT`"]
+pub struct SEXTTOUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SEXTTOUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u16) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `HS`"]
+pub type HS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `HS`"]
+pub struct HS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u16) & 0x01) << 10);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Bus Error"]
+    #[inline(always)]
+    pub fn buserr(&self) -> BUSERR_R {
+        BUSERR_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Transmit Collision"]
+    #[inline(always)]
+    pub fn coll(&self) -> COLL_R {
+        COLL_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Received Not Acknowledge"]
+    #[inline(always)]
+    pub fn rxnack(&self) -> RXNACK_R {
+        RXNACK_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Read/Write Direction"]
+    #[inline(always)]
+    pub fn dir(&self) -> DIR_R {
+        DIR_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Repeated Start"]
+    #[inline(always)]
+    pub fn sr(&self) -> SR_R {
+        SR_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - SCL Low Timeout"]
+    #[inline(always)]
+    pub fn lowtout(&self) -> LOWTOUT_R {
+        LOWTOUT_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Clock Hold"]
+    #[inline(always)]
+    pub fn clkhold(&self) -> CLKHOLD_R {
+        CLKHOLD_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Slave SCL Low Extend Timeout"]
+    #[inline(always)]
+    pub fn sexttout(&self) -> SEXTTOUT_R {
+        SEXTTOUT_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - High Speed"]
+    #[inline(always)]
+    pub fn hs(&self) -> HS_R {
+        HS_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Bus Error"]
+    #[inline(always)]
+    pub fn buserr(&mut self) -> BUSERR_W {
+        BUSERR_W { w: self }
+    }
+    #[doc = "Bit 1 - Transmit Collision"]
+    #[inline(always)]
+    pub fn coll(&mut self) -> COLL_W {
+        COLL_W { w: self }
+    }
+    #[doc = "Bit 6 - SCL Low Timeout"]
+    #[inline(always)]
+    pub fn lowtout(&mut self) -> LOWTOUT_W {
+        LOWTOUT_W { w: self }
+    }
+    #[doc = "Bit 9 - Slave SCL Low Extend Timeout"]
+    #[inline(always)]
+    pub fn sexttout(&mut self) -> SEXTTOUT_W {
+        SEXTTOUT_W { w: self }
+    }
+    #[doc = "Bit 10 - High Speed"]
+    #[inline(always)]
+    pub fn hs(&mut self) -> HS_W {
+        HS_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/i2cs/syncbusy.rs
+++ b/pac/atsamd11c14a/src/sercom0/i2cs/syncbusy.rs
@@ -1,0 +1,18 @@
+#[doc = "Reader of register SYNCBUSY"]
+pub type R = crate::R<u32, super::SYNCBUSY>;
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Software Reset Synchronization Busy"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - SERCOM Enable Synchronization Busy"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/spi.rs
+++ b/pac/atsamd11c14a/src/sercom0/spi.rs
@@ -1,0 +1,119 @@
+#[doc = "SPI Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrla](ctrla) module"]
+pub type CTRLA = crate::Reg<u32, _CTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLA;
+#[doc = "`read()` method returns [ctrla::R](ctrla::R) reader structure"]
+impl crate::Readable for CTRLA {}
+#[doc = "`write(|w| ..)` method takes [ctrla::W](ctrla::W) writer structure"]
+impl crate::Writable for CTRLA {}
+#[doc = "SPI Control A"]
+pub mod ctrla;
+#[doc = "SPI Control B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlb](ctrlb) module"]
+pub type CTRLB = crate::Reg<u32, _CTRLB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLB;
+#[doc = "`read()` method returns [ctrlb::R](ctrlb::R) reader structure"]
+impl crate::Readable for CTRLB {}
+#[doc = "`write(|w| ..)` method takes [ctrlb::W](ctrlb::W) writer structure"]
+impl crate::Writable for CTRLB {}
+#[doc = "SPI Control B"]
+pub mod ctrlb;
+#[doc = "SPI Baud Rate\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [baud](baud) module"]
+pub type BAUD = crate::Reg<u8, _BAUD>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _BAUD;
+#[doc = "`read()` method returns [baud::R](baud::R) reader structure"]
+impl crate::Readable for BAUD {}
+#[doc = "`write(|w| ..)` method takes [baud::W](baud::W) writer structure"]
+impl crate::Writable for BAUD {}
+#[doc = "SPI Baud Rate"]
+pub mod baud;
+#[doc = "SPI Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "SPI Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "SPI Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "SPI Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "SPI Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "SPI Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "SPI Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u16, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "`write(|w| ..)` method takes [status::W](status::W) writer structure"]
+impl crate::Writable for STATUS {}
+#[doc = "SPI Status"]
+pub mod status;
+#[doc = "SPI Syncbusy\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [syncbusy](syncbusy) module"]
+pub type SYNCBUSY = crate::Reg<u32, _SYNCBUSY>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _SYNCBUSY;
+#[doc = "`read()` method returns [syncbusy::R](syncbusy::R) reader structure"]
+impl crate::Readable for SYNCBUSY {}
+#[doc = "SPI Syncbusy"]
+pub mod syncbusy;
+#[doc = "SPI Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [addr](addr) module"]
+pub type ADDR = crate::Reg<u32, _ADDR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _ADDR;
+#[doc = "`read()` method returns [addr::R](addr::R) reader structure"]
+impl crate::Readable for ADDR {}
+#[doc = "`write(|w| ..)` method takes [addr::W](addr::W) writer structure"]
+impl crate::Writable for ADDR {}
+#[doc = "SPI Address"]
+pub mod addr;
+#[doc = "SPI Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [data](data) module"]
+pub type DATA = crate::Reg<u32, _DATA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DATA;
+#[doc = "`read()` method returns [data::R](data::R) reader structure"]
+impl crate::Readable for DATA {}
+#[doc = "`write(|w| ..)` method takes [data::W](data::W) writer structure"]
+impl crate::Writable for DATA {}
+#[doc = "SPI Data"]
+pub mod data;
+#[doc = "SPI Debug Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dbgctrl](dbgctrl) module"]
+pub type DBGCTRL = crate::Reg<u8, _DBGCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DBGCTRL;
+#[doc = "`read()` method returns [dbgctrl::R](dbgctrl::R) reader structure"]
+impl crate::Readable for DBGCTRL {}
+#[doc = "`write(|w| ..)` method takes [dbgctrl::W](dbgctrl::W) writer structure"]
+impl crate::Writable for DBGCTRL {}
+#[doc = "SPI Debug Control"]
+pub mod dbgctrl;

--- a/pac/atsamd11c14a/src/sercom0/spi/addr.rs
+++ b/pac/atsamd11c14a/src/sercom0/spi/addr.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register ADDR"]
+pub type R = crate::R<u32, super::ADDR>;
+#[doc = "Writer for register ADDR"]
+pub type W = crate::W<u32, super::ADDR>;
+#[doc = "Register ADDR `reset()`'s with value 0"]
+impl crate::ResetValue for super::ADDR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ADDR`"]
+pub type ADDR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `ADDR`"]
+pub struct ADDR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ADDR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xff) | ((value as u32) & 0xff);
+        self.w
+    }
+}
+#[doc = "Reader of field `ADDRMASK`"]
+pub type ADDRMASK_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `ADDRMASK`"]
+pub struct ADDRMASK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ADDRMASK_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0xff << 16)) | (((value as u32) & 0xff) << 16);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:7 - Address Value"]
+    #[inline(always)]
+    pub fn addr(&self) -> ADDR_R {
+        ADDR_R::new((self.bits & 0xff) as u8)
+    }
+    #[doc = "Bits 16:23 - Address Mask"]
+    #[inline(always)]
+    pub fn addrmask(&self) -> ADDRMASK_R {
+        ADDRMASK_R::new(((self.bits >> 16) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Address Value"]
+    #[inline(always)]
+    pub fn addr(&mut self) -> ADDR_W {
+        ADDR_W { w: self }
+    }
+    #[doc = "Bits 16:23 - Address Mask"]
+    #[inline(always)]
+    pub fn addrmask(&mut self) -> ADDRMASK_W {
+        ADDRMASK_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/spi/baud.rs
+++ b/pac/atsamd11c14a/src/sercom0/spi/baud.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register BAUD"]
+pub type R = crate::R<u8, super::BAUD>;
+#[doc = "Writer for register BAUD"]
+pub type W = crate::W<u8, super::BAUD>;
+#[doc = "Register BAUD `reset()`'s with value 0"]
+impl crate::ResetValue for super::BAUD {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `BAUD`"]
+pub type BAUD_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `BAUD`"]
+pub struct BAUD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BAUD_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xff) | ((value as u8) & 0xff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:7 - Baud Rate Value"]
+    #[inline(always)]
+    pub fn baud(&self) -> BAUD_R {
+        BAUD_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Baud Rate Value"]
+    #[inline(always)]
+    pub fn baud(&mut self) -> BAUD_W {
+        BAUD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/spi/ctrla.rs
+++ b/pac/atsamd11c14a/src/sercom0/spi/ctrla.rs
@@ -1,0 +1,460 @@
+#[doc = "Reader of register CTRLA"]
+pub type R = crate::R<u32, super::CTRLA>;
+#[doc = "Writer for register CTRLA"]
+pub type W = crate::W<u32, super::CTRLA>;
+#[doc = "Register CTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLA {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Operating Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MODE_A {
+    #[doc = "0: USART mode with external clock"]
+    USART_EXT_CLK,
+    #[doc = "1: USART mode with internal clock"]
+    USART_INT_CLK,
+    #[doc = "2: SPI mode with external clock"]
+    SPI_SLAVE,
+    #[doc = "3: SPI mode with internal clock"]
+    SPI_MASTER,
+    #[doc = "4: I2C mode with external clock"]
+    I2C_SLAVE,
+    #[doc = "5: I2C mode with internal clock"]
+    I2C_MASTER,
+}
+impl From<MODE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: MODE_A) -> Self {
+        match variant {
+            MODE_A::USART_EXT_CLK => 0,
+            MODE_A::USART_INT_CLK => 1,
+            MODE_A::SPI_SLAVE => 2,
+            MODE_A::SPI_MASTER => 3,
+            MODE_A::I2C_SLAVE => 4,
+            MODE_A::I2C_MASTER => 5,
+        }
+    }
+}
+#[doc = "Reader of field `MODE`"]
+pub type MODE_R = crate::R<u8, MODE_A>;
+impl MODE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, MODE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(MODE_A::USART_EXT_CLK),
+            1 => Val(MODE_A::USART_INT_CLK),
+            2 => Val(MODE_A::SPI_SLAVE),
+            3 => Val(MODE_A::SPI_MASTER),
+            4 => Val(MODE_A::I2C_SLAVE),
+            5 => Val(MODE_A::I2C_MASTER),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `USART_EXT_CLK`"]
+    #[inline(always)]
+    pub fn is_usart_ext_clk(&self) -> bool {
+        *self == MODE_A::USART_EXT_CLK
+    }
+    #[doc = "Checks if the value of the field is `USART_INT_CLK`"]
+    #[inline(always)]
+    pub fn is_usart_int_clk(&self) -> bool {
+        *self == MODE_A::USART_INT_CLK
+    }
+    #[doc = "Checks if the value of the field is `SPI_SLAVE`"]
+    #[inline(always)]
+    pub fn is_spi_slave(&self) -> bool {
+        *self == MODE_A::SPI_SLAVE
+    }
+    #[doc = "Checks if the value of the field is `SPI_MASTER`"]
+    #[inline(always)]
+    pub fn is_spi_master(&self) -> bool {
+        *self == MODE_A::SPI_MASTER
+    }
+    #[doc = "Checks if the value of the field is `I2C_SLAVE`"]
+    #[inline(always)]
+    pub fn is_i2c_slave(&self) -> bool {
+        *self == MODE_A::I2C_SLAVE
+    }
+    #[doc = "Checks if the value of the field is `I2C_MASTER`"]
+    #[inline(always)]
+    pub fn is_i2c_master(&self) -> bool {
+        *self == MODE_A::I2C_MASTER
+    }
+}
+#[doc = "Write proxy for field `MODE`"]
+pub struct MODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MODE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: MODE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "USART mode with external clock"]
+    #[inline(always)]
+    pub fn usart_ext_clk(self) -> &'a mut W {
+        self.variant(MODE_A::USART_EXT_CLK)
+    }
+    #[doc = "USART mode with internal clock"]
+    #[inline(always)]
+    pub fn usart_int_clk(self) -> &'a mut W {
+        self.variant(MODE_A::USART_INT_CLK)
+    }
+    #[doc = "SPI mode with external clock"]
+    #[inline(always)]
+    pub fn spi_slave(self) -> &'a mut W {
+        self.variant(MODE_A::SPI_SLAVE)
+    }
+    #[doc = "SPI mode with internal clock"]
+    #[inline(always)]
+    pub fn spi_master(self) -> &'a mut W {
+        self.variant(MODE_A::SPI_MASTER)
+    }
+    #[doc = "I2C mode with external clock"]
+    #[inline(always)]
+    pub fn i2c_slave(self) -> &'a mut W {
+        self.variant(MODE_A::I2C_SLAVE)
+    }
+    #[doc = "I2C mode with internal clock"]
+    #[inline(always)]
+    pub fn i2c_master(self) -> &'a mut W {
+        self.variant(MODE_A::I2C_MASTER)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 2)) | (((value as u32) & 0x07) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `IBON`"]
+pub type IBON_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `IBON`"]
+pub struct IBON_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> IBON_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `DOPO`"]
+pub type DOPO_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DOPO`"]
+pub struct DOPO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DOPO_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 16)) | (((value as u32) & 0x03) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `DIPO`"]
+pub type DIPO_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DIPO`"]
+pub struct DIPO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIPO_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 20)) | (((value as u32) & 0x03) << 20);
+        self.w
+    }
+}
+#[doc = "Reader of field `FORM`"]
+pub type FORM_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `FORM`"]
+pub struct FORM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FORM_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 24)) | (((value as u32) & 0x0f) << 24);
+        self.w
+    }
+}
+#[doc = "Reader of field `CPHA`"]
+pub type CPHA_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CPHA`"]
+pub struct CPHA_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CPHA_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 28)) | (((value as u32) & 0x01) << 28);
+        self.w
+    }
+}
+#[doc = "Reader of field `CPOL`"]
+pub type CPOL_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CPOL`"]
+pub struct CPOL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CPOL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 29)) | (((value as u32) & 0x01) << 29);
+        self.w
+    }
+}
+#[doc = "Reader of field `DORD`"]
+pub type DORD_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DORD`"]
+pub struct DORD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DORD_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 30)) | (((value as u32) & 0x01) << 30);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 2:4 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 2) & 0x07) as u8)
+    }
+    #[doc = "Bit 7 - Run during Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Immediate Buffer Overflow Notification"]
+    #[inline(always)]
+    pub fn ibon(&self) -> IBON_R {
+        IBON_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bits 16:17 - Data Out Pinout"]
+    #[inline(always)]
+    pub fn dopo(&self) -> DOPO_R {
+        DOPO_R::new(((self.bits >> 16) & 0x03) as u8)
+    }
+    #[doc = "Bits 20:21 - Data In Pinout"]
+    #[inline(always)]
+    pub fn dipo(&self) -> DIPO_R {
+        DIPO_R::new(((self.bits >> 20) & 0x03) as u8)
+    }
+    #[doc = "Bits 24:27 - Frame Format"]
+    #[inline(always)]
+    pub fn form(&self) -> FORM_R {
+        FORM_R::new(((self.bits >> 24) & 0x0f) as u8)
+    }
+    #[doc = "Bit 28 - Clock Phase"]
+    #[inline(always)]
+    pub fn cpha(&self) -> CPHA_R {
+        CPHA_R::new(((self.bits >> 28) & 0x01) != 0)
+    }
+    #[doc = "Bit 29 - Clock Polarity"]
+    #[inline(always)]
+    pub fn cpol(&self) -> CPOL_R {
+        CPOL_R::new(((self.bits >> 29) & 0x01) != 0)
+    }
+    #[doc = "Bit 30 - Data Order"]
+    #[inline(always)]
+    pub fn dord(&self) -> DORD_R {
+        DORD_R::new(((self.bits >> 30) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bits 2:4 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&mut self) -> MODE_W {
+        MODE_W { w: self }
+    }
+    #[doc = "Bit 7 - Run during Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bit 8 - Immediate Buffer Overflow Notification"]
+    #[inline(always)]
+    pub fn ibon(&mut self) -> IBON_W {
+        IBON_W { w: self }
+    }
+    #[doc = "Bits 16:17 - Data Out Pinout"]
+    #[inline(always)]
+    pub fn dopo(&mut self) -> DOPO_W {
+        DOPO_W { w: self }
+    }
+    #[doc = "Bits 20:21 - Data In Pinout"]
+    #[inline(always)]
+    pub fn dipo(&mut self) -> DIPO_W {
+        DIPO_W { w: self }
+    }
+    #[doc = "Bits 24:27 - Frame Format"]
+    #[inline(always)]
+    pub fn form(&mut self) -> FORM_W {
+        FORM_W { w: self }
+    }
+    #[doc = "Bit 28 - Clock Phase"]
+    #[inline(always)]
+    pub fn cpha(&mut self) -> CPHA_W {
+        CPHA_W { w: self }
+    }
+    #[doc = "Bit 29 - Clock Polarity"]
+    #[inline(always)]
+    pub fn cpol(&mut self) -> CPOL_W {
+        CPOL_W { w: self }
+    }
+    #[doc = "Bit 30 - Data Order"]
+    #[inline(always)]
+    pub fn dord(&mut self) -> DORD_W {
+        DORD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/spi/ctrlb.rs
+++ b/pac/atsamd11c14a/src/sercom0/spi/ctrlb.rs
@@ -1,0 +1,200 @@
+#[doc = "Reader of register CTRLB"]
+pub type R = crate::R<u32, super::CTRLB>;
+#[doc = "Writer for register CTRLB"]
+pub type W = crate::W<u32, super::CTRLB>;
+#[doc = "Register CTRLB `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLB {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CHSIZE`"]
+pub type CHSIZE_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `CHSIZE`"]
+pub struct CHSIZE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CHSIZE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u32) & 0x07);
+        self.w
+    }
+}
+#[doc = "Reader of field `PLOADEN`"]
+pub type PLOADEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PLOADEN`"]
+pub struct PLOADEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PLOADEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `SSDE`"]
+pub type SSDE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SSDE`"]
+pub struct SSDE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SSDE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `MSSEN`"]
+pub type MSSEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MSSEN`"]
+pub struct MSSEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MSSEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u32) & 0x01) << 13);
+        self.w
+    }
+}
+#[doc = "Reader of field `AMODE`"]
+pub type AMODE_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `AMODE`"]
+pub struct AMODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> AMODE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 14)) | (((value as u32) & 0x03) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXEN`"]
+pub type RXEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RXEN`"]
+pub struct RXEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Character Size"]
+    #[inline(always)]
+    pub fn chsize(&self) -> CHSIZE_R {
+        CHSIZE_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bit 6 - Data Preload Enable"]
+    #[inline(always)]
+    pub fn ploaden(&self) -> PLOADEN_R {
+        PLOADEN_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Slave Select Low Detect Enable"]
+    #[inline(always)]
+    pub fn ssde(&self) -> SSDE_R {
+        SSDE_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Master Slave Select Enable"]
+    #[inline(always)]
+    pub fn mssen(&self) -> MSSEN_R {
+        MSSEN_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+    #[doc = "Bits 14:15 - Address Mode"]
+    #[inline(always)]
+    pub fn amode(&self) -> AMODE_R {
+        AMODE_R::new(((self.bits >> 14) & 0x03) as u8)
+    }
+    #[doc = "Bit 17 - Receiver Enable"]
+    #[inline(always)]
+    pub fn rxen(&self) -> RXEN_R {
+        RXEN_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Character Size"]
+    #[inline(always)]
+    pub fn chsize(&mut self) -> CHSIZE_W {
+        CHSIZE_W { w: self }
+    }
+    #[doc = "Bit 6 - Data Preload Enable"]
+    #[inline(always)]
+    pub fn ploaden(&mut self) -> PLOADEN_W {
+        PLOADEN_W { w: self }
+    }
+    #[doc = "Bit 9 - Slave Select Low Detect Enable"]
+    #[inline(always)]
+    pub fn ssde(&mut self) -> SSDE_W {
+        SSDE_W { w: self }
+    }
+    #[doc = "Bit 13 - Master Slave Select Enable"]
+    #[inline(always)]
+    pub fn mssen(&mut self) -> MSSEN_W {
+        MSSEN_W { w: self }
+    }
+    #[doc = "Bits 14:15 - Address Mode"]
+    #[inline(always)]
+    pub fn amode(&mut self) -> AMODE_W {
+        AMODE_W { w: self }
+    }
+    #[doc = "Bit 17 - Receiver Enable"]
+    #[inline(always)]
+    pub fn rxen(&mut self) -> RXEN_W {
+        RXEN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/spi/data.rs
+++ b/pac/atsamd11c14a/src/sercom0/spi/data.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register DATA"]
+pub type R = crate::R<u32, super::DATA>;
+#[doc = "Writer for register DATA"]
+pub type W = crate::W<u32, super::DATA>;
+#[doc = "Register DATA `reset()`'s with value 0"]
+impl crate::ResetValue for super::DATA {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DATA`"]
+pub type DATA_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `DATA`"]
+pub struct DATA_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DATA_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01ff) | ((value as u32) & 0x01ff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:8 - Data Value"]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new((self.bits & 0x01ff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:8 - Data Value"]
+    #[inline(always)]
+    pub fn data(&mut self) -> DATA_W {
+        DATA_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/spi/dbgctrl.rs
+++ b/pac/atsamd11c14a/src/sercom0/spi/dbgctrl.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register DBGCTRL"]
+pub type R = crate::R<u8, super::DBGCTRL>;
+#[doc = "Writer for register DBGCTRL"]
+pub type W = crate::W<u8, super::DBGCTRL>;
+#[doc = "Register DBGCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::DBGCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DBGSTOP`"]
+pub type DBGSTOP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DBGSTOP`"]
+pub struct DBGSTOP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DBGSTOP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Debug Mode"]
+    #[inline(always)]
+    pub fn dbgstop(&self) -> DBGSTOP_R {
+        DBGSTOP_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Debug Mode"]
+    #[inline(always)]
+    pub fn dbgstop(&mut self) -> DBGSTOP_W {
+        DBGSTOP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/spi/intenclr.rs
+++ b/pac/atsamd11c14a/src/sercom0/spi/intenclr.rs
@@ -1,0 +1,186 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DRE`"]
+pub type DRE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DRE`"]
+pub struct DRE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DRE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `TXC`"]
+pub type TXC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TXC`"]
+pub struct TXC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TXC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXC`"]
+pub type RXC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RXC`"]
+pub struct RXC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `SSL`"]
+pub type SSL_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SSL`"]
+pub struct SSL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SSL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERROR`"]
+pub type ERROR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERROR`"]
+pub struct ERROR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERROR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Data Register Empty Interrupt Disable"]
+    #[inline(always)]
+    pub fn dre(&self) -> DRE_R {
+        DRE_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Transmit Complete Interrupt Disable"]
+    #[inline(always)]
+    pub fn txc(&self) -> TXC_R {
+        TXC_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Receive Complete Interrupt Disable"]
+    #[inline(always)]
+    pub fn rxc(&self) -> RXC_R {
+        RXC_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Slave Select Low Interrupt Disable"]
+    #[inline(always)]
+    pub fn ssl(&self) -> SSL_R {
+        SSL_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Disable"]
+    #[inline(always)]
+    pub fn error(&self) -> ERROR_R {
+        ERROR_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Data Register Empty Interrupt Disable"]
+    #[inline(always)]
+    pub fn dre(&mut self) -> DRE_W {
+        DRE_W { w: self }
+    }
+    #[doc = "Bit 1 - Transmit Complete Interrupt Disable"]
+    #[inline(always)]
+    pub fn txc(&mut self) -> TXC_W {
+        TXC_W { w: self }
+    }
+    #[doc = "Bit 2 - Receive Complete Interrupt Disable"]
+    #[inline(always)]
+    pub fn rxc(&mut self) -> RXC_W {
+        RXC_W { w: self }
+    }
+    #[doc = "Bit 3 - Slave Select Low Interrupt Disable"]
+    #[inline(always)]
+    pub fn ssl(&mut self) -> SSL_W {
+        SSL_W { w: self }
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Disable"]
+    #[inline(always)]
+    pub fn error(&mut self) -> ERROR_W {
+        ERROR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/spi/intenset.rs
+++ b/pac/atsamd11c14a/src/sercom0/spi/intenset.rs
@@ -1,0 +1,186 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DRE`"]
+pub type DRE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DRE`"]
+pub struct DRE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DRE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `TXC`"]
+pub type TXC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TXC`"]
+pub struct TXC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TXC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXC`"]
+pub type RXC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RXC`"]
+pub struct RXC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `SSL`"]
+pub type SSL_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SSL`"]
+pub struct SSL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SSL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERROR`"]
+pub type ERROR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERROR`"]
+pub struct ERROR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERROR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Data Register Empty Interrupt Enable"]
+    #[inline(always)]
+    pub fn dre(&self) -> DRE_R {
+        DRE_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Transmit Complete Interrupt Enable"]
+    #[inline(always)]
+    pub fn txc(&self) -> TXC_R {
+        TXC_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Receive Complete Interrupt Enable"]
+    #[inline(always)]
+    pub fn rxc(&self) -> RXC_R {
+        RXC_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Slave Select Low Interrupt Enable"]
+    #[inline(always)]
+    pub fn ssl(&self) -> SSL_R {
+        SSL_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn error(&self) -> ERROR_R {
+        ERROR_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Data Register Empty Interrupt Enable"]
+    #[inline(always)]
+    pub fn dre(&mut self) -> DRE_W {
+        DRE_W { w: self }
+    }
+    #[doc = "Bit 1 - Transmit Complete Interrupt Enable"]
+    #[inline(always)]
+    pub fn txc(&mut self) -> TXC_W {
+        TXC_W { w: self }
+    }
+    #[doc = "Bit 2 - Receive Complete Interrupt Enable"]
+    #[inline(always)]
+    pub fn rxc(&mut self) -> RXC_W {
+        RXC_W { w: self }
+    }
+    #[doc = "Bit 3 - Slave Select Low Interrupt Enable"]
+    #[inline(always)]
+    pub fn ssl(&mut self) -> SSL_W {
+        SSL_W { w: self }
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn error(&mut self) -> ERROR_W {
+        ERROR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/spi/intflag.rs
+++ b/pac/atsamd11c14a/src/sercom0/spi/intflag.rs
@@ -1,0 +1,132 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DRE`"]
+pub type DRE_R = crate::R<bool, bool>;
+#[doc = "Reader of field `TXC`"]
+pub type TXC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TXC`"]
+pub struct TXC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TXC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXC`"]
+pub type RXC_R = crate::R<bool, bool>;
+#[doc = "Reader of field `SSL`"]
+pub type SSL_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SSL`"]
+pub struct SSL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SSL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERROR`"]
+pub type ERROR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERROR`"]
+pub struct ERROR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERROR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Data Register Empty Interrupt"]
+    #[inline(always)]
+    pub fn dre(&self) -> DRE_R {
+        DRE_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Transmit Complete Interrupt"]
+    #[inline(always)]
+    pub fn txc(&self) -> TXC_R {
+        TXC_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Receive Complete Interrupt"]
+    #[inline(always)]
+    pub fn rxc(&self) -> RXC_R {
+        RXC_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Slave Select Low Interrupt Flag"]
+    #[inline(always)]
+    pub fn ssl(&self) -> SSL_R {
+        SSL_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt"]
+    #[inline(always)]
+    pub fn error(&self) -> ERROR_R {
+        ERROR_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 1 - Transmit Complete Interrupt"]
+    #[inline(always)]
+    pub fn txc(&mut self) -> TXC_W {
+        TXC_W { w: self }
+    }
+    #[doc = "Bit 3 - Slave Select Low Interrupt Flag"]
+    #[inline(always)]
+    pub fn ssl(&mut self) -> SSL_W {
+        SSL_W { w: self }
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt"]
+    #[inline(always)]
+    pub fn error(&mut self) -> ERROR_W {
+        ERROR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/spi/status.rs
+++ b/pac/atsamd11c14a/src/sercom0/spi/status.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u16, super::STATUS>;
+#[doc = "Writer for register STATUS"]
+pub type W = crate::W<u16, super::STATUS>;
+#[doc = "Register STATUS `reset()`'s with value 0"]
+impl crate::ResetValue for super::STATUS {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `BUFOVF`"]
+pub type BUFOVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BUFOVF`"]
+pub struct BUFOVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BUFOVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 2 - Buffer Overflow"]
+    #[inline(always)]
+    pub fn bufovf(&self) -> BUFOVF_R {
+        BUFOVF_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 2 - Buffer Overflow"]
+    #[inline(always)]
+    pub fn bufovf(&mut self) -> BUFOVF_W {
+        BUFOVF_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/spi/syncbusy.rs
+++ b/pac/atsamd11c14a/src/sercom0/spi/syncbusy.rs
@@ -1,0 +1,25 @@
+#[doc = "Reader of register SYNCBUSY"]
+pub type R = crate::R<u32, super::SYNCBUSY>;
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CTRLB`"]
+pub type CTRLB_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Software Reset Synchronization Busy"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - SERCOM Enable Synchronization Busy"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - CTRLB Synchronization Busy"]
+    #[inline(always)]
+    pub fn ctrlb(&self) -> CTRLB_R {
+        CTRLB_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/usart.rs
+++ b/pac/atsamd11c14a/src/sercom0/usart.rs
@@ -1,0 +1,152 @@
+#[doc = "USART Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrla](ctrla) module"]
+pub type CTRLA = crate::Reg<u32, _CTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLA;
+#[doc = "`read()` method returns [ctrla::R](ctrla::R) reader structure"]
+impl crate::Readable for CTRLA {}
+#[doc = "`write(|w| ..)` method takes [ctrla::W](ctrla::W) writer structure"]
+impl crate::Writable for CTRLA {}
+#[doc = "USART Control A"]
+pub mod ctrla;
+#[doc = "USART Control B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlb](ctrlb) module"]
+pub type CTRLB = crate::Reg<u32, _CTRLB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLB;
+#[doc = "`read()` method returns [ctrlb::R](ctrlb::R) reader structure"]
+impl crate::Readable for CTRLB {}
+#[doc = "`write(|w| ..)` method takes [ctrlb::W](ctrlb::W) writer structure"]
+impl crate::Writable for CTRLB {}
+#[doc = "USART Control B"]
+pub mod ctrlb;
+#[doc = "USART Baud Rate\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [baud](baud) module"]
+pub type BAUD = crate::Reg<u16, _BAUD>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _BAUD;
+#[doc = "`read()` method returns [baud::R](baud::R) reader structure"]
+impl crate::Readable for BAUD {}
+#[doc = "`write(|w| ..)` method takes [baud::W](baud::W) writer structure"]
+impl crate::Writable for BAUD {}
+#[doc = "USART Baud Rate"]
+pub mod baud;
+#[doc = "USART Baud Rate\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [baud_frac_mode](baud_frac_mode) module"]
+pub type BAUD_FRAC_MODE = crate::Reg<u16, _BAUD_FRAC_MODE>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _BAUD_FRAC_MODE;
+#[doc = "`read()` method returns [baud_frac_mode::R](baud_frac_mode::R) reader structure"]
+impl crate::Readable for BAUD_FRAC_MODE {}
+#[doc = "`write(|w| ..)` method takes [baud_frac_mode::W](baud_frac_mode::W) writer structure"]
+impl crate::Writable for BAUD_FRAC_MODE {}
+#[doc = "USART Baud Rate"]
+pub mod baud_frac_mode;
+#[doc = "USART Baud Rate\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [baud_fracfp_mode](baud_fracfp_mode) module"]
+pub type BAUD_FRACFP_MODE = crate::Reg<u16, _BAUD_FRACFP_MODE>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _BAUD_FRACFP_MODE;
+#[doc = "`read()` method returns [baud_fracfp_mode::R](baud_fracfp_mode::R) reader structure"]
+impl crate::Readable for BAUD_FRACFP_MODE {}
+#[doc = "`write(|w| ..)` method takes [baud_fracfp_mode::W](baud_fracfp_mode::W) writer structure"]
+impl crate::Writable for BAUD_FRACFP_MODE {}
+#[doc = "USART Baud Rate"]
+pub mod baud_fracfp_mode;
+#[doc = "USART Baud Rate\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [baud_usartfp_mode](baud_usartfp_mode) module"]
+pub type BAUD_USARTFP_MODE = crate::Reg<u16, _BAUD_USARTFP_MODE>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _BAUD_USARTFP_MODE;
+#[doc = "`read()` method returns [baud_usartfp_mode::R](baud_usartfp_mode::R) reader structure"]
+impl crate::Readable for BAUD_USARTFP_MODE {}
+#[doc = "`write(|w| ..)` method takes [baud_usartfp_mode::W](baud_usartfp_mode::W) writer structure"]
+impl crate::Writable for BAUD_USARTFP_MODE {}
+#[doc = "USART Baud Rate"]
+pub mod baud_usartfp_mode;
+#[doc = "USART Receive Pulse Length\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [rxpl](rxpl) module"]
+pub type RXPL = crate::Reg<u8, _RXPL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _RXPL;
+#[doc = "`read()` method returns [rxpl::R](rxpl::R) reader structure"]
+impl crate::Readable for RXPL {}
+#[doc = "`write(|w| ..)` method takes [rxpl::W](rxpl::W) writer structure"]
+impl crate::Writable for RXPL {}
+#[doc = "USART Receive Pulse Length"]
+pub mod rxpl;
+#[doc = "USART Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "USART Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "USART Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "USART Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "USART Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "USART Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "USART Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u16, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "`write(|w| ..)` method takes [status::W](status::W) writer structure"]
+impl crate::Writable for STATUS {}
+#[doc = "USART Status"]
+pub mod status;
+#[doc = "USART Syncbusy\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [syncbusy](syncbusy) module"]
+pub type SYNCBUSY = crate::Reg<u32, _SYNCBUSY>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _SYNCBUSY;
+#[doc = "`read()` method returns [syncbusy::R](syncbusy::R) reader structure"]
+impl crate::Readable for SYNCBUSY {}
+#[doc = "USART Syncbusy"]
+pub mod syncbusy;
+#[doc = "USART Data\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [data](data) module"]
+pub type DATA = crate::Reg<u16, _DATA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DATA;
+#[doc = "`read()` method returns [data::R](data::R) reader structure"]
+impl crate::Readable for DATA {}
+#[doc = "`write(|w| ..)` method takes [data::W](data::W) writer structure"]
+impl crate::Writable for DATA {}
+#[doc = "USART Data"]
+pub mod data;
+#[doc = "USART Debug Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dbgctrl](dbgctrl) module"]
+pub type DBGCTRL = crate::Reg<u8, _DBGCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DBGCTRL;
+#[doc = "`read()` method returns [dbgctrl::R](dbgctrl::R) reader structure"]
+impl crate::Readable for DBGCTRL {}
+#[doc = "`write(|w| ..)` method takes [dbgctrl::W](dbgctrl::W) writer structure"]
+impl crate::Writable for DBGCTRL {}
+#[doc = "USART Debug Control"]
+pub mod dbgctrl;

--- a/pac/atsamd11c14a/src/sercom0/usart/baud.rs
+++ b/pac/atsamd11c14a/src/sercom0/usart/baud.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register BAUD"]
+pub type R = crate::R<u16, super::BAUD>;
+#[doc = "Writer for register BAUD"]
+pub type W = crate::W<u16, super::BAUD>;
+#[doc = "Register BAUD `reset()`'s with value 0"]
+impl crate::ResetValue for super::BAUD {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `BAUD`"]
+pub type BAUD_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `BAUD`"]
+pub struct BAUD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BAUD_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff) | ((value as u16) & 0xffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:15 - Baud Rate Value"]
+    #[inline(always)]
+    pub fn baud(&self) -> BAUD_R {
+        BAUD_R::new((self.bits & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Baud Rate Value"]
+    #[inline(always)]
+    pub fn baud(&mut self) -> BAUD_W {
+        BAUD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/usart/baud_frac_mode.rs
+++ b/pac/atsamd11c14a/src/sercom0/usart/baud_frac_mode.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register BAUD_FRAC_MODE"]
+pub type R = crate::R<u16, super::BAUD_FRAC_MODE>;
+#[doc = "Writer for register BAUD_FRAC_MODE"]
+pub type W = crate::W<u16, super::BAUD_FRAC_MODE>;
+#[doc = "Register BAUD_FRAC_MODE `reset()`'s with value 0"]
+impl crate::ResetValue for super::BAUD_FRAC_MODE {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `BAUD`"]
+pub type BAUD_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `BAUD`"]
+pub struct BAUD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BAUD_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x1fff) | ((value as u16) & 0x1fff);
+        self.w
+    }
+}
+#[doc = "Reader of field `FP`"]
+pub type FP_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `FP`"]
+pub struct FP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FP_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 13)) | (((value as u16) & 0x07) << 13);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:12 - Baud Rate Value"]
+    #[inline(always)]
+    pub fn baud(&self) -> BAUD_R {
+        BAUD_R::new((self.bits & 0x1fff) as u16)
+    }
+    #[doc = "Bits 13:15 - Fractional Part"]
+    #[inline(always)]
+    pub fn fp(&self) -> FP_R {
+        FP_R::new(((self.bits >> 13) & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:12 - Baud Rate Value"]
+    #[inline(always)]
+    pub fn baud(&mut self) -> BAUD_W {
+        BAUD_W { w: self }
+    }
+    #[doc = "Bits 13:15 - Fractional Part"]
+    #[inline(always)]
+    pub fn fp(&mut self) -> FP_W {
+        FP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/usart/baud_fracfp_mode.rs
+++ b/pac/atsamd11c14a/src/sercom0/usart/baud_fracfp_mode.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register BAUD_FRACFP_MODE"]
+pub type R = crate::R<u16, super::BAUD_FRACFP_MODE>;
+#[doc = "Writer for register BAUD_FRACFP_MODE"]
+pub type W = crate::W<u16, super::BAUD_FRACFP_MODE>;
+#[doc = "Register BAUD_FRACFP_MODE `reset()`'s with value 0"]
+impl crate::ResetValue for super::BAUD_FRACFP_MODE {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `BAUD`"]
+pub type BAUD_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `BAUD`"]
+pub struct BAUD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BAUD_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x1fff) | ((value as u16) & 0x1fff);
+        self.w
+    }
+}
+#[doc = "Reader of field `FP`"]
+pub type FP_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `FP`"]
+pub struct FP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FP_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 13)) | (((value as u16) & 0x07) << 13);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:12 - Baud Rate Value"]
+    #[inline(always)]
+    pub fn baud(&self) -> BAUD_R {
+        BAUD_R::new((self.bits & 0x1fff) as u16)
+    }
+    #[doc = "Bits 13:15 - Fractional Part"]
+    #[inline(always)]
+    pub fn fp(&self) -> FP_R {
+        FP_R::new(((self.bits >> 13) & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:12 - Baud Rate Value"]
+    #[inline(always)]
+    pub fn baud(&mut self) -> BAUD_W {
+        BAUD_W { w: self }
+    }
+    #[doc = "Bits 13:15 - Fractional Part"]
+    #[inline(always)]
+    pub fn fp(&mut self) -> FP_W {
+        FP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/usart/baud_usartfp_mode.rs
+++ b/pac/atsamd11c14a/src/sercom0/usart/baud_usartfp_mode.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register BAUD_USARTFP_MODE"]
+pub type R = crate::R<u16, super::BAUD_USARTFP_MODE>;
+#[doc = "Writer for register BAUD_USARTFP_MODE"]
+pub type W = crate::W<u16, super::BAUD_USARTFP_MODE>;
+#[doc = "Register BAUD_USARTFP_MODE `reset()`'s with value 0"]
+impl crate::ResetValue for super::BAUD_USARTFP_MODE {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `BAUD`"]
+pub type BAUD_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `BAUD`"]
+pub struct BAUD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BAUD_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff) | ((value as u16) & 0xffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:15 - Baud Rate Value"]
+    #[inline(always)]
+    pub fn baud(&self) -> BAUD_R {
+        BAUD_R::new((self.bits & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Baud Rate Value"]
+    #[inline(always)]
+    pub fn baud(&mut self) -> BAUD_W {
+        BAUD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/usart/ctrla.rs
+++ b/pac/atsamd11c14a/src/sercom0/usart/ctrla.rs
@@ -1,0 +1,508 @@
+#[doc = "Reader of register CTRLA"]
+pub type R = crate::R<u32, super::CTRLA>;
+#[doc = "Writer for register CTRLA"]
+pub type W = crate::W<u32, super::CTRLA>;
+#[doc = "Register CTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLA {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Operating Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MODE_A {
+    #[doc = "0: USART mode with external clock"]
+    USART_EXT_CLK,
+    #[doc = "1: USART mode with internal clock"]
+    USART_INT_CLK,
+    #[doc = "2: SPI mode with external clock"]
+    SPI_SLAVE,
+    #[doc = "3: SPI mode with internal clock"]
+    SPI_MASTER,
+    #[doc = "4: I2C mode with external clock"]
+    I2C_SLAVE,
+    #[doc = "5: I2C mode with internal clock"]
+    I2C_MASTER,
+}
+impl From<MODE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: MODE_A) -> Self {
+        match variant {
+            MODE_A::USART_EXT_CLK => 0,
+            MODE_A::USART_INT_CLK => 1,
+            MODE_A::SPI_SLAVE => 2,
+            MODE_A::SPI_MASTER => 3,
+            MODE_A::I2C_SLAVE => 4,
+            MODE_A::I2C_MASTER => 5,
+        }
+    }
+}
+#[doc = "Reader of field `MODE`"]
+pub type MODE_R = crate::R<u8, MODE_A>;
+impl MODE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, MODE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(MODE_A::USART_EXT_CLK),
+            1 => Val(MODE_A::USART_INT_CLK),
+            2 => Val(MODE_A::SPI_SLAVE),
+            3 => Val(MODE_A::SPI_MASTER),
+            4 => Val(MODE_A::I2C_SLAVE),
+            5 => Val(MODE_A::I2C_MASTER),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `USART_EXT_CLK`"]
+    #[inline(always)]
+    pub fn is_usart_ext_clk(&self) -> bool {
+        *self == MODE_A::USART_EXT_CLK
+    }
+    #[doc = "Checks if the value of the field is `USART_INT_CLK`"]
+    #[inline(always)]
+    pub fn is_usart_int_clk(&self) -> bool {
+        *self == MODE_A::USART_INT_CLK
+    }
+    #[doc = "Checks if the value of the field is `SPI_SLAVE`"]
+    #[inline(always)]
+    pub fn is_spi_slave(&self) -> bool {
+        *self == MODE_A::SPI_SLAVE
+    }
+    #[doc = "Checks if the value of the field is `SPI_MASTER`"]
+    #[inline(always)]
+    pub fn is_spi_master(&self) -> bool {
+        *self == MODE_A::SPI_MASTER
+    }
+    #[doc = "Checks if the value of the field is `I2C_SLAVE`"]
+    #[inline(always)]
+    pub fn is_i2c_slave(&self) -> bool {
+        *self == MODE_A::I2C_SLAVE
+    }
+    #[doc = "Checks if the value of the field is `I2C_MASTER`"]
+    #[inline(always)]
+    pub fn is_i2c_master(&self) -> bool {
+        *self == MODE_A::I2C_MASTER
+    }
+}
+#[doc = "Write proxy for field `MODE`"]
+pub struct MODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MODE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: MODE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "USART mode with external clock"]
+    #[inline(always)]
+    pub fn usart_ext_clk(self) -> &'a mut W {
+        self.variant(MODE_A::USART_EXT_CLK)
+    }
+    #[doc = "USART mode with internal clock"]
+    #[inline(always)]
+    pub fn usart_int_clk(self) -> &'a mut W {
+        self.variant(MODE_A::USART_INT_CLK)
+    }
+    #[doc = "SPI mode with external clock"]
+    #[inline(always)]
+    pub fn spi_slave(self) -> &'a mut W {
+        self.variant(MODE_A::SPI_SLAVE)
+    }
+    #[doc = "SPI mode with internal clock"]
+    #[inline(always)]
+    pub fn spi_master(self) -> &'a mut W {
+        self.variant(MODE_A::SPI_MASTER)
+    }
+    #[doc = "I2C mode with external clock"]
+    #[inline(always)]
+    pub fn i2c_slave(self) -> &'a mut W {
+        self.variant(MODE_A::I2C_SLAVE)
+    }
+    #[doc = "I2C mode with internal clock"]
+    #[inline(always)]
+    pub fn i2c_master(self) -> &'a mut W {
+        self.variant(MODE_A::I2C_MASTER)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 2)) | (((value as u32) & 0x07) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `IBON`"]
+pub type IBON_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `IBON`"]
+pub struct IBON_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> IBON_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `SAMPR`"]
+pub type SAMPR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `SAMPR`"]
+pub struct SAMPR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SAMPR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 13)) | (((value as u32) & 0x07) << 13);
+        self.w
+    }
+}
+#[doc = "Reader of field `TXPO`"]
+pub type TXPO_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `TXPO`"]
+pub struct TXPO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TXPO_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 16)) | (((value as u32) & 0x03) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXPO`"]
+pub type RXPO_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `RXPO`"]
+pub struct RXPO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXPO_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 20)) | (((value as u32) & 0x03) << 20);
+        self.w
+    }
+}
+#[doc = "Reader of field `SAMPA`"]
+pub type SAMPA_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `SAMPA`"]
+pub struct SAMPA_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SAMPA_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 22)) | (((value as u32) & 0x03) << 22);
+        self.w
+    }
+}
+#[doc = "Reader of field `FORM`"]
+pub type FORM_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `FORM`"]
+pub struct FORM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FORM_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 24)) | (((value as u32) & 0x0f) << 24);
+        self.w
+    }
+}
+#[doc = "Reader of field `CMODE`"]
+pub type CMODE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CMODE`"]
+pub struct CMODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMODE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 28)) | (((value as u32) & 0x01) << 28);
+        self.w
+    }
+}
+#[doc = "Reader of field `CPOL`"]
+pub type CPOL_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CPOL`"]
+pub struct CPOL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CPOL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 29)) | (((value as u32) & 0x01) << 29);
+        self.w
+    }
+}
+#[doc = "Reader of field `DORD`"]
+pub type DORD_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DORD`"]
+pub struct DORD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DORD_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 30)) | (((value as u32) & 0x01) << 30);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 2:4 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 2) & 0x07) as u8)
+    }
+    #[doc = "Bit 7 - Run during Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Immediate Buffer Overflow Notification"]
+    #[inline(always)]
+    pub fn ibon(&self) -> IBON_R {
+        IBON_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bits 13:15 - Sample"]
+    #[inline(always)]
+    pub fn sampr(&self) -> SAMPR_R {
+        SAMPR_R::new(((self.bits >> 13) & 0x07) as u8)
+    }
+    #[doc = "Bits 16:17 - Transmit Data Pinout"]
+    #[inline(always)]
+    pub fn txpo(&self) -> TXPO_R {
+        TXPO_R::new(((self.bits >> 16) & 0x03) as u8)
+    }
+    #[doc = "Bits 20:21 - Receive Data Pinout"]
+    #[inline(always)]
+    pub fn rxpo(&self) -> RXPO_R {
+        RXPO_R::new(((self.bits >> 20) & 0x03) as u8)
+    }
+    #[doc = "Bits 22:23 - Sample Adjustment"]
+    #[inline(always)]
+    pub fn sampa(&self) -> SAMPA_R {
+        SAMPA_R::new(((self.bits >> 22) & 0x03) as u8)
+    }
+    #[doc = "Bits 24:27 - Frame Format"]
+    #[inline(always)]
+    pub fn form(&self) -> FORM_R {
+        FORM_R::new(((self.bits >> 24) & 0x0f) as u8)
+    }
+    #[doc = "Bit 28 - Communication Mode"]
+    #[inline(always)]
+    pub fn cmode(&self) -> CMODE_R {
+        CMODE_R::new(((self.bits >> 28) & 0x01) != 0)
+    }
+    #[doc = "Bit 29 - Clock Polarity"]
+    #[inline(always)]
+    pub fn cpol(&self) -> CPOL_R {
+        CPOL_R::new(((self.bits >> 29) & 0x01) != 0)
+    }
+    #[doc = "Bit 30 - Data Order"]
+    #[inline(always)]
+    pub fn dord(&self) -> DORD_R {
+        DORD_R::new(((self.bits >> 30) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bits 2:4 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&mut self) -> MODE_W {
+        MODE_W { w: self }
+    }
+    #[doc = "Bit 7 - Run during Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bit 8 - Immediate Buffer Overflow Notification"]
+    #[inline(always)]
+    pub fn ibon(&mut self) -> IBON_W {
+        IBON_W { w: self }
+    }
+    #[doc = "Bits 13:15 - Sample"]
+    #[inline(always)]
+    pub fn sampr(&mut self) -> SAMPR_W {
+        SAMPR_W { w: self }
+    }
+    #[doc = "Bits 16:17 - Transmit Data Pinout"]
+    #[inline(always)]
+    pub fn txpo(&mut self) -> TXPO_W {
+        TXPO_W { w: self }
+    }
+    #[doc = "Bits 20:21 - Receive Data Pinout"]
+    #[inline(always)]
+    pub fn rxpo(&mut self) -> RXPO_W {
+        RXPO_W { w: self }
+    }
+    #[doc = "Bits 22:23 - Sample Adjustment"]
+    #[inline(always)]
+    pub fn sampa(&mut self) -> SAMPA_W {
+        SAMPA_W { w: self }
+    }
+    #[doc = "Bits 24:27 - Frame Format"]
+    #[inline(always)]
+    pub fn form(&mut self) -> FORM_W {
+        FORM_W { w: self }
+    }
+    #[doc = "Bit 28 - Communication Mode"]
+    #[inline(always)]
+    pub fn cmode(&mut self) -> CMODE_W {
+        CMODE_W { w: self }
+    }
+    #[doc = "Bit 29 - Clock Polarity"]
+    #[inline(always)]
+    pub fn cpol(&mut self) -> CPOL_W {
+        CPOL_W { w: self }
+    }
+    #[doc = "Bit 30 - Data Order"]
+    #[inline(always)]
+    pub fn dord(&mut self) -> DORD_W {
+        DORD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/usart/ctrlb.rs
+++ b/pac/atsamd11c14a/src/sercom0/usart/ctrlb.rs
@@ -1,0 +1,278 @@
+#[doc = "Reader of register CTRLB"]
+pub type R = crate::R<u32, super::CTRLB>;
+#[doc = "Writer for register CTRLB"]
+pub type W = crate::W<u32, super::CTRLB>;
+#[doc = "Register CTRLB `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLB {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CHSIZE`"]
+pub type CHSIZE_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `CHSIZE`"]
+pub struct CHSIZE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CHSIZE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u32) & 0x07);
+        self.w
+    }
+}
+#[doc = "Reader of field `SBMODE`"]
+pub type SBMODE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SBMODE`"]
+pub struct SBMODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SBMODE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `COLDEN`"]
+pub type COLDEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `COLDEN`"]
+pub struct COLDEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COLDEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `SFDE`"]
+pub type SFDE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SFDE`"]
+pub struct SFDE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SFDE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENC`"]
+pub type ENC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENC`"]
+pub struct ENC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u32) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `PMODE`"]
+pub type PMODE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PMODE`"]
+pub struct PMODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PMODE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u32) & 0x01) << 13);
+        self.w
+    }
+}
+#[doc = "Reader of field `TXEN`"]
+pub type TXEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TXEN`"]
+pub struct TXEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TXEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXEN`"]
+pub type RXEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RXEN`"]
+pub struct RXEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Character Size"]
+    #[inline(always)]
+    pub fn chsize(&self) -> CHSIZE_R {
+        CHSIZE_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bit 6 - Stop Bit Mode"]
+    #[inline(always)]
+    pub fn sbmode(&self) -> SBMODE_R {
+        SBMODE_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Collision Detection Enable"]
+    #[inline(always)]
+    pub fn colden(&self) -> COLDEN_R {
+        COLDEN_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Start of Frame Detection Enable"]
+    #[inline(always)]
+    pub fn sfde(&self) -> SFDE_R {
+        SFDE_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Encoding Format"]
+    #[inline(always)]
+    pub fn enc(&self) -> ENC_R {
+        ENC_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Parity Mode"]
+    #[inline(always)]
+    pub fn pmode(&self) -> PMODE_R {
+        PMODE_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - Transmitter Enable"]
+    #[inline(always)]
+    pub fn txen(&self) -> TXEN_R {
+        TXEN_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bit 17 - Receiver Enable"]
+    #[inline(always)]
+    pub fn rxen(&self) -> RXEN_R {
+        RXEN_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Character Size"]
+    #[inline(always)]
+    pub fn chsize(&mut self) -> CHSIZE_W {
+        CHSIZE_W { w: self }
+    }
+    #[doc = "Bit 6 - Stop Bit Mode"]
+    #[inline(always)]
+    pub fn sbmode(&mut self) -> SBMODE_W {
+        SBMODE_W { w: self }
+    }
+    #[doc = "Bit 8 - Collision Detection Enable"]
+    #[inline(always)]
+    pub fn colden(&mut self) -> COLDEN_W {
+        COLDEN_W { w: self }
+    }
+    #[doc = "Bit 9 - Start of Frame Detection Enable"]
+    #[inline(always)]
+    pub fn sfde(&mut self) -> SFDE_W {
+        SFDE_W { w: self }
+    }
+    #[doc = "Bit 10 - Encoding Format"]
+    #[inline(always)]
+    pub fn enc(&mut self) -> ENC_W {
+        ENC_W { w: self }
+    }
+    #[doc = "Bit 13 - Parity Mode"]
+    #[inline(always)]
+    pub fn pmode(&mut self) -> PMODE_W {
+        PMODE_W { w: self }
+    }
+    #[doc = "Bit 16 - Transmitter Enable"]
+    #[inline(always)]
+    pub fn txen(&mut self) -> TXEN_W {
+        TXEN_W { w: self }
+    }
+    #[doc = "Bit 17 - Receiver Enable"]
+    #[inline(always)]
+    pub fn rxen(&mut self) -> RXEN_W {
+        RXEN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/usart/data.rs
+++ b/pac/atsamd11c14a/src/sercom0/usart/data.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register DATA"]
+pub type R = crate::R<u16, super::DATA>;
+#[doc = "Writer for register DATA"]
+pub type W = crate::W<u16, super::DATA>;
+#[doc = "Register DATA `reset()`'s with value 0"]
+impl crate::ResetValue for super::DATA {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DATA`"]
+pub type DATA_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `DATA`"]
+pub struct DATA_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DATA_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01ff) | ((value as u16) & 0x01ff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:8 - Data Value"]
+    #[inline(always)]
+    pub fn data(&self) -> DATA_R {
+        DATA_R::new((self.bits & 0x01ff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:8 - Data Value"]
+    #[inline(always)]
+    pub fn data(&mut self) -> DATA_W {
+        DATA_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/usart/dbgctrl.rs
+++ b/pac/atsamd11c14a/src/sercom0/usart/dbgctrl.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register DBGCTRL"]
+pub type R = crate::R<u8, super::DBGCTRL>;
+#[doc = "Writer for register DBGCTRL"]
+pub type W = crate::W<u8, super::DBGCTRL>;
+#[doc = "Register DBGCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::DBGCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DBGSTOP`"]
+pub type DBGSTOP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DBGSTOP`"]
+pub struct DBGSTOP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DBGSTOP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Debug Mode"]
+    #[inline(always)]
+    pub fn dbgstop(&self) -> DBGSTOP_R {
+        DBGSTOP_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Debug Mode"]
+    #[inline(always)]
+    pub fn dbgstop(&mut self) -> DBGSTOP_W {
+        DBGSTOP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/usart/intenclr.rs
+++ b/pac/atsamd11c14a/src/sercom0/usart/intenclr.rs
@@ -1,0 +1,254 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DRE`"]
+pub type DRE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DRE`"]
+pub struct DRE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DRE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `TXC`"]
+pub type TXC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TXC`"]
+pub struct TXC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TXC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXC`"]
+pub type RXC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RXC`"]
+pub struct RXC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXS`"]
+pub type RXS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RXS`"]
+pub struct RXS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `CTSIC`"]
+pub type CTSIC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CTSIC`"]
+pub struct CTSIC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CTSIC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXBRK`"]
+pub type RXBRK_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RXBRK`"]
+pub struct RXBRK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXBRK_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERROR`"]
+pub type ERROR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERROR`"]
+pub struct ERROR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERROR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Data Register Empty Interrupt Disable"]
+    #[inline(always)]
+    pub fn dre(&self) -> DRE_R {
+        DRE_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Transmit Complete Interrupt Disable"]
+    #[inline(always)]
+    pub fn txc(&self) -> TXC_R {
+        TXC_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Receive Complete Interrupt Disable"]
+    #[inline(always)]
+    pub fn rxc(&self) -> RXC_R {
+        RXC_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Receive Start Interrupt Disable"]
+    #[inline(always)]
+    pub fn rxs(&self) -> RXS_R {
+        RXS_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Clear To Send Input Change Interrupt Disable"]
+    #[inline(always)]
+    pub fn ctsic(&self) -> CTSIC_R {
+        CTSIC_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Break Received Interrupt Disable"]
+    #[inline(always)]
+    pub fn rxbrk(&self) -> RXBRK_R {
+        RXBRK_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Disable"]
+    #[inline(always)]
+    pub fn error(&self) -> ERROR_R {
+        ERROR_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Data Register Empty Interrupt Disable"]
+    #[inline(always)]
+    pub fn dre(&mut self) -> DRE_W {
+        DRE_W { w: self }
+    }
+    #[doc = "Bit 1 - Transmit Complete Interrupt Disable"]
+    #[inline(always)]
+    pub fn txc(&mut self) -> TXC_W {
+        TXC_W { w: self }
+    }
+    #[doc = "Bit 2 - Receive Complete Interrupt Disable"]
+    #[inline(always)]
+    pub fn rxc(&mut self) -> RXC_W {
+        RXC_W { w: self }
+    }
+    #[doc = "Bit 3 - Receive Start Interrupt Disable"]
+    #[inline(always)]
+    pub fn rxs(&mut self) -> RXS_W {
+        RXS_W { w: self }
+    }
+    #[doc = "Bit 4 - Clear To Send Input Change Interrupt Disable"]
+    #[inline(always)]
+    pub fn ctsic(&mut self) -> CTSIC_W {
+        CTSIC_W { w: self }
+    }
+    #[doc = "Bit 5 - Break Received Interrupt Disable"]
+    #[inline(always)]
+    pub fn rxbrk(&mut self) -> RXBRK_W {
+        RXBRK_W { w: self }
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Disable"]
+    #[inline(always)]
+    pub fn error(&mut self) -> ERROR_W {
+        ERROR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/usart/intenset.rs
+++ b/pac/atsamd11c14a/src/sercom0/usart/intenset.rs
@@ -1,0 +1,254 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DRE`"]
+pub type DRE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DRE`"]
+pub struct DRE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DRE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `TXC`"]
+pub type TXC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TXC`"]
+pub struct TXC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TXC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXC`"]
+pub type RXC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RXC`"]
+pub struct RXC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXS`"]
+pub type RXS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RXS`"]
+pub struct RXS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `CTSIC`"]
+pub type CTSIC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CTSIC`"]
+pub struct CTSIC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CTSIC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXBRK`"]
+pub type RXBRK_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RXBRK`"]
+pub struct RXBRK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXBRK_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERROR`"]
+pub type ERROR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERROR`"]
+pub struct ERROR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERROR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Data Register Empty Interrupt Enable"]
+    #[inline(always)]
+    pub fn dre(&self) -> DRE_R {
+        DRE_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Transmit Complete Interrupt Enable"]
+    #[inline(always)]
+    pub fn txc(&self) -> TXC_R {
+        TXC_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Receive Complete Interrupt Enable"]
+    #[inline(always)]
+    pub fn rxc(&self) -> RXC_R {
+        RXC_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Receive Start Interrupt Enable"]
+    #[inline(always)]
+    pub fn rxs(&self) -> RXS_R {
+        RXS_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Clear To Send Input Change Interrupt Enable"]
+    #[inline(always)]
+    pub fn ctsic(&self) -> CTSIC_R {
+        CTSIC_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Break Received Interrupt Enable"]
+    #[inline(always)]
+    pub fn rxbrk(&self) -> RXBRK_R {
+        RXBRK_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn error(&self) -> ERROR_R {
+        ERROR_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Data Register Empty Interrupt Enable"]
+    #[inline(always)]
+    pub fn dre(&mut self) -> DRE_W {
+        DRE_W { w: self }
+    }
+    #[doc = "Bit 1 - Transmit Complete Interrupt Enable"]
+    #[inline(always)]
+    pub fn txc(&mut self) -> TXC_W {
+        TXC_W { w: self }
+    }
+    #[doc = "Bit 2 - Receive Complete Interrupt Enable"]
+    #[inline(always)]
+    pub fn rxc(&mut self) -> RXC_W {
+        RXC_W { w: self }
+    }
+    #[doc = "Bit 3 - Receive Start Interrupt Enable"]
+    #[inline(always)]
+    pub fn rxs(&mut self) -> RXS_W {
+        RXS_W { w: self }
+    }
+    #[doc = "Bit 4 - Clear To Send Input Change Interrupt Enable"]
+    #[inline(always)]
+    pub fn ctsic(&mut self) -> CTSIC_W {
+        CTSIC_W { w: self }
+    }
+    #[doc = "Bit 5 - Break Received Interrupt Enable"]
+    #[inline(always)]
+    pub fn rxbrk(&mut self) -> RXBRK_W {
+        RXBRK_W { w: self }
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn error(&mut self) -> ERROR_W {
+        ERROR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/usart/intflag.rs
+++ b/pac/atsamd11c14a/src/sercom0/usart/intflag.rs
@@ -1,0 +1,193 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DRE`"]
+pub type DRE_R = crate::R<bool, bool>;
+#[doc = "Reader of field `TXC`"]
+pub type TXC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TXC`"]
+pub struct TXC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TXC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXC`"]
+pub type RXC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RXS`"]
+pub struct RXS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `CTSIC`"]
+pub type CTSIC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CTSIC`"]
+pub struct CTSIC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CTSIC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXBRK`"]
+pub type RXBRK_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RXBRK`"]
+pub struct RXBRK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXBRK_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERROR`"]
+pub type ERROR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERROR`"]
+pub struct ERROR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERROR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Data Register Empty Interrupt"]
+    #[inline(always)]
+    pub fn dre(&self) -> DRE_R {
+        DRE_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Transmit Complete Interrupt"]
+    #[inline(always)]
+    pub fn txc(&self) -> TXC_R {
+        TXC_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Receive Complete Interrupt"]
+    #[inline(always)]
+    pub fn rxc(&self) -> RXC_R {
+        RXC_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Clear To Send Input Change Interrupt"]
+    #[inline(always)]
+    pub fn ctsic(&self) -> CTSIC_R {
+        CTSIC_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Break Received Interrupt"]
+    #[inline(always)]
+    pub fn rxbrk(&self) -> RXBRK_R {
+        RXBRK_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt"]
+    #[inline(always)]
+    pub fn error(&self) -> ERROR_R {
+        ERROR_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 1 - Transmit Complete Interrupt"]
+    #[inline(always)]
+    pub fn txc(&mut self) -> TXC_W {
+        TXC_W { w: self }
+    }
+    #[doc = "Bit 3 - Receive Start Interrupt"]
+    #[inline(always)]
+    pub fn rxs(&mut self) -> RXS_W {
+        RXS_W { w: self }
+    }
+    #[doc = "Bit 4 - Clear To Send Input Change Interrupt"]
+    #[inline(always)]
+    pub fn ctsic(&mut self) -> CTSIC_W {
+        CTSIC_W { w: self }
+    }
+    #[doc = "Bit 5 - Break Received Interrupt"]
+    #[inline(always)]
+    pub fn rxbrk(&mut self) -> RXBRK_W {
+        RXBRK_W { w: self }
+    }
+    #[doc = "Bit 7 - Combined Error Interrupt"]
+    #[inline(always)]
+    pub fn error(&mut self) -> ERROR_W {
+        ERROR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/usart/rxpl.rs
+++ b/pac/atsamd11c14a/src/sercom0/usart/rxpl.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register RXPL"]
+pub type R = crate::R<u8, super::RXPL>;
+#[doc = "Writer for register RXPL"]
+pub type W = crate::W<u8, super::RXPL>;
+#[doc = "Register RXPL `reset()`'s with value 0"]
+impl crate::ResetValue for super::RXPL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `RXPL`"]
+pub type RXPL_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `RXPL`"]
+pub struct RXPL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXPL_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xff) | ((value as u8) & 0xff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:7 - Receive Pulse Length"]
+    #[inline(always)]
+    pub fn rxpl(&self) -> RXPL_R {
+        RXPL_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Receive Pulse Length"]
+    #[inline(always)]
+    pub fn rxpl(&mut self) -> RXPL_W {
+        RXPL_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/usart/status.rs
+++ b/pac/atsamd11c14a/src/sercom0/usart/status.rs
@@ -1,0 +1,193 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u16, super::STATUS>;
+#[doc = "Writer for register STATUS"]
+pub type W = crate::W<u16, super::STATUS>;
+#[doc = "Register STATUS `reset()`'s with value 0"]
+impl crate::ResetValue for super::STATUS {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `PERR`"]
+pub type PERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PERR`"]
+pub struct PERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `FERR`"]
+pub type FERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FERR`"]
+pub struct FERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `BUFOVF`"]
+pub type BUFOVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BUFOVF`"]
+pub struct BUFOVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BUFOVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `CTS`"]
+pub type CTS_R = crate::R<bool, bool>;
+#[doc = "Reader of field `ISF`"]
+pub type ISF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ISF`"]
+pub struct ISF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ISF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `COLL`"]
+pub type COLL_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `COLL`"]
+pub struct COLL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COLL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Parity Error"]
+    #[inline(always)]
+    pub fn perr(&self) -> PERR_R {
+        PERR_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Frame Error"]
+    #[inline(always)]
+    pub fn ferr(&self) -> FERR_R {
+        FERR_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Buffer Overflow"]
+    #[inline(always)]
+    pub fn bufovf(&self) -> BUFOVF_R {
+        BUFOVF_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Clear To Send"]
+    #[inline(always)]
+    pub fn cts(&self) -> CTS_R {
+        CTS_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Inconsistent Sync Field"]
+    #[inline(always)]
+    pub fn isf(&self) -> ISF_R {
+        ISF_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Collision Detected"]
+    #[inline(always)]
+    pub fn coll(&self) -> COLL_R {
+        COLL_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Parity Error"]
+    #[inline(always)]
+    pub fn perr(&mut self) -> PERR_W {
+        PERR_W { w: self }
+    }
+    #[doc = "Bit 1 - Frame Error"]
+    #[inline(always)]
+    pub fn ferr(&mut self) -> FERR_W {
+        FERR_W { w: self }
+    }
+    #[doc = "Bit 2 - Buffer Overflow"]
+    #[inline(always)]
+    pub fn bufovf(&mut self) -> BUFOVF_W {
+        BUFOVF_W { w: self }
+    }
+    #[doc = "Bit 4 - Inconsistent Sync Field"]
+    #[inline(always)]
+    pub fn isf(&mut self) -> ISF_W {
+        ISF_W { w: self }
+    }
+    #[doc = "Bit 5 - Collision Detected"]
+    #[inline(always)]
+    pub fn coll(&mut self) -> COLL_W {
+        COLL_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sercom0/usart/syncbusy.rs
+++ b/pac/atsamd11c14a/src/sercom0/usart/syncbusy.rs
@@ -1,0 +1,25 @@
+#[doc = "Reader of register SYNCBUSY"]
+pub type R = crate::R<u32, super::SYNCBUSY>;
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CTRLB`"]
+pub type CTRLB_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Software Reset Synchronization Busy"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - SERCOM Enable Synchronization Busy"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - CTRLB Synchronization Busy"]
+    #[inline(always)]
+    pub fn ctrlb(&self) -> CTRLB_R {
+        CTRLB_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl.rs
+++ b/pac/atsamd11c14a/src/sysctrl.rs
@@ -1,0 +1,252 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Interrupt Enable Clear"]
+    pub intenclr: INTENCLR,
+    #[doc = "0x04 - Interrupt Enable Set"]
+    pub intenset: INTENSET,
+    #[doc = "0x08 - Interrupt Flag Status and Clear"]
+    pub intflag: INTFLAG,
+    #[doc = "0x0c - Power and Clocks Status"]
+    pub pclksr: PCLKSR,
+    #[doc = "0x10 - External Multipurpose Crystal Oscillator (XOSC) Control"]
+    pub xosc: XOSC,
+    _reserved5: [u8; 2usize],
+    #[doc = "0x14 - 32kHz External Crystal Oscillator (XOSC32K) Control"]
+    pub xosc32k: XOSC32K,
+    _reserved6: [u8; 2usize],
+    #[doc = "0x18 - 32kHz Internal Oscillator (OSC32K) Control"]
+    pub osc32k: OSC32K,
+    #[doc = "0x1c - 32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control"]
+    pub osculp32k: OSCULP32K,
+    _reserved8: [u8; 3usize],
+    #[doc = "0x20 - 8MHz Internal Oscillator (OSC8M) Control"]
+    pub osc8m: OSC8M,
+    #[doc = "0x24 - DFLL48M Control"]
+    pub dfllctrl: DFLLCTRL,
+    _reserved10: [u8; 2usize],
+    #[doc = "0x28 - DFLL48M Value"]
+    pub dfllval: DFLLVAL,
+    #[doc = "0x2c - DFLL48M Multiplier"]
+    pub dfllmul: DFLLMUL,
+    #[doc = "0x30 - DFLL48M Synchronization"]
+    pub dfllsync: DFLLSYNC,
+    _reserved13: [u8; 3usize],
+    #[doc = "0x34 - 3.3V Brown-Out Detector (BOD33) Control"]
+    pub bod33: BOD33,
+    _reserved14: [u8; 8usize],
+    #[doc = "0x40 - Voltage References System (VREF) Control"]
+    pub vref: VREF,
+    #[doc = "0x44 - DPLL Control A"]
+    pub dpllctrla: DPLLCTRLA,
+    _reserved16: [u8; 3usize],
+    #[doc = "0x48 - DPLL Ratio Control"]
+    pub dpllratio: DPLLRATIO,
+    #[doc = "0x4c - DPLL Control B"]
+    pub dpllctrlb: DPLLCTRLB,
+    #[doc = "0x50 - DPLL Status"]
+    pub dpllstatus: DPLLSTATUS,
+}
+#[doc = "Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u32, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u32, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u32, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Power and Clocks Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pclksr](pclksr) module"]
+pub type PCLKSR = crate::Reg<u32, _PCLKSR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PCLKSR;
+#[doc = "`read()` method returns [pclksr::R](pclksr::R) reader structure"]
+impl crate::Readable for PCLKSR {}
+#[doc = "Power and Clocks Status"]
+pub mod pclksr;
+#[doc = "External Multipurpose Crystal Oscillator (XOSC) Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [xosc](xosc) module"]
+pub type XOSC = crate::Reg<u16, _XOSC>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _XOSC;
+#[doc = "`read()` method returns [xosc::R](xosc::R) reader structure"]
+impl crate::Readable for XOSC {}
+#[doc = "`write(|w| ..)` method takes [xosc::W](xosc::W) writer structure"]
+impl crate::Writable for XOSC {}
+#[doc = "External Multipurpose Crystal Oscillator (XOSC) Control"]
+pub mod xosc;
+#[doc = "32kHz External Crystal Oscillator (XOSC32K) Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [xosc32k](xosc32k) module"]
+pub type XOSC32K = crate::Reg<u16, _XOSC32K>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _XOSC32K;
+#[doc = "`read()` method returns [xosc32k::R](xosc32k::R) reader structure"]
+impl crate::Readable for XOSC32K {}
+#[doc = "`write(|w| ..)` method takes [xosc32k::W](xosc32k::W) writer structure"]
+impl crate::Writable for XOSC32K {}
+#[doc = "32kHz External Crystal Oscillator (XOSC32K) Control"]
+pub mod xosc32k;
+#[doc = "32kHz Internal Oscillator (OSC32K) Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [osc32k](osc32k) module"]
+pub type OSC32K = crate::Reg<u32, _OSC32K>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _OSC32K;
+#[doc = "`read()` method returns [osc32k::R](osc32k::R) reader structure"]
+impl crate::Readable for OSC32K {}
+#[doc = "`write(|w| ..)` method takes [osc32k::W](osc32k::W) writer structure"]
+impl crate::Writable for OSC32K {}
+#[doc = "32kHz Internal Oscillator (OSC32K) Control"]
+pub mod osc32k;
+#[doc = "32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [osculp32k](osculp32k) module"]
+pub type OSCULP32K = crate::Reg<u8, _OSCULP32K>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _OSCULP32K;
+#[doc = "`read()` method returns [osculp32k::R](osculp32k::R) reader structure"]
+impl crate::Readable for OSCULP32K {}
+#[doc = "`write(|w| ..)` method takes [osculp32k::W](osculp32k::W) writer structure"]
+impl crate::Writable for OSCULP32K {}
+#[doc = "32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control"]
+pub mod osculp32k;
+#[doc = "8MHz Internal Oscillator (OSC8M) Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [osc8m](osc8m) module"]
+pub type OSC8M = crate::Reg<u32, _OSC8M>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _OSC8M;
+#[doc = "`read()` method returns [osc8m::R](osc8m::R) reader structure"]
+impl crate::Readable for OSC8M {}
+#[doc = "`write(|w| ..)` method takes [osc8m::W](osc8m::W) writer structure"]
+impl crate::Writable for OSC8M {}
+#[doc = "8MHz Internal Oscillator (OSC8M) Control"]
+pub mod osc8m;
+#[doc = "DFLL48M Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dfllctrl](dfllctrl) module"]
+pub type DFLLCTRL = crate::Reg<u16, _DFLLCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DFLLCTRL;
+#[doc = "`read()` method returns [dfllctrl::R](dfllctrl::R) reader structure"]
+impl crate::Readable for DFLLCTRL {}
+#[doc = "`write(|w| ..)` method takes [dfllctrl::W](dfllctrl::W) writer structure"]
+impl crate::Writable for DFLLCTRL {}
+#[doc = "DFLL48M Control"]
+pub mod dfllctrl;
+#[doc = "DFLL48M Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dfllval](dfllval) module"]
+pub type DFLLVAL = crate::Reg<u32, _DFLLVAL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DFLLVAL;
+#[doc = "`read()` method returns [dfllval::R](dfllval::R) reader structure"]
+impl crate::Readable for DFLLVAL {}
+#[doc = "`write(|w| ..)` method takes [dfllval::W](dfllval::W) writer structure"]
+impl crate::Writable for DFLLVAL {}
+#[doc = "DFLL48M Value"]
+pub mod dfllval;
+#[doc = "DFLL48M Multiplier\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dfllmul](dfllmul) module"]
+pub type DFLLMUL = crate::Reg<u32, _DFLLMUL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DFLLMUL;
+#[doc = "`read()` method returns [dfllmul::R](dfllmul::R) reader structure"]
+impl crate::Readable for DFLLMUL {}
+#[doc = "`write(|w| ..)` method takes [dfllmul::W](dfllmul::W) writer structure"]
+impl crate::Writable for DFLLMUL {}
+#[doc = "DFLL48M Multiplier"]
+pub mod dfllmul;
+#[doc = "DFLL48M Synchronization\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dfllsync](dfllsync) module"]
+pub type DFLLSYNC = crate::Reg<u8, _DFLLSYNC>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DFLLSYNC;
+#[doc = "`write(|w| ..)` method takes [dfllsync::W](dfllsync::W) writer structure"]
+impl crate::Writable for DFLLSYNC {}
+#[doc = "DFLL48M Synchronization"]
+pub mod dfllsync;
+#[doc = "3.3V Brown-Out Detector (BOD33) Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [bod33](bod33) module"]
+pub type BOD33 = crate::Reg<u32, _BOD33>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _BOD33;
+#[doc = "`read()` method returns [bod33::R](bod33::R) reader structure"]
+impl crate::Readable for BOD33 {}
+#[doc = "`write(|w| ..)` method takes [bod33::W](bod33::W) writer structure"]
+impl crate::Writable for BOD33 {}
+#[doc = "3.3V Brown-Out Detector (BOD33) Control"]
+pub mod bod33;
+#[doc = "Voltage References System (VREF) Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [vref](vref) module"]
+pub type VREF = crate::Reg<u32, _VREF>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _VREF;
+#[doc = "`read()` method returns [vref::R](vref::R) reader structure"]
+impl crate::Readable for VREF {}
+#[doc = "`write(|w| ..)` method takes [vref::W](vref::W) writer structure"]
+impl crate::Writable for VREF {}
+#[doc = "Voltage References System (VREF) Control"]
+pub mod vref;
+#[doc = "DPLL Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dpllctrla](dpllctrla) module"]
+pub type DPLLCTRLA = crate::Reg<u8, _DPLLCTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DPLLCTRLA;
+#[doc = "`read()` method returns [dpllctrla::R](dpllctrla::R) reader structure"]
+impl crate::Readable for DPLLCTRLA {}
+#[doc = "`write(|w| ..)` method takes [dpllctrla::W](dpllctrla::W) writer structure"]
+impl crate::Writable for DPLLCTRLA {}
+#[doc = "DPLL Control A"]
+pub mod dpllctrla;
+#[doc = "DPLL Ratio Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dpllratio](dpllratio) module"]
+pub type DPLLRATIO = crate::Reg<u32, _DPLLRATIO>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DPLLRATIO;
+#[doc = "`read()` method returns [dpllratio::R](dpllratio::R) reader structure"]
+impl crate::Readable for DPLLRATIO {}
+#[doc = "`write(|w| ..)` method takes [dpllratio::W](dpllratio::W) writer structure"]
+impl crate::Writable for DPLLRATIO {}
+#[doc = "DPLL Ratio Control"]
+pub mod dpllratio;
+#[doc = "DPLL Control B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dpllctrlb](dpllctrlb) module"]
+pub type DPLLCTRLB = crate::Reg<u32, _DPLLCTRLB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DPLLCTRLB;
+#[doc = "`read()` method returns [dpllctrlb::R](dpllctrlb::R) reader structure"]
+impl crate::Readable for DPLLCTRLB {}
+#[doc = "`write(|w| ..)` method takes [dpllctrlb::W](dpllctrlb::W) writer structure"]
+impl crate::Writable for DPLLCTRLB {}
+#[doc = "DPLL Control B"]
+pub mod dpllctrlb;
+#[doc = "DPLL Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dpllstatus](dpllstatus) module"]
+pub type DPLLSTATUS = crate::Reg<u8, _DPLLSTATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DPLLSTATUS;
+#[doc = "`read()` method returns [dpllstatus::R](dpllstatus::R) reader structure"]
+impl crate::Readable for DPLLSTATUS {}
+#[doc = "DPLL Status"]
+pub mod dpllstatus;

--- a/pac/atsamd11c14a/src/sysctrl/bod33.rs
+++ b/pac/atsamd11c14a/src/sysctrl/bod33.rs
@@ -1,0 +1,577 @@
+#[doc = "Reader of register BOD33"]
+pub type R = crate::R<u32, super::BOD33>;
+#[doc = "Writer for register BOD33"]
+pub type W = crate::W<u32, super::BOD33>;
+#[doc = "Register BOD33 `reset()`'s with value 0"]
+impl crate::ResetValue for super::BOD33 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `HYST`"]
+pub type HYST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `HYST`"]
+pub struct HYST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HYST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "BOD33 Action\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ACTION_A {
+    #[doc = "0: No action"]
+    NONE,
+    #[doc = "1: The BOD33 generates a reset"]
+    RESET,
+    #[doc = "2: The BOD33 generates an interrupt"]
+    INTERRUPT,
+}
+impl From<ACTION_A> for u8 {
+    #[inline(always)]
+    fn from(variant: ACTION_A) -> Self {
+        match variant {
+            ACTION_A::NONE => 0,
+            ACTION_A::RESET => 1,
+            ACTION_A::INTERRUPT => 2,
+        }
+    }
+}
+#[doc = "Reader of field `ACTION`"]
+pub type ACTION_R = crate::R<u8, ACTION_A>;
+impl ACTION_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, ACTION_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(ACTION_A::NONE),
+            1 => Val(ACTION_A::RESET),
+            2 => Val(ACTION_A::INTERRUPT),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == ACTION_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RESET`"]
+    #[inline(always)]
+    pub fn is_reset(&self) -> bool {
+        *self == ACTION_A::RESET
+    }
+    #[doc = "Checks if the value of the field is `INTERRUPT`"]
+    #[inline(always)]
+    pub fn is_interrupt(&self) -> bool {
+        *self == ACTION_A::INTERRUPT
+    }
+}
+#[doc = "Write proxy for field `ACTION`"]
+pub struct ACTION_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ACTION_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: ACTION_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No action"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(ACTION_A::NONE)
+    }
+    #[doc = "The BOD33 generates a reset"]
+    #[inline(always)]
+    pub fn reset(self) -> &'a mut W {
+        self.variant(ACTION_A::RESET)
+    }
+    #[doc = "The BOD33 generates an interrupt"]
+    #[inline(always)]
+    pub fn interrupt(self) -> &'a mut W {
+        self.variant(ACTION_A::INTERRUPT)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 3)) | (((value as u32) & 0x03) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `MODE`"]
+pub type MODE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MODE`"]
+pub struct MODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MODE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `CEN`"]
+pub type CEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CEN`"]
+pub struct CEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Prescaler Select\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PSEL_A {
+    #[doc = "0: Divide clock by 2"]
+    DIV2,
+    #[doc = "1: Divide clock by 4"]
+    DIV4,
+    #[doc = "2: Divide clock by 8"]
+    DIV8,
+    #[doc = "3: Divide clock by 16"]
+    DIV16,
+    #[doc = "4: Divide clock by 32"]
+    DIV32,
+    #[doc = "5: Divide clock by 64"]
+    DIV64,
+    #[doc = "6: Divide clock by 128"]
+    DIV128,
+    #[doc = "7: Divide clock by 256"]
+    DIV256,
+    #[doc = "8: Divide clock by 512"]
+    DIV512,
+    #[doc = "9: Divide clock by 1024"]
+    DIV1K,
+    #[doc = "10: Divide clock by 2048"]
+    DIV2K,
+    #[doc = "11: Divide clock by 4096"]
+    DIV4K,
+    #[doc = "12: Divide clock by 8192"]
+    DIV8K,
+    #[doc = "13: Divide clock by 16384"]
+    DIV16K,
+    #[doc = "14: Divide clock by 32768"]
+    DIV32K,
+    #[doc = "15: Divide clock by 65536"]
+    DIV64K,
+}
+impl From<PSEL_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PSEL_A) -> Self {
+        match variant {
+            PSEL_A::DIV2 => 0,
+            PSEL_A::DIV4 => 1,
+            PSEL_A::DIV8 => 2,
+            PSEL_A::DIV16 => 3,
+            PSEL_A::DIV32 => 4,
+            PSEL_A::DIV64 => 5,
+            PSEL_A::DIV128 => 6,
+            PSEL_A::DIV256 => 7,
+            PSEL_A::DIV512 => 8,
+            PSEL_A::DIV1K => 9,
+            PSEL_A::DIV2K => 10,
+            PSEL_A::DIV4K => 11,
+            PSEL_A::DIV8K => 12,
+            PSEL_A::DIV16K => 13,
+            PSEL_A::DIV32K => 14,
+            PSEL_A::DIV64K => 15,
+        }
+    }
+}
+#[doc = "Reader of field `PSEL`"]
+pub type PSEL_R = crate::R<u8, PSEL_A>;
+impl PSEL_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> PSEL_A {
+        match self.bits {
+            0 => PSEL_A::DIV2,
+            1 => PSEL_A::DIV4,
+            2 => PSEL_A::DIV8,
+            3 => PSEL_A::DIV16,
+            4 => PSEL_A::DIV32,
+            5 => PSEL_A::DIV64,
+            6 => PSEL_A::DIV128,
+            7 => PSEL_A::DIV256,
+            8 => PSEL_A::DIV512,
+            9 => PSEL_A::DIV1K,
+            10 => PSEL_A::DIV2K,
+            11 => PSEL_A::DIV4K,
+            12 => PSEL_A::DIV8K,
+            13 => PSEL_A::DIV16K,
+            14 => PSEL_A::DIV32K,
+            15 => PSEL_A::DIV64K,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DIV2`"]
+    #[inline(always)]
+    pub fn is_div2(&self) -> bool {
+        *self == PSEL_A::DIV2
+    }
+    #[doc = "Checks if the value of the field is `DIV4`"]
+    #[inline(always)]
+    pub fn is_div4(&self) -> bool {
+        *self == PSEL_A::DIV4
+    }
+    #[doc = "Checks if the value of the field is `DIV8`"]
+    #[inline(always)]
+    pub fn is_div8(&self) -> bool {
+        *self == PSEL_A::DIV8
+    }
+    #[doc = "Checks if the value of the field is `DIV16`"]
+    #[inline(always)]
+    pub fn is_div16(&self) -> bool {
+        *self == PSEL_A::DIV16
+    }
+    #[doc = "Checks if the value of the field is `DIV32`"]
+    #[inline(always)]
+    pub fn is_div32(&self) -> bool {
+        *self == PSEL_A::DIV32
+    }
+    #[doc = "Checks if the value of the field is `DIV64`"]
+    #[inline(always)]
+    pub fn is_div64(&self) -> bool {
+        *self == PSEL_A::DIV64
+    }
+    #[doc = "Checks if the value of the field is `DIV128`"]
+    #[inline(always)]
+    pub fn is_div128(&self) -> bool {
+        *self == PSEL_A::DIV128
+    }
+    #[doc = "Checks if the value of the field is `DIV256`"]
+    #[inline(always)]
+    pub fn is_div256(&self) -> bool {
+        *self == PSEL_A::DIV256
+    }
+    #[doc = "Checks if the value of the field is `DIV512`"]
+    #[inline(always)]
+    pub fn is_div512(&self) -> bool {
+        *self == PSEL_A::DIV512
+    }
+    #[doc = "Checks if the value of the field is `DIV1K`"]
+    #[inline(always)]
+    pub fn is_div1k(&self) -> bool {
+        *self == PSEL_A::DIV1K
+    }
+    #[doc = "Checks if the value of the field is `DIV2K`"]
+    #[inline(always)]
+    pub fn is_div2k(&self) -> bool {
+        *self == PSEL_A::DIV2K
+    }
+    #[doc = "Checks if the value of the field is `DIV4K`"]
+    #[inline(always)]
+    pub fn is_div4k(&self) -> bool {
+        *self == PSEL_A::DIV4K
+    }
+    #[doc = "Checks if the value of the field is `DIV8K`"]
+    #[inline(always)]
+    pub fn is_div8k(&self) -> bool {
+        *self == PSEL_A::DIV8K
+    }
+    #[doc = "Checks if the value of the field is `DIV16K`"]
+    #[inline(always)]
+    pub fn is_div16k(&self) -> bool {
+        *self == PSEL_A::DIV16K
+    }
+    #[doc = "Checks if the value of the field is `DIV32K`"]
+    #[inline(always)]
+    pub fn is_div32k(&self) -> bool {
+        *self == PSEL_A::DIV32K
+    }
+    #[doc = "Checks if the value of the field is `DIV64K`"]
+    #[inline(always)]
+    pub fn is_div64k(&self) -> bool {
+        *self == PSEL_A::DIV64K
+    }
+}
+#[doc = "Write proxy for field `PSEL`"]
+pub struct PSEL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PSEL_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PSEL_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Divide clock by 2"]
+    #[inline(always)]
+    pub fn div2(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV2)
+    }
+    #[doc = "Divide clock by 4"]
+    #[inline(always)]
+    pub fn div4(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV4)
+    }
+    #[doc = "Divide clock by 8"]
+    #[inline(always)]
+    pub fn div8(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV8)
+    }
+    #[doc = "Divide clock by 16"]
+    #[inline(always)]
+    pub fn div16(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV16)
+    }
+    #[doc = "Divide clock by 32"]
+    #[inline(always)]
+    pub fn div32(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV32)
+    }
+    #[doc = "Divide clock by 64"]
+    #[inline(always)]
+    pub fn div64(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV64)
+    }
+    #[doc = "Divide clock by 128"]
+    #[inline(always)]
+    pub fn div128(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV128)
+    }
+    #[doc = "Divide clock by 256"]
+    #[inline(always)]
+    pub fn div256(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV256)
+    }
+    #[doc = "Divide clock by 512"]
+    #[inline(always)]
+    pub fn div512(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV512)
+    }
+    #[doc = "Divide clock by 1024"]
+    #[inline(always)]
+    pub fn div1k(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV1K)
+    }
+    #[doc = "Divide clock by 2048"]
+    #[inline(always)]
+    pub fn div2k(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV2K)
+    }
+    #[doc = "Divide clock by 4096"]
+    #[inline(always)]
+    pub fn div4k(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV4K)
+    }
+    #[doc = "Divide clock by 8192"]
+    #[inline(always)]
+    pub fn div8k(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV8K)
+    }
+    #[doc = "Divide clock by 16384"]
+    #[inline(always)]
+    pub fn div16k(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV16K)
+    }
+    #[doc = "Divide clock by 32768"]
+    #[inline(always)]
+    pub fn div32k(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV32K)
+    }
+    #[doc = "Divide clock by 65536"]
+    #[inline(always)]
+    pub fn div64k(self) -> &'a mut W {
+        self.variant(PSEL_A::DIV64K)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 12)) | (((value as u32) & 0x0f) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `LEVEL`"]
+pub type LEVEL_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `LEVEL`"]
+pub struct LEVEL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LEVEL_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x3f << 16)) | (((value as u32) & 0x3f) << 16);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Hysteresis"]
+    #[inline(always)]
+    pub fn hyst(&self) -> HYST_R {
+        HYST_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bits 3:4 - BOD33 Action"]
+    #[inline(always)]
+    pub fn action(&self) -> ACTION_R {
+        ACTION_R::new(((self.bits >> 3) & 0x03) as u8)
+    }
+    #[doc = "Bit 6 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Operation Mode"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Clock Enable"]
+    #[inline(always)]
+    pub fn cen(&self) -> CEN_R {
+        CEN_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bits 12:15 - Prescaler Select"]
+    #[inline(always)]
+    pub fn psel(&self) -> PSEL_R {
+        PSEL_R::new(((self.bits >> 12) & 0x0f) as u8)
+    }
+    #[doc = "Bits 16:21 - BOD33 Threshold Level"]
+    #[inline(always)]
+    pub fn level(&self) -> LEVEL_R {
+        LEVEL_R::new(((self.bits >> 16) & 0x3f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bit 2 - Hysteresis"]
+    #[inline(always)]
+    pub fn hyst(&mut self) -> HYST_W {
+        HYST_W { w: self }
+    }
+    #[doc = "Bits 3:4 - BOD33 Action"]
+    #[inline(always)]
+    pub fn action(&mut self) -> ACTION_W {
+        ACTION_W { w: self }
+    }
+    #[doc = "Bit 6 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bit 8 - Operation Mode"]
+    #[inline(always)]
+    pub fn mode(&mut self) -> MODE_W {
+        MODE_W { w: self }
+    }
+    #[doc = "Bit 9 - Clock Enable"]
+    #[inline(always)]
+    pub fn cen(&mut self) -> CEN_W {
+        CEN_W { w: self }
+    }
+    #[doc = "Bits 12:15 - Prescaler Select"]
+    #[inline(always)]
+    pub fn psel(&mut self) -> PSEL_W {
+        PSEL_W { w: self }
+    }
+    #[doc = "Bits 16:21 - BOD33 Threshold Level"]
+    #[inline(always)]
+    pub fn level(&mut self) -> LEVEL_W {
+        LEVEL_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/dfllctrl.rs
+++ b/pac/atsamd11c14a/src/sysctrl/dfllctrl.rs
@@ -1,0 +1,390 @@
+#[doc = "Reader of register DFLLCTRL"]
+pub type R = crate::R<u16, super::DFLLCTRL>;
+#[doc = "Writer for register DFLLCTRL"]
+pub type W = crate::W<u16, super::DFLLCTRL>;
+#[doc = "Register DFLLCTRL `reset()`'s with value 0x80"]
+impl crate::ResetValue for super::DFLLCTRL {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x80
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `MODE`"]
+pub type MODE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MODE`"]
+pub struct MODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MODE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `STABLE`"]
+pub type STABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `STABLE`"]
+pub struct STABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u16) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `LLAW`"]
+pub type LLAW_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LLAW`"]
+pub struct LLAW_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LLAW_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `USBCRM`"]
+pub type USBCRM_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `USBCRM`"]
+pub struct USBCRM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> USBCRM_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `ONDEMAND`"]
+pub type ONDEMAND_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ONDEMAND`"]
+pub struct ONDEMAND_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ONDEMAND_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `CCDIS`"]
+pub type CCDIS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CCDIS`"]
+pub struct CCDIS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CCDIS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `QLDIS`"]
+pub type QLDIS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `QLDIS`"]
+pub struct QLDIS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> QLDIS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u16) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `BPLCKC`"]
+pub type BPLCKC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BPLCKC`"]
+pub struct BPLCKC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BPLCKC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u16) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `WAITLOCK`"]
+pub type WAITLOCK_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WAITLOCK`"]
+pub struct WAITLOCK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAITLOCK_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u16) & 0x01) << 11);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - DFLL Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Operating Mode Selection"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Stable DFLL Frequency"]
+    #[inline(always)]
+    pub fn stable(&self) -> STABLE_R {
+        STABLE_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Lose Lock After Wake"]
+    #[inline(always)]
+    pub fn llaw(&self) -> LLAW_R {
+        LLAW_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - USB Clock Recovery Mode"]
+    #[inline(always)]
+    pub fn usbcrm(&self) -> USBCRM_R {
+        USBCRM_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - On Demand Control"]
+    #[inline(always)]
+    pub fn ondemand(&self) -> ONDEMAND_R {
+        ONDEMAND_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Chill Cycle Disable"]
+    #[inline(always)]
+    pub fn ccdis(&self) -> CCDIS_R {
+        CCDIS_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Quick Lock Disable"]
+    #[inline(always)]
+    pub fn qldis(&self) -> QLDIS_R {
+        QLDIS_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Bypass Coarse Lock"]
+    #[inline(always)]
+    pub fn bplckc(&self) -> BPLCKC_R {
+        BPLCKC_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Wait Lock"]
+    #[inline(always)]
+    pub fn waitlock(&self) -> WAITLOCK_R {
+        WAITLOCK_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 1 - DFLL Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bit 2 - Operating Mode Selection"]
+    #[inline(always)]
+    pub fn mode(&mut self) -> MODE_W {
+        MODE_W { w: self }
+    }
+    #[doc = "Bit 3 - Stable DFLL Frequency"]
+    #[inline(always)]
+    pub fn stable(&mut self) -> STABLE_W {
+        STABLE_W { w: self }
+    }
+    #[doc = "Bit 4 - Lose Lock After Wake"]
+    #[inline(always)]
+    pub fn llaw(&mut self) -> LLAW_W {
+        LLAW_W { w: self }
+    }
+    #[doc = "Bit 5 - USB Clock Recovery Mode"]
+    #[inline(always)]
+    pub fn usbcrm(&mut self) -> USBCRM_W {
+        USBCRM_W { w: self }
+    }
+    #[doc = "Bit 6 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bit 7 - On Demand Control"]
+    #[inline(always)]
+    pub fn ondemand(&mut self) -> ONDEMAND_W {
+        ONDEMAND_W { w: self }
+    }
+    #[doc = "Bit 8 - Chill Cycle Disable"]
+    #[inline(always)]
+    pub fn ccdis(&mut self) -> CCDIS_W {
+        CCDIS_W { w: self }
+    }
+    #[doc = "Bit 9 - Quick Lock Disable"]
+    #[inline(always)]
+    pub fn qldis(&mut self) -> QLDIS_W {
+        QLDIS_W { w: self }
+    }
+    #[doc = "Bit 10 - Bypass Coarse Lock"]
+    #[inline(always)]
+    pub fn bplckc(&mut self) -> BPLCKC_W {
+        BPLCKC_W { w: self }
+    }
+    #[doc = "Bit 11 - Wait Lock"]
+    #[inline(always)]
+    pub fn waitlock(&mut self) -> WAITLOCK_W {
+        WAITLOCK_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/dfllmul.rs
+++ b/pac/atsamd11c14a/src/sysctrl/dfllmul.rs
@@ -1,0 +1,88 @@
+#[doc = "Reader of register DFLLMUL"]
+pub type R = crate::R<u32, super::DFLLMUL>;
+#[doc = "Writer for register DFLLMUL"]
+pub type W = crate::W<u32, super::DFLLMUL>;
+#[doc = "Register DFLLMUL `reset()`'s with value 0"]
+impl crate::ResetValue for super::DFLLMUL {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `MUL`"]
+pub type MUL_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `MUL`"]
+pub struct MUL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MUL_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff) | ((value as u32) & 0xffff);
+        self.w
+    }
+}
+#[doc = "Reader of field `FSTEP`"]
+pub type FSTEP_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `FSTEP`"]
+pub struct FSTEP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FSTEP_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03ff << 16)) | (((value as u32) & 0x03ff) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `CSTEP`"]
+pub type CSTEP_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `CSTEP`"]
+pub struct CSTEP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CSTEP_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x3f << 26)) | (((value as u32) & 0x3f) << 26);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:15 - DFLL Multiply Factor"]
+    #[inline(always)]
+    pub fn mul(&self) -> MUL_R {
+        MUL_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bits 16:25 - Fine Maximum Step"]
+    #[inline(always)]
+    pub fn fstep(&self) -> FSTEP_R {
+        FSTEP_R::new(((self.bits >> 16) & 0x03ff) as u16)
+    }
+    #[doc = "Bits 26:31 - Coarse Maximum Step"]
+    #[inline(always)]
+    pub fn cstep(&self) -> CSTEP_R {
+        CSTEP_R::new(((self.bits >> 26) & 0x3f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - DFLL Multiply Factor"]
+    #[inline(always)]
+    pub fn mul(&mut self) -> MUL_W {
+        MUL_W { w: self }
+    }
+    #[doc = "Bits 16:25 - Fine Maximum Step"]
+    #[inline(always)]
+    pub fn fstep(&mut self) -> FSTEP_W {
+        FSTEP_W { w: self }
+    }
+    #[doc = "Bits 26:31 - Coarse Maximum Step"]
+    #[inline(always)]
+    pub fn cstep(&mut self) -> CSTEP_W {
+        CSTEP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/dfllsync.rs
+++ b/pac/atsamd11c14a/src/sysctrl/dfllsync.rs
@@ -1,0 +1,39 @@
+#[doc = "Writer for register DFLLSYNC"]
+pub type W = crate::W<u8, super::DFLLSYNC>;
+#[doc = "Register DFLLSYNC `reset()`'s with value 0"]
+impl crate::ResetValue for super::DFLLSYNC {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Write proxy for field `READREQ`"]
+pub struct READREQ_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> READREQ_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl W {
+    #[doc = "Bit 7 - Read Request"]
+    #[inline(always)]
+    pub fn readreq(&mut self) -> READREQ_W {
+        READREQ_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/dfllval.rs
+++ b/pac/atsamd11c14a/src/sysctrl/dfllval.rs
@@ -1,0 +1,71 @@
+#[doc = "Reader of register DFLLVAL"]
+pub type R = crate::R<u32, super::DFLLVAL>;
+#[doc = "Writer for register DFLLVAL"]
+pub type W = crate::W<u32, super::DFLLVAL>;
+#[doc = "Register DFLLVAL `reset()`'s with value 0"]
+impl crate::ResetValue for super::DFLLVAL {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `FINE`"]
+pub type FINE_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `FINE`"]
+pub struct FINE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FINE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x03ff) | ((value as u32) & 0x03ff);
+        self.w
+    }
+}
+#[doc = "Reader of field `COARSE`"]
+pub type COARSE_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `COARSE`"]
+pub struct COARSE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COARSE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x3f << 10)) | (((value as u32) & 0x3f) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `DIFF`"]
+pub type DIFF_R = crate::R<u16, u16>;
+impl R {
+    #[doc = "Bits 0:9 - Fine Value"]
+    #[inline(always)]
+    pub fn fine(&self) -> FINE_R {
+        FINE_R::new((self.bits & 0x03ff) as u16)
+    }
+    #[doc = "Bits 10:15 - Coarse Value"]
+    #[inline(always)]
+    pub fn coarse(&self) -> COARSE_R {
+        COARSE_R::new(((self.bits >> 10) & 0x3f) as u8)
+    }
+    #[doc = "Bits 16:31 - Multiplication Ratio Difference"]
+    #[inline(always)]
+    pub fn diff(&self) -> DIFF_R {
+        DIFF_R::new(((self.bits >> 16) & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:9 - Fine Value"]
+    #[inline(always)]
+    pub fn fine(&mut self) -> FINE_W {
+        FINE_W { w: self }
+    }
+    #[doc = "Bits 10:15 - Coarse Value"]
+    #[inline(always)]
+    pub fn coarse(&mut self) -> COARSE_W {
+        COARSE_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/dpllctrla.rs
+++ b/pac/atsamd11c14a/src/sysctrl/dpllctrla.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register DPLLCTRLA"]
+pub type R = crate::R<u8, super::DPLLCTRLA>;
+#[doc = "Writer for register DPLLCTRLA"]
+pub type W = crate::W<u8, super::DPLLCTRLA>;
+#[doc = "Register DPLLCTRLA `reset()`'s with value 0x80"]
+impl crate::ResetValue for super::DPLLCTRLA {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x80
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `ONDEMAND`"]
+pub type ONDEMAND_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ONDEMAND`"]
+pub struct ONDEMAND_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ONDEMAND_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - DPLL Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - On Demand Clock Activation"]
+    #[inline(always)]
+    pub fn ondemand(&self) -> ONDEMAND_R {
+        ONDEMAND_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 1 - DPLL Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bit 6 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bit 7 - On Demand Clock Activation"]
+    #[inline(always)]
+    pub fn ondemand(&mut self) -> ONDEMAND_W {
+        ONDEMAND_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/dpllctrlb.rs
+++ b/pac/atsamd11c14a/src/sysctrl/dpllctrlb.rs
@@ -1,0 +1,461 @@
+#[doc = "Reader of register DPLLCTRLB"]
+pub type R = crate::R<u32, super::DPLLCTRLB>;
+#[doc = "Writer for register DPLLCTRLB"]
+pub type W = crate::W<u32, super::DPLLCTRLB>;
+#[doc = "Register DPLLCTRLB `reset()`'s with value 0"]
+impl crate::ResetValue for super::DPLLCTRLB {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Proportional Integral Filter Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FILTER_A {
+    #[doc = "0: Default filter mode"]
+    DEFAULT,
+    #[doc = "1: Low bandwidth filter"]
+    LBFILT,
+    #[doc = "2: High bandwidth filter"]
+    HBFILT,
+    #[doc = "3: High damping filter"]
+    HDFILT,
+}
+impl From<FILTER_A> for u8 {
+    #[inline(always)]
+    fn from(variant: FILTER_A) -> Self {
+        match variant {
+            FILTER_A::DEFAULT => 0,
+            FILTER_A::LBFILT => 1,
+            FILTER_A::HBFILT => 2,
+            FILTER_A::HDFILT => 3,
+        }
+    }
+}
+#[doc = "Reader of field `FILTER`"]
+pub type FILTER_R = crate::R<u8, FILTER_A>;
+impl FILTER_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> FILTER_A {
+        match self.bits {
+            0 => FILTER_A::DEFAULT,
+            1 => FILTER_A::LBFILT,
+            2 => FILTER_A::HBFILT,
+            3 => FILTER_A::HDFILT,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DEFAULT`"]
+    #[inline(always)]
+    pub fn is_default(&self) -> bool {
+        *self == FILTER_A::DEFAULT
+    }
+    #[doc = "Checks if the value of the field is `LBFILT`"]
+    #[inline(always)]
+    pub fn is_lbfilt(&self) -> bool {
+        *self == FILTER_A::LBFILT
+    }
+    #[doc = "Checks if the value of the field is `HBFILT`"]
+    #[inline(always)]
+    pub fn is_hbfilt(&self) -> bool {
+        *self == FILTER_A::HBFILT
+    }
+    #[doc = "Checks if the value of the field is `HDFILT`"]
+    #[inline(always)]
+    pub fn is_hdfilt(&self) -> bool {
+        *self == FILTER_A::HDFILT
+    }
+}
+#[doc = "Write proxy for field `FILTER`"]
+pub struct FILTER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FILTER_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: FILTER_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Default filter mode"]
+    #[inline(always)]
+    pub fn default(self) -> &'a mut W {
+        self.variant(FILTER_A::DEFAULT)
+    }
+    #[doc = "Low bandwidth filter"]
+    #[inline(always)]
+    pub fn lbfilt(self) -> &'a mut W {
+        self.variant(FILTER_A::LBFILT)
+    }
+    #[doc = "High bandwidth filter"]
+    #[inline(always)]
+    pub fn hbfilt(self) -> &'a mut W {
+        self.variant(FILTER_A::HBFILT)
+    }
+    #[doc = "High damping filter"]
+    #[inline(always)]
+    pub fn hdfilt(self) -> &'a mut W {
+        self.variant(FILTER_A::HDFILT)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x03) | ((value as u32) & 0x03);
+        self.w
+    }
+}
+#[doc = "Reader of field `LPEN`"]
+pub type LPEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LPEN`"]
+pub struct LPEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LPEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `WUF`"]
+pub type WUF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WUF`"]
+pub struct WUF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WUF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reference Clock Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum REFCLK_A {
+    #[doc = "0: CLK_DPLL_REF0 clock reference"]
+    REF0,
+    #[doc = "1: CLK_DPLL_REF1 clock reference"]
+    REF1,
+    #[doc = "2: GCLK_DPLL clock reference"]
+    GCLK,
+}
+impl From<REFCLK_A> for u8 {
+    #[inline(always)]
+    fn from(variant: REFCLK_A) -> Self {
+        match variant {
+            REFCLK_A::REF0 => 0,
+            REFCLK_A::REF1 => 1,
+            REFCLK_A::GCLK => 2,
+        }
+    }
+}
+#[doc = "Reader of field `REFCLK`"]
+pub type REFCLK_R = crate::R<u8, REFCLK_A>;
+impl REFCLK_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, REFCLK_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(REFCLK_A::REF0),
+            1 => Val(REFCLK_A::REF1),
+            2 => Val(REFCLK_A::GCLK),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `REF0`"]
+    #[inline(always)]
+    pub fn is_ref0(&self) -> bool {
+        *self == REFCLK_A::REF0
+    }
+    #[doc = "Checks if the value of the field is `REF1`"]
+    #[inline(always)]
+    pub fn is_ref1(&self) -> bool {
+        *self == REFCLK_A::REF1
+    }
+    #[doc = "Checks if the value of the field is `GCLK`"]
+    #[inline(always)]
+    pub fn is_gclk(&self) -> bool {
+        *self == REFCLK_A::GCLK
+    }
+}
+#[doc = "Write proxy for field `REFCLK`"]
+pub struct REFCLK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> REFCLK_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: REFCLK_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "CLK_DPLL_REF0 clock reference"]
+    #[inline(always)]
+    pub fn ref0(self) -> &'a mut W {
+        self.variant(REFCLK_A::REF0)
+    }
+    #[doc = "CLK_DPLL_REF1 clock reference"]
+    #[inline(always)]
+    pub fn ref1(self) -> &'a mut W {
+        self.variant(REFCLK_A::REF1)
+    }
+    #[doc = "GCLK_DPLL clock reference"]
+    #[inline(always)]
+    pub fn gclk(self) -> &'a mut W {
+        self.variant(REFCLK_A::GCLK)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 4)) | (((value as u32) & 0x03) << 4);
+        self.w
+    }
+}
+#[doc = "Lock Time\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LTIME_A {
+    #[doc = "0: Default\tNo time-out"]
+    NONE,
+    #[doc = "4: 8MS\tTime-out if no lock within 8 ms"]
+    _8MS,
+    #[doc = "5: 9MS\tTime-out if no lock within 9 ms"]
+    _9MS,
+    #[doc = "6: 10MS\tTime-out if no lock within 10 ms"]
+    _10MS,
+    #[doc = "7: 11MS\tTime-out if no lock within 11 ms"]
+    _11MS,
+}
+impl From<LTIME_A> for u8 {
+    #[inline(always)]
+    fn from(variant: LTIME_A) -> Self {
+        match variant {
+            LTIME_A::NONE => 0,
+            LTIME_A::_8MS => 4,
+            LTIME_A::_9MS => 5,
+            LTIME_A::_10MS => 6,
+            LTIME_A::_11MS => 7,
+        }
+    }
+}
+#[doc = "Reader of field `LTIME`"]
+pub type LTIME_R = crate::R<u8, LTIME_A>;
+impl LTIME_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, LTIME_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(LTIME_A::NONE),
+            4 => Val(LTIME_A::_8MS),
+            5 => Val(LTIME_A::_9MS),
+            6 => Val(LTIME_A::_10MS),
+            7 => Val(LTIME_A::_11MS),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == LTIME_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `_8MS`"]
+    #[inline(always)]
+    pub fn is_8ms(&self) -> bool {
+        *self == LTIME_A::_8MS
+    }
+    #[doc = "Checks if the value of the field is `_9MS`"]
+    #[inline(always)]
+    pub fn is_9ms(&self) -> bool {
+        *self == LTIME_A::_9MS
+    }
+    #[doc = "Checks if the value of the field is `_10MS`"]
+    #[inline(always)]
+    pub fn is_10ms(&self) -> bool {
+        *self == LTIME_A::_10MS
+    }
+    #[doc = "Checks if the value of the field is `_11MS`"]
+    #[inline(always)]
+    pub fn is_11ms(&self) -> bool {
+        *self == LTIME_A::_11MS
+    }
+}
+#[doc = "Write proxy for field `LTIME`"]
+pub struct LTIME_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LTIME_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: LTIME_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Default No time-out"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(LTIME_A::NONE)
+    }
+    #[doc = "8MS Time-out if no lock within 8 ms"]
+    #[inline(always)]
+    pub fn _8ms(self) -> &'a mut W {
+        self.variant(LTIME_A::_8MS)
+    }
+    #[doc = "9MS Time-out if no lock within 9 ms"]
+    #[inline(always)]
+    pub fn _9ms(self) -> &'a mut W {
+        self.variant(LTIME_A::_9MS)
+    }
+    #[doc = "10MS Time-out if no lock within 10 ms"]
+    #[inline(always)]
+    pub fn _10ms(self) -> &'a mut W {
+        self.variant(LTIME_A::_10MS)
+    }
+    #[doc = "11MS Time-out if no lock within 11 ms"]
+    #[inline(always)]
+    pub fn _11ms(self) -> &'a mut W {
+        self.variant(LTIME_A::_11MS)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 8)) | (((value as u32) & 0x07) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `LBYPASS`"]
+pub type LBYPASS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LBYPASS`"]
+pub struct LBYPASS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LBYPASS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u32) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `DIV`"]
+pub type DIV_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `DIV`"]
+pub struct DIV_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIV_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07ff << 16)) | (((value as u32) & 0x07ff) << 16);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:1 - Proportional Integral Filter Selection"]
+    #[inline(always)]
+    pub fn filter(&self) -> FILTER_R {
+        FILTER_R::new((self.bits & 0x03) as u8)
+    }
+    #[doc = "Bit 2 - Low-Power Enable"]
+    #[inline(always)]
+    pub fn lpen(&self) -> LPEN_R {
+        LPEN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Wake Up Fast"]
+    #[inline(always)]
+    pub fn wuf(&self) -> WUF_R {
+        WUF_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bits 4:5 - Reference Clock Selection"]
+    #[inline(always)]
+    pub fn refclk(&self) -> REFCLK_R {
+        REFCLK_R::new(((self.bits >> 4) & 0x03) as u8)
+    }
+    #[doc = "Bits 8:10 - Lock Time"]
+    #[inline(always)]
+    pub fn ltime(&self) -> LTIME_R {
+        LTIME_R::new(((self.bits >> 8) & 0x07) as u8)
+    }
+    #[doc = "Bit 12 - Lock Bypass"]
+    #[inline(always)]
+    pub fn lbypass(&self) -> LBYPASS_R {
+        LBYPASS_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bits 16:26 - Clock Divider"]
+    #[inline(always)]
+    pub fn div(&self) -> DIV_R {
+        DIV_R::new(((self.bits >> 16) & 0x07ff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:1 - Proportional Integral Filter Selection"]
+    #[inline(always)]
+    pub fn filter(&mut self) -> FILTER_W {
+        FILTER_W { w: self }
+    }
+    #[doc = "Bit 2 - Low-Power Enable"]
+    #[inline(always)]
+    pub fn lpen(&mut self) -> LPEN_W {
+        LPEN_W { w: self }
+    }
+    #[doc = "Bit 3 - Wake Up Fast"]
+    #[inline(always)]
+    pub fn wuf(&mut self) -> WUF_W {
+        WUF_W { w: self }
+    }
+    #[doc = "Bits 4:5 - Reference Clock Selection"]
+    #[inline(always)]
+    pub fn refclk(&mut self) -> REFCLK_W {
+        REFCLK_W { w: self }
+    }
+    #[doc = "Bits 8:10 - Lock Time"]
+    #[inline(always)]
+    pub fn ltime(&mut self) -> LTIME_W {
+        LTIME_W { w: self }
+    }
+    #[doc = "Bit 12 - Lock Bypass"]
+    #[inline(always)]
+    pub fn lbypass(&mut self) -> LBYPASS_W {
+        LBYPASS_W { w: self }
+    }
+    #[doc = "Bits 16:26 - Clock Divider"]
+    #[inline(always)]
+    pub fn div(&mut self) -> DIV_W {
+        DIV_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/dpllratio.rs
+++ b/pac/atsamd11c14a/src/sysctrl/dpllratio.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register DPLLRATIO"]
+pub type R = crate::R<u32, super::DPLLRATIO>;
+#[doc = "Writer for register DPLLRATIO"]
+pub type W = crate::W<u32, super::DPLLRATIO>;
+#[doc = "Register DPLLRATIO `reset()`'s with value 0"]
+impl crate::ResetValue for super::DPLLRATIO {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `LDR`"]
+pub type LDR_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `LDR`"]
+pub struct LDR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LDR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0fff) | ((value as u32) & 0x0fff);
+        self.w
+    }
+}
+#[doc = "Reader of field `LDRFRAC`"]
+pub type LDRFRAC_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `LDRFRAC`"]
+pub struct LDRFRAC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LDRFRAC_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 16)) | (((value as u32) & 0x0f) << 16);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:11 - Loop Divider Ratio"]
+    #[inline(always)]
+    pub fn ldr(&self) -> LDR_R {
+        LDR_R::new((self.bits & 0x0fff) as u16)
+    }
+    #[doc = "Bits 16:19 - Loop Divider Ratio Fractional Part"]
+    #[inline(always)]
+    pub fn ldrfrac(&self) -> LDRFRAC_R {
+        LDRFRAC_R::new(((self.bits >> 16) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:11 - Loop Divider Ratio"]
+    #[inline(always)]
+    pub fn ldr(&mut self) -> LDR_W {
+        LDR_W { w: self }
+    }
+    #[doc = "Bits 16:19 - Loop Divider Ratio Fractional Part"]
+    #[inline(always)]
+    pub fn ldrfrac(&mut self) -> LDRFRAC_W {
+        LDRFRAC_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/dpllstatus.rs
+++ b/pac/atsamd11c14a/src/sysctrl/dpllstatus.rs
@@ -1,0 +1,32 @@
+#[doc = "Reader of register DPLLSTATUS"]
+pub type R = crate::R<u8, super::DPLLSTATUS>;
+#[doc = "Reader of field `LOCK`"]
+pub type LOCK_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CLKRDY`"]
+pub type CLKRDY_R = crate::R<bool, bool>;
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Reader of field `DIV`"]
+pub type DIV_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - DPLL Lock Status"]
+    #[inline(always)]
+    pub fn lock(&self) -> LOCK_R {
+        LOCK_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Output Clock Ready"]
+    #[inline(always)]
+    pub fn clkrdy(&self) -> CLKRDY_R {
+        CLKRDY_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - DPLL Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Divider Enable"]
+    #[inline(always)]
+    pub fn div(&self) -> DIV_R {
+        DIV_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/intenclr.rs
+++ b/pac/atsamd11c14a/src/sysctrl/intenclr.rs
@@ -1,0 +1,526 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u32, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u32, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `XOSCRDY`"]
+pub type XOSCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `XOSCRDY`"]
+pub struct XOSCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> XOSCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `XOSC32KRDY`"]
+pub type XOSC32KRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `XOSC32KRDY`"]
+pub struct XOSC32KRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> XOSC32KRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `OSC32KRDY`"]
+pub type OSC32KRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OSC32KRDY`"]
+pub struct OSC32KRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OSC32KRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `OSC8MRDY`"]
+pub type OSC8MRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OSC8MRDY`"]
+pub struct OSC8MRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OSC8MRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFLLRDY`"]
+pub type DFLLRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFLLRDY`"]
+pub struct DFLLRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFLLRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFLLOOB`"]
+pub type DFLLOOB_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFLLOOB`"]
+pub struct DFLLOOB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFLLOOB_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFLLLCKF`"]
+pub type DFLLLCKF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFLLLCKF`"]
+pub struct DFLLLCKF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFLLLCKF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFLLLCKC`"]
+pub type DFLLLCKC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFLLLCKC`"]
+pub struct DFLLLCKC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFLLLCKC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFLLRCS`"]
+pub type DFLLRCS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFLLRCS`"]
+pub struct DFLLRCS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFLLRCS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `BOD33RDY`"]
+pub type BOD33RDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BOD33RDY`"]
+pub struct BOD33RDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BOD33RDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `BOD33DET`"]
+pub type BOD33DET_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BOD33DET`"]
+pub struct BOD33DET_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BOD33DET_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u32) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `B33SRDY`"]
+pub type B33SRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `B33SRDY`"]
+pub struct B33SRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> B33SRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `DPLLLCKR`"]
+pub type DPLLLCKR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DPLLLCKR`"]
+pub struct DPLLLCKR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DPLLLCKR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Reader of field `DPLLLCKF`"]
+pub type DPLLLCKF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DPLLLCKF`"]
+pub struct DPLLLCKF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DPLLLCKF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `DPLLLTO`"]
+pub type DPLLLTO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DPLLLTO`"]
+pub struct DPLLLTO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DPLLLTO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - XOSC Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn xoscrdy(&self) -> XOSCRDY_R {
+        XOSCRDY_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - XOSC32K Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn xosc32krdy(&self) -> XOSC32KRDY_R {
+        XOSC32KRDY_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - OSC32K Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn osc32krdy(&self) -> OSC32KRDY_R {
+        OSC32KRDY_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - OSC8M Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn osc8mrdy(&self) -> OSC8MRDY_R {
+        OSC8MRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - DFLL Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn dfllrdy(&self) -> DFLLRDY_R {
+        DFLLRDY_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - DFLL Out Of Bounds Interrupt Enable"]
+    #[inline(always)]
+    pub fn dflloob(&self) -> DFLLOOB_R {
+        DFLLOOB_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - DFLL Lock Fine Interrupt Enable"]
+    #[inline(always)]
+    pub fn dflllckf(&self) -> DFLLLCKF_R {
+        DFLLLCKF_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - DFLL Lock Coarse Interrupt Enable"]
+    #[inline(always)]
+    pub fn dflllckc(&self) -> DFLLLCKC_R {
+        DFLLLCKC_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - DFLL Reference Clock Stopped Interrupt Enable"]
+    #[inline(always)]
+    pub fn dfllrcs(&self) -> DFLLRCS_R {
+        DFLLRCS_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - BOD33 Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn bod33rdy(&self) -> BOD33RDY_R {
+        BOD33RDY_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - BOD33 Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn bod33det(&self) -> BOD33DET_R {
+        BOD33DET_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - BOD33 Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn b33srdy(&self) -> B33SRDY_R {
+        B33SRDY_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - DPLL Lock Rise Interrupt Enable"]
+    #[inline(always)]
+    pub fn dplllckr(&self) -> DPLLLCKR_R {
+        DPLLLCKR_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - DPLL Lock Fall Interrupt Enable"]
+    #[inline(always)]
+    pub fn dplllckf(&self) -> DPLLLCKF_R {
+        DPLLLCKF_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bit 17 - DPLL Lock Timeout Interrupt Enable"]
+    #[inline(always)]
+    pub fn dplllto(&self) -> DPLLLTO_R {
+        DPLLLTO_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - XOSC Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn xoscrdy(&mut self) -> XOSCRDY_W {
+        XOSCRDY_W { w: self }
+    }
+    #[doc = "Bit 1 - XOSC32K Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn xosc32krdy(&mut self) -> XOSC32KRDY_W {
+        XOSC32KRDY_W { w: self }
+    }
+    #[doc = "Bit 2 - OSC32K Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn osc32krdy(&mut self) -> OSC32KRDY_W {
+        OSC32KRDY_W { w: self }
+    }
+    #[doc = "Bit 3 - OSC8M Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn osc8mrdy(&mut self) -> OSC8MRDY_W {
+        OSC8MRDY_W { w: self }
+    }
+    #[doc = "Bit 4 - DFLL Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn dfllrdy(&mut self) -> DFLLRDY_W {
+        DFLLRDY_W { w: self }
+    }
+    #[doc = "Bit 5 - DFLL Out Of Bounds Interrupt Enable"]
+    #[inline(always)]
+    pub fn dflloob(&mut self) -> DFLLOOB_W {
+        DFLLOOB_W { w: self }
+    }
+    #[doc = "Bit 6 - DFLL Lock Fine Interrupt Enable"]
+    #[inline(always)]
+    pub fn dflllckf(&mut self) -> DFLLLCKF_W {
+        DFLLLCKF_W { w: self }
+    }
+    #[doc = "Bit 7 - DFLL Lock Coarse Interrupt Enable"]
+    #[inline(always)]
+    pub fn dflllckc(&mut self) -> DFLLLCKC_W {
+        DFLLLCKC_W { w: self }
+    }
+    #[doc = "Bit 8 - DFLL Reference Clock Stopped Interrupt Enable"]
+    #[inline(always)]
+    pub fn dfllrcs(&mut self) -> DFLLRCS_W {
+        DFLLRCS_W { w: self }
+    }
+    #[doc = "Bit 9 - BOD33 Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn bod33rdy(&mut self) -> BOD33RDY_W {
+        BOD33RDY_W { w: self }
+    }
+    #[doc = "Bit 10 - BOD33 Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn bod33det(&mut self) -> BOD33DET_W {
+        BOD33DET_W { w: self }
+    }
+    #[doc = "Bit 11 - BOD33 Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn b33srdy(&mut self) -> B33SRDY_W {
+        B33SRDY_W { w: self }
+    }
+    #[doc = "Bit 15 - DPLL Lock Rise Interrupt Enable"]
+    #[inline(always)]
+    pub fn dplllckr(&mut self) -> DPLLLCKR_W {
+        DPLLLCKR_W { w: self }
+    }
+    #[doc = "Bit 16 - DPLL Lock Fall Interrupt Enable"]
+    #[inline(always)]
+    pub fn dplllckf(&mut self) -> DPLLLCKF_W {
+        DPLLLCKF_W { w: self }
+    }
+    #[doc = "Bit 17 - DPLL Lock Timeout Interrupt Enable"]
+    #[inline(always)]
+    pub fn dplllto(&mut self) -> DPLLLTO_W {
+        DPLLLTO_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/intenset.rs
+++ b/pac/atsamd11c14a/src/sysctrl/intenset.rs
@@ -1,0 +1,526 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u32, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u32, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `XOSCRDY`"]
+pub type XOSCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `XOSCRDY`"]
+pub struct XOSCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> XOSCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `XOSC32KRDY`"]
+pub type XOSC32KRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `XOSC32KRDY`"]
+pub struct XOSC32KRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> XOSC32KRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `OSC32KRDY`"]
+pub type OSC32KRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OSC32KRDY`"]
+pub struct OSC32KRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OSC32KRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `OSC8MRDY`"]
+pub type OSC8MRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OSC8MRDY`"]
+pub struct OSC8MRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OSC8MRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFLLRDY`"]
+pub type DFLLRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFLLRDY`"]
+pub struct DFLLRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFLLRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFLLOOB`"]
+pub type DFLLOOB_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFLLOOB`"]
+pub struct DFLLOOB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFLLOOB_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFLLLCKF`"]
+pub type DFLLLCKF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFLLLCKF`"]
+pub struct DFLLLCKF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFLLLCKF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFLLLCKC`"]
+pub type DFLLLCKC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFLLLCKC`"]
+pub struct DFLLLCKC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFLLLCKC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFLLRCS`"]
+pub type DFLLRCS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFLLRCS`"]
+pub struct DFLLRCS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFLLRCS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `BOD33RDY`"]
+pub type BOD33RDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BOD33RDY`"]
+pub struct BOD33RDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BOD33RDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `BOD33DET`"]
+pub type BOD33DET_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BOD33DET`"]
+pub struct BOD33DET_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BOD33DET_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u32) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `B33SRDY`"]
+pub type B33SRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `B33SRDY`"]
+pub struct B33SRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> B33SRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `DPLLLCKR`"]
+pub type DPLLLCKR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DPLLLCKR`"]
+pub struct DPLLLCKR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DPLLLCKR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Reader of field `DPLLLCKF`"]
+pub type DPLLLCKF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DPLLLCKF`"]
+pub struct DPLLLCKF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DPLLLCKF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `DPLLLTO`"]
+pub type DPLLLTO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DPLLLTO`"]
+pub struct DPLLLTO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DPLLLTO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - XOSC Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn xoscrdy(&self) -> XOSCRDY_R {
+        XOSCRDY_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - XOSC32K Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn xosc32krdy(&self) -> XOSC32KRDY_R {
+        XOSC32KRDY_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - OSC32K Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn osc32krdy(&self) -> OSC32KRDY_R {
+        OSC32KRDY_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - OSC8M Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn osc8mrdy(&self) -> OSC8MRDY_R {
+        OSC8MRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - DFLL Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn dfllrdy(&self) -> DFLLRDY_R {
+        DFLLRDY_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - DFLL Out Of Bounds Interrupt Enable"]
+    #[inline(always)]
+    pub fn dflloob(&self) -> DFLLOOB_R {
+        DFLLOOB_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - DFLL Lock Fine Interrupt Enable"]
+    #[inline(always)]
+    pub fn dflllckf(&self) -> DFLLLCKF_R {
+        DFLLLCKF_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - DFLL Lock Coarse Interrupt Enable"]
+    #[inline(always)]
+    pub fn dflllckc(&self) -> DFLLLCKC_R {
+        DFLLLCKC_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - DFLL Reference Clock Stopped Interrupt Enable"]
+    #[inline(always)]
+    pub fn dfllrcs(&self) -> DFLLRCS_R {
+        DFLLRCS_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - BOD33 Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn bod33rdy(&self) -> BOD33RDY_R {
+        BOD33RDY_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - BOD33 Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn bod33det(&self) -> BOD33DET_R {
+        BOD33DET_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - BOD33 Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn b33srdy(&self) -> B33SRDY_R {
+        B33SRDY_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - DPLL Lock Rise Interrupt Enable"]
+    #[inline(always)]
+    pub fn dplllckr(&self) -> DPLLLCKR_R {
+        DPLLLCKR_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - DPLL Lock Fall Interrupt Enable"]
+    #[inline(always)]
+    pub fn dplllckf(&self) -> DPLLLCKF_R {
+        DPLLLCKF_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bit 17 - DPLL Lock Timeout Interrupt Enable"]
+    #[inline(always)]
+    pub fn dplllto(&self) -> DPLLLTO_R {
+        DPLLLTO_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - XOSC Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn xoscrdy(&mut self) -> XOSCRDY_W {
+        XOSCRDY_W { w: self }
+    }
+    #[doc = "Bit 1 - XOSC32K Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn xosc32krdy(&mut self) -> XOSC32KRDY_W {
+        XOSC32KRDY_W { w: self }
+    }
+    #[doc = "Bit 2 - OSC32K Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn osc32krdy(&mut self) -> OSC32KRDY_W {
+        OSC32KRDY_W { w: self }
+    }
+    #[doc = "Bit 3 - OSC8M Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn osc8mrdy(&mut self) -> OSC8MRDY_W {
+        OSC8MRDY_W { w: self }
+    }
+    #[doc = "Bit 4 - DFLL Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn dfllrdy(&mut self) -> DFLLRDY_W {
+        DFLLRDY_W { w: self }
+    }
+    #[doc = "Bit 5 - DFLL Out Of Bounds Interrupt Enable"]
+    #[inline(always)]
+    pub fn dflloob(&mut self) -> DFLLOOB_W {
+        DFLLOOB_W { w: self }
+    }
+    #[doc = "Bit 6 - DFLL Lock Fine Interrupt Enable"]
+    #[inline(always)]
+    pub fn dflllckf(&mut self) -> DFLLLCKF_W {
+        DFLLLCKF_W { w: self }
+    }
+    #[doc = "Bit 7 - DFLL Lock Coarse Interrupt Enable"]
+    #[inline(always)]
+    pub fn dflllckc(&mut self) -> DFLLLCKC_W {
+        DFLLLCKC_W { w: self }
+    }
+    #[doc = "Bit 8 - DFLL Reference Clock Stopped Interrupt Enable"]
+    #[inline(always)]
+    pub fn dfllrcs(&mut self) -> DFLLRCS_W {
+        DFLLRCS_W { w: self }
+    }
+    #[doc = "Bit 9 - BOD33 Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn bod33rdy(&mut self) -> BOD33RDY_W {
+        BOD33RDY_W { w: self }
+    }
+    #[doc = "Bit 10 - BOD33 Detection Interrupt Enable"]
+    #[inline(always)]
+    pub fn bod33det(&mut self) -> BOD33DET_W {
+        BOD33DET_W { w: self }
+    }
+    #[doc = "Bit 11 - BOD33 Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn b33srdy(&mut self) -> B33SRDY_W {
+        B33SRDY_W { w: self }
+    }
+    #[doc = "Bit 15 - DPLL Lock Rise Interrupt Enable"]
+    #[inline(always)]
+    pub fn dplllckr(&mut self) -> DPLLLCKR_W {
+        DPLLLCKR_W { w: self }
+    }
+    #[doc = "Bit 16 - DPLL Lock Fall Interrupt Enable"]
+    #[inline(always)]
+    pub fn dplllckf(&mut self) -> DPLLLCKF_W {
+        DPLLLCKF_W { w: self }
+    }
+    #[doc = "Bit 17 - DPLL Lock Timeout Interrupt Enable"]
+    #[inline(always)]
+    pub fn dplllto(&mut self) -> DPLLLTO_W {
+        DPLLLTO_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/intflag.rs
+++ b/pac/atsamd11c14a/src/sysctrl/intflag.rs
@@ -1,0 +1,526 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u32, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u32, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `XOSCRDY`"]
+pub type XOSCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `XOSCRDY`"]
+pub struct XOSCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> XOSCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `XOSC32KRDY`"]
+pub type XOSC32KRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `XOSC32KRDY`"]
+pub struct XOSC32KRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> XOSC32KRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `OSC32KRDY`"]
+pub type OSC32KRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OSC32KRDY`"]
+pub struct OSC32KRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OSC32KRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `OSC8MRDY`"]
+pub type OSC8MRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OSC8MRDY`"]
+pub struct OSC8MRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OSC8MRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFLLRDY`"]
+pub type DFLLRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFLLRDY`"]
+pub struct DFLLRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFLLRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFLLOOB`"]
+pub type DFLLOOB_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFLLOOB`"]
+pub struct DFLLOOB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFLLOOB_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFLLLCKF`"]
+pub type DFLLLCKF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFLLLCKF`"]
+pub struct DFLLLCKF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFLLLCKF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFLLLCKC`"]
+pub type DFLLLCKC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFLLLCKC`"]
+pub struct DFLLLCKC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFLLLCKC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFLLRCS`"]
+pub type DFLLRCS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFLLRCS`"]
+pub struct DFLLRCS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFLLRCS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `BOD33RDY`"]
+pub type BOD33RDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BOD33RDY`"]
+pub struct BOD33RDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BOD33RDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `BOD33DET`"]
+pub type BOD33DET_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BOD33DET`"]
+pub struct BOD33DET_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BOD33DET_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u32) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `B33SRDY`"]
+pub type B33SRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `B33SRDY`"]
+pub struct B33SRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> B33SRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `DPLLLCKR`"]
+pub type DPLLLCKR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DPLLLCKR`"]
+pub struct DPLLLCKR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DPLLLCKR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Reader of field `DPLLLCKF`"]
+pub type DPLLLCKF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DPLLLCKF`"]
+pub struct DPLLLCKF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DPLLLCKF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `DPLLLTO`"]
+pub type DPLLLTO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DPLLLTO`"]
+pub struct DPLLLTO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DPLLLTO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - XOSC Ready"]
+    #[inline(always)]
+    pub fn xoscrdy(&self) -> XOSCRDY_R {
+        XOSCRDY_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - XOSC32K Ready"]
+    #[inline(always)]
+    pub fn xosc32krdy(&self) -> XOSC32KRDY_R {
+        XOSC32KRDY_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - OSC32K Ready"]
+    #[inline(always)]
+    pub fn osc32krdy(&self) -> OSC32KRDY_R {
+        OSC32KRDY_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - OSC8M Ready"]
+    #[inline(always)]
+    pub fn osc8mrdy(&self) -> OSC8MRDY_R {
+        OSC8MRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - DFLL Ready"]
+    #[inline(always)]
+    pub fn dfllrdy(&self) -> DFLLRDY_R {
+        DFLLRDY_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - DFLL Out Of Bounds"]
+    #[inline(always)]
+    pub fn dflloob(&self) -> DFLLOOB_R {
+        DFLLOOB_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - DFLL Lock Fine"]
+    #[inline(always)]
+    pub fn dflllckf(&self) -> DFLLLCKF_R {
+        DFLLLCKF_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - DFLL Lock Coarse"]
+    #[inline(always)]
+    pub fn dflllckc(&self) -> DFLLLCKC_R {
+        DFLLLCKC_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - DFLL Reference Clock Stopped"]
+    #[inline(always)]
+    pub fn dfllrcs(&self) -> DFLLRCS_R {
+        DFLLRCS_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - BOD33 Ready"]
+    #[inline(always)]
+    pub fn bod33rdy(&self) -> BOD33RDY_R {
+        BOD33RDY_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - BOD33 Detection"]
+    #[inline(always)]
+    pub fn bod33det(&self) -> BOD33DET_R {
+        BOD33DET_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - BOD33 Synchronization Ready"]
+    #[inline(always)]
+    pub fn b33srdy(&self) -> B33SRDY_R {
+        B33SRDY_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - DPLL Lock Rise"]
+    #[inline(always)]
+    pub fn dplllckr(&self) -> DPLLLCKR_R {
+        DPLLLCKR_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - DPLL Lock Fall"]
+    #[inline(always)]
+    pub fn dplllckf(&self) -> DPLLLCKF_R {
+        DPLLLCKF_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bit 17 - DPLL Lock Timeout"]
+    #[inline(always)]
+    pub fn dplllto(&self) -> DPLLLTO_R {
+        DPLLLTO_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - XOSC Ready"]
+    #[inline(always)]
+    pub fn xoscrdy(&mut self) -> XOSCRDY_W {
+        XOSCRDY_W { w: self }
+    }
+    #[doc = "Bit 1 - XOSC32K Ready"]
+    #[inline(always)]
+    pub fn xosc32krdy(&mut self) -> XOSC32KRDY_W {
+        XOSC32KRDY_W { w: self }
+    }
+    #[doc = "Bit 2 - OSC32K Ready"]
+    #[inline(always)]
+    pub fn osc32krdy(&mut self) -> OSC32KRDY_W {
+        OSC32KRDY_W { w: self }
+    }
+    #[doc = "Bit 3 - OSC8M Ready"]
+    #[inline(always)]
+    pub fn osc8mrdy(&mut self) -> OSC8MRDY_W {
+        OSC8MRDY_W { w: self }
+    }
+    #[doc = "Bit 4 - DFLL Ready"]
+    #[inline(always)]
+    pub fn dfllrdy(&mut self) -> DFLLRDY_W {
+        DFLLRDY_W { w: self }
+    }
+    #[doc = "Bit 5 - DFLL Out Of Bounds"]
+    #[inline(always)]
+    pub fn dflloob(&mut self) -> DFLLOOB_W {
+        DFLLOOB_W { w: self }
+    }
+    #[doc = "Bit 6 - DFLL Lock Fine"]
+    #[inline(always)]
+    pub fn dflllckf(&mut self) -> DFLLLCKF_W {
+        DFLLLCKF_W { w: self }
+    }
+    #[doc = "Bit 7 - DFLL Lock Coarse"]
+    #[inline(always)]
+    pub fn dflllckc(&mut self) -> DFLLLCKC_W {
+        DFLLLCKC_W { w: self }
+    }
+    #[doc = "Bit 8 - DFLL Reference Clock Stopped"]
+    #[inline(always)]
+    pub fn dfllrcs(&mut self) -> DFLLRCS_W {
+        DFLLRCS_W { w: self }
+    }
+    #[doc = "Bit 9 - BOD33 Ready"]
+    #[inline(always)]
+    pub fn bod33rdy(&mut self) -> BOD33RDY_W {
+        BOD33RDY_W { w: self }
+    }
+    #[doc = "Bit 10 - BOD33 Detection"]
+    #[inline(always)]
+    pub fn bod33det(&mut self) -> BOD33DET_W {
+        BOD33DET_W { w: self }
+    }
+    #[doc = "Bit 11 - BOD33 Synchronization Ready"]
+    #[inline(always)]
+    pub fn b33srdy(&mut self) -> B33SRDY_W {
+        B33SRDY_W { w: self }
+    }
+    #[doc = "Bit 15 - DPLL Lock Rise"]
+    #[inline(always)]
+    pub fn dplllckr(&mut self) -> DPLLLCKR_W {
+        DPLLLCKR_W { w: self }
+    }
+    #[doc = "Bit 16 - DPLL Lock Fall"]
+    #[inline(always)]
+    pub fn dplllckf(&mut self) -> DPLLLCKF_W {
+        DPLLLCKF_W { w: self }
+    }
+    #[doc = "Bit 17 - DPLL Lock Timeout"]
+    #[inline(always)]
+    pub fn dplllto(&mut self) -> DPLLLTO_W {
+        DPLLLTO_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/osc32k.rs
+++ b/pac/atsamd11c14a/src/sysctrl/osc32k.rs
@@ -1,0 +1,268 @@
+#[doc = "Reader of register OSC32K"]
+pub type R = crate::R<u32, super::OSC32K>;
+#[doc = "Writer for register OSC32K"]
+pub type W = crate::W<u32, super::OSC32K>;
+#[doc = "Register OSC32K `reset()`'s with value 0x003f_0080"]
+impl crate::ResetValue for super::OSC32K {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x003f_0080
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `EN32K`"]
+pub type EN32K_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EN32K`"]
+pub struct EN32K_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EN32K_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `EN1K`"]
+pub type EN1K_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EN1K`"]
+pub struct EN1K_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EN1K_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `ONDEMAND`"]
+pub type ONDEMAND_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ONDEMAND`"]
+pub struct ONDEMAND_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ONDEMAND_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `STARTUP`"]
+pub type STARTUP_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `STARTUP`"]
+pub struct STARTUP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STARTUP_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 8)) | (((value as u32) & 0x07) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `WRTLOCK`"]
+pub type WRTLOCK_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WRTLOCK`"]
+pub struct WRTLOCK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WRTLOCK_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u32) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `CALIB`"]
+pub type CALIB_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `CALIB`"]
+pub struct CALIB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CALIB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x7f << 16)) | (((value as u32) & 0x7f) << 16);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - Oscillator Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - 32kHz Output Enable"]
+    #[inline(always)]
+    pub fn en32k(&self) -> EN32K_R {
+        EN32K_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - 1kHz Output Enable"]
+    #[inline(always)]
+    pub fn en1k(&self) -> EN1K_R {
+        EN1K_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - On Demand Control"]
+    #[inline(always)]
+    pub fn ondemand(&self) -> ONDEMAND_R {
+        ONDEMAND_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bits 8:10 - Oscillator Start-Up Time"]
+    #[inline(always)]
+    pub fn startup(&self) -> STARTUP_R {
+        STARTUP_R::new(((self.bits >> 8) & 0x07) as u8)
+    }
+    #[doc = "Bit 12 - Write Lock"]
+    #[inline(always)]
+    pub fn wrtlock(&self) -> WRTLOCK_R {
+        WRTLOCK_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bits 16:22 - Oscillator Calibration"]
+    #[inline(always)]
+    pub fn calib(&self) -> CALIB_R {
+        CALIB_R::new(((self.bits >> 16) & 0x7f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 1 - Oscillator Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bit 2 - 32kHz Output Enable"]
+    #[inline(always)]
+    pub fn en32k(&mut self) -> EN32K_W {
+        EN32K_W { w: self }
+    }
+    #[doc = "Bit 3 - 1kHz Output Enable"]
+    #[inline(always)]
+    pub fn en1k(&mut self) -> EN1K_W {
+        EN1K_W { w: self }
+    }
+    #[doc = "Bit 6 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bit 7 - On Demand Control"]
+    #[inline(always)]
+    pub fn ondemand(&mut self) -> ONDEMAND_W {
+        ONDEMAND_W { w: self }
+    }
+    #[doc = "Bits 8:10 - Oscillator Start-Up Time"]
+    #[inline(always)]
+    pub fn startup(&mut self) -> STARTUP_W {
+        STARTUP_W { w: self }
+    }
+    #[doc = "Bit 12 - Write Lock"]
+    #[inline(always)]
+    pub fn wrtlock(&mut self) -> WRTLOCK_W {
+        WRTLOCK_W { w: self }
+    }
+    #[doc = "Bits 16:22 - Oscillator Calibration"]
+    #[inline(always)]
+    pub fn calib(&mut self) -> CALIB_W {
+        CALIB_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/osc8m.rs
+++ b/pac/atsamd11c14a/src/sysctrl/osc8m.rs
@@ -1,0 +1,356 @@
+#[doc = "Reader of register OSC8M"]
+pub type R = crate::R<u32, super::OSC8M>;
+#[doc = "Writer for register OSC8M"]
+pub type W = crate::W<u32, super::OSC8M>;
+#[doc = "Register OSC8M `reset()`'s with value 0x8707_0382"]
+impl crate::ResetValue for super::OSC8M {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x8707_0382
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `ONDEMAND`"]
+pub type ONDEMAND_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ONDEMAND`"]
+pub struct ONDEMAND_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ONDEMAND_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Oscillator Prescaler\n\nValue on reset: 3"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PRESC_A {
+    #[doc = "0: 1"]
+    _0,
+    #[doc = "1: 2"]
+    _1,
+    #[doc = "2: 4"]
+    _2,
+    #[doc = "3: 8"]
+    _3,
+}
+impl From<PRESC_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PRESC_A) -> Self {
+        match variant {
+            PRESC_A::_0 => 0,
+            PRESC_A::_1 => 1,
+            PRESC_A::_2 => 2,
+            PRESC_A::_3 => 3,
+        }
+    }
+}
+#[doc = "Reader of field `PRESC`"]
+pub type PRESC_R = crate::R<u8, PRESC_A>;
+impl PRESC_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> PRESC_A {
+        match self.bits {
+            0 => PRESC_A::_0,
+            1 => PRESC_A::_1,
+            2 => PRESC_A::_2,
+            3 => PRESC_A::_3,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `_0`"]
+    #[inline(always)]
+    pub fn is_0(&self) -> bool {
+        *self == PRESC_A::_0
+    }
+    #[doc = "Checks if the value of the field is `_1`"]
+    #[inline(always)]
+    pub fn is_1(&self) -> bool {
+        *self == PRESC_A::_1
+    }
+    #[doc = "Checks if the value of the field is `_2`"]
+    #[inline(always)]
+    pub fn is_2(&self) -> bool {
+        *self == PRESC_A::_2
+    }
+    #[doc = "Checks if the value of the field is `_3`"]
+    #[inline(always)]
+    pub fn is_3(&self) -> bool {
+        *self == PRESC_A::_3
+    }
+}
+#[doc = "Write proxy for field `PRESC`"]
+pub struct PRESC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PRESC_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PRESC_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "1"]
+    #[inline(always)]
+    pub fn _0(self) -> &'a mut W {
+        self.variant(PRESC_A::_0)
+    }
+    #[doc = "2"]
+    #[inline(always)]
+    pub fn _1(self) -> &'a mut W {
+        self.variant(PRESC_A::_1)
+    }
+    #[doc = "4"]
+    #[inline(always)]
+    pub fn _2(self) -> &'a mut W {
+        self.variant(PRESC_A::_2)
+    }
+    #[doc = "8"]
+    #[inline(always)]
+    pub fn _3(self) -> &'a mut W {
+        self.variant(PRESC_A::_3)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 8)) | (((value as u32) & 0x03) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `CALIB`"]
+pub type CALIB_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `CALIB`"]
+pub struct CALIB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CALIB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0fff << 16)) | (((value as u32) & 0x0fff) << 16);
+        self.w
+    }
+}
+#[doc = "Oscillator Frequency Range\n\nValue on reset: 2"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FRANGE_A {
+    #[doc = "0: 4 to 6MHz"]
+    _0,
+    #[doc = "1: 6 to 8MHz"]
+    _1,
+    #[doc = "2: 8 to 11MHz"]
+    _2,
+    #[doc = "3: 11 to 15MHz"]
+    _3,
+}
+impl From<FRANGE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: FRANGE_A) -> Self {
+        match variant {
+            FRANGE_A::_0 => 0,
+            FRANGE_A::_1 => 1,
+            FRANGE_A::_2 => 2,
+            FRANGE_A::_3 => 3,
+        }
+    }
+}
+#[doc = "Reader of field `FRANGE`"]
+pub type FRANGE_R = crate::R<u8, FRANGE_A>;
+impl FRANGE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> FRANGE_A {
+        match self.bits {
+            0 => FRANGE_A::_0,
+            1 => FRANGE_A::_1,
+            2 => FRANGE_A::_2,
+            3 => FRANGE_A::_3,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `_0`"]
+    #[inline(always)]
+    pub fn is_0(&self) -> bool {
+        *self == FRANGE_A::_0
+    }
+    #[doc = "Checks if the value of the field is `_1`"]
+    #[inline(always)]
+    pub fn is_1(&self) -> bool {
+        *self == FRANGE_A::_1
+    }
+    #[doc = "Checks if the value of the field is `_2`"]
+    #[inline(always)]
+    pub fn is_2(&self) -> bool {
+        *self == FRANGE_A::_2
+    }
+    #[doc = "Checks if the value of the field is `_3`"]
+    #[inline(always)]
+    pub fn is_3(&self) -> bool {
+        *self == FRANGE_A::_3
+    }
+}
+#[doc = "Write proxy for field `FRANGE`"]
+pub struct FRANGE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FRANGE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: FRANGE_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "4 to 6MHz"]
+    #[inline(always)]
+    pub fn _0(self) -> &'a mut W {
+        self.variant(FRANGE_A::_0)
+    }
+    #[doc = "6 to 8MHz"]
+    #[inline(always)]
+    pub fn _1(self) -> &'a mut W {
+        self.variant(FRANGE_A::_1)
+    }
+    #[doc = "8 to 11MHz"]
+    #[inline(always)]
+    pub fn _2(self) -> &'a mut W {
+        self.variant(FRANGE_A::_2)
+    }
+    #[doc = "11 to 15MHz"]
+    #[inline(always)]
+    pub fn _3(self) -> &'a mut W {
+        self.variant(FRANGE_A::_3)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 30)) | (((value as u32) & 0x03) << 30);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - Oscillator Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - On Demand Control"]
+    #[inline(always)]
+    pub fn ondemand(&self) -> ONDEMAND_R {
+        ONDEMAND_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bits 8:9 - Oscillator Prescaler"]
+    #[inline(always)]
+    pub fn presc(&self) -> PRESC_R {
+        PRESC_R::new(((self.bits >> 8) & 0x03) as u8)
+    }
+    #[doc = "Bits 16:27 - Oscillator Calibration"]
+    #[inline(always)]
+    pub fn calib(&self) -> CALIB_R {
+        CALIB_R::new(((self.bits >> 16) & 0x0fff) as u16)
+    }
+    #[doc = "Bits 30:31 - Oscillator Frequency Range"]
+    #[inline(always)]
+    pub fn frange(&self) -> FRANGE_R {
+        FRANGE_R::new(((self.bits >> 30) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 1 - Oscillator Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bit 6 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bit 7 - On Demand Control"]
+    #[inline(always)]
+    pub fn ondemand(&mut self) -> ONDEMAND_W {
+        ONDEMAND_W { w: self }
+    }
+    #[doc = "Bits 8:9 - Oscillator Prescaler"]
+    #[inline(always)]
+    pub fn presc(&mut self) -> PRESC_W {
+        PRESC_W { w: self }
+    }
+    #[doc = "Bits 16:27 - Oscillator Calibration"]
+    #[inline(always)]
+    pub fn calib(&mut self) -> CALIB_W {
+        CALIB_W { w: self }
+    }
+    #[doc = "Bits 30:31 - Oscillator Frequency Range"]
+    #[inline(always)]
+    pub fn frange(&mut self) -> FRANGE_W {
+        FRANGE_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/osculp32k.rs
+++ b/pac/atsamd11c14a/src/sysctrl/osculp32k.rs
@@ -1,0 +1,74 @@
+#[doc = "Reader of register OSCULP32K"]
+pub type R = crate::R<u8, super::OSCULP32K>;
+#[doc = "Writer for register OSCULP32K"]
+pub type W = crate::W<u8, super::OSCULP32K>;
+#[doc = "Register OSCULP32K `reset()`'s with value 0x1f"]
+impl crate::ResetValue for super::OSCULP32K {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x1f
+    }
+}
+#[doc = "Reader of field `CALIB`"]
+pub type CALIB_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `CALIB`"]
+pub struct CALIB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CALIB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x1f) | ((value as u8) & 0x1f);
+        self.w
+    }
+}
+#[doc = "Reader of field `WRTLOCK`"]
+pub type WRTLOCK_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WRTLOCK`"]
+pub struct WRTLOCK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WRTLOCK_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:4 - Oscillator Calibration"]
+    #[inline(always)]
+    pub fn calib(&self) -> CALIB_R {
+        CALIB_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bit 7 - Write Lock"]
+    #[inline(always)]
+    pub fn wrtlock(&self) -> WRTLOCK_R {
+        WRTLOCK_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - Oscillator Calibration"]
+    #[inline(always)]
+    pub fn calib(&mut self) -> CALIB_W {
+        CALIB_W { w: self }
+    }
+    #[doc = "Bit 7 - Write Lock"]
+    #[inline(always)]
+    pub fn wrtlock(&mut self) -> WRTLOCK_W {
+        WRTLOCK_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/pclksr.rs
+++ b/pac/atsamd11c14a/src/sysctrl/pclksr.rs
@@ -1,0 +1,109 @@
+#[doc = "Reader of register PCLKSR"]
+pub type R = crate::R<u32, super::PCLKSR>;
+#[doc = "Reader of field `XOSCRDY`"]
+pub type XOSCRDY_R = crate::R<bool, bool>;
+#[doc = "Reader of field `XOSC32KRDY`"]
+pub type XOSC32KRDY_R = crate::R<bool, bool>;
+#[doc = "Reader of field `OSC32KRDY`"]
+pub type OSC32KRDY_R = crate::R<bool, bool>;
+#[doc = "Reader of field `OSC8MRDY`"]
+pub type OSC8MRDY_R = crate::R<bool, bool>;
+#[doc = "Reader of field `DFLLRDY`"]
+pub type DFLLRDY_R = crate::R<bool, bool>;
+#[doc = "Reader of field `DFLLOOB`"]
+pub type DFLLOOB_R = crate::R<bool, bool>;
+#[doc = "Reader of field `DFLLLCKF`"]
+pub type DFLLLCKF_R = crate::R<bool, bool>;
+#[doc = "Reader of field `DFLLLCKC`"]
+pub type DFLLLCKC_R = crate::R<bool, bool>;
+#[doc = "Reader of field `DFLLRCS`"]
+pub type DFLLRCS_R = crate::R<bool, bool>;
+#[doc = "Reader of field `BOD33RDY`"]
+pub type BOD33RDY_R = crate::R<bool, bool>;
+#[doc = "Reader of field `BOD33DET`"]
+pub type BOD33DET_R = crate::R<bool, bool>;
+#[doc = "Reader of field `B33SRDY`"]
+pub type B33SRDY_R = crate::R<bool, bool>;
+#[doc = "Reader of field `DPLLLCKR`"]
+pub type DPLLLCKR_R = crate::R<bool, bool>;
+#[doc = "Reader of field `DPLLLCKF`"]
+pub type DPLLLCKF_R = crate::R<bool, bool>;
+#[doc = "Reader of field `DPLLLTO`"]
+pub type DPLLLTO_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - XOSC Ready"]
+    #[inline(always)]
+    pub fn xoscrdy(&self) -> XOSCRDY_R {
+        XOSCRDY_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - XOSC32K Ready"]
+    #[inline(always)]
+    pub fn xosc32krdy(&self) -> XOSC32KRDY_R {
+        XOSC32KRDY_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - OSC32K Ready"]
+    #[inline(always)]
+    pub fn osc32krdy(&self) -> OSC32KRDY_R {
+        OSC32KRDY_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - OSC8M Ready"]
+    #[inline(always)]
+    pub fn osc8mrdy(&self) -> OSC8MRDY_R {
+        OSC8MRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - DFLL Ready"]
+    #[inline(always)]
+    pub fn dfllrdy(&self) -> DFLLRDY_R {
+        DFLLRDY_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - DFLL Out Of Bounds"]
+    #[inline(always)]
+    pub fn dflloob(&self) -> DFLLOOB_R {
+        DFLLOOB_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - DFLL Lock Fine"]
+    #[inline(always)]
+    pub fn dflllckf(&self) -> DFLLLCKF_R {
+        DFLLLCKF_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - DFLL Lock Coarse"]
+    #[inline(always)]
+    pub fn dflllckc(&self) -> DFLLLCKC_R {
+        DFLLLCKC_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - DFLL Reference Clock Stopped"]
+    #[inline(always)]
+    pub fn dfllrcs(&self) -> DFLLRCS_R {
+        DFLLRCS_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - BOD33 Ready"]
+    #[inline(always)]
+    pub fn bod33rdy(&self) -> BOD33RDY_R {
+        BOD33RDY_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - BOD33 Detection"]
+    #[inline(always)]
+    pub fn bod33det(&self) -> BOD33DET_R {
+        BOD33DET_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - BOD33 Synchronization Ready"]
+    #[inline(always)]
+    pub fn b33srdy(&self) -> B33SRDY_R {
+        B33SRDY_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - DPLL Lock Rise"]
+    #[inline(always)]
+    pub fn dplllckr(&self) -> DPLLLCKR_R {
+        DPLLLCKR_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - DPLL Lock Fall"]
+    #[inline(always)]
+    pub fn dplllckf(&self) -> DPLLLCKF_R {
+        DPLLLCKF_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bit 17 - DPLL Lock Timeout"]
+    #[inline(always)]
+    pub fn dplllto(&self) -> DPLLLTO_R {
+        DPLLLTO_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/vref.rs
+++ b/pac/atsamd11c14a/src/sysctrl/vref.rs
@@ -1,0 +1,108 @@
+#[doc = "Reader of register VREF"]
+pub type R = crate::R<u32, super::VREF>;
+#[doc = "Writer for register VREF"]
+pub type W = crate::W<u32, super::VREF>;
+#[doc = "Register VREF `reset()`'s with value 0"]
+impl crate::ResetValue for super::VREF {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `TSEN`"]
+pub type TSEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TSEN`"]
+pub struct TSEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TSEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `BGOUTEN`"]
+pub type BGOUTEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BGOUTEN`"]
+pub struct BGOUTEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BGOUTEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `CALIB`"]
+pub type CALIB_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `CALIB`"]
+pub struct CALIB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CALIB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07ff << 16)) | (((value as u32) & 0x07ff) << 16);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - Temperature Sensor Enable"]
+    #[inline(always)]
+    pub fn tsen(&self) -> TSEN_R {
+        TSEN_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Bandgap Output Enable"]
+    #[inline(always)]
+    pub fn bgouten(&self) -> BGOUTEN_R {
+        BGOUTEN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bits 16:26 - Bandgap Voltage Generator Calibration"]
+    #[inline(always)]
+    pub fn calib(&self) -> CALIB_R {
+        CALIB_R::new(((self.bits >> 16) & 0x07ff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bit 1 - Temperature Sensor Enable"]
+    #[inline(always)]
+    pub fn tsen(&mut self) -> TSEN_W {
+        TSEN_W { w: self }
+    }
+    #[doc = "Bit 2 - Bandgap Output Enable"]
+    #[inline(always)]
+    pub fn bgouten(&mut self) -> BGOUTEN_W {
+        BGOUTEN_W { w: self }
+    }
+    #[doc = "Bits 16:26 - Bandgap Voltage Generator Calibration"]
+    #[inline(always)]
+    pub fn calib(&mut self) -> CALIB_W {
+        CALIB_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/xosc.rs
+++ b/pac/atsamd11c14a/src/sysctrl/xosc.rs
@@ -1,0 +1,330 @@
+#[doc = "Reader of register XOSC"]
+pub type R = crate::R<u16, super::XOSC>;
+#[doc = "Writer for register XOSC"]
+pub type W = crate::W<u16, super::XOSC>;
+#[doc = "Register XOSC `reset()`'s with value 0x80"]
+impl crate::ResetValue for super::XOSC {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x80
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `XTALEN`"]
+pub type XTALEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `XTALEN`"]
+pub struct XTALEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> XTALEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `ONDEMAND`"]
+pub type ONDEMAND_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ONDEMAND`"]
+pub struct ONDEMAND_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ONDEMAND_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Oscillator Gain\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum GAIN_A {
+    #[doc = "0: 2MHz"]
+    _0,
+    #[doc = "1: 4MHz"]
+    _1,
+    #[doc = "2: 8MHz"]
+    _2,
+    #[doc = "3: 16MHz"]
+    _3,
+    #[doc = "4: 30MHz"]
+    _4,
+}
+impl From<GAIN_A> for u8 {
+    #[inline(always)]
+    fn from(variant: GAIN_A) -> Self {
+        match variant {
+            GAIN_A::_0 => 0,
+            GAIN_A::_1 => 1,
+            GAIN_A::_2 => 2,
+            GAIN_A::_3 => 3,
+            GAIN_A::_4 => 4,
+        }
+    }
+}
+#[doc = "Reader of field `GAIN`"]
+pub type GAIN_R = crate::R<u8, GAIN_A>;
+impl GAIN_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, GAIN_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(GAIN_A::_0),
+            1 => Val(GAIN_A::_1),
+            2 => Val(GAIN_A::_2),
+            3 => Val(GAIN_A::_3),
+            4 => Val(GAIN_A::_4),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `_0`"]
+    #[inline(always)]
+    pub fn is_0(&self) -> bool {
+        *self == GAIN_A::_0
+    }
+    #[doc = "Checks if the value of the field is `_1`"]
+    #[inline(always)]
+    pub fn is_1(&self) -> bool {
+        *self == GAIN_A::_1
+    }
+    #[doc = "Checks if the value of the field is `_2`"]
+    #[inline(always)]
+    pub fn is_2(&self) -> bool {
+        *self == GAIN_A::_2
+    }
+    #[doc = "Checks if the value of the field is `_3`"]
+    #[inline(always)]
+    pub fn is_3(&self) -> bool {
+        *self == GAIN_A::_3
+    }
+    #[doc = "Checks if the value of the field is `_4`"]
+    #[inline(always)]
+    pub fn is_4(&self) -> bool {
+        *self == GAIN_A::_4
+    }
+}
+#[doc = "Write proxy for field `GAIN`"]
+pub struct GAIN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> GAIN_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: GAIN_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "2MHz"]
+    #[inline(always)]
+    pub fn _0(self) -> &'a mut W {
+        self.variant(GAIN_A::_0)
+    }
+    #[doc = "4MHz"]
+    #[inline(always)]
+    pub fn _1(self) -> &'a mut W {
+        self.variant(GAIN_A::_1)
+    }
+    #[doc = "8MHz"]
+    #[inline(always)]
+    pub fn _2(self) -> &'a mut W {
+        self.variant(GAIN_A::_2)
+    }
+    #[doc = "16MHz"]
+    #[inline(always)]
+    pub fn _3(self) -> &'a mut W {
+        self.variant(GAIN_A::_3)
+    }
+    #[doc = "30MHz"]
+    #[inline(always)]
+    pub fn _4(self) -> &'a mut W {
+        self.variant(GAIN_A::_4)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 8)) | (((value as u16) & 0x07) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `AMPGC`"]
+pub type AMPGC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `AMPGC`"]
+pub struct AMPGC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> AMPGC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u16) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `STARTUP`"]
+pub type STARTUP_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `STARTUP`"]
+pub struct STARTUP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STARTUP_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 12)) | (((value as u16) & 0x0f) << 12);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - Oscillator Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Crystal Oscillator Enable"]
+    #[inline(always)]
+    pub fn xtalen(&self) -> XTALEN_R {
+        XTALEN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - On Demand Control"]
+    #[inline(always)]
+    pub fn ondemand(&self) -> ONDEMAND_R {
+        ONDEMAND_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bits 8:10 - Oscillator Gain"]
+    #[inline(always)]
+    pub fn gain(&self) -> GAIN_R {
+        GAIN_R::new(((self.bits >> 8) & 0x07) as u8)
+    }
+    #[doc = "Bit 11 - Automatic Amplitude Gain Control"]
+    #[inline(always)]
+    pub fn ampgc(&self) -> AMPGC_R {
+        AMPGC_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bits 12:15 - Start-Up Time"]
+    #[inline(always)]
+    pub fn startup(&self) -> STARTUP_R {
+        STARTUP_R::new(((self.bits >> 12) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 1 - Oscillator Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bit 2 - Crystal Oscillator Enable"]
+    #[inline(always)]
+    pub fn xtalen(&mut self) -> XTALEN_W {
+        XTALEN_W { w: self }
+    }
+    #[doc = "Bit 6 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bit 7 - On Demand Control"]
+    #[inline(always)]
+    pub fn ondemand(&mut self) -> ONDEMAND_W {
+        ONDEMAND_W { w: self }
+    }
+    #[doc = "Bits 8:10 - Oscillator Gain"]
+    #[inline(always)]
+    pub fn gain(&mut self) -> GAIN_W {
+        GAIN_W { w: self }
+    }
+    #[doc = "Bit 11 - Automatic Amplitude Gain Control"]
+    #[inline(always)]
+    pub fn ampgc(&mut self) -> AMPGC_W {
+        AMPGC_W { w: self }
+    }
+    #[doc = "Bits 12:15 - Start-Up Time"]
+    #[inline(always)]
+    pub fn startup(&mut self) -> STARTUP_W {
+        STARTUP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/sysctrl/xosc32k.rs
+++ b/pac/atsamd11c14a/src/sysctrl/xosc32k.rs
@@ -1,0 +1,312 @@
+#[doc = "Reader of register XOSC32K"]
+pub type R = crate::R<u16, super::XOSC32K>;
+#[doc = "Writer for register XOSC32K"]
+pub type W = crate::W<u16, super::XOSC32K>;
+#[doc = "Register XOSC32K `reset()`'s with value 0x80"]
+impl crate::ResetValue for super::XOSC32K {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x80
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `XTALEN`"]
+pub type XTALEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `XTALEN`"]
+pub struct XTALEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> XTALEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `EN32K`"]
+pub type EN32K_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EN32K`"]
+pub struct EN32K_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EN32K_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u16) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `EN1K`"]
+pub type EN1K_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EN1K`"]
+pub struct EN1K_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EN1K_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `AAMPEN`"]
+pub type AAMPEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `AAMPEN`"]
+pub struct AAMPEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> AAMPEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `ONDEMAND`"]
+pub type ONDEMAND_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ONDEMAND`"]
+pub struct ONDEMAND_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ONDEMAND_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `STARTUP`"]
+pub type STARTUP_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `STARTUP`"]
+pub struct STARTUP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STARTUP_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 8)) | (((value as u16) & 0x07) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `WRTLOCK`"]
+pub type WRTLOCK_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WRTLOCK`"]
+pub struct WRTLOCK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WRTLOCK_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u16) & 0x01) << 12);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - Oscillator Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Crystal Oscillator Enable"]
+    #[inline(always)]
+    pub fn xtalen(&self) -> XTALEN_R {
+        XTALEN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - 32kHz Output Enable"]
+    #[inline(always)]
+    pub fn en32k(&self) -> EN32K_R {
+        EN32K_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - 1kHz Output Enable"]
+    #[inline(always)]
+    pub fn en1k(&self) -> EN1K_R {
+        EN1K_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Automatic Amplitude Control Enable"]
+    #[inline(always)]
+    pub fn aampen(&self) -> AAMPEN_R {
+        AAMPEN_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - On Demand Control"]
+    #[inline(always)]
+    pub fn ondemand(&self) -> ONDEMAND_R {
+        ONDEMAND_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bits 8:10 - Oscillator Start-Up Time"]
+    #[inline(always)]
+    pub fn startup(&self) -> STARTUP_R {
+        STARTUP_R::new(((self.bits >> 8) & 0x07) as u8)
+    }
+    #[doc = "Bit 12 - Write Lock"]
+    #[inline(always)]
+    pub fn wrtlock(&self) -> WRTLOCK_R {
+        WRTLOCK_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 1 - Oscillator Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bit 2 - Crystal Oscillator Enable"]
+    #[inline(always)]
+    pub fn xtalen(&mut self) -> XTALEN_W {
+        XTALEN_W { w: self }
+    }
+    #[doc = "Bit 3 - 32kHz Output Enable"]
+    #[inline(always)]
+    pub fn en32k(&mut self) -> EN32K_W {
+        EN32K_W { w: self }
+    }
+    #[doc = "Bit 4 - 1kHz Output Enable"]
+    #[inline(always)]
+    pub fn en1k(&mut self) -> EN1K_W {
+        EN1K_W { w: self }
+    }
+    #[doc = "Bit 5 - Automatic Amplitude Control Enable"]
+    #[inline(always)]
+    pub fn aampen(&mut self) -> AAMPEN_W {
+        AAMPEN_W { w: self }
+    }
+    #[doc = "Bit 6 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bit 7 - On Demand Control"]
+    #[inline(always)]
+    pub fn ondemand(&mut self) -> ONDEMAND_W {
+        ONDEMAND_W { w: self }
+    }
+    #[doc = "Bits 8:10 - Oscillator Start-Up Time"]
+    #[inline(always)]
+    pub fn startup(&mut self) -> STARTUP_W {
+        STARTUP_W { w: self }
+    }
+    #[doc = "Bit 12 - Write Lock"]
+    #[inline(always)]
+    pub fn wrtlock(&mut self) -> WRTLOCK_W {
+        WRTLOCK_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1.rs
+++ b/pac/atsamd11c14a/src/tc1.rs
@@ -1,0 +1,148 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    _reserved_0_count8: [u8; 32usize],
+}
+impl RegisterBlock {
+    #[doc = "0x00 - 32-bit Counter Mode"]
+    #[inline(always)]
+    pub fn count32(&self) -> &COUNT32 {
+        unsafe { &*(((self as *const Self) as *const u8).add(0usize) as *const COUNT32) }
+    }
+    #[doc = "0x00 - 32-bit Counter Mode"]
+    #[inline(always)]
+    pub fn count32_mut(&self) -> &mut COUNT32 {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(0usize) as *mut COUNT32) }
+    }
+    #[doc = "0x00 - 16-bit Counter Mode"]
+    #[inline(always)]
+    pub fn count16(&self) -> &COUNT16 {
+        unsafe { &*(((self as *const Self) as *const u8).add(0usize) as *const COUNT16) }
+    }
+    #[doc = "0x00 - 16-bit Counter Mode"]
+    #[inline(always)]
+    pub fn count16_mut(&self) -> &mut COUNT16 {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(0usize) as *mut COUNT16) }
+    }
+    #[doc = "0x00 - 8-bit Counter Mode"]
+    #[inline(always)]
+    pub fn count8(&self) -> &COUNT8 {
+        unsafe { &*(((self as *const Self) as *const u8).add(0usize) as *const COUNT8) }
+    }
+    #[doc = "0x00 - 8-bit Counter Mode"]
+    #[inline(always)]
+    pub fn count8_mut(&self) -> &mut COUNT8 {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(0usize) as *mut COUNT8) }
+    }
+}
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct COUNT8 {
+    #[doc = "0x00 - Control A"]
+    pub ctrla: self::count8::CTRLA,
+    #[doc = "0x02 - Read Request"]
+    pub readreq: self::count8::READREQ,
+    #[doc = "0x04 - Control B Clear"]
+    pub ctrlbclr: self::count8::CTRLBCLR,
+    #[doc = "0x05 - Control B Set"]
+    pub ctrlbset: self::count8::CTRLBSET,
+    #[doc = "0x06 - Control C"]
+    pub ctrlc: self::count8::CTRLC,
+    _reserved5: [u8; 1usize],
+    #[doc = "0x08 - Debug Control"]
+    pub dbgctrl: self::count8::DBGCTRL,
+    _reserved6: [u8; 1usize],
+    #[doc = "0x0a - Event Control"]
+    pub evctrl: self::count8::EVCTRL,
+    #[doc = "0x0c - Interrupt Enable Clear"]
+    pub intenclr: self::count8::INTENCLR,
+    #[doc = "0x0d - Interrupt Enable Set"]
+    pub intenset: self::count8::INTENSET,
+    #[doc = "0x0e - Interrupt Flag Status and Clear"]
+    pub intflag: self::count8::INTFLAG,
+    #[doc = "0x0f - Status"]
+    pub status: self::count8::STATUS,
+    #[doc = "0x10 - COUNT8 Counter Value"]
+    pub count: self::count8::COUNT,
+    _reserved12: [u8; 3usize],
+    #[doc = "0x14 - COUNT8 Period Value"]
+    pub per: self::count8::PER,
+    _reserved13: [u8; 3usize],
+    #[doc = "0x18 - COUNT8 Compare/Capture"]
+    pub cc: [self::count8::CC; 2],
+}
+#[doc = r"Register block"]
+#[doc = "8-bit Counter Mode"]
+pub mod count8;
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct COUNT16 {
+    #[doc = "0x00 - Control A"]
+    pub ctrla: self::count16::CTRLA,
+    #[doc = "0x02 - Read Request"]
+    pub readreq: self::count16::READREQ,
+    #[doc = "0x04 - Control B Clear"]
+    pub ctrlbclr: self::count16::CTRLBCLR,
+    #[doc = "0x05 - Control B Set"]
+    pub ctrlbset: self::count16::CTRLBSET,
+    #[doc = "0x06 - Control C"]
+    pub ctrlc: self::count16::CTRLC,
+    _reserved5: [u8; 1usize],
+    #[doc = "0x08 - Debug Control"]
+    pub dbgctrl: self::count16::DBGCTRL,
+    _reserved6: [u8; 1usize],
+    #[doc = "0x0a - Event Control"]
+    pub evctrl: self::count16::EVCTRL,
+    #[doc = "0x0c - Interrupt Enable Clear"]
+    pub intenclr: self::count16::INTENCLR,
+    #[doc = "0x0d - Interrupt Enable Set"]
+    pub intenset: self::count16::INTENSET,
+    #[doc = "0x0e - Interrupt Flag Status and Clear"]
+    pub intflag: self::count16::INTFLAG,
+    #[doc = "0x0f - Status"]
+    pub status: self::count16::STATUS,
+    #[doc = "0x10 - COUNT16 Counter Value"]
+    pub count: self::count16::COUNT,
+    _reserved12: [u8; 6usize],
+    #[doc = "0x18 - COUNT16 Compare/Capture"]
+    pub cc: [self::count16::CC; 2],
+}
+#[doc = r"Register block"]
+#[doc = "16-bit Counter Mode"]
+pub mod count16;
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct COUNT32 {
+    #[doc = "0x00 - Control A"]
+    pub ctrla: self::count32::CTRLA,
+    #[doc = "0x02 - Read Request"]
+    pub readreq: self::count32::READREQ,
+    #[doc = "0x04 - Control B Clear"]
+    pub ctrlbclr: self::count32::CTRLBCLR,
+    #[doc = "0x05 - Control B Set"]
+    pub ctrlbset: self::count32::CTRLBSET,
+    #[doc = "0x06 - Control C"]
+    pub ctrlc: self::count32::CTRLC,
+    _reserved5: [u8; 1usize],
+    #[doc = "0x08 - Debug Control"]
+    pub dbgctrl: self::count32::DBGCTRL,
+    _reserved6: [u8; 1usize],
+    #[doc = "0x0a - Event Control"]
+    pub evctrl: self::count32::EVCTRL,
+    #[doc = "0x0c - Interrupt Enable Clear"]
+    pub intenclr: self::count32::INTENCLR,
+    #[doc = "0x0d - Interrupt Enable Set"]
+    pub intenset: self::count32::INTENSET,
+    #[doc = "0x0e - Interrupt Flag Status and Clear"]
+    pub intflag: self::count32::INTFLAG,
+    #[doc = "0x0f - Status"]
+    pub status: self::count32::STATUS,
+    #[doc = "0x10 - COUNT32 Counter Value"]
+    pub count: self::count32::COUNT,
+    _reserved12: [u8; 4usize],
+    #[doc = "0x18 - COUNT32 Compare/Capture"]
+    pub cc: [self::count32::CC; 2],
+}
+#[doc = r"Register block"]
+#[doc = "32-bit Counter Mode"]
+pub mod count32;

--- a/pac/atsamd11c14a/src/tc1/count16.rs
+++ b/pac/atsamd11c14a/src/tc1/count16.rs
@@ -1,0 +1,141 @@
+#[doc = "Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrla](ctrla) module"]
+pub type CTRLA = crate::Reg<u16, _CTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLA;
+#[doc = "`read()` method returns [ctrla::R](ctrla::R) reader structure"]
+impl crate::Readable for CTRLA {}
+#[doc = "`write(|w| ..)` method takes [ctrla::W](ctrla::W) writer structure"]
+impl crate::Writable for CTRLA {}
+#[doc = "Control A"]
+pub mod ctrla;
+#[doc = "Read Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [readreq](readreq) module"]
+pub type READREQ = crate::Reg<u16, _READREQ>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _READREQ;
+#[doc = "`read()` method returns [readreq::R](readreq::R) reader structure"]
+impl crate::Readable for READREQ {}
+#[doc = "`write(|w| ..)` method takes [readreq::W](readreq::W) writer structure"]
+impl crate::Writable for READREQ {}
+#[doc = "Read Request"]
+pub mod readreq;
+#[doc = "Control B Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlbclr](ctrlbclr) module"]
+pub type CTRLBCLR = crate::Reg<u8, _CTRLBCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLBCLR;
+#[doc = "`read()` method returns [ctrlbclr::R](ctrlbclr::R) reader structure"]
+impl crate::Readable for CTRLBCLR {}
+#[doc = "`write(|w| ..)` method takes [ctrlbclr::W](ctrlbclr::W) writer structure"]
+impl crate::Writable for CTRLBCLR {}
+#[doc = "Control B Clear"]
+pub mod ctrlbclr;
+#[doc = "Control B Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlbset](ctrlbset) module"]
+pub type CTRLBSET = crate::Reg<u8, _CTRLBSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLBSET;
+#[doc = "`read()` method returns [ctrlbset::R](ctrlbset::R) reader structure"]
+impl crate::Readable for CTRLBSET {}
+#[doc = "`write(|w| ..)` method takes [ctrlbset::W](ctrlbset::W) writer structure"]
+impl crate::Writable for CTRLBSET {}
+#[doc = "Control B Set"]
+pub mod ctrlbset;
+#[doc = "Control C\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlc](ctrlc) module"]
+pub type CTRLC = crate::Reg<u8, _CTRLC>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLC;
+#[doc = "`read()` method returns [ctrlc::R](ctrlc::R) reader structure"]
+impl crate::Readable for CTRLC {}
+#[doc = "`write(|w| ..)` method takes [ctrlc::W](ctrlc::W) writer structure"]
+impl crate::Writable for CTRLC {}
+#[doc = "Control C"]
+pub mod ctrlc;
+#[doc = "Debug Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dbgctrl](dbgctrl) module"]
+pub type DBGCTRL = crate::Reg<u8, _DBGCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DBGCTRL;
+#[doc = "`read()` method returns [dbgctrl::R](dbgctrl::R) reader structure"]
+impl crate::Readable for DBGCTRL {}
+#[doc = "`write(|w| ..)` method takes [dbgctrl::W](dbgctrl::W) writer structure"]
+impl crate::Writable for DBGCTRL {}
+#[doc = "Debug Control"]
+pub mod dbgctrl;
+#[doc = "Event Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [evctrl](evctrl) module"]
+pub type EVCTRL = crate::Reg<u16, _EVCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EVCTRL;
+#[doc = "`read()` method returns [evctrl::R](evctrl::R) reader structure"]
+impl crate::Readable for EVCTRL {}
+#[doc = "`write(|w| ..)` method takes [evctrl::W](evctrl::W) writer structure"]
+impl crate::Writable for EVCTRL {}
+#[doc = "Event Control"]
+pub mod evctrl;
+#[doc = "Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u8, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "Status"]
+pub mod status;
+#[doc = "COUNT16 Counter Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [count](count) module"]
+pub type COUNT = crate::Reg<u16, _COUNT>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _COUNT;
+#[doc = "`read()` method returns [count::R](count::R) reader structure"]
+impl crate::Readable for COUNT {}
+#[doc = "`write(|w| ..)` method takes [count::W](count::W) writer structure"]
+impl crate::Writable for COUNT {}
+#[doc = "COUNT16 Counter Value"]
+pub mod count;
+#[doc = "COUNT16 Compare/Capture\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc](cc) module"]
+pub type CC = crate::Reg<u16, _CC>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CC;
+#[doc = "`read()` method returns [cc::R](cc::R) reader structure"]
+impl crate::Readable for CC {}
+#[doc = "`write(|w| ..)` method takes [cc::W](cc::W) writer structure"]
+impl crate::Writable for CC {}
+#[doc = "COUNT16 Compare/Capture"]
+pub mod cc;

--- a/pac/atsamd11c14a/src/tc1/count16/cc.rs
+++ b/pac/atsamd11c14a/src/tc1/count16/cc.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register CC%s"]
+pub type R = crate::R<u16, super::CC>;
+#[doc = "Writer for register CC%s"]
+pub type W = crate::W<u16, super::CC>;
+#[doc = "Register CC%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::CC {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CC`"]
+pub type CC_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `CC`"]
+pub struct CC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CC_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff) | ((value as u16) & 0xffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:15 - Compare/Capture Value"]
+    #[inline(always)]
+    pub fn cc(&self) -> CC_R {
+        CC_R::new((self.bits & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Compare/Capture Value"]
+    #[inline(always)]
+    pub fn cc(&mut self) -> CC_W {
+        CC_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count16/count.rs
+++ b/pac/atsamd11c14a/src/tc1/count16/count.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register COUNT"]
+pub type R = crate::R<u16, super::COUNT>;
+#[doc = "Writer for register COUNT"]
+pub type W = crate::W<u16, super::COUNT>;
+#[doc = "Register COUNT `reset()`'s with value 0"]
+impl crate::ResetValue for super::COUNT {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `COUNT`"]
+pub type COUNT_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `COUNT`"]
+pub struct COUNT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COUNT_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff) | ((value as u16) & 0xffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:15 - Count Value"]
+    #[inline(always)]
+    pub fn count(&self) -> COUNT_R {
+        COUNT_R::new((self.bits & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Count Value"]
+    #[inline(always)]
+    pub fn count(&mut self) -> COUNT_W {
+        COUNT_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count16/ctrla.rs
+++ b/pac/atsamd11c14a/src/tc1/count16/ctrla.rs
@@ -1,0 +1,565 @@
+#[doc = "Reader of register CTRLA"]
+pub type R = crate::R<u16, super::CTRLA>;
+#[doc = "Writer for register CTRLA"]
+pub type W = crate::W<u16, super::CTRLA>;
+#[doc = "Register CTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLA {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "TC Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MODE_A {
+    #[doc = "0: Counter in 16-bit mode"]
+    COUNT16,
+    #[doc = "1: Counter in 8-bit mode"]
+    COUNT8,
+    #[doc = "2: Counter in 32-bit mode"]
+    COUNT32,
+}
+impl From<MODE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: MODE_A) -> Self {
+        match variant {
+            MODE_A::COUNT16 => 0,
+            MODE_A::COUNT8 => 1,
+            MODE_A::COUNT32 => 2,
+        }
+    }
+}
+#[doc = "Reader of field `MODE`"]
+pub type MODE_R = crate::R<u8, MODE_A>;
+impl MODE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, MODE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(MODE_A::COUNT16),
+            1 => Val(MODE_A::COUNT8),
+            2 => Val(MODE_A::COUNT32),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `COUNT16`"]
+    #[inline(always)]
+    pub fn is_count16(&self) -> bool {
+        *self == MODE_A::COUNT16
+    }
+    #[doc = "Checks if the value of the field is `COUNT8`"]
+    #[inline(always)]
+    pub fn is_count8(&self) -> bool {
+        *self == MODE_A::COUNT8
+    }
+    #[doc = "Checks if the value of the field is `COUNT32`"]
+    #[inline(always)]
+    pub fn is_count32(&self) -> bool {
+        *self == MODE_A::COUNT32
+    }
+}
+#[doc = "Write proxy for field `MODE`"]
+pub struct MODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MODE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: MODE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Counter in 16-bit mode"]
+    #[inline(always)]
+    pub fn count16(self) -> &'a mut W {
+        self.variant(MODE_A::COUNT16)
+    }
+    #[doc = "Counter in 8-bit mode"]
+    #[inline(always)]
+    pub fn count8(self) -> &'a mut W {
+        self.variant(MODE_A::COUNT8)
+    }
+    #[doc = "Counter in 32-bit mode"]
+    #[inline(always)]
+    pub fn count32(self) -> &'a mut W {
+        self.variant(MODE_A::COUNT32)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 2)) | (((value as u16) & 0x03) << 2);
+        self.w
+    }
+}
+#[doc = "Waveform Generation Operation\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum WAVEGEN_A {
+    #[doc = "0: `0`"]
+    NFRQ,
+    #[doc = "1: `1`"]
+    MFRQ,
+    #[doc = "2: `10`"]
+    NPWM,
+    #[doc = "3: `11`"]
+    MPWM,
+}
+impl From<WAVEGEN_A> for u8 {
+    #[inline(always)]
+    fn from(variant: WAVEGEN_A) -> Self {
+        match variant {
+            WAVEGEN_A::NFRQ => 0,
+            WAVEGEN_A::MFRQ => 1,
+            WAVEGEN_A::NPWM => 2,
+            WAVEGEN_A::MPWM => 3,
+        }
+    }
+}
+#[doc = "Reader of field `WAVEGEN`"]
+pub type WAVEGEN_R = crate::R<u8, WAVEGEN_A>;
+impl WAVEGEN_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> WAVEGEN_A {
+        match self.bits {
+            0 => WAVEGEN_A::NFRQ,
+            1 => WAVEGEN_A::MFRQ,
+            2 => WAVEGEN_A::NPWM,
+            3 => WAVEGEN_A::MPWM,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NFRQ`"]
+    #[inline(always)]
+    pub fn is_nfrq(&self) -> bool {
+        *self == WAVEGEN_A::NFRQ
+    }
+    #[doc = "Checks if the value of the field is `MFRQ`"]
+    #[inline(always)]
+    pub fn is_mfrq(&self) -> bool {
+        *self == WAVEGEN_A::MFRQ
+    }
+    #[doc = "Checks if the value of the field is `NPWM`"]
+    #[inline(always)]
+    pub fn is_npwm(&self) -> bool {
+        *self == WAVEGEN_A::NPWM
+    }
+    #[doc = "Checks if the value of the field is `MPWM`"]
+    #[inline(always)]
+    pub fn is_mpwm(&self) -> bool {
+        *self == WAVEGEN_A::MPWM
+    }
+}
+#[doc = "Write proxy for field `WAVEGEN`"]
+pub struct WAVEGEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAVEGEN_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: WAVEGEN_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "`0`"]
+    #[inline(always)]
+    pub fn nfrq(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::NFRQ)
+    }
+    #[doc = "`1`"]
+    #[inline(always)]
+    pub fn mfrq(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::MFRQ)
+    }
+    #[doc = "`10`"]
+    #[inline(always)]
+    pub fn npwm(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::NPWM)
+    }
+    #[doc = "`11`"]
+    #[inline(always)]
+    pub fn mpwm(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::MPWM)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 5)) | (((value as u16) & 0x03) << 5);
+        self.w
+    }
+}
+#[doc = "Prescaler\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PRESCALER_A {
+    #[doc = "0: Prescaler: GCLK_TC"]
+    DIV1,
+    #[doc = "1: Prescaler: GCLK_TC/2"]
+    DIV2,
+    #[doc = "2: Prescaler: GCLK_TC/4"]
+    DIV4,
+    #[doc = "3: Prescaler: GCLK_TC/8"]
+    DIV8,
+    #[doc = "4: Prescaler: GCLK_TC/16"]
+    DIV16,
+    #[doc = "5: Prescaler: GCLK_TC/64"]
+    DIV64,
+    #[doc = "6: Prescaler: GCLK_TC/256"]
+    DIV256,
+    #[doc = "7: Prescaler: GCLK_TC/1024"]
+    DIV1024,
+}
+impl From<PRESCALER_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PRESCALER_A) -> Self {
+        match variant {
+            PRESCALER_A::DIV1 => 0,
+            PRESCALER_A::DIV2 => 1,
+            PRESCALER_A::DIV4 => 2,
+            PRESCALER_A::DIV8 => 3,
+            PRESCALER_A::DIV16 => 4,
+            PRESCALER_A::DIV64 => 5,
+            PRESCALER_A::DIV256 => 6,
+            PRESCALER_A::DIV1024 => 7,
+        }
+    }
+}
+#[doc = "Reader of field `PRESCALER`"]
+pub type PRESCALER_R = crate::R<u8, PRESCALER_A>;
+impl PRESCALER_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> PRESCALER_A {
+        match self.bits {
+            0 => PRESCALER_A::DIV1,
+            1 => PRESCALER_A::DIV2,
+            2 => PRESCALER_A::DIV4,
+            3 => PRESCALER_A::DIV8,
+            4 => PRESCALER_A::DIV16,
+            5 => PRESCALER_A::DIV64,
+            6 => PRESCALER_A::DIV256,
+            7 => PRESCALER_A::DIV1024,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DIV1`"]
+    #[inline(always)]
+    pub fn is_div1(&self) -> bool {
+        *self == PRESCALER_A::DIV1
+    }
+    #[doc = "Checks if the value of the field is `DIV2`"]
+    #[inline(always)]
+    pub fn is_div2(&self) -> bool {
+        *self == PRESCALER_A::DIV2
+    }
+    #[doc = "Checks if the value of the field is `DIV4`"]
+    #[inline(always)]
+    pub fn is_div4(&self) -> bool {
+        *self == PRESCALER_A::DIV4
+    }
+    #[doc = "Checks if the value of the field is `DIV8`"]
+    #[inline(always)]
+    pub fn is_div8(&self) -> bool {
+        *self == PRESCALER_A::DIV8
+    }
+    #[doc = "Checks if the value of the field is `DIV16`"]
+    #[inline(always)]
+    pub fn is_div16(&self) -> bool {
+        *self == PRESCALER_A::DIV16
+    }
+    #[doc = "Checks if the value of the field is `DIV64`"]
+    #[inline(always)]
+    pub fn is_div64(&self) -> bool {
+        *self == PRESCALER_A::DIV64
+    }
+    #[doc = "Checks if the value of the field is `DIV256`"]
+    #[inline(always)]
+    pub fn is_div256(&self) -> bool {
+        *self == PRESCALER_A::DIV256
+    }
+    #[doc = "Checks if the value of the field is `DIV1024`"]
+    #[inline(always)]
+    pub fn is_div1024(&self) -> bool {
+        *self == PRESCALER_A::DIV1024
+    }
+}
+#[doc = "Write proxy for field `PRESCALER`"]
+pub struct PRESCALER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PRESCALER_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PRESCALER_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Prescaler: GCLK_TC"]
+    #[inline(always)]
+    pub fn div1(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV1)
+    }
+    #[doc = "Prescaler: GCLK_TC/2"]
+    #[inline(always)]
+    pub fn div2(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV2)
+    }
+    #[doc = "Prescaler: GCLK_TC/4"]
+    #[inline(always)]
+    pub fn div4(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV4)
+    }
+    #[doc = "Prescaler: GCLK_TC/8"]
+    #[inline(always)]
+    pub fn div8(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV8)
+    }
+    #[doc = "Prescaler: GCLK_TC/16"]
+    #[inline(always)]
+    pub fn div16(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV16)
+    }
+    #[doc = "Prescaler: GCLK_TC/64"]
+    #[inline(always)]
+    pub fn div64(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV64)
+    }
+    #[doc = "Prescaler: GCLK_TC/256"]
+    #[inline(always)]
+    pub fn div256(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV256)
+    }
+    #[doc = "Prescaler: GCLK_TC/1024"]
+    #[inline(always)]
+    pub fn div1024(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV1024)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 8)) | (((value as u16) & 0x07) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u16) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Prescaler and Counter Synchronization\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PRESCSYNC_A {
+    #[doc = "0: Reload or reset the counter on next generic clock"]
+    GCLK,
+    #[doc = "1: Reload or reset the counter on next prescaler clock"]
+    PRESC,
+    #[doc = "2: Reload or reset the counter on next generic clock. Reset the prescaler counter"]
+    RESYNC,
+}
+impl From<PRESCSYNC_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PRESCSYNC_A) -> Self {
+        match variant {
+            PRESCSYNC_A::GCLK => 0,
+            PRESCSYNC_A::PRESC => 1,
+            PRESCSYNC_A::RESYNC => 2,
+        }
+    }
+}
+#[doc = "Reader of field `PRESCSYNC`"]
+pub type PRESCSYNC_R = crate::R<u8, PRESCSYNC_A>;
+impl PRESCSYNC_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, PRESCSYNC_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(PRESCSYNC_A::GCLK),
+            1 => Val(PRESCSYNC_A::PRESC),
+            2 => Val(PRESCSYNC_A::RESYNC),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `GCLK`"]
+    #[inline(always)]
+    pub fn is_gclk(&self) -> bool {
+        *self == PRESCSYNC_A::GCLK
+    }
+    #[doc = "Checks if the value of the field is `PRESC`"]
+    #[inline(always)]
+    pub fn is_presc(&self) -> bool {
+        *self == PRESCSYNC_A::PRESC
+    }
+    #[doc = "Checks if the value of the field is `RESYNC`"]
+    #[inline(always)]
+    pub fn is_resync(&self) -> bool {
+        *self == PRESCSYNC_A::RESYNC
+    }
+}
+#[doc = "Write proxy for field `PRESCSYNC`"]
+pub struct PRESCSYNC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PRESCSYNC_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PRESCSYNC_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Reload or reset the counter on next generic clock"]
+    #[inline(always)]
+    pub fn gclk(self) -> &'a mut W {
+        self.variant(PRESCSYNC_A::GCLK)
+    }
+    #[doc = "Reload or reset the counter on next prescaler clock"]
+    #[inline(always)]
+    pub fn presc(self) -> &'a mut W {
+        self.variant(PRESCSYNC_A::PRESC)
+    }
+    #[doc = "Reload or reset the counter on next generic clock. Reset the prescaler counter"]
+    #[inline(always)]
+    pub fn resync(self) -> &'a mut W {
+        self.variant(PRESCSYNC_A::RESYNC)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 12)) | (((value as u16) & 0x03) << 12);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 2:3 - TC Mode"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 2) & 0x03) as u8)
+    }
+    #[doc = "Bits 5:6 - Waveform Generation Operation"]
+    #[inline(always)]
+    pub fn wavegen(&self) -> WAVEGEN_R {
+        WAVEGEN_R::new(((self.bits >> 5) & 0x03) as u8)
+    }
+    #[doc = "Bits 8:10 - Prescaler"]
+    #[inline(always)]
+    pub fn prescaler(&self) -> PRESCALER_R {
+        PRESCALER_R::new(((self.bits >> 8) & 0x07) as u8)
+    }
+    #[doc = "Bit 11 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bits 12:13 - Prescaler and Counter Synchronization"]
+    #[inline(always)]
+    pub fn prescsync(&self) -> PRESCSYNC_R {
+        PRESCSYNC_R::new(((self.bits >> 12) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bits 2:3 - TC Mode"]
+    #[inline(always)]
+    pub fn mode(&mut self) -> MODE_W {
+        MODE_W { w: self }
+    }
+    #[doc = "Bits 5:6 - Waveform Generation Operation"]
+    #[inline(always)]
+    pub fn wavegen(&mut self) -> WAVEGEN_W {
+        WAVEGEN_W { w: self }
+    }
+    #[doc = "Bits 8:10 - Prescaler"]
+    #[inline(always)]
+    pub fn prescaler(&mut self) -> PRESCALER_W {
+        PRESCALER_W { w: self }
+    }
+    #[doc = "Bit 11 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bits 12:13 - Prescaler and Counter Synchronization"]
+    #[inline(always)]
+    pub fn prescsync(&mut self) -> PRESCSYNC_W {
+        PRESCSYNC_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count16/ctrlbclr.rs
+++ b/pac/atsamd11c14a/src/tc1/count16/ctrlbclr.rs
@@ -1,0 +1,176 @@
+#[doc = "Reader of register CTRLBCLR"]
+pub type R = crate::R<u8, super::CTRLBCLR>;
+#[doc = "Writer for register CTRLBCLR"]
+pub type W = crate::W<u8, super::CTRLBCLR>;
+#[doc = "Register CTRLBCLR `reset()`'s with value 0x02"]
+impl crate::ResetValue for super::CTRLBCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x02
+    }
+}
+#[doc = "Reader of field `DIR`"]
+pub type DIR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DIR`"]
+pub struct DIR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ONESHOT`"]
+pub type ONESHOT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ONESHOT`"]
+pub struct ONESHOT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ONESHOT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Command\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CMD_A {
+    #[doc = "0: No action"]
+    NONE,
+    #[doc = "1: Force a start, restart or retrigger"]
+    RETRIGGER,
+    #[doc = "2: Force a stop"]
+    STOP,
+}
+impl From<CMD_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CMD_A) -> Self {
+        match variant {
+            CMD_A::NONE => 0,
+            CMD_A::RETRIGGER => 1,
+            CMD_A::STOP => 2,
+        }
+    }
+}
+#[doc = "Reader of field `CMD`"]
+pub type CMD_R = crate::R<u8, CMD_A>;
+impl CMD_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, CMD_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(CMD_A::NONE),
+            1 => Val(CMD_A::RETRIGGER),
+            2 => Val(CMD_A::STOP),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == CMD_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RETRIGGER`"]
+    #[inline(always)]
+    pub fn is_retrigger(&self) -> bool {
+        *self == CMD_A::RETRIGGER
+    }
+    #[doc = "Checks if the value of the field is `STOP`"]
+    #[inline(always)]
+    pub fn is_stop(&self) -> bool {
+        *self == CMD_A::STOP
+    }
+}
+#[doc = "Write proxy for field `CMD`"]
+pub struct CMD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMD_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CMD_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No action"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(CMD_A::NONE)
+    }
+    #[doc = "Force a start, restart or retrigger"]
+    #[inline(always)]
+    pub fn retrigger(self) -> &'a mut W {
+        self.variant(CMD_A::RETRIGGER)
+    }
+    #[doc = "Force a stop"]
+    #[inline(always)]
+    pub fn stop(self) -> &'a mut W {
+        self.variant(CMD_A::STOP)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 6)) | (((value as u8) & 0x03) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&self) -> DIR_R {
+        DIR_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&self) -> ONESHOT_R {
+        ONESHOT_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bits 6:7 - Command"]
+    #[inline(always)]
+    pub fn cmd(&self) -> CMD_R {
+        CMD_R::new(((self.bits >> 6) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&mut self) -> DIR_W {
+        DIR_W { w: self }
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&mut self) -> ONESHOT_W {
+        ONESHOT_W { w: self }
+    }
+    #[doc = "Bits 6:7 - Command"]
+    #[inline(always)]
+    pub fn cmd(&mut self) -> CMD_W {
+        CMD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count16/ctrlbset.rs
+++ b/pac/atsamd11c14a/src/tc1/count16/ctrlbset.rs
@@ -1,0 +1,176 @@
+#[doc = "Reader of register CTRLBSET"]
+pub type R = crate::R<u8, super::CTRLBSET>;
+#[doc = "Writer for register CTRLBSET"]
+pub type W = crate::W<u8, super::CTRLBSET>;
+#[doc = "Register CTRLBSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLBSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DIR`"]
+pub type DIR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DIR`"]
+pub struct DIR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ONESHOT`"]
+pub type ONESHOT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ONESHOT`"]
+pub struct ONESHOT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ONESHOT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Command\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CMD_A {
+    #[doc = "0: No action"]
+    NONE,
+    #[doc = "1: Force a start, restart or retrigger"]
+    RETRIGGER,
+    #[doc = "2: Force a stop"]
+    STOP,
+}
+impl From<CMD_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CMD_A) -> Self {
+        match variant {
+            CMD_A::NONE => 0,
+            CMD_A::RETRIGGER => 1,
+            CMD_A::STOP => 2,
+        }
+    }
+}
+#[doc = "Reader of field `CMD`"]
+pub type CMD_R = crate::R<u8, CMD_A>;
+impl CMD_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, CMD_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(CMD_A::NONE),
+            1 => Val(CMD_A::RETRIGGER),
+            2 => Val(CMD_A::STOP),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == CMD_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RETRIGGER`"]
+    #[inline(always)]
+    pub fn is_retrigger(&self) -> bool {
+        *self == CMD_A::RETRIGGER
+    }
+    #[doc = "Checks if the value of the field is `STOP`"]
+    #[inline(always)]
+    pub fn is_stop(&self) -> bool {
+        *self == CMD_A::STOP
+    }
+}
+#[doc = "Write proxy for field `CMD`"]
+pub struct CMD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMD_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CMD_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No action"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(CMD_A::NONE)
+    }
+    #[doc = "Force a start, restart or retrigger"]
+    #[inline(always)]
+    pub fn retrigger(self) -> &'a mut W {
+        self.variant(CMD_A::RETRIGGER)
+    }
+    #[doc = "Force a stop"]
+    #[inline(always)]
+    pub fn stop(self) -> &'a mut W {
+        self.variant(CMD_A::STOP)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 6)) | (((value as u8) & 0x03) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&self) -> DIR_R {
+        DIR_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&self) -> ONESHOT_R {
+        ONESHOT_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bits 6:7 - Command"]
+    #[inline(always)]
+    pub fn cmd(&self) -> CMD_R {
+        CMD_R::new(((self.bits >> 6) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&mut self) -> DIR_W {
+        DIR_W { w: self }
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&mut self) -> ONESHOT_W {
+        ONESHOT_W { w: self }
+    }
+    #[doc = "Bits 6:7 - Command"]
+    #[inline(always)]
+    pub fn cmd(&mut self) -> CMD_W {
+        CMD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count16/ctrlc.rs
+++ b/pac/atsamd11c14a/src/tc1/count16/ctrlc.rs
@@ -1,0 +1,152 @@
+#[doc = "Reader of register CTRLC"]
+pub type R = crate::R<u8, super::CTRLC>;
+#[doc = "Writer for register CTRLC"]
+pub type W = crate::W<u8, super::CTRLC>;
+#[doc = "Register CTRLC `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLC {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `INVEN0`"]
+pub type INVEN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INVEN0`"]
+pub struct INVEN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INVEN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `INVEN1`"]
+pub type INVEN1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INVEN1`"]
+pub struct INVEN1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INVEN1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `CPTEN0`"]
+pub type CPTEN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CPTEN0`"]
+pub struct CPTEN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CPTEN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `CPTEN1`"]
+pub type CPTEN1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CPTEN1`"]
+pub struct CPTEN1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CPTEN1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Output Waveform 0 Invert Enable"]
+    #[inline(always)]
+    pub fn inven0(&self) -> INVEN0_R {
+        INVEN0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Output Waveform 1 Invert Enable"]
+    #[inline(always)]
+    pub fn inven1(&self) -> INVEN1_R {
+        INVEN1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Capture Channel 0 Enable"]
+    #[inline(always)]
+    pub fn cpten0(&self) -> CPTEN0_R {
+        CPTEN0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Capture Channel 1 Enable"]
+    #[inline(always)]
+    pub fn cpten1(&self) -> CPTEN1_R {
+        CPTEN1_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Output Waveform 0 Invert Enable"]
+    #[inline(always)]
+    pub fn inven0(&mut self) -> INVEN0_W {
+        INVEN0_W { w: self }
+    }
+    #[doc = "Bit 1 - Output Waveform 1 Invert Enable"]
+    #[inline(always)]
+    pub fn inven1(&mut self) -> INVEN1_W {
+        INVEN1_W { w: self }
+    }
+    #[doc = "Bit 4 - Capture Channel 0 Enable"]
+    #[inline(always)]
+    pub fn cpten0(&mut self) -> CPTEN0_W {
+        CPTEN0_W { w: self }
+    }
+    #[doc = "Bit 5 - Capture Channel 1 Enable"]
+    #[inline(always)]
+    pub fn cpten1(&mut self) -> CPTEN1_W {
+        CPTEN1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count16/dbgctrl.rs
+++ b/pac/atsamd11c14a/src/tc1/count16/dbgctrl.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register DBGCTRL"]
+pub type R = crate::R<u8, super::DBGCTRL>;
+#[doc = "Writer for register DBGCTRL"]
+pub type W = crate::W<u8, super::DBGCTRL>;
+#[doc = "Register DBGCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::DBGCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DBGRUN`"]
+pub type DBGRUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DBGRUN`"]
+pub struct DBGRUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DBGRUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Debug Run Mode"]
+    #[inline(always)]
+    pub fn dbgrun(&self) -> DBGRUN_R {
+        DBGRUN_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Debug Run Mode"]
+    #[inline(always)]
+    pub fn dbgrun(&mut self) -> DBGRUN_W {
+        DBGRUN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count16/evctrl.rs
+++ b/pac/atsamd11c14a/src/tc1/count16/evctrl.rs
@@ -1,0 +1,320 @@
+#[doc = "Reader of register EVCTRL"]
+pub type R = crate::R<u16, super::EVCTRL>;
+#[doc = "Writer for register EVCTRL"]
+pub type W = crate::W<u16, super::EVCTRL>;
+#[doc = "Register EVCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::EVCTRL {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Event Action\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum EVACT_A {
+    #[doc = "0: Event action disabled"]
+    OFF,
+    #[doc = "1: Start, restart or retrigger TC on event"]
+    RETRIGGER,
+    #[doc = "2: Count on event"]
+    COUNT,
+    #[doc = "3: Start TC on event"]
+    START,
+    #[doc = "5: Period captured in CC0, pulse width in CC1"]
+    PPW,
+    #[doc = "6: Period captured in CC1, pulse width in CC0"]
+    PWP,
+}
+impl From<EVACT_A> for u8 {
+    #[inline(always)]
+    fn from(variant: EVACT_A) -> Self {
+        match variant {
+            EVACT_A::OFF => 0,
+            EVACT_A::RETRIGGER => 1,
+            EVACT_A::COUNT => 2,
+            EVACT_A::START => 3,
+            EVACT_A::PPW => 5,
+            EVACT_A::PWP => 6,
+        }
+    }
+}
+#[doc = "Reader of field `EVACT`"]
+pub type EVACT_R = crate::R<u8, EVACT_A>;
+impl EVACT_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, EVACT_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(EVACT_A::OFF),
+            1 => Val(EVACT_A::RETRIGGER),
+            2 => Val(EVACT_A::COUNT),
+            3 => Val(EVACT_A::START),
+            5 => Val(EVACT_A::PPW),
+            6 => Val(EVACT_A::PWP),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `OFF`"]
+    #[inline(always)]
+    pub fn is_off(&self) -> bool {
+        *self == EVACT_A::OFF
+    }
+    #[doc = "Checks if the value of the field is `RETRIGGER`"]
+    #[inline(always)]
+    pub fn is_retrigger(&self) -> bool {
+        *self == EVACT_A::RETRIGGER
+    }
+    #[doc = "Checks if the value of the field is `COUNT`"]
+    #[inline(always)]
+    pub fn is_count(&self) -> bool {
+        *self == EVACT_A::COUNT
+    }
+    #[doc = "Checks if the value of the field is `START`"]
+    #[inline(always)]
+    pub fn is_start(&self) -> bool {
+        *self == EVACT_A::START
+    }
+    #[doc = "Checks if the value of the field is `PPW`"]
+    #[inline(always)]
+    pub fn is_ppw(&self) -> bool {
+        *self == EVACT_A::PPW
+    }
+    #[doc = "Checks if the value of the field is `PWP`"]
+    #[inline(always)]
+    pub fn is_pwp(&self) -> bool {
+        *self == EVACT_A::PWP
+    }
+}
+#[doc = "Write proxy for field `EVACT`"]
+pub struct EVACT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVACT_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: EVACT_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Event action disabled"]
+    #[inline(always)]
+    pub fn off(self) -> &'a mut W {
+        self.variant(EVACT_A::OFF)
+    }
+    #[doc = "Start, restart or retrigger TC on event"]
+    #[inline(always)]
+    pub fn retrigger(self) -> &'a mut W {
+        self.variant(EVACT_A::RETRIGGER)
+    }
+    #[doc = "Count on event"]
+    #[inline(always)]
+    pub fn count(self) -> &'a mut W {
+        self.variant(EVACT_A::COUNT)
+    }
+    #[doc = "Start TC on event"]
+    #[inline(always)]
+    pub fn start(self) -> &'a mut W {
+        self.variant(EVACT_A::START)
+    }
+    #[doc = "Period captured in CC0, pulse width in CC1"]
+    #[inline(always)]
+    pub fn ppw(self) -> &'a mut W {
+        self.variant(EVACT_A::PPW)
+    }
+    #[doc = "Period captured in CC1, pulse width in CC0"]
+    #[inline(always)]
+    pub fn pwp(self) -> &'a mut W {
+        self.variant(EVACT_A::PWP)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u16) & 0x07);
+        self.w
+    }
+}
+#[doc = "Reader of field `TCINV`"]
+pub type TCINV_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TCINV`"]
+pub struct TCINV_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TCINV_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `TCEI`"]
+pub type TCEI_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TCEI`"]
+pub struct TCEI_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TCEI_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVFEO`"]
+pub type OVFEO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVFEO`"]
+pub struct OVFEO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVFEO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `MCEO0`"]
+pub type MCEO0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MCEO0`"]
+pub struct MCEO0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MCEO0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u16) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `MCEO1`"]
+pub type MCEO1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MCEO1`"]
+pub struct MCEO1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MCEO1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u16) & 0x01) << 13);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Event Action"]
+    #[inline(always)]
+    pub fn evact(&self) -> EVACT_R {
+        EVACT_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bit 4 - TC Inverted Event Input"]
+    #[inline(always)]
+    pub fn tcinv(&self) -> TCINV_R {
+        TCINV_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - TC Event Input"]
+    #[inline(always)]
+    pub fn tcei(&self) -> TCEI_R {
+        TCEI_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Overflow/Underflow Event Output Enable"]
+    #[inline(always)]
+    pub fn ovfeo(&self) -> OVFEO_R {
+        OVFEO_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - Match or Capture Channel 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo0(&self) -> MCEO0_R {
+        MCEO0_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Match or Capture Channel 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo1(&self) -> MCEO1_R {
+        MCEO1_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Event Action"]
+    #[inline(always)]
+    pub fn evact(&mut self) -> EVACT_W {
+        EVACT_W { w: self }
+    }
+    #[doc = "Bit 4 - TC Inverted Event Input"]
+    #[inline(always)]
+    pub fn tcinv(&mut self) -> TCINV_W {
+        TCINV_W { w: self }
+    }
+    #[doc = "Bit 5 - TC Event Input"]
+    #[inline(always)]
+    pub fn tcei(&mut self) -> TCEI_W {
+        TCEI_W { w: self }
+    }
+    #[doc = "Bit 8 - Overflow/Underflow Event Output Enable"]
+    #[inline(always)]
+    pub fn ovfeo(&mut self) -> OVFEO_W {
+        OVFEO_W { w: self }
+    }
+    #[doc = "Bit 12 - Match or Capture Channel 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo0(&mut self) -> MCEO0_W {
+        MCEO0_W { w: self }
+    }
+    #[doc = "Bit 13 - Match or Capture Channel 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo1(&mut self) -> MCEO1_W {
+        MCEO1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count16/intenclr.rs
+++ b/pac/atsamd11c14a/src/tc1/count16/intenclr.rs
@@ -1,0 +1,186 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERR`"]
+pub type ERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERR`"]
+pub struct ERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC0`"]
+pub type MC0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC0`"]
+pub struct MC0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC1`"]
+pub type MC1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC1`"]
+pub struct MC1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&self) -> ERR_R {
+        ERR_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&self) -> MC0_R {
+        MC0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&self) -> MC1_R {
+        MC1_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&mut self) -> ERR_W {
+        ERR_W { w: self }
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&mut self) -> MC0_W {
+        MC0_W { w: self }
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&mut self) -> MC1_W {
+        MC1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count16/intenset.rs
+++ b/pac/atsamd11c14a/src/tc1/count16/intenset.rs
@@ -1,0 +1,186 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERR`"]
+pub type ERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERR`"]
+pub struct ERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC0`"]
+pub type MC0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC0`"]
+pub struct MC0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC1`"]
+pub type MC1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC1`"]
+pub struct MC1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&self) -> ERR_R {
+        ERR_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&self) -> MC0_R {
+        MC0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&self) -> MC1_R {
+        MC1_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&mut self) -> ERR_W {
+        ERR_W { w: self }
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&mut self) -> MC0_W {
+        MC0_W { w: self }
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&mut self) -> MC1_W {
+        MC1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count16/intflag.rs
+++ b/pac/atsamd11c14a/src/tc1/count16/intflag.rs
@@ -1,0 +1,186 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERR`"]
+pub type ERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERR`"]
+pub struct ERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC0`"]
+pub type MC0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC0`"]
+pub struct MC0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC1`"]
+pub type MC1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC1`"]
+pub struct MC1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Overflow"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Error"]
+    #[inline(always)]
+    pub fn err(&self) -> ERR_R {
+        ERR_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0"]
+    #[inline(always)]
+    pub fn mc0(&self) -> MC0_R {
+        MC0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1"]
+    #[inline(always)]
+    pub fn mc1(&self) -> MC1_R {
+        MC1_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Overflow"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+    #[doc = "Bit 1 - Error"]
+    #[inline(always)]
+    pub fn err(&mut self) -> ERR_W {
+        ERR_W { w: self }
+    }
+    #[doc = "Bit 3 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0"]
+    #[inline(always)]
+    pub fn mc0(&mut self) -> MC0_W {
+        MC0_W { w: self }
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1"]
+    #[inline(always)]
+    pub fn mc1(&mut self) -> MC1_W {
+        MC1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count16/readreq.rs
+++ b/pac/atsamd11c14a/src/tc1/count16/readreq.rs
@@ -1,0 +1,108 @@
+#[doc = "Reader of register READREQ"]
+pub type R = crate::R<u16, super::READREQ>;
+#[doc = "Writer for register READREQ"]
+pub type W = crate::W<u16, super::READREQ>;
+#[doc = "Register READREQ `reset()`'s with value 0"]
+impl crate::ResetValue for super::READREQ {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ADDR`"]
+pub type ADDR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `ADDR`"]
+pub struct ADDR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ADDR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x1f) | ((value as u16) & 0x1f);
+        self.w
+    }
+}
+#[doc = "Reader of field `RCONT`"]
+pub type RCONT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RCONT`"]
+pub struct RCONT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RCONT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u16) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `RREQ`"]
+pub type RREQ_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RREQ`"]
+pub struct RREQ_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RREQ_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u16) & 0x01) << 15);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:4 - Address"]
+    #[inline(always)]
+    pub fn addr(&self) -> ADDR_R {
+        ADDR_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bit 14 - Read Continuously"]
+    #[inline(always)]
+    pub fn rcont(&self) -> RCONT_R {
+        RCONT_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Read Request"]
+    #[inline(always)]
+    pub fn rreq(&self) -> RREQ_R {
+        RREQ_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - Address"]
+    #[inline(always)]
+    pub fn addr(&mut self) -> ADDR_W {
+        ADDR_W { w: self }
+    }
+    #[doc = "Bit 14 - Read Continuously"]
+    #[inline(always)]
+    pub fn rcont(&mut self) -> RCONT_W {
+        RCONT_W { w: self }
+    }
+    #[doc = "Bit 15 - Read Request"]
+    #[inline(always)]
+    pub fn rreq(&mut self) -> RREQ_W {
+        RREQ_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count16/status.rs
+++ b/pac/atsamd11c14a/src/tc1/count16/status.rs
@@ -1,0 +1,25 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u8, super::STATUS>;
+#[doc = "Reader of field `STOP`"]
+pub type STOP_R = crate::R<bool, bool>;
+#[doc = "Reader of field `SLAVE`"]
+pub type SLAVE_R = crate::R<bool, bool>;
+#[doc = "Reader of field `SYNCBUSY`"]
+pub type SYNCBUSY_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 3 - Stop"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Slave"]
+    #[inline(always)]
+    pub fn slave(&self) -> SLAVE_R {
+        SLAVE_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Synchronization Busy"]
+    #[inline(always)]
+    pub fn syncbusy(&self) -> SYNCBUSY_R {
+        SYNCBUSY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count32.rs
+++ b/pac/atsamd11c14a/src/tc1/count32.rs
@@ -1,0 +1,141 @@
+#[doc = "Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrla](ctrla) module"]
+pub type CTRLA = crate::Reg<u16, _CTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLA;
+#[doc = "`read()` method returns [ctrla::R](ctrla::R) reader structure"]
+impl crate::Readable for CTRLA {}
+#[doc = "`write(|w| ..)` method takes [ctrla::W](ctrla::W) writer structure"]
+impl crate::Writable for CTRLA {}
+#[doc = "Control A"]
+pub mod ctrla;
+#[doc = "Read Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [readreq](readreq) module"]
+pub type READREQ = crate::Reg<u16, _READREQ>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _READREQ;
+#[doc = "`read()` method returns [readreq::R](readreq::R) reader structure"]
+impl crate::Readable for READREQ {}
+#[doc = "`write(|w| ..)` method takes [readreq::W](readreq::W) writer structure"]
+impl crate::Writable for READREQ {}
+#[doc = "Read Request"]
+pub mod readreq;
+#[doc = "Control B Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlbclr](ctrlbclr) module"]
+pub type CTRLBCLR = crate::Reg<u8, _CTRLBCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLBCLR;
+#[doc = "`read()` method returns [ctrlbclr::R](ctrlbclr::R) reader structure"]
+impl crate::Readable for CTRLBCLR {}
+#[doc = "`write(|w| ..)` method takes [ctrlbclr::W](ctrlbclr::W) writer structure"]
+impl crate::Writable for CTRLBCLR {}
+#[doc = "Control B Clear"]
+pub mod ctrlbclr;
+#[doc = "Control B Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlbset](ctrlbset) module"]
+pub type CTRLBSET = crate::Reg<u8, _CTRLBSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLBSET;
+#[doc = "`read()` method returns [ctrlbset::R](ctrlbset::R) reader structure"]
+impl crate::Readable for CTRLBSET {}
+#[doc = "`write(|w| ..)` method takes [ctrlbset::W](ctrlbset::W) writer structure"]
+impl crate::Writable for CTRLBSET {}
+#[doc = "Control B Set"]
+pub mod ctrlbset;
+#[doc = "Control C\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlc](ctrlc) module"]
+pub type CTRLC = crate::Reg<u8, _CTRLC>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLC;
+#[doc = "`read()` method returns [ctrlc::R](ctrlc::R) reader structure"]
+impl crate::Readable for CTRLC {}
+#[doc = "`write(|w| ..)` method takes [ctrlc::W](ctrlc::W) writer structure"]
+impl crate::Writable for CTRLC {}
+#[doc = "Control C"]
+pub mod ctrlc;
+#[doc = "Debug Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dbgctrl](dbgctrl) module"]
+pub type DBGCTRL = crate::Reg<u8, _DBGCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DBGCTRL;
+#[doc = "`read()` method returns [dbgctrl::R](dbgctrl::R) reader structure"]
+impl crate::Readable for DBGCTRL {}
+#[doc = "`write(|w| ..)` method takes [dbgctrl::W](dbgctrl::W) writer structure"]
+impl crate::Writable for DBGCTRL {}
+#[doc = "Debug Control"]
+pub mod dbgctrl;
+#[doc = "Event Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [evctrl](evctrl) module"]
+pub type EVCTRL = crate::Reg<u16, _EVCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EVCTRL;
+#[doc = "`read()` method returns [evctrl::R](evctrl::R) reader structure"]
+impl crate::Readable for EVCTRL {}
+#[doc = "`write(|w| ..)` method takes [evctrl::W](evctrl::W) writer structure"]
+impl crate::Writable for EVCTRL {}
+#[doc = "Event Control"]
+pub mod evctrl;
+#[doc = "Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u8, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "Status"]
+pub mod status;
+#[doc = "COUNT32 Counter Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [count](count) module"]
+pub type COUNT = crate::Reg<u32, _COUNT>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _COUNT;
+#[doc = "`read()` method returns [count::R](count::R) reader structure"]
+impl crate::Readable for COUNT {}
+#[doc = "`write(|w| ..)` method takes [count::W](count::W) writer structure"]
+impl crate::Writable for COUNT {}
+#[doc = "COUNT32 Counter Value"]
+pub mod count;
+#[doc = "COUNT32 Compare/Capture\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc](cc) module"]
+pub type CC = crate::Reg<u32, _CC>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CC;
+#[doc = "`read()` method returns [cc::R](cc::R) reader structure"]
+impl crate::Readable for CC {}
+#[doc = "`write(|w| ..)` method takes [cc::W](cc::W) writer structure"]
+impl crate::Writable for CC {}
+#[doc = "COUNT32 Compare/Capture"]
+pub mod cc;

--- a/pac/atsamd11c14a/src/tc1/count32/cc.rs
+++ b/pac/atsamd11c14a/src/tc1/count32/cc.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register CC%s"]
+pub type R = crate::R<u32, super::CC>;
+#[doc = "Writer for register CC%s"]
+pub type W = crate::W<u32, super::CC>;
+#[doc = "Register CC%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::CC {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CC`"]
+pub type CC_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `CC`"]
+pub struct CC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CC_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Compare/Capture Value"]
+    #[inline(always)]
+    pub fn cc(&self) -> CC_R {
+        CC_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Compare/Capture Value"]
+    #[inline(always)]
+    pub fn cc(&mut self) -> CC_W {
+        CC_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count32/count.rs
+++ b/pac/atsamd11c14a/src/tc1/count32/count.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register COUNT"]
+pub type R = crate::R<u32, super::COUNT>;
+#[doc = "Writer for register COUNT"]
+pub type W = crate::W<u32, super::COUNT>;
+#[doc = "Register COUNT `reset()`'s with value 0"]
+impl crate::ResetValue for super::COUNT {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `COUNT`"]
+pub type COUNT_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `COUNT`"]
+pub struct COUNT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COUNT_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Count Value"]
+    #[inline(always)]
+    pub fn count(&self) -> COUNT_R {
+        COUNT_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Count Value"]
+    #[inline(always)]
+    pub fn count(&mut self) -> COUNT_W {
+        COUNT_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count32/ctrla.rs
+++ b/pac/atsamd11c14a/src/tc1/count32/ctrla.rs
@@ -1,0 +1,565 @@
+#[doc = "Reader of register CTRLA"]
+pub type R = crate::R<u16, super::CTRLA>;
+#[doc = "Writer for register CTRLA"]
+pub type W = crate::W<u16, super::CTRLA>;
+#[doc = "Register CTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLA {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "TC Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MODE_A {
+    #[doc = "0: Counter in 16-bit mode"]
+    COUNT16,
+    #[doc = "1: Counter in 8-bit mode"]
+    COUNT8,
+    #[doc = "2: Counter in 32-bit mode"]
+    COUNT32,
+}
+impl From<MODE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: MODE_A) -> Self {
+        match variant {
+            MODE_A::COUNT16 => 0,
+            MODE_A::COUNT8 => 1,
+            MODE_A::COUNT32 => 2,
+        }
+    }
+}
+#[doc = "Reader of field `MODE`"]
+pub type MODE_R = crate::R<u8, MODE_A>;
+impl MODE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, MODE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(MODE_A::COUNT16),
+            1 => Val(MODE_A::COUNT8),
+            2 => Val(MODE_A::COUNT32),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `COUNT16`"]
+    #[inline(always)]
+    pub fn is_count16(&self) -> bool {
+        *self == MODE_A::COUNT16
+    }
+    #[doc = "Checks if the value of the field is `COUNT8`"]
+    #[inline(always)]
+    pub fn is_count8(&self) -> bool {
+        *self == MODE_A::COUNT8
+    }
+    #[doc = "Checks if the value of the field is `COUNT32`"]
+    #[inline(always)]
+    pub fn is_count32(&self) -> bool {
+        *self == MODE_A::COUNT32
+    }
+}
+#[doc = "Write proxy for field `MODE`"]
+pub struct MODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MODE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: MODE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Counter in 16-bit mode"]
+    #[inline(always)]
+    pub fn count16(self) -> &'a mut W {
+        self.variant(MODE_A::COUNT16)
+    }
+    #[doc = "Counter in 8-bit mode"]
+    #[inline(always)]
+    pub fn count8(self) -> &'a mut W {
+        self.variant(MODE_A::COUNT8)
+    }
+    #[doc = "Counter in 32-bit mode"]
+    #[inline(always)]
+    pub fn count32(self) -> &'a mut W {
+        self.variant(MODE_A::COUNT32)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 2)) | (((value as u16) & 0x03) << 2);
+        self.w
+    }
+}
+#[doc = "Waveform Generation Operation\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum WAVEGEN_A {
+    #[doc = "0: `0`"]
+    NFRQ,
+    #[doc = "1: `1`"]
+    MFRQ,
+    #[doc = "2: `10`"]
+    NPWM,
+    #[doc = "3: `11`"]
+    MPWM,
+}
+impl From<WAVEGEN_A> for u8 {
+    #[inline(always)]
+    fn from(variant: WAVEGEN_A) -> Self {
+        match variant {
+            WAVEGEN_A::NFRQ => 0,
+            WAVEGEN_A::MFRQ => 1,
+            WAVEGEN_A::NPWM => 2,
+            WAVEGEN_A::MPWM => 3,
+        }
+    }
+}
+#[doc = "Reader of field `WAVEGEN`"]
+pub type WAVEGEN_R = crate::R<u8, WAVEGEN_A>;
+impl WAVEGEN_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> WAVEGEN_A {
+        match self.bits {
+            0 => WAVEGEN_A::NFRQ,
+            1 => WAVEGEN_A::MFRQ,
+            2 => WAVEGEN_A::NPWM,
+            3 => WAVEGEN_A::MPWM,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NFRQ`"]
+    #[inline(always)]
+    pub fn is_nfrq(&self) -> bool {
+        *self == WAVEGEN_A::NFRQ
+    }
+    #[doc = "Checks if the value of the field is `MFRQ`"]
+    #[inline(always)]
+    pub fn is_mfrq(&self) -> bool {
+        *self == WAVEGEN_A::MFRQ
+    }
+    #[doc = "Checks if the value of the field is `NPWM`"]
+    #[inline(always)]
+    pub fn is_npwm(&self) -> bool {
+        *self == WAVEGEN_A::NPWM
+    }
+    #[doc = "Checks if the value of the field is `MPWM`"]
+    #[inline(always)]
+    pub fn is_mpwm(&self) -> bool {
+        *self == WAVEGEN_A::MPWM
+    }
+}
+#[doc = "Write proxy for field `WAVEGEN`"]
+pub struct WAVEGEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAVEGEN_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: WAVEGEN_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "`0`"]
+    #[inline(always)]
+    pub fn nfrq(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::NFRQ)
+    }
+    #[doc = "`1`"]
+    #[inline(always)]
+    pub fn mfrq(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::MFRQ)
+    }
+    #[doc = "`10`"]
+    #[inline(always)]
+    pub fn npwm(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::NPWM)
+    }
+    #[doc = "`11`"]
+    #[inline(always)]
+    pub fn mpwm(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::MPWM)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 5)) | (((value as u16) & 0x03) << 5);
+        self.w
+    }
+}
+#[doc = "Prescaler\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PRESCALER_A {
+    #[doc = "0: Prescaler: GCLK_TC"]
+    DIV1,
+    #[doc = "1: Prescaler: GCLK_TC/2"]
+    DIV2,
+    #[doc = "2: Prescaler: GCLK_TC/4"]
+    DIV4,
+    #[doc = "3: Prescaler: GCLK_TC/8"]
+    DIV8,
+    #[doc = "4: Prescaler: GCLK_TC/16"]
+    DIV16,
+    #[doc = "5: Prescaler: GCLK_TC/64"]
+    DIV64,
+    #[doc = "6: Prescaler: GCLK_TC/256"]
+    DIV256,
+    #[doc = "7: Prescaler: GCLK_TC/1024"]
+    DIV1024,
+}
+impl From<PRESCALER_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PRESCALER_A) -> Self {
+        match variant {
+            PRESCALER_A::DIV1 => 0,
+            PRESCALER_A::DIV2 => 1,
+            PRESCALER_A::DIV4 => 2,
+            PRESCALER_A::DIV8 => 3,
+            PRESCALER_A::DIV16 => 4,
+            PRESCALER_A::DIV64 => 5,
+            PRESCALER_A::DIV256 => 6,
+            PRESCALER_A::DIV1024 => 7,
+        }
+    }
+}
+#[doc = "Reader of field `PRESCALER`"]
+pub type PRESCALER_R = crate::R<u8, PRESCALER_A>;
+impl PRESCALER_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> PRESCALER_A {
+        match self.bits {
+            0 => PRESCALER_A::DIV1,
+            1 => PRESCALER_A::DIV2,
+            2 => PRESCALER_A::DIV4,
+            3 => PRESCALER_A::DIV8,
+            4 => PRESCALER_A::DIV16,
+            5 => PRESCALER_A::DIV64,
+            6 => PRESCALER_A::DIV256,
+            7 => PRESCALER_A::DIV1024,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DIV1`"]
+    #[inline(always)]
+    pub fn is_div1(&self) -> bool {
+        *self == PRESCALER_A::DIV1
+    }
+    #[doc = "Checks if the value of the field is `DIV2`"]
+    #[inline(always)]
+    pub fn is_div2(&self) -> bool {
+        *self == PRESCALER_A::DIV2
+    }
+    #[doc = "Checks if the value of the field is `DIV4`"]
+    #[inline(always)]
+    pub fn is_div4(&self) -> bool {
+        *self == PRESCALER_A::DIV4
+    }
+    #[doc = "Checks if the value of the field is `DIV8`"]
+    #[inline(always)]
+    pub fn is_div8(&self) -> bool {
+        *self == PRESCALER_A::DIV8
+    }
+    #[doc = "Checks if the value of the field is `DIV16`"]
+    #[inline(always)]
+    pub fn is_div16(&self) -> bool {
+        *self == PRESCALER_A::DIV16
+    }
+    #[doc = "Checks if the value of the field is `DIV64`"]
+    #[inline(always)]
+    pub fn is_div64(&self) -> bool {
+        *self == PRESCALER_A::DIV64
+    }
+    #[doc = "Checks if the value of the field is `DIV256`"]
+    #[inline(always)]
+    pub fn is_div256(&self) -> bool {
+        *self == PRESCALER_A::DIV256
+    }
+    #[doc = "Checks if the value of the field is `DIV1024`"]
+    #[inline(always)]
+    pub fn is_div1024(&self) -> bool {
+        *self == PRESCALER_A::DIV1024
+    }
+}
+#[doc = "Write proxy for field `PRESCALER`"]
+pub struct PRESCALER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PRESCALER_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PRESCALER_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Prescaler: GCLK_TC"]
+    #[inline(always)]
+    pub fn div1(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV1)
+    }
+    #[doc = "Prescaler: GCLK_TC/2"]
+    #[inline(always)]
+    pub fn div2(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV2)
+    }
+    #[doc = "Prescaler: GCLK_TC/4"]
+    #[inline(always)]
+    pub fn div4(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV4)
+    }
+    #[doc = "Prescaler: GCLK_TC/8"]
+    #[inline(always)]
+    pub fn div8(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV8)
+    }
+    #[doc = "Prescaler: GCLK_TC/16"]
+    #[inline(always)]
+    pub fn div16(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV16)
+    }
+    #[doc = "Prescaler: GCLK_TC/64"]
+    #[inline(always)]
+    pub fn div64(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV64)
+    }
+    #[doc = "Prescaler: GCLK_TC/256"]
+    #[inline(always)]
+    pub fn div256(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV256)
+    }
+    #[doc = "Prescaler: GCLK_TC/1024"]
+    #[inline(always)]
+    pub fn div1024(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV1024)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 8)) | (((value as u16) & 0x07) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u16) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Prescaler and Counter Synchronization\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PRESCSYNC_A {
+    #[doc = "0: Reload or reset the counter on next generic clock"]
+    GCLK,
+    #[doc = "1: Reload or reset the counter on next prescaler clock"]
+    PRESC,
+    #[doc = "2: Reload or reset the counter on next generic clock. Reset the prescaler counter"]
+    RESYNC,
+}
+impl From<PRESCSYNC_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PRESCSYNC_A) -> Self {
+        match variant {
+            PRESCSYNC_A::GCLK => 0,
+            PRESCSYNC_A::PRESC => 1,
+            PRESCSYNC_A::RESYNC => 2,
+        }
+    }
+}
+#[doc = "Reader of field `PRESCSYNC`"]
+pub type PRESCSYNC_R = crate::R<u8, PRESCSYNC_A>;
+impl PRESCSYNC_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, PRESCSYNC_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(PRESCSYNC_A::GCLK),
+            1 => Val(PRESCSYNC_A::PRESC),
+            2 => Val(PRESCSYNC_A::RESYNC),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `GCLK`"]
+    #[inline(always)]
+    pub fn is_gclk(&self) -> bool {
+        *self == PRESCSYNC_A::GCLK
+    }
+    #[doc = "Checks if the value of the field is `PRESC`"]
+    #[inline(always)]
+    pub fn is_presc(&self) -> bool {
+        *self == PRESCSYNC_A::PRESC
+    }
+    #[doc = "Checks if the value of the field is `RESYNC`"]
+    #[inline(always)]
+    pub fn is_resync(&self) -> bool {
+        *self == PRESCSYNC_A::RESYNC
+    }
+}
+#[doc = "Write proxy for field `PRESCSYNC`"]
+pub struct PRESCSYNC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PRESCSYNC_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PRESCSYNC_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Reload or reset the counter on next generic clock"]
+    #[inline(always)]
+    pub fn gclk(self) -> &'a mut W {
+        self.variant(PRESCSYNC_A::GCLK)
+    }
+    #[doc = "Reload or reset the counter on next prescaler clock"]
+    #[inline(always)]
+    pub fn presc(self) -> &'a mut W {
+        self.variant(PRESCSYNC_A::PRESC)
+    }
+    #[doc = "Reload or reset the counter on next generic clock. Reset the prescaler counter"]
+    #[inline(always)]
+    pub fn resync(self) -> &'a mut W {
+        self.variant(PRESCSYNC_A::RESYNC)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 12)) | (((value as u16) & 0x03) << 12);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 2:3 - TC Mode"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 2) & 0x03) as u8)
+    }
+    #[doc = "Bits 5:6 - Waveform Generation Operation"]
+    #[inline(always)]
+    pub fn wavegen(&self) -> WAVEGEN_R {
+        WAVEGEN_R::new(((self.bits >> 5) & 0x03) as u8)
+    }
+    #[doc = "Bits 8:10 - Prescaler"]
+    #[inline(always)]
+    pub fn prescaler(&self) -> PRESCALER_R {
+        PRESCALER_R::new(((self.bits >> 8) & 0x07) as u8)
+    }
+    #[doc = "Bit 11 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bits 12:13 - Prescaler and Counter Synchronization"]
+    #[inline(always)]
+    pub fn prescsync(&self) -> PRESCSYNC_R {
+        PRESCSYNC_R::new(((self.bits >> 12) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bits 2:3 - TC Mode"]
+    #[inline(always)]
+    pub fn mode(&mut self) -> MODE_W {
+        MODE_W { w: self }
+    }
+    #[doc = "Bits 5:6 - Waveform Generation Operation"]
+    #[inline(always)]
+    pub fn wavegen(&mut self) -> WAVEGEN_W {
+        WAVEGEN_W { w: self }
+    }
+    #[doc = "Bits 8:10 - Prescaler"]
+    #[inline(always)]
+    pub fn prescaler(&mut self) -> PRESCALER_W {
+        PRESCALER_W { w: self }
+    }
+    #[doc = "Bit 11 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bits 12:13 - Prescaler and Counter Synchronization"]
+    #[inline(always)]
+    pub fn prescsync(&mut self) -> PRESCSYNC_W {
+        PRESCSYNC_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count32/ctrlbclr.rs
+++ b/pac/atsamd11c14a/src/tc1/count32/ctrlbclr.rs
@@ -1,0 +1,176 @@
+#[doc = "Reader of register CTRLBCLR"]
+pub type R = crate::R<u8, super::CTRLBCLR>;
+#[doc = "Writer for register CTRLBCLR"]
+pub type W = crate::W<u8, super::CTRLBCLR>;
+#[doc = "Register CTRLBCLR `reset()`'s with value 0x02"]
+impl crate::ResetValue for super::CTRLBCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x02
+    }
+}
+#[doc = "Reader of field `DIR`"]
+pub type DIR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DIR`"]
+pub struct DIR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ONESHOT`"]
+pub type ONESHOT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ONESHOT`"]
+pub struct ONESHOT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ONESHOT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Command\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CMD_A {
+    #[doc = "0: No action"]
+    NONE,
+    #[doc = "1: Force a start, restart or retrigger"]
+    RETRIGGER,
+    #[doc = "2: Force a stop"]
+    STOP,
+}
+impl From<CMD_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CMD_A) -> Self {
+        match variant {
+            CMD_A::NONE => 0,
+            CMD_A::RETRIGGER => 1,
+            CMD_A::STOP => 2,
+        }
+    }
+}
+#[doc = "Reader of field `CMD`"]
+pub type CMD_R = crate::R<u8, CMD_A>;
+impl CMD_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, CMD_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(CMD_A::NONE),
+            1 => Val(CMD_A::RETRIGGER),
+            2 => Val(CMD_A::STOP),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == CMD_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RETRIGGER`"]
+    #[inline(always)]
+    pub fn is_retrigger(&self) -> bool {
+        *self == CMD_A::RETRIGGER
+    }
+    #[doc = "Checks if the value of the field is `STOP`"]
+    #[inline(always)]
+    pub fn is_stop(&self) -> bool {
+        *self == CMD_A::STOP
+    }
+}
+#[doc = "Write proxy for field `CMD`"]
+pub struct CMD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMD_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CMD_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No action"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(CMD_A::NONE)
+    }
+    #[doc = "Force a start, restart or retrigger"]
+    #[inline(always)]
+    pub fn retrigger(self) -> &'a mut W {
+        self.variant(CMD_A::RETRIGGER)
+    }
+    #[doc = "Force a stop"]
+    #[inline(always)]
+    pub fn stop(self) -> &'a mut W {
+        self.variant(CMD_A::STOP)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 6)) | (((value as u8) & 0x03) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&self) -> DIR_R {
+        DIR_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&self) -> ONESHOT_R {
+        ONESHOT_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bits 6:7 - Command"]
+    #[inline(always)]
+    pub fn cmd(&self) -> CMD_R {
+        CMD_R::new(((self.bits >> 6) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&mut self) -> DIR_W {
+        DIR_W { w: self }
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&mut self) -> ONESHOT_W {
+        ONESHOT_W { w: self }
+    }
+    #[doc = "Bits 6:7 - Command"]
+    #[inline(always)]
+    pub fn cmd(&mut self) -> CMD_W {
+        CMD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count32/ctrlbset.rs
+++ b/pac/atsamd11c14a/src/tc1/count32/ctrlbset.rs
@@ -1,0 +1,176 @@
+#[doc = "Reader of register CTRLBSET"]
+pub type R = crate::R<u8, super::CTRLBSET>;
+#[doc = "Writer for register CTRLBSET"]
+pub type W = crate::W<u8, super::CTRLBSET>;
+#[doc = "Register CTRLBSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLBSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DIR`"]
+pub type DIR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DIR`"]
+pub struct DIR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ONESHOT`"]
+pub type ONESHOT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ONESHOT`"]
+pub struct ONESHOT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ONESHOT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Command\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CMD_A {
+    #[doc = "0: No action"]
+    NONE,
+    #[doc = "1: Force a start, restart or retrigger"]
+    RETRIGGER,
+    #[doc = "2: Force a stop"]
+    STOP,
+}
+impl From<CMD_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CMD_A) -> Self {
+        match variant {
+            CMD_A::NONE => 0,
+            CMD_A::RETRIGGER => 1,
+            CMD_A::STOP => 2,
+        }
+    }
+}
+#[doc = "Reader of field `CMD`"]
+pub type CMD_R = crate::R<u8, CMD_A>;
+impl CMD_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, CMD_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(CMD_A::NONE),
+            1 => Val(CMD_A::RETRIGGER),
+            2 => Val(CMD_A::STOP),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == CMD_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RETRIGGER`"]
+    #[inline(always)]
+    pub fn is_retrigger(&self) -> bool {
+        *self == CMD_A::RETRIGGER
+    }
+    #[doc = "Checks if the value of the field is `STOP`"]
+    #[inline(always)]
+    pub fn is_stop(&self) -> bool {
+        *self == CMD_A::STOP
+    }
+}
+#[doc = "Write proxy for field `CMD`"]
+pub struct CMD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMD_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CMD_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No action"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(CMD_A::NONE)
+    }
+    #[doc = "Force a start, restart or retrigger"]
+    #[inline(always)]
+    pub fn retrigger(self) -> &'a mut W {
+        self.variant(CMD_A::RETRIGGER)
+    }
+    #[doc = "Force a stop"]
+    #[inline(always)]
+    pub fn stop(self) -> &'a mut W {
+        self.variant(CMD_A::STOP)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 6)) | (((value as u8) & 0x03) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&self) -> DIR_R {
+        DIR_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&self) -> ONESHOT_R {
+        ONESHOT_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bits 6:7 - Command"]
+    #[inline(always)]
+    pub fn cmd(&self) -> CMD_R {
+        CMD_R::new(((self.bits >> 6) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&mut self) -> DIR_W {
+        DIR_W { w: self }
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&mut self) -> ONESHOT_W {
+        ONESHOT_W { w: self }
+    }
+    #[doc = "Bits 6:7 - Command"]
+    #[inline(always)]
+    pub fn cmd(&mut self) -> CMD_W {
+        CMD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count32/ctrlc.rs
+++ b/pac/atsamd11c14a/src/tc1/count32/ctrlc.rs
@@ -1,0 +1,152 @@
+#[doc = "Reader of register CTRLC"]
+pub type R = crate::R<u8, super::CTRLC>;
+#[doc = "Writer for register CTRLC"]
+pub type W = crate::W<u8, super::CTRLC>;
+#[doc = "Register CTRLC `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLC {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `INVEN0`"]
+pub type INVEN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INVEN0`"]
+pub struct INVEN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INVEN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `INVEN1`"]
+pub type INVEN1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INVEN1`"]
+pub struct INVEN1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INVEN1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `CPTEN0`"]
+pub type CPTEN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CPTEN0`"]
+pub struct CPTEN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CPTEN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `CPTEN1`"]
+pub type CPTEN1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CPTEN1`"]
+pub struct CPTEN1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CPTEN1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Output Waveform 0 Invert Enable"]
+    #[inline(always)]
+    pub fn inven0(&self) -> INVEN0_R {
+        INVEN0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Output Waveform 1 Invert Enable"]
+    #[inline(always)]
+    pub fn inven1(&self) -> INVEN1_R {
+        INVEN1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Capture Channel 0 Enable"]
+    #[inline(always)]
+    pub fn cpten0(&self) -> CPTEN0_R {
+        CPTEN0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Capture Channel 1 Enable"]
+    #[inline(always)]
+    pub fn cpten1(&self) -> CPTEN1_R {
+        CPTEN1_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Output Waveform 0 Invert Enable"]
+    #[inline(always)]
+    pub fn inven0(&mut self) -> INVEN0_W {
+        INVEN0_W { w: self }
+    }
+    #[doc = "Bit 1 - Output Waveform 1 Invert Enable"]
+    #[inline(always)]
+    pub fn inven1(&mut self) -> INVEN1_W {
+        INVEN1_W { w: self }
+    }
+    #[doc = "Bit 4 - Capture Channel 0 Enable"]
+    #[inline(always)]
+    pub fn cpten0(&mut self) -> CPTEN0_W {
+        CPTEN0_W { w: self }
+    }
+    #[doc = "Bit 5 - Capture Channel 1 Enable"]
+    #[inline(always)]
+    pub fn cpten1(&mut self) -> CPTEN1_W {
+        CPTEN1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count32/dbgctrl.rs
+++ b/pac/atsamd11c14a/src/tc1/count32/dbgctrl.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register DBGCTRL"]
+pub type R = crate::R<u8, super::DBGCTRL>;
+#[doc = "Writer for register DBGCTRL"]
+pub type W = crate::W<u8, super::DBGCTRL>;
+#[doc = "Register DBGCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::DBGCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DBGRUN`"]
+pub type DBGRUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DBGRUN`"]
+pub struct DBGRUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DBGRUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Debug Run Mode"]
+    #[inline(always)]
+    pub fn dbgrun(&self) -> DBGRUN_R {
+        DBGRUN_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Debug Run Mode"]
+    #[inline(always)]
+    pub fn dbgrun(&mut self) -> DBGRUN_W {
+        DBGRUN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count32/evctrl.rs
+++ b/pac/atsamd11c14a/src/tc1/count32/evctrl.rs
@@ -1,0 +1,320 @@
+#[doc = "Reader of register EVCTRL"]
+pub type R = crate::R<u16, super::EVCTRL>;
+#[doc = "Writer for register EVCTRL"]
+pub type W = crate::W<u16, super::EVCTRL>;
+#[doc = "Register EVCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::EVCTRL {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Event Action\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum EVACT_A {
+    #[doc = "0: Event action disabled"]
+    OFF,
+    #[doc = "1: Start, restart or retrigger TC on event"]
+    RETRIGGER,
+    #[doc = "2: Count on event"]
+    COUNT,
+    #[doc = "3: Start TC on event"]
+    START,
+    #[doc = "5: Period captured in CC0, pulse width in CC1"]
+    PPW,
+    #[doc = "6: Period captured in CC1, pulse width in CC0"]
+    PWP,
+}
+impl From<EVACT_A> for u8 {
+    #[inline(always)]
+    fn from(variant: EVACT_A) -> Self {
+        match variant {
+            EVACT_A::OFF => 0,
+            EVACT_A::RETRIGGER => 1,
+            EVACT_A::COUNT => 2,
+            EVACT_A::START => 3,
+            EVACT_A::PPW => 5,
+            EVACT_A::PWP => 6,
+        }
+    }
+}
+#[doc = "Reader of field `EVACT`"]
+pub type EVACT_R = crate::R<u8, EVACT_A>;
+impl EVACT_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, EVACT_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(EVACT_A::OFF),
+            1 => Val(EVACT_A::RETRIGGER),
+            2 => Val(EVACT_A::COUNT),
+            3 => Val(EVACT_A::START),
+            5 => Val(EVACT_A::PPW),
+            6 => Val(EVACT_A::PWP),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `OFF`"]
+    #[inline(always)]
+    pub fn is_off(&self) -> bool {
+        *self == EVACT_A::OFF
+    }
+    #[doc = "Checks if the value of the field is `RETRIGGER`"]
+    #[inline(always)]
+    pub fn is_retrigger(&self) -> bool {
+        *self == EVACT_A::RETRIGGER
+    }
+    #[doc = "Checks if the value of the field is `COUNT`"]
+    #[inline(always)]
+    pub fn is_count(&self) -> bool {
+        *self == EVACT_A::COUNT
+    }
+    #[doc = "Checks if the value of the field is `START`"]
+    #[inline(always)]
+    pub fn is_start(&self) -> bool {
+        *self == EVACT_A::START
+    }
+    #[doc = "Checks if the value of the field is `PPW`"]
+    #[inline(always)]
+    pub fn is_ppw(&self) -> bool {
+        *self == EVACT_A::PPW
+    }
+    #[doc = "Checks if the value of the field is `PWP`"]
+    #[inline(always)]
+    pub fn is_pwp(&self) -> bool {
+        *self == EVACT_A::PWP
+    }
+}
+#[doc = "Write proxy for field `EVACT`"]
+pub struct EVACT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVACT_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: EVACT_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Event action disabled"]
+    #[inline(always)]
+    pub fn off(self) -> &'a mut W {
+        self.variant(EVACT_A::OFF)
+    }
+    #[doc = "Start, restart or retrigger TC on event"]
+    #[inline(always)]
+    pub fn retrigger(self) -> &'a mut W {
+        self.variant(EVACT_A::RETRIGGER)
+    }
+    #[doc = "Count on event"]
+    #[inline(always)]
+    pub fn count(self) -> &'a mut W {
+        self.variant(EVACT_A::COUNT)
+    }
+    #[doc = "Start TC on event"]
+    #[inline(always)]
+    pub fn start(self) -> &'a mut W {
+        self.variant(EVACT_A::START)
+    }
+    #[doc = "Period captured in CC0, pulse width in CC1"]
+    #[inline(always)]
+    pub fn ppw(self) -> &'a mut W {
+        self.variant(EVACT_A::PPW)
+    }
+    #[doc = "Period captured in CC1, pulse width in CC0"]
+    #[inline(always)]
+    pub fn pwp(self) -> &'a mut W {
+        self.variant(EVACT_A::PWP)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u16) & 0x07);
+        self.w
+    }
+}
+#[doc = "Reader of field `TCINV`"]
+pub type TCINV_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TCINV`"]
+pub struct TCINV_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TCINV_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `TCEI`"]
+pub type TCEI_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TCEI`"]
+pub struct TCEI_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TCEI_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVFEO`"]
+pub type OVFEO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVFEO`"]
+pub struct OVFEO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVFEO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `MCEO0`"]
+pub type MCEO0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MCEO0`"]
+pub struct MCEO0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MCEO0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u16) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `MCEO1`"]
+pub type MCEO1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MCEO1`"]
+pub struct MCEO1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MCEO1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u16) & 0x01) << 13);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Event Action"]
+    #[inline(always)]
+    pub fn evact(&self) -> EVACT_R {
+        EVACT_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bit 4 - TC Inverted Event Input"]
+    #[inline(always)]
+    pub fn tcinv(&self) -> TCINV_R {
+        TCINV_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - TC Event Input"]
+    #[inline(always)]
+    pub fn tcei(&self) -> TCEI_R {
+        TCEI_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Overflow/Underflow Event Output Enable"]
+    #[inline(always)]
+    pub fn ovfeo(&self) -> OVFEO_R {
+        OVFEO_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - Match or Capture Channel 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo0(&self) -> MCEO0_R {
+        MCEO0_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Match or Capture Channel 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo1(&self) -> MCEO1_R {
+        MCEO1_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Event Action"]
+    #[inline(always)]
+    pub fn evact(&mut self) -> EVACT_W {
+        EVACT_W { w: self }
+    }
+    #[doc = "Bit 4 - TC Inverted Event Input"]
+    #[inline(always)]
+    pub fn tcinv(&mut self) -> TCINV_W {
+        TCINV_W { w: self }
+    }
+    #[doc = "Bit 5 - TC Event Input"]
+    #[inline(always)]
+    pub fn tcei(&mut self) -> TCEI_W {
+        TCEI_W { w: self }
+    }
+    #[doc = "Bit 8 - Overflow/Underflow Event Output Enable"]
+    #[inline(always)]
+    pub fn ovfeo(&mut self) -> OVFEO_W {
+        OVFEO_W { w: self }
+    }
+    #[doc = "Bit 12 - Match or Capture Channel 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo0(&mut self) -> MCEO0_W {
+        MCEO0_W { w: self }
+    }
+    #[doc = "Bit 13 - Match or Capture Channel 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo1(&mut self) -> MCEO1_W {
+        MCEO1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count32/intenclr.rs
+++ b/pac/atsamd11c14a/src/tc1/count32/intenclr.rs
@@ -1,0 +1,186 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERR`"]
+pub type ERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERR`"]
+pub struct ERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC0`"]
+pub type MC0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC0`"]
+pub struct MC0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC1`"]
+pub type MC1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC1`"]
+pub struct MC1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&self) -> ERR_R {
+        ERR_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&self) -> MC0_R {
+        MC0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&self) -> MC1_R {
+        MC1_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&mut self) -> ERR_W {
+        ERR_W { w: self }
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&mut self) -> MC0_W {
+        MC0_W { w: self }
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&mut self) -> MC1_W {
+        MC1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count32/intenset.rs
+++ b/pac/atsamd11c14a/src/tc1/count32/intenset.rs
@@ -1,0 +1,186 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERR`"]
+pub type ERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERR`"]
+pub struct ERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC0`"]
+pub type MC0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC0`"]
+pub struct MC0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC1`"]
+pub type MC1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC1`"]
+pub struct MC1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&self) -> ERR_R {
+        ERR_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&self) -> MC0_R {
+        MC0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&self) -> MC1_R {
+        MC1_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&mut self) -> ERR_W {
+        ERR_W { w: self }
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&mut self) -> MC0_W {
+        MC0_W { w: self }
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&mut self) -> MC1_W {
+        MC1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count32/intflag.rs
+++ b/pac/atsamd11c14a/src/tc1/count32/intflag.rs
@@ -1,0 +1,186 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERR`"]
+pub type ERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERR`"]
+pub struct ERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC0`"]
+pub type MC0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC0`"]
+pub struct MC0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC1`"]
+pub type MC1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC1`"]
+pub struct MC1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Overflow"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Error"]
+    #[inline(always)]
+    pub fn err(&self) -> ERR_R {
+        ERR_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0"]
+    #[inline(always)]
+    pub fn mc0(&self) -> MC0_R {
+        MC0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1"]
+    #[inline(always)]
+    pub fn mc1(&self) -> MC1_R {
+        MC1_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Overflow"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+    #[doc = "Bit 1 - Error"]
+    #[inline(always)]
+    pub fn err(&mut self) -> ERR_W {
+        ERR_W { w: self }
+    }
+    #[doc = "Bit 3 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0"]
+    #[inline(always)]
+    pub fn mc0(&mut self) -> MC0_W {
+        MC0_W { w: self }
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1"]
+    #[inline(always)]
+    pub fn mc1(&mut self) -> MC1_W {
+        MC1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count32/readreq.rs
+++ b/pac/atsamd11c14a/src/tc1/count32/readreq.rs
@@ -1,0 +1,108 @@
+#[doc = "Reader of register READREQ"]
+pub type R = crate::R<u16, super::READREQ>;
+#[doc = "Writer for register READREQ"]
+pub type W = crate::W<u16, super::READREQ>;
+#[doc = "Register READREQ `reset()`'s with value 0"]
+impl crate::ResetValue for super::READREQ {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ADDR`"]
+pub type ADDR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `ADDR`"]
+pub struct ADDR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ADDR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x1f) | ((value as u16) & 0x1f);
+        self.w
+    }
+}
+#[doc = "Reader of field `RCONT`"]
+pub type RCONT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RCONT`"]
+pub struct RCONT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RCONT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u16) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `RREQ`"]
+pub type RREQ_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RREQ`"]
+pub struct RREQ_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RREQ_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u16) & 0x01) << 15);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:4 - Address"]
+    #[inline(always)]
+    pub fn addr(&self) -> ADDR_R {
+        ADDR_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bit 14 - Read Continuously"]
+    #[inline(always)]
+    pub fn rcont(&self) -> RCONT_R {
+        RCONT_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Read Request"]
+    #[inline(always)]
+    pub fn rreq(&self) -> RREQ_R {
+        RREQ_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - Address"]
+    #[inline(always)]
+    pub fn addr(&mut self) -> ADDR_W {
+        ADDR_W { w: self }
+    }
+    #[doc = "Bit 14 - Read Continuously"]
+    #[inline(always)]
+    pub fn rcont(&mut self) -> RCONT_W {
+        RCONT_W { w: self }
+    }
+    #[doc = "Bit 15 - Read Request"]
+    #[inline(always)]
+    pub fn rreq(&mut self) -> RREQ_W {
+        RREQ_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count32/status.rs
+++ b/pac/atsamd11c14a/src/tc1/count32/status.rs
@@ -1,0 +1,25 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u8, super::STATUS>;
+#[doc = "Reader of field `STOP`"]
+pub type STOP_R = crate::R<bool, bool>;
+#[doc = "Reader of field `SLAVE`"]
+pub type SLAVE_R = crate::R<bool, bool>;
+#[doc = "Reader of field `SYNCBUSY`"]
+pub type SYNCBUSY_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 3 - Stop"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Slave"]
+    #[inline(always)]
+    pub fn slave(&self) -> SLAVE_R {
+        SLAVE_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Synchronization Busy"]
+    #[inline(always)]
+    pub fn syncbusy(&self) -> SYNCBUSY_R {
+        SYNCBUSY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count8.rs
+++ b/pac/atsamd11c14a/src/tc1/count8.rs
@@ -1,0 +1,152 @@
+#[doc = "Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrla](ctrla) module"]
+pub type CTRLA = crate::Reg<u16, _CTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLA;
+#[doc = "`read()` method returns [ctrla::R](ctrla::R) reader structure"]
+impl crate::Readable for CTRLA {}
+#[doc = "`write(|w| ..)` method takes [ctrla::W](ctrla::W) writer structure"]
+impl crate::Writable for CTRLA {}
+#[doc = "Control A"]
+pub mod ctrla;
+#[doc = "Read Request\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [readreq](readreq) module"]
+pub type READREQ = crate::Reg<u16, _READREQ>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _READREQ;
+#[doc = "`read()` method returns [readreq::R](readreq::R) reader structure"]
+impl crate::Readable for READREQ {}
+#[doc = "`write(|w| ..)` method takes [readreq::W](readreq::W) writer structure"]
+impl crate::Writable for READREQ {}
+#[doc = "Read Request"]
+pub mod readreq;
+#[doc = "Control B Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlbclr](ctrlbclr) module"]
+pub type CTRLBCLR = crate::Reg<u8, _CTRLBCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLBCLR;
+#[doc = "`read()` method returns [ctrlbclr::R](ctrlbclr::R) reader structure"]
+impl crate::Readable for CTRLBCLR {}
+#[doc = "`write(|w| ..)` method takes [ctrlbclr::W](ctrlbclr::W) writer structure"]
+impl crate::Writable for CTRLBCLR {}
+#[doc = "Control B Clear"]
+pub mod ctrlbclr;
+#[doc = "Control B Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlbset](ctrlbset) module"]
+pub type CTRLBSET = crate::Reg<u8, _CTRLBSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLBSET;
+#[doc = "`read()` method returns [ctrlbset::R](ctrlbset::R) reader structure"]
+impl crate::Readable for CTRLBSET {}
+#[doc = "`write(|w| ..)` method takes [ctrlbset::W](ctrlbset::W) writer structure"]
+impl crate::Writable for CTRLBSET {}
+#[doc = "Control B Set"]
+pub mod ctrlbset;
+#[doc = "Control C\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlc](ctrlc) module"]
+pub type CTRLC = crate::Reg<u8, _CTRLC>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLC;
+#[doc = "`read()` method returns [ctrlc::R](ctrlc::R) reader structure"]
+impl crate::Readable for CTRLC {}
+#[doc = "`write(|w| ..)` method takes [ctrlc::W](ctrlc::W) writer structure"]
+impl crate::Writable for CTRLC {}
+#[doc = "Control C"]
+pub mod ctrlc;
+#[doc = "Debug Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dbgctrl](dbgctrl) module"]
+pub type DBGCTRL = crate::Reg<u8, _DBGCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DBGCTRL;
+#[doc = "`read()` method returns [dbgctrl::R](dbgctrl::R) reader structure"]
+impl crate::Readable for DBGCTRL {}
+#[doc = "`write(|w| ..)` method takes [dbgctrl::W](dbgctrl::W) writer structure"]
+impl crate::Writable for DBGCTRL {}
+#[doc = "Debug Control"]
+pub mod dbgctrl;
+#[doc = "Event Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [evctrl](evctrl) module"]
+pub type EVCTRL = crate::Reg<u16, _EVCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EVCTRL;
+#[doc = "`read()` method returns [evctrl::R](evctrl::R) reader structure"]
+impl crate::Readable for EVCTRL {}
+#[doc = "`write(|w| ..)` method takes [evctrl::W](evctrl::W) writer structure"]
+impl crate::Writable for EVCTRL {}
+#[doc = "Event Control"]
+pub mod evctrl;
+#[doc = "Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u8, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "Status"]
+pub mod status;
+#[doc = "COUNT8 Counter Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [count](count) module"]
+pub type COUNT = crate::Reg<u8, _COUNT>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _COUNT;
+#[doc = "`read()` method returns [count::R](count::R) reader structure"]
+impl crate::Readable for COUNT {}
+#[doc = "`write(|w| ..)` method takes [count::W](count::W) writer structure"]
+impl crate::Writable for COUNT {}
+#[doc = "COUNT8 Counter Value"]
+pub mod count;
+#[doc = "COUNT8 Period Value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [per](per) module"]
+pub type PER = crate::Reg<u8, _PER>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PER;
+#[doc = "`read()` method returns [per::R](per::R) reader structure"]
+impl crate::Readable for PER {}
+#[doc = "`write(|w| ..)` method takes [per::W](per::W) writer structure"]
+impl crate::Writable for PER {}
+#[doc = "COUNT8 Period Value"]
+pub mod per;
+#[doc = "COUNT8 Compare/Capture\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc](cc) module"]
+pub type CC = crate::Reg<u8, _CC>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CC;
+#[doc = "`read()` method returns [cc::R](cc::R) reader structure"]
+impl crate::Readable for CC {}
+#[doc = "`write(|w| ..)` method takes [cc::W](cc::W) writer structure"]
+impl crate::Writable for CC {}
+#[doc = "COUNT8 Compare/Capture"]
+pub mod cc;

--- a/pac/atsamd11c14a/src/tc1/count8/cc.rs
+++ b/pac/atsamd11c14a/src/tc1/count8/cc.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register CC%s"]
+pub type R = crate::R<u8, super::CC>;
+#[doc = "Writer for register CC%s"]
+pub type W = crate::W<u8, super::CC>;
+#[doc = "Register CC%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::CC {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CC`"]
+pub type CC_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `CC`"]
+pub struct CC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CC_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xff) | ((value as u8) & 0xff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:7 - Compare/Capture Value"]
+    #[inline(always)]
+    pub fn cc(&self) -> CC_R {
+        CC_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Compare/Capture Value"]
+    #[inline(always)]
+    pub fn cc(&mut self) -> CC_W {
+        CC_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count8/count.rs
+++ b/pac/atsamd11c14a/src/tc1/count8/count.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register COUNT"]
+pub type R = crate::R<u8, super::COUNT>;
+#[doc = "Writer for register COUNT"]
+pub type W = crate::W<u8, super::COUNT>;
+#[doc = "Register COUNT `reset()`'s with value 0"]
+impl crate::ResetValue for super::COUNT {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `COUNT`"]
+pub type COUNT_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `COUNT`"]
+pub struct COUNT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COUNT_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xff) | ((value as u8) & 0xff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:7 - Counter Value"]
+    #[inline(always)]
+    pub fn count(&self) -> COUNT_R {
+        COUNT_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Counter Value"]
+    #[inline(always)]
+    pub fn count(&mut self) -> COUNT_W {
+        COUNT_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count8/ctrla.rs
+++ b/pac/atsamd11c14a/src/tc1/count8/ctrla.rs
@@ -1,0 +1,565 @@
+#[doc = "Reader of register CTRLA"]
+pub type R = crate::R<u16, super::CTRLA>;
+#[doc = "Writer for register CTRLA"]
+pub type W = crate::W<u16, super::CTRLA>;
+#[doc = "Register CTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLA {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "TC Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MODE_A {
+    #[doc = "0: Counter in 16-bit mode"]
+    COUNT16,
+    #[doc = "1: Counter in 8-bit mode"]
+    COUNT8,
+    #[doc = "2: Counter in 32-bit mode"]
+    COUNT32,
+}
+impl From<MODE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: MODE_A) -> Self {
+        match variant {
+            MODE_A::COUNT16 => 0,
+            MODE_A::COUNT8 => 1,
+            MODE_A::COUNT32 => 2,
+        }
+    }
+}
+#[doc = "Reader of field `MODE`"]
+pub type MODE_R = crate::R<u8, MODE_A>;
+impl MODE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, MODE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(MODE_A::COUNT16),
+            1 => Val(MODE_A::COUNT8),
+            2 => Val(MODE_A::COUNT32),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `COUNT16`"]
+    #[inline(always)]
+    pub fn is_count16(&self) -> bool {
+        *self == MODE_A::COUNT16
+    }
+    #[doc = "Checks if the value of the field is `COUNT8`"]
+    #[inline(always)]
+    pub fn is_count8(&self) -> bool {
+        *self == MODE_A::COUNT8
+    }
+    #[doc = "Checks if the value of the field is `COUNT32`"]
+    #[inline(always)]
+    pub fn is_count32(&self) -> bool {
+        *self == MODE_A::COUNT32
+    }
+}
+#[doc = "Write proxy for field `MODE`"]
+pub struct MODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MODE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: MODE_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Counter in 16-bit mode"]
+    #[inline(always)]
+    pub fn count16(self) -> &'a mut W {
+        self.variant(MODE_A::COUNT16)
+    }
+    #[doc = "Counter in 8-bit mode"]
+    #[inline(always)]
+    pub fn count8(self) -> &'a mut W {
+        self.variant(MODE_A::COUNT8)
+    }
+    #[doc = "Counter in 32-bit mode"]
+    #[inline(always)]
+    pub fn count32(self) -> &'a mut W {
+        self.variant(MODE_A::COUNT32)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 2)) | (((value as u16) & 0x03) << 2);
+        self.w
+    }
+}
+#[doc = "Waveform Generation Operation\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum WAVEGEN_A {
+    #[doc = "0: `0`"]
+    NFRQ,
+    #[doc = "1: `1`"]
+    MFRQ,
+    #[doc = "2: `10`"]
+    NPWM,
+    #[doc = "3: `11`"]
+    MPWM,
+}
+impl From<WAVEGEN_A> for u8 {
+    #[inline(always)]
+    fn from(variant: WAVEGEN_A) -> Self {
+        match variant {
+            WAVEGEN_A::NFRQ => 0,
+            WAVEGEN_A::MFRQ => 1,
+            WAVEGEN_A::NPWM => 2,
+            WAVEGEN_A::MPWM => 3,
+        }
+    }
+}
+#[doc = "Reader of field `WAVEGEN`"]
+pub type WAVEGEN_R = crate::R<u8, WAVEGEN_A>;
+impl WAVEGEN_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> WAVEGEN_A {
+        match self.bits {
+            0 => WAVEGEN_A::NFRQ,
+            1 => WAVEGEN_A::MFRQ,
+            2 => WAVEGEN_A::NPWM,
+            3 => WAVEGEN_A::MPWM,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NFRQ`"]
+    #[inline(always)]
+    pub fn is_nfrq(&self) -> bool {
+        *self == WAVEGEN_A::NFRQ
+    }
+    #[doc = "Checks if the value of the field is `MFRQ`"]
+    #[inline(always)]
+    pub fn is_mfrq(&self) -> bool {
+        *self == WAVEGEN_A::MFRQ
+    }
+    #[doc = "Checks if the value of the field is `NPWM`"]
+    #[inline(always)]
+    pub fn is_npwm(&self) -> bool {
+        *self == WAVEGEN_A::NPWM
+    }
+    #[doc = "Checks if the value of the field is `MPWM`"]
+    #[inline(always)]
+    pub fn is_mpwm(&self) -> bool {
+        *self == WAVEGEN_A::MPWM
+    }
+}
+#[doc = "Write proxy for field `WAVEGEN`"]
+pub struct WAVEGEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAVEGEN_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: WAVEGEN_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "`0`"]
+    #[inline(always)]
+    pub fn nfrq(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::NFRQ)
+    }
+    #[doc = "`1`"]
+    #[inline(always)]
+    pub fn mfrq(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::MFRQ)
+    }
+    #[doc = "`10`"]
+    #[inline(always)]
+    pub fn npwm(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::NPWM)
+    }
+    #[doc = "`11`"]
+    #[inline(always)]
+    pub fn mpwm(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::MPWM)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 5)) | (((value as u16) & 0x03) << 5);
+        self.w
+    }
+}
+#[doc = "Prescaler\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PRESCALER_A {
+    #[doc = "0: Prescaler: GCLK_TC"]
+    DIV1,
+    #[doc = "1: Prescaler: GCLK_TC/2"]
+    DIV2,
+    #[doc = "2: Prescaler: GCLK_TC/4"]
+    DIV4,
+    #[doc = "3: Prescaler: GCLK_TC/8"]
+    DIV8,
+    #[doc = "4: Prescaler: GCLK_TC/16"]
+    DIV16,
+    #[doc = "5: Prescaler: GCLK_TC/64"]
+    DIV64,
+    #[doc = "6: Prescaler: GCLK_TC/256"]
+    DIV256,
+    #[doc = "7: Prescaler: GCLK_TC/1024"]
+    DIV1024,
+}
+impl From<PRESCALER_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PRESCALER_A) -> Self {
+        match variant {
+            PRESCALER_A::DIV1 => 0,
+            PRESCALER_A::DIV2 => 1,
+            PRESCALER_A::DIV4 => 2,
+            PRESCALER_A::DIV8 => 3,
+            PRESCALER_A::DIV16 => 4,
+            PRESCALER_A::DIV64 => 5,
+            PRESCALER_A::DIV256 => 6,
+            PRESCALER_A::DIV1024 => 7,
+        }
+    }
+}
+#[doc = "Reader of field `PRESCALER`"]
+pub type PRESCALER_R = crate::R<u8, PRESCALER_A>;
+impl PRESCALER_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> PRESCALER_A {
+        match self.bits {
+            0 => PRESCALER_A::DIV1,
+            1 => PRESCALER_A::DIV2,
+            2 => PRESCALER_A::DIV4,
+            3 => PRESCALER_A::DIV8,
+            4 => PRESCALER_A::DIV16,
+            5 => PRESCALER_A::DIV64,
+            6 => PRESCALER_A::DIV256,
+            7 => PRESCALER_A::DIV1024,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DIV1`"]
+    #[inline(always)]
+    pub fn is_div1(&self) -> bool {
+        *self == PRESCALER_A::DIV1
+    }
+    #[doc = "Checks if the value of the field is `DIV2`"]
+    #[inline(always)]
+    pub fn is_div2(&self) -> bool {
+        *self == PRESCALER_A::DIV2
+    }
+    #[doc = "Checks if the value of the field is `DIV4`"]
+    #[inline(always)]
+    pub fn is_div4(&self) -> bool {
+        *self == PRESCALER_A::DIV4
+    }
+    #[doc = "Checks if the value of the field is `DIV8`"]
+    #[inline(always)]
+    pub fn is_div8(&self) -> bool {
+        *self == PRESCALER_A::DIV8
+    }
+    #[doc = "Checks if the value of the field is `DIV16`"]
+    #[inline(always)]
+    pub fn is_div16(&self) -> bool {
+        *self == PRESCALER_A::DIV16
+    }
+    #[doc = "Checks if the value of the field is `DIV64`"]
+    #[inline(always)]
+    pub fn is_div64(&self) -> bool {
+        *self == PRESCALER_A::DIV64
+    }
+    #[doc = "Checks if the value of the field is `DIV256`"]
+    #[inline(always)]
+    pub fn is_div256(&self) -> bool {
+        *self == PRESCALER_A::DIV256
+    }
+    #[doc = "Checks if the value of the field is `DIV1024`"]
+    #[inline(always)]
+    pub fn is_div1024(&self) -> bool {
+        *self == PRESCALER_A::DIV1024
+    }
+}
+#[doc = "Write proxy for field `PRESCALER`"]
+pub struct PRESCALER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PRESCALER_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PRESCALER_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Prescaler: GCLK_TC"]
+    #[inline(always)]
+    pub fn div1(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV1)
+    }
+    #[doc = "Prescaler: GCLK_TC/2"]
+    #[inline(always)]
+    pub fn div2(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV2)
+    }
+    #[doc = "Prescaler: GCLK_TC/4"]
+    #[inline(always)]
+    pub fn div4(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV4)
+    }
+    #[doc = "Prescaler: GCLK_TC/8"]
+    #[inline(always)]
+    pub fn div8(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV8)
+    }
+    #[doc = "Prescaler: GCLK_TC/16"]
+    #[inline(always)]
+    pub fn div16(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV16)
+    }
+    #[doc = "Prescaler: GCLK_TC/64"]
+    #[inline(always)]
+    pub fn div64(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV64)
+    }
+    #[doc = "Prescaler: GCLK_TC/256"]
+    #[inline(always)]
+    pub fn div256(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV256)
+    }
+    #[doc = "Prescaler: GCLK_TC/1024"]
+    #[inline(always)]
+    pub fn div1024(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV1024)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 8)) | (((value as u16) & 0x07) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u16) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Prescaler and Counter Synchronization\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PRESCSYNC_A {
+    #[doc = "0: Reload or reset the counter on next generic clock"]
+    GCLK,
+    #[doc = "1: Reload or reset the counter on next prescaler clock"]
+    PRESC,
+    #[doc = "2: Reload or reset the counter on next generic clock. Reset the prescaler counter"]
+    RESYNC,
+}
+impl From<PRESCSYNC_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PRESCSYNC_A) -> Self {
+        match variant {
+            PRESCSYNC_A::GCLK => 0,
+            PRESCSYNC_A::PRESC => 1,
+            PRESCSYNC_A::RESYNC => 2,
+        }
+    }
+}
+#[doc = "Reader of field `PRESCSYNC`"]
+pub type PRESCSYNC_R = crate::R<u8, PRESCSYNC_A>;
+impl PRESCSYNC_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, PRESCSYNC_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(PRESCSYNC_A::GCLK),
+            1 => Val(PRESCSYNC_A::PRESC),
+            2 => Val(PRESCSYNC_A::RESYNC),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `GCLK`"]
+    #[inline(always)]
+    pub fn is_gclk(&self) -> bool {
+        *self == PRESCSYNC_A::GCLK
+    }
+    #[doc = "Checks if the value of the field is `PRESC`"]
+    #[inline(always)]
+    pub fn is_presc(&self) -> bool {
+        *self == PRESCSYNC_A::PRESC
+    }
+    #[doc = "Checks if the value of the field is `RESYNC`"]
+    #[inline(always)]
+    pub fn is_resync(&self) -> bool {
+        *self == PRESCSYNC_A::RESYNC
+    }
+}
+#[doc = "Write proxy for field `PRESCSYNC`"]
+pub struct PRESCSYNC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PRESCSYNC_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PRESCSYNC_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Reload or reset the counter on next generic clock"]
+    #[inline(always)]
+    pub fn gclk(self) -> &'a mut W {
+        self.variant(PRESCSYNC_A::GCLK)
+    }
+    #[doc = "Reload or reset the counter on next prescaler clock"]
+    #[inline(always)]
+    pub fn presc(self) -> &'a mut W {
+        self.variant(PRESCSYNC_A::PRESC)
+    }
+    #[doc = "Reload or reset the counter on next generic clock. Reset the prescaler counter"]
+    #[inline(always)]
+    pub fn resync(self) -> &'a mut W {
+        self.variant(PRESCSYNC_A::RESYNC)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 12)) | (((value as u16) & 0x03) << 12);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 2:3 - TC Mode"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 2) & 0x03) as u8)
+    }
+    #[doc = "Bits 5:6 - Waveform Generation Operation"]
+    #[inline(always)]
+    pub fn wavegen(&self) -> WAVEGEN_R {
+        WAVEGEN_R::new(((self.bits >> 5) & 0x03) as u8)
+    }
+    #[doc = "Bits 8:10 - Prescaler"]
+    #[inline(always)]
+    pub fn prescaler(&self) -> PRESCALER_R {
+        PRESCALER_R::new(((self.bits >> 8) & 0x07) as u8)
+    }
+    #[doc = "Bit 11 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bits 12:13 - Prescaler and Counter Synchronization"]
+    #[inline(always)]
+    pub fn prescsync(&self) -> PRESCSYNC_R {
+        PRESCSYNC_R::new(((self.bits >> 12) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bits 2:3 - TC Mode"]
+    #[inline(always)]
+    pub fn mode(&mut self) -> MODE_W {
+        MODE_W { w: self }
+    }
+    #[doc = "Bits 5:6 - Waveform Generation Operation"]
+    #[inline(always)]
+    pub fn wavegen(&mut self) -> WAVEGEN_W {
+        WAVEGEN_W { w: self }
+    }
+    #[doc = "Bits 8:10 - Prescaler"]
+    #[inline(always)]
+    pub fn prescaler(&mut self) -> PRESCALER_W {
+        PRESCALER_W { w: self }
+    }
+    #[doc = "Bit 11 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bits 12:13 - Prescaler and Counter Synchronization"]
+    #[inline(always)]
+    pub fn prescsync(&mut self) -> PRESCSYNC_W {
+        PRESCSYNC_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count8/ctrlbclr.rs
+++ b/pac/atsamd11c14a/src/tc1/count8/ctrlbclr.rs
@@ -1,0 +1,176 @@
+#[doc = "Reader of register CTRLBCLR"]
+pub type R = crate::R<u8, super::CTRLBCLR>;
+#[doc = "Writer for register CTRLBCLR"]
+pub type W = crate::W<u8, super::CTRLBCLR>;
+#[doc = "Register CTRLBCLR `reset()`'s with value 0x02"]
+impl crate::ResetValue for super::CTRLBCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x02
+    }
+}
+#[doc = "Reader of field `DIR`"]
+pub type DIR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DIR`"]
+pub struct DIR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ONESHOT`"]
+pub type ONESHOT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ONESHOT`"]
+pub struct ONESHOT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ONESHOT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Command\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CMD_A {
+    #[doc = "0: No action"]
+    NONE,
+    #[doc = "1: Force a start, restart or retrigger"]
+    RETRIGGER,
+    #[doc = "2: Force a stop"]
+    STOP,
+}
+impl From<CMD_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CMD_A) -> Self {
+        match variant {
+            CMD_A::NONE => 0,
+            CMD_A::RETRIGGER => 1,
+            CMD_A::STOP => 2,
+        }
+    }
+}
+#[doc = "Reader of field `CMD`"]
+pub type CMD_R = crate::R<u8, CMD_A>;
+impl CMD_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, CMD_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(CMD_A::NONE),
+            1 => Val(CMD_A::RETRIGGER),
+            2 => Val(CMD_A::STOP),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == CMD_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RETRIGGER`"]
+    #[inline(always)]
+    pub fn is_retrigger(&self) -> bool {
+        *self == CMD_A::RETRIGGER
+    }
+    #[doc = "Checks if the value of the field is `STOP`"]
+    #[inline(always)]
+    pub fn is_stop(&self) -> bool {
+        *self == CMD_A::STOP
+    }
+}
+#[doc = "Write proxy for field `CMD`"]
+pub struct CMD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMD_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CMD_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No action"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(CMD_A::NONE)
+    }
+    #[doc = "Force a start, restart or retrigger"]
+    #[inline(always)]
+    pub fn retrigger(self) -> &'a mut W {
+        self.variant(CMD_A::RETRIGGER)
+    }
+    #[doc = "Force a stop"]
+    #[inline(always)]
+    pub fn stop(self) -> &'a mut W {
+        self.variant(CMD_A::STOP)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 6)) | (((value as u8) & 0x03) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&self) -> DIR_R {
+        DIR_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&self) -> ONESHOT_R {
+        ONESHOT_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bits 6:7 - Command"]
+    #[inline(always)]
+    pub fn cmd(&self) -> CMD_R {
+        CMD_R::new(((self.bits >> 6) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&mut self) -> DIR_W {
+        DIR_W { w: self }
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&mut self) -> ONESHOT_W {
+        ONESHOT_W { w: self }
+    }
+    #[doc = "Bits 6:7 - Command"]
+    #[inline(always)]
+    pub fn cmd(&mut self) -> CMD_W {
+        CMD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count8/ctrlbset.rs
+++ b/pac/atsamd11c14a/src/tc1/count8/ctrlbset.rs
@@ -1,0 +1,176 @@
+#[doc = "Reader of register CTRLBSET"]
+pub type R = crate::R<u8, super::CTRLBSET>;
+#[doc = "Writer for register CTRLBSET"]
+pub type W = crate::W<u8, super::CTRLBSET>;
+#[doc = "Register CTRLBSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLBSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DIR`"]
+pub type DIR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DIR`"]
+pub struct DIR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ONESHOT`"]
+pub type ONESHOT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ONESHOT`"]
+pub struct ONESHOT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ONESHOT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Command\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CMD_A {
+    #[doc = "0: No action"]
+    NONE,
+    #[doc = "1: Force a start, restart or retrigger"]
+    RETRIGGER,
+    #[doc = "2: Force a stop"]
+    STOP,
+}
+impl From<CMD_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CMD_A) -> Self {
+        match variant {
+            CMD_A::NONE => 0,
+            CMD_A::RETRIGGER => 1,
+            CMD_A::STOP => 2,
+        }
+    }
+}
+#[doc = "Reader of field `CMD`"]
+pub type CMD_R = crate::R<u8, CMD_A>;
+impl CMD_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, CMD_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(CMD_A::NONE),
+            1 => Val(CMD_A::RETRIGGER),
+            2 => Val(CMD_A::STOP),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == CMD_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RETRIGGER`"]
+    #[inline(always)]
+    pub fn is_retrigger(&self) -> bool {
+        *self == CMD_A::RETRIGGER
+    }
+    #[doc = "Checks if the value of the field is `STOP`"]
+    #[inline(always)]
+    pub fn is_stop(&self) -> bool {
+        *self == CMD_A::STOP
+    }
+}
+#[doc = "Write proxy for field `CMD`"]
+pub struct CMD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMD_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CMD_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No action"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(CMD_A::NONE)
+    }
+    #[doc = "Force a start, restart or retrigger"]
+    #[inline(always)]
+    pub fn retrigger(self) -> &'a mut W {
+        self.variant(CMD_A::RETRIGGER)
+    }
+    #[doc = "Force a stop"]
+    #[inline(always)]
+    pub fn stop(self) -> &'a mut W {
+        self.variant(CMD_A::STOP)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 6)) | (((value as u8) & 0x03) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&self) -> DIR_R {
+        DIR_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&self) -> ONESHOT_R {
+        ONESHOT_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bits 6:7 - Command"]
+    #[inline(always)]
+    pub fn cmd(&self) -> CMD_R {
+        CMD_R::new(((self.bits >> 6) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&mut self) -> DIR_W {
+        DIR_W { w: self }
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&mut self) -> ONESHOT_W {
+        ONESHOT_W { w: self }
+    }
+    #[doc = "Bits 6:7 - Command"]
+    #[inline(always)]
+    pub fn cmd(&mut self) -> CMD_W {
+        CMD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count8/ctrlc.rs
+++ b/pac/atsamd11c14a/src/tc1/count8/ctrlc.rs
@@ -1,0 +1,152 @@
+#[doc = "Reader of register CTRLC"]
+pub type R = crate::R<u8, super::CTRLC>;
+#[doc = "Writer for register CTRLC"]
+pub type W = crate::W<u8, super::CTRLC>;
+#[doc = "Register CTRLC `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLC {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `INVEN0`"]
+pub type INVEN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INVEN0`"]
+pub struct INVEN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INVEN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `INVEN1`"]
+pub type INVEN1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INVEN1`"]
+pub struct INVEN1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INVEN1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `CPTEN0`"]
+pub type CPTEN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CPTEN0`"]
+pub struct CPTEN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CPTEN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `CPTEN1`"]
+pub type CPTEN1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CPTEN1`"]
+pub struct CPTEN1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CPTEN1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Output Waveform 0 Invert Enable"]
+    #[inline(always)]
+    pub fn inven0(&self) -> INVEN0_R {
+        INVEN0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Output Waveform 1 Invert Enable"]
+    #[inline(always)]
+    pub fn inven1(&self) -> INVEN1_R {
+        INVEN1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Capture Channel 0 Enable"]
+    #[inline(always)]
+    pub fn cpten0(&self) -> CPTEN0_R {
+        CPTEN0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Capture Channel 1 Enable"]
+    #[inline(always)]
+    pub fn cpten1(&self) -> CPTEN1_R {
+        CPTEN1_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Output Waveform 0 Invert Enable"]
+    #[inline(always)]
+    pub fn inven0(&mut self) -> INVEN0_W {
+        INVEN0_W { w: self }
+    }
+    #[doc = "Bit 1 - Output Waveform 1 Invert Enable"]
+    #[inline(always)]
+    pub fn inven1(&mut self) -> INVEN1_W {
+        INVEN1_W { w: self }
+    }
+    #[doc = "Bit 4 - Capture Channel 0 Enable"]
+    #[inline(always)]
+    pub fn cpten0(&mut self) -> CPTEN0_W {
+        CPTEN0_W { w: self }
+    }
+    #[doc = "Bit 5 - Capture Channel 1 Enable"]
+    #[inline(always)]
+    pub fn cpten1(&mut self) -> CPTEN1_W {
+        CPTEN1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count8/dbgctrl.rs
+++ b/pac/atsamd11c14a/src/tc1/count8/dbgctrl.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register DBGCTRL"]
+pub type R = crate::R<u8, super::DBGCTRL>;
+#[doc = "Writer for register DBGCTRL"]
+pub type W = crate::W<u8, super::DBGCTRL>;
+#[doc = "Register DBGCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::DBGCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DBGRUN`"]
+pub type DBGRUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DBGRUN`"]
+pub struct DBGRUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DBGRUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Debug Run Mode"]
+    #[inline(always)]
+    pub fn dbgrun(&self) -> DBGRUN_R {
+        DBGRUN_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Debug Run Mode"]
+    #[inline(always)]
+    pub fn dbgrun(&mut self) -> DBGRUN_W {
+        DBGRUN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count8/evctrl.rs
+++ b/pac/atsamd11c14a/src/tc1/count8/evctrl.rs
@@ -1,0 +1,320 @@
+#[doc = "Reader of register EVCTRL"]
+pub type R = crate::R<u16, super::EVCTRL>;
+#[doc = "Writer for register EVCTRL"]
+pub type W = crate::W<u16, super::EVCTRL>;
+#[doc = "Register EVCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::EVCTRL {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Event Action\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum EVACT_A {
+    #[doc = "0: Event action disabled"]
+    OFF,
+    #[doc = "1: Start, restart or retrigger TC on event"]
+    RETRIGGER,
+    #[doc = "2: Count on event"]
+    COUNT,
+    #[doc = "3: Start TC on event"]
+    START,
+    #[doc = "5: Period captured in CC0, pulse width in CC1"]
+    PPW,
+    #[doc = "6: Period captured in CC1, pulse width in CC0"]
+    PWP,
+}
+impl From<EVACT_A> for u8 {
+    #[inline(always)]
+    fn from(variant: EVACT_A) -> Self {
+        match variant {
+            EVACT_A::OFF => 0,
+            EVACT_A::RETRIGGER => 1,
+            EVACT_A::COUNT => 2,
+            EVACT_A::START => 3,
+            EVACT_A::PPW => 5,
+            EVACT_A::PWP => 6,
+        }
+    }
+}
+#[doc = "Reader of field `EVACT`"]
+pub type EVACT_R = crate::R<u8, EVACT_A>;
+impl EVACT_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, EVACT_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(EVACT_A::OFF),
+            1 => Val(EVACT_A::RETRIGGER),
+            2 => Val(EVACT_A::COUNT),
+            3 => Val(EVACT_A::START),
+            5 => Val(EVACT_A::PPW),
+            6 => Val(EVACT_A::PWP),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `OFF`"]
+    #[inline(always)]
+    pub fn is_off(&self) -> bool {
+        *self == EVACT_A::OFF
+    }
+    #[doc = "Checks if the value of the field is `RETRIGGER`"]
+    #[inline(always)]
+    pub fn is_retrigger(&self) -> bool {
+        *self == EVACT_A::RETRIGGER
+    }
+    #[doc = "Checks if the value of the field is `COUNT`"]
+    #[inline(always)]
+    pub fn is_count(&self) -> bool {
+        *self == EVACT_A::COUNT
+    }
+    #[doc = "Checks if the value of the field is `START`"]
+    #[inline(always)]
+    pub fn is_start(&self) -> bool {
+        *self == EVACT_A::START
+    }
+    #[doc = "Checks if the value of the field is `PPW`"]
+    #[inline(always)]
+    pub fn is_ppw(&self) -> bool {
+        *self == EVACT_A::PPW
+    }
+    #[doc = "Checks if the value of the field is `PWP`"]
+    #[inline(always)]
+    pub fn is_pwp(&self) -> bool {
+        *self == EVACT_A::PWP
+    }
+}
+#[doc = "Write proxy for field `EVACT`"]
+pub struct EVACT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVACT_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: EVACT_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Event action disabled"]
+    #[inline(always)]
+    pub fn off(self) -> &'a mut W {
+        self.variant(EVACT_A::OFF)
+    }
+    #[doc = "Start, restart or retrigger TC on event"]
+    #[inline(always)]
+    pub fn retrigger(self) -> &'a mut W {
+        self.variant(EVACT_A::RETRIGGER)
+    }
+    #[doc = "Count on event"]
+    #[inline(always)]
+    pub fn count(self) -> &'a mut W {
+        self.variant(EVACT_A::COUNT)
+    }
+    #[doc = "Start TC on event"]
+    #[inline(always)]
+    pub fn start(self) -> &'a mut W {
+        self.variant(EVACT_A::START)
+    }
+    #[doc = "Period captured in CC0, pulse width in CC1"]
+    #[inline(always)]
+    pub fn ppw(self) -> &'a mut W {
+        self.variant(EVACT_A::PPW)
+    }
+    #[doc = "Period captured in CC1, pulse width in CC0"]
+    #[inline(always)]
+    pub fn pwp(self) -> &'a mut W {
+        self.variant(EVACT_A::PWP)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u16) & 0x07);
+        self.w
+    }
+}
+#[doc = "Reader of field `TCINV`"]
+pub type TCINV_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TCINV`"]
+pub struct TCINV_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TCINV_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `TCEI`"]
+pub type TCEI_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TCEI`"]
+pub struct TCEI_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TCEI_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVFEO`"]
+pub type OVFEO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVFEO`"]
+pub struct OVFEO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVFEO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `MCEO0`"]
+pub type MCEO0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MCEO0`"]
+pub struct MCEO0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MCEO0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u16) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `MCEO1`"]
+pub type MCEO1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MCEO1`"]
+pub struct MCEO1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MCEO1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u16) & 0x01) << 13);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Event Action"]
+    #[inline(always)]
+    pub fn evact(&self) -> EVACT_R {
+        EVACT_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bit 4 - TC Inverted Event Input"]
+    #[inline(always)]
+    pub fn tcinv(&self) -> TCINV_R {
+        TCINV_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - TC Event Input"]
+    #[inline(always)]
+    pub fn tcei(&self) -> TCEI_R {
+        TCEI_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Overflow/Underflow Event Output Enable"]
+    #[inline(always)]
+    pub fn ovfeo(&self) -> OVFEO_R {
+        OVFEO_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - Match or Capture Channel 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo0(&self) -> MCEO0_R {
+        MCEO0_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Match or Capture Channel 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo1(&self) -> MCEO1_R {
+        MCEO1_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Event Action"]
+    #[inline(always)]
+    pub fn evact(&mut self) -> EVACT_W {
+        EVACT_W { w: self }
+    }
+    #[doc = "Bit 4 - TC Inverted Event Input"]
+    #[inline(always)]
+    pub fn tcinv(&mut self) -> TCINV_W {
+        TCINV_W { w: self }
+    }
+    #[doc = "Bit 5 - TC Event Input"]
+    #[inline(always)]
+    pub fn tcei(&mut self) -> TCEI_W {
+        TCEI_W { w: self }
+    }
+    #[doc = "Bit 8 - Overflow/Underflow Event Output Enable"]
+    #[inline(always)]
+    pub fn ovfeo(&mut self) -> OVFEO_W {
+        OVFEO_W { w: self }
+    }
+    #[doc = "Bit 12 - Match or Capture Channel 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo0(&mut self) -> MCEO0_W {
+        MCEO0_W { w: self }
+    }
+    #[doc = "Bit 13 - Match or Capture Channel 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo1(&mut self) -> MCEO1_W {
+        MCEO1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count8/intenclr.rs
+++ b/pac/atsamd11c14a/src/tc1/count8/intenclr.rs
@@ -1,0 +1,186 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERR`"]
+pub type ERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERR`"]
+pub struct ERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC0`"]
+pub type MC0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC0`"]
+pub struct MC0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC1`"]
+pub type MC1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC1`"]
+pub struct MC1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&self) -> ERR_R {
+        ERR_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&self) -> MC0_R {
+        MC0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&self) -> MC1_R {
+        MC1_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&mut self) -> ERR_W {
+        ERR_W { w: self }
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&mut self) -> MC0_W {
+        MC0_W { w: self }
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&mut self) -> MC1_W {
+        MC1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count8/intenset.rs
+++ b/pac/atsamd11c14a/src/tc1/count8/intenset.rs
@@ -1,0 +1,186 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERR`"]
+pub type ERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERR`"]
+pub struct ERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC0`"]
+pub type MC0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC0`"]
+pub struct MC0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC1`"]
+pub type MC1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC1`"]
+pub struct MC1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&self) -> ERR_R {
+        ERR_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&self) -> MC0_R {
+        MC0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&self) -> MC1_R {
+        MC1_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+    #[doc = "Bit 1 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&mut self) -> ERR_W {
+        ERR_W { w: self }
+    }
+    #[doc = "Bit 3 - Synchronization Ready Interrupt Enable"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&mut self) -> MC0_W {
+        MC0_W { w: self }
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&mut self) -> MC1_W {
+        MC1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count8/intflag.rs
+++ b/pac/atsamd11c14a/src/tc1/count8/intflag.rs
@@ -1,0 +1,186 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERR`"]
+pub type ERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERR`"]
+pub struct ERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SYNCRDY`"]
+pub type SYNCRDY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCRDY`"]
+pub struct SYNCRDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCRDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC0`"]
+pub type MC0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC0`"]
+pub struct MC0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC1`"]
+pub type MC1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC1`"]
+pub struct MC1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Overflow"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Error"]
+    #[inline(always)]
+    pub fn err(&self) -> ERR_R {
+        ERR_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&self) -> SYNCRDY_R {
+        SYNCRDY_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0"]
+    #[inline(always)]
+    pub fn mc0(&self) -> MC0_R {
+        MC0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1"]
+    #[inline(always)]
+    pub fn mc1(&self) -> MC1_R {
+        MC1_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Overflow"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+    #[doc = "Bit 1 - Error"]
+    #[inline(always)]
+    pub fn err(&mut self) -> ERR_W {
+        ERR_W { w: self }
+    }
+    #[doc = "Bit 3 - Synchronization Ready"]
+    #[inline(always)]
+    pub fn syncrdy(&mut self) -> SYNCRDY_W {
+        SYNCRDY_W { w: self }
+    }
+    #[doc = "Bit 4 - Match or Capture Channel 0"]
+    #[inline(always)]
+    pub fn mc0(&mut self) -> MC0_W {
+        MC0_W { w: self }
+    }
+    #[doc = "Bit 5 - Match or Capture Channel 1"]
+    #[inline(always)]
+    pub fn mc1(&mut self) -> MC1_W {
+        MC1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count8/per.rs
+++ b/pac/atsamd11c14a/src/tc1/count8/per.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register PER"]
+pub type R = crate::R<u8, super::PER>;
+#[doc = "Writer for register PER"]
+pub type W = crate::W<u8, super::PER>;
+#[doc = "Register PER `reset()`'s with value 0xff"]
+impl crate::ResetValue for super::PER {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0xff
+    }
+}
+#[doc = "Reader of field `PER`"]
+pub type PER_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `PER`"]
+pub struct PER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PER_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xff) | ((value as u8) & 0xff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:7 - Period Value"]
+    #[inline(always)]
+    pub fn per(&self) -> PER_R {
+        PER_R::new((self.bits & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Period Value"]
+    #[inline(always)]
+    pub fn per(&mut self) -> PER_W {
+        PER_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count8/readreq.rs
+++ b/pac/atsamd11c14a/src/tc1/count8/readreq.rs
@@ -1,0 +1,108 @@
+#[doc = "Reader of register READREQ"]
+pub type R = crate::R<u16, super::READREQ>;
+#[doc = "Writer for register READREQ"]
+pub type W = crate::W<u16, super::READREQ>;
+#[doc = "Register READREQ `reset()`'s with value 0"]
+impl crate::ResetValue for super::READREQ {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ADDR`"]
+pub type ADDR_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `ADDR`"]
+pub struct ADDR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ADDR_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x1f) | ((value as u16) & 0x1f);
+        self.w
+    }
+}
+#[doc = "Reader of field `RCONT`"]
+pub type RCONT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RCONT`"]
+pub struct RCONT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RCONT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u16) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `RREQ`"]
+pub type RREQ_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RREQ`"]
+pub struct RREQ_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RREQ_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u16) & 0x01) << 15);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:4 - Address"]
+    #[inline(always)]
+    pub fn addr(&self) -> ADDR_R {
+        ADDR_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bit 14 - Read Continuously"]
+    #[inline(always)]
+    pub fn rcont(&self) -> RCONT_R {
+        RCONT_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Read Request"]
+    #[inline(always)]
+    pub fn rreq(&self) -> RREQ_R {
+        RREQ_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - Address"]
+    #[inline(always)]
+    pub fn addr(&mut self) -> ADDR_W {
+        ADDR_W { w: self }
+    }
+    #[doc = "Bit 14 - Read Continuously"]
+    #[inline(always)]
+    pub fn rcont(&mut self) -> RCONT_W {
+        RCONT_W { w: self }
+    }
+    #[doc = "Bit 15 - Read Request"]
+    #[inline(always)]
+    pub fn rreq(&mut self) -> RREQ_W {
+        RREQ_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tc1/count8/status.rs
+++ b/pac/atsamd11c14a/src/tc1/count8/status.rs
@@ -1,0 +1,25 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u8, super::STATUS>;
+#[doc = "Reader of field `STOP`"]
+pub type STOP_R = crate::R<bool, bool>;
+#[doc = "Reader of field `SLAVE`"]
+pub type SLAVE_R = crate::R<bool, bool>;
+#[doc = "Reader of field `SYNCBUSY`"]
+pub type SYNCBUSY_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 3 - Stop"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Slave"]
+    #[inline(always)]
+    pub fn slave(&self) -> SLAVE_R {
+        SLAVE_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Synchronization Busy"]
+    #[inline(always)]
+    pub fn syncbusy(&self) -> SYNCBUSY_R {
+        SYNCBUSY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0.rs
+++ b/pac/atsamd11c14a/src/tcc0.rs
@@ -1,0 +1,669 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Control A"]
+    pub ctrla: CTRLA,
+    #[doc = "0x04 - Control B Clear"]
+    pub ctrlbclr: CTRLBCLR,
+    #[doc = "0x05 - Control B Set"]
+    pub ctrlbset: CTRLBSET,
+    _reserved3: [u8; 2usize],
+    #[doc = "0x08 - Synchronization Busy"]
+    pub syncbusy: SYNCBUSY,
+    #[doc = "0x0c - Recoverable Fault A Configuration"]
+    pub fctrla: FCTRLA,
+    #[doc = "0x10 - Recoverable Fault B Configuration"]
+    pub fctrlb: FCTRLB,
+    #[doc = "0x14 - Waveform Extension Configuration"]
+    pub wexctrl: WEXCTRL,
+    #[doc = "0x18 - Driver Control"]
+    pub drvctrl: DRVCTRL,
+    _reserved8: [u8; 2usize],
+    #[doc = "0x1e - Debug Control"]
+    pub dbgctrl: DBGCTRL,
+    _reserved9: [u8; 1usize],
+    #[doc = "0x20 - Event Control"]
+    pub evctrl: EVCTRL,
+    #[doc = "0x24 - Interrupt Enable Clear"]
+    pub intenclr: INTENCLR,
+    #[doc = "0x28 - Interrupt Enable Set"]
+    pub intenset: INTENSET,
+    #[doc = "0x2c - Interrupt Flag Status and Clear"]
+    pub intflag: INTFLAG,
+    #[doc = "0x30 - Status"]
+    pub status: STATUS,
+    _reserved_14_count: [u8; 4usize],
+    #[doc = "0x38 - Pattern"]
+    pub patt: PATT,
+    _reserved16: [u8; 2usize],
+    #[doc = "0x3c - Waveform Control"]
+    pub wave: WAVE,
+    _reserved_17_per: [u8; 4usize],
+    _reserved_18_cc: [u8; 16usize],
+    _reserved19: [u8; 16usize],
+    #[doc = "0x64 - Pattern Buffer"]
+    pub pattb: PATTB,
+    _reserved20: [u8; 2usize],
+    #[doc = "0x68 - Waveform Control Buffer"]
+    pub waveb: WAVEB,
+    _reserved_21_perb: [u8; 4usize],
+    _reserved_22_ccb: [u8; 16usize],
+}
+impl RegisterBlock {
+    #[doc = "0x34 - Count"]
+    #[inline(always)]
+    pub fn count_dith6(&self) -> &COUNT_DITH6 {
+        unsafe { &*(((self as *const Self) as *const u8).add(52usize) as *const COUNT_DITH6) }
+    }
+    #[doc = "0x34 - Count"]
+    #[inline(always)]
+    pub fn count_dith6_mut(&self) -> &mut COUNT_DITH6 {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(52usize) as *mut COUNT_DITH6) }
+    }
+    #[doc = "0x34 - Count"]
+    #[inline(always)]
+    pub fn count_dith5(&self) -> &COUNT_DITH5 {
+        unsafe { &*(((self as *const Self) as *const u8).add(52usize) as *const COUNT_DITH5) }
+    }
+    #[doc = "0x34 - Count"]
+    #[inline(always)]
+    pub fn count_dith5_mut(&self) -> &mut COUNT_DITH5 {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(52usize) as *mut COUNT_DITH5) }
+    }
+    #[doc = "0x34 - Count"]
+    #[inline(always)]
+    pub fn count_dith4(&self) -> &COUNT_DITH4 {
+        unsafe { &*(((self as *const Self) as *const u8).add(52usize) as *const COUNT_DITH4) }
+    }
+    #[doc = "0x34 - Count"]
+    #[inline(always)]
+    pub fn count_dith4_mut(&self) -> &mut COUNT_DITH4 {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(52usize) as *mut COUNT_DITH4) }
+    }
+    #[doc = "0x34 - Count"]
+    #[inline(always)]
+    pub fn count(&self) -> &COUNT {
+        unsafe { &*(((self as *const Self) as *const u8).add(52usize) as *const COUNT) }
+    }
+    #[doc = "0x34 - Count"]
+    #[inline(always)]
+    pub fn count_mut(&self) -> &mut COUNT {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(52usize) as *mut COUNT) }
+    }
+    #[doc = "0x40 - Period"]
+    #[inline(always)]
+    pub fn per_dith6(&self) -> &PER_DITH6 {
+        unsafe { &*(((self as *const Self) as *const u8).add(64usize) as *const PER_DITH6) }
+    }
+    #[doc = "0x40 - Period"]
+    #[inline(always)]
+    pub fn per_dith6_mut(&self) -> &mut PER_DITH6 {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(64usize) as *mut PER_DITH6) }
+    }
+    #[doc = "0x40 - Period"]
+    #[inline(always)]
+    pub fn per_dith5(&self) -> &PER_DITH5 {
+        unsafe { &*(((self as *const Self) as *const u8).add(64usize) as *const PER_DITH5) }
+    }
+    #[doc = "0x40 - Period"]
+    #[inline(always)]
+    pub fn per_dith5_mut(&self) -> &mut PER_DITH5 {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(64usize) as *mut PER_DITH5) }
+    }
+    #[doc = "0x40 - Period"]
+    #[inline(always)]
+    pub fn per_dith4(&self) -> &PER_DITH4 {
+        unsafe { &*(((self as *const Self) as *const u8).add(64usize) as *const PER_DITH4) }
+    }
+    #[doc = "0x40 - Period"]
+    #[inline(always)]
+    pub fn per_dith4_mut(&self) -> &mut PER_DITH4 {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(64usize) as *mut PER_DITH4) }
+    }
+    #[doc = "0x40 - Period"]
+    #[inline(always)]
+    pub fn per(&self) -> &PER {
+        unsafe { &*(((self as *const Self) as *const u8).add(64usize) as *const PER) }
+    }
+    #[doc = "0x40 - Period"]
+    #[inline(always)]
+    pub fn per_mut(&self) -> &mut PER {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(64usize) as *mut PER) }
+    }
+    #[doc = "0x44 - Compare and Capture"]
+    #[inline(always)]
+    pub fn cc_dith6(&self) -> &[CC_DITH6; 4] {
+        unsafe { &*(((self as *const Self) as *const u8).add(68usize) as *const [CC_DITH6; 4]) }
+    }
+    #[doc = "0x44 - Compare and Capture"]
+    #[inline(always)]
+    pub fn cc_dith6_mut(&self) -> &mut [CC_DITH6; 4] {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(68usize) as *mut [CC_DITH6; 4]) }
+    }
+    #[doc = "0x44 - Compare and Capture"]
+    #[inline(always)]
+    pub fn cc_dith5(&self) -> &[CC_DITH5; 4] {
+        unsafe { &*(((self as *const Self) as *const u8).add(68usize) as *const [CC_DITH5; 4]) }
+    }
+    #[doc = "0x44 - Compare and Capture"]
+    #[inline(always)]
+    pub fn cc_dith5_mut(&self) -> &mut [CC_DITH5; 4] {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(68usize) as *mut [CC_DITH5; 4]) }
+    }
+    #[doc = "0x44 - Compare and Capture"]
+    #[inline(always)]
+    pub fn cc_dith4(&self) -> &[CC_DITH4; 4] {
+        unsafe { &*(((self as *const Self) as *const u8).add(68usize) as *const [CC_DITH4; 4]) }
+    }
+    #[doc = "0x44 - Compare and Capture"]
+    #[inline(always)]
+    pub fn cc_dith4_mut(&self) -> &mut [CC_DITH4; 4] {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(68usize) as *mut [CC_DITH4; 4]) }
+    }
+    #[doc = "0x44 - Compare and Capture"]
+    #[inline(always)]
+    pub fn cc(&self) -> &[CC; 4] {
+        unsafe { &*(((self as *const Self) as *const u8).add(68usize) as *const [CC; 4]) }
+    }
+    #[doc = "0x44 - Compare and Capture"]
+    #[inline(always)]
+    pub fn cc_mut(&self) -> &mut [CC; 4] {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(68usize) as *mut [CC; 4]) }
+    }
+    #[doc = "0x6c - Period Buffer"]
+    #[inline(always)]
+    pub fn perb_dith6(&self) -> &PERB_DITH6 {
+        unsafe { &*(((self as *const Self) as *const u8).add(108usize) as *const PERB_DITH6) }
+    }
+    #[doc = "0x6c - Period Buffer"]
+    #[inline(always)]
+    pub fn perb_dith6_mut(&self) -> &mut PERB_DITH6 {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(108usize) as *mut PERB_DITH6) }
+    }
+    #[doc = "0x6c - Period Buffer"]
+    #[inline(always)]
+    pub fn perb_dith5(&self) -> &PERB_DITH5 {
+        unsafe { &*(((self as *const Self) as *const u8).add(108usize) as *const PERB_DITH5) }
+    }
+    #[doc = "0x6c - Period Buffer"]
+    #[inline(always)]
+    pub fn perb_dith5_mut(&self) -> &mut PERB_DITH5 {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(108usize) as *mut PERB_DITH5) }
+    }
+    #[doc = "0x6c - Period Buffer"]
+    #[inline(always)]
+    pub fn perb_dith4(&self) -> &PERB_DITH4 {
+        unsafe { &*(((self as *const Self) as *const u8).add(108usize) as *const PERB_DITH4) }
+    }
+    #[doc = "0x6c - Period Buffer"]
+    #[inline(always)]
+    pub fn perb_dith4_mut(&self) -> &mut PERB_DITH4 {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(108usize) as *mut PERB_DITH4) }
+    }
+    #[doc = "0x6c - Period Buffer"]
+    #[inline(always)]
+    pub fn perb(&self) -> &PERB {
+        unsafe { &*(((self as *const Self) as *const u8).add(108usize) as *const PERB) }
+    }
+    #[doc = "0x6c - Period Buffer"]
+    #[inline(always)]
+    pub fn perb_mut(&self) -> &mut PERB {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(108usize) as *mut PERB) }
+    }
+    #[doc = "0x70 - Compare and Capture Buffer"]
+    #[inline(always)]
+    pub fn ccb_dith6(&self) -> &[CCB_DITH6; 4] {
+        unsafe { &*(((self as *const Self) as *const u8).add(112usize) as *const [CCB_DITH6; 4]) }
+    }
+    #[doc = "0x70 - Compare and Capture Buffer"]
+    #[inline(always)]
+    pub fn ccb_dith6_mut(&self) -> &mut [CCB_DITH6; 4] {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(112usize) as *mut [CCB_DITH6; 4]) }
+    }
+    #[doc = "0x70 - Compare and Capture Buffer"]
+    #[inline(always)]
+    pub fn ccb_dith5(&self) -> &[CCB_DITH5; 4] {
+        unsafe { &*(((self as *const Self) as *const u8).add(112usize) as *const [CCB_DITH5; 4]) }
+    }
+    #[doc = "0x70 - Compare and Capture Buffer"]
+    #[inline(always)]
+    pub fn ccb_dith5_mut(&self) -> &mut [CCB_DITH5; 4] {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(112usize) as *mut [CCB_DITH5; 4]) }
+    }
+    #[doc = "0x70 - Compare and Capture Buffer"]
+    #[inline(always)]
+    pub fn ccb_dith4(&self) -> &[CCB_DITH4; 4] {
+        unsafe { &*(((self as *const Self) as *const u8).add(112usize) as *const [CCB_DITH4; 4]) }
+    }
+    #[doc = "0x70 - Compare and Capture Buffer"]
+    #[inline(always)]
+    pub fn ccb_dith4_mut(&self) -> &mut [CCB_DITH4; 4] {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(112usize) as *mut [CCB_DITH4; 4]) }
+    }
+    #[doc = "0x70 - Compare and Capture Buffer"]
+    #[inline(always)]
+    pub fn ccb(&self) -> &[CCB; 4] {
+        unsafe { &*(((self as *const Self) as *const u8).add(112usize) as *const [CCB; 4]) }
+    }
+    #[doc = "0x70 - Compare and Capture Buffer"]
+    #[inline(always)]
+    pub fn ccb_mut(&self) -> &mut [CCB; 4] {
+        unsafe { &mut *(((self as *const Self) as *mut u8).add(112usize) as *mut [CCB; 4]) }
+    }
+}
+#[doc = "Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrla](ctrla) module"]
+pub type CTRLA = crate::Reg<u32, _CTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLA;
+#[doc = "`read()` method returns [ctrla::R](ctrla::R) reader structure"]
+impl crate::Readable for CTRLA {}
+#[doc = "`write(|w| ..)` method takes [ctrla::W](ctrla::W) writer structure"]
+impl crate::Writable for CTRLA {}
+#[doc = "Control A"]
+pub mod ctrla;
+#[doc = "Control B Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlbclr](ctrlbclr) module"]
+pub type CTRLBCLR = crate::Reg<u8, _CTRLBCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLBCLR;
+#[doc = "`read()` method returns [ctrlbclr::R](ctrlbclr::R) reader structure"]
+impl crate::Readable for CTRLBCLR {}
+#[doc = "`write(|w| ..)` method takes [ctrlbclr::W](ctrlbclr::W) writer structure"]
+impl crate::Writable for CTRLBCLR {}
+#[doc = "Control B Clear"]
+pub mod ctrlbclr;
+#[doc = "Control B Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlbset](ctrlbset) module"]
+pub type CTRLBSET = crate::Reg<u8, _CTRLBSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLBSET;
+#[doc = "`read()` method returns [ctrlbset::R](ctrlbset::R) reader structure"]
+impl crate::Readable for CTRLBSET {}
+#[doc = "`write(|w| ..)` method takes [ctrlbset::W](ctrlbset::W) writer structure"]
+impl crate::Writable for CTRLBSET {}
+#[doc = "Control B Set"]
+pub mod ctrlbset;
+#[doc = "Synchronization Busy\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [syncbusy](syncbusy) module"]
+pub type SYNCBUSY = crate::Reg<u32, _SYNCBUSY>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _SYNCBUSY;
+#[doc = "`read()` method returns [syncbusy::R](syncbusy::R) reader structure"]
+impl crate::Readable for SYNCBUSY {}
+#[doc = "Synchronization Busy"]
+pub mod syncbusy;
+#[doc = "Recoverable Fault A Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fctrla](fctrla) module"]
+pub type FCTRLA = crate::Reg<u32, _FCTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _FCTRLA;
+#[doc = "`read()` method returns [fctrla::R](fctrla::R) reader structure"]
+impl crate::Readable for FCTRLA {}
+#[doc = "`write(|w| ..)` method takes [fctrla::W](fctrla::W) writer structure"]
+impl crate::Writable for FCTRLA {}
+#[doc = "Recoverable Fault A Configuration"]
+pub mod fctrla;
+#[doc = "Recoverable Fault B Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fctrlb](fctrlb) module"]
+pub type FCTRLB = crate::Reg<u32, _FCTRLB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _FCTRLB;
+#[doc = "`read()` method returns [fctrlb::R](fctrlb::R) reader structure"]
+impl crate::Readable for FCTRLB {}
+#[doc = "`write(|w| ..)` method takes [fctrlb::W](fctrlb::W) writer structure"]
+impl crate::Writable for FCTRLB {}
+#[doc = "Recoverable Fault B Configuration"]
+pub mod fctrlb;
+#[doc = "Waveform Extension Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [wexctrl](wexctrl) module"]
+pub type WEXCTRL = crate::Reg<u32, _WEXCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WEXCTRL;
+#[doc = "`read()` method returns [wexctrl::R](wexctrl::R) reader structure"]
+impl crate::Readable for WEXCTRL {}
+#[doc = "`write(|w| ..)` method takes [wexctrl::W](wexctrl::W) writer structure"]
+impl crate::Writable for WEXCTRL {}
+#[doc = "Waveform Extension Configuration"]
+pub mod wexctrl;
+#[doc = "Driver Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [drvctrl](drvctrl) module"]
+pub type DRVCTRL = crate::Reg<u32, _DRVCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DRVCTRL;
+#[doc = "`read()` method returns [drvctrl::R](drvctrl::R) reader structure"]
+impl crate::Readable for DRVCTRL {}
+#[doc = "`write(|w| ..)` method takes [drvctrl::W](drvctrl::W) writer structure"]
+impl crate::Writable for DRVCTRL {}
+#[doc = "Driver Control"]
+pub mod drvctrl;
+#[doc = "Debug Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dbgctrl](dbgctrl) module"]
+pub type DBGCTRL = crate::Reg<u8, _DBGCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DBGCTRL;
+#[doc = "`read()` method returns [dbgctrl::R](dbgctrl::R) reader structure"]
+impl crate::Readable for DBGCTRL {}
+#[doc = "`write(|w| ..)` method takes [dbgctrl::W](dbgctrl::W) writer structure"]
+impl crate::Writable for DBGCTRL {}
+#[doc = "Debug Control"]
+pub mod dbgctrl;
+#[doc = "Event Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [evctrl](evctrl) module"]
+pub type EVCTRL = crate::Reg<u32, _EVCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EVCTRL;
+#[doc = "`read()` method returns [evctrl::R](evctrl::R) reader structure"]
+impl crate::Readable for EVCTRL {}
+#[doc = "`write(|w| ..)` method takes [evctrl::W](evctrl::W) writer structure"]
+impl crate::Writable for EVCTRL {}
+#[doc = "Event Control"]
+pub mod evctrl;
+#[doc = "Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u32, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u32, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u32, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Status\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u32, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "`write(|w| ..)` method takes [status::W](status::W) writer structure"]
+impl crate::Writable for STATUS {}
+#[doc = "Status"]
+pub mod status;
+#[doc = "Count\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [count](count) module"]
+pub type COUNT = crate::Reg<u32, _COUNT>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _COUNT;
+#[doc = "`read()` method returns [count::R](count::R) reader structure"]
+impl crate::Readable for COUNT {}
+#[doc = "`write(|w| ..)` method takes [count::W](count::W) writer structure"]
+impl crate::Writable for COUNT {}
+#[doc = "Count"]
+pub mod count;
+#[doc = "Count\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [count_dith4](count_dith4) module"]
+pub type COUNT_DITH4 = crate::Reg<u32, _COUNT_DITH4>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _COUNT_DITH4;
+#[doc = "`read()` method returns [count_dith4::R](count_dith4::R) reader structure"]
+impl crate::Readable for COUNT_DITH4 {}
+#[doc = "`write(|w| ..)` method takes [count_dith4::W](count_dith4::W) writer structure"]
+impl crate::Writable for COUNT_DITH4 {}
+#[doc = "Count"]
+pub mod count_dith4;
+#[doc = "Count\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [count_dith5](count_dith5) module"]
+pub type COUNT_DITH5 = crate::Reg<u32, _COUNT_DITH5>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _COUNT_DITH5;
+#[doc = "`read()` method returns [count_dith5::R](count_dith5::R) reader structure"]
+impl crate::Readable for COUNT_DITH5 {}
+#[doc = "`write(|w| ..)` method takes [count_dith5::W](count_dith5::W) writer structure"]
+impl crate::Writable for COUNT_DITH5 {}
+#[doc = "Count"]
+pub mod count_dith5;
+#[doc = "Count\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [count_dith6](count_dith6) module"]
+pub type COUNT_DITH6 = crate::Reg<u32, _COUNT_DITH6>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _COUNT_DITH6;
+#[doc = "`read()` method returns [count_dith6::R](count_dith6::R) reader structure"]
+impl crate::Readable for COUNT_DITH6 {}
+#[doc = "`write(|w| ..)` method takes [count_dith6::W](count_dith6::W) writer structure"]
+impl crate::Writable for COUNT_DITH6 {}
+#[doc = "Count"]
+pub mod count_dith6;
+#[doc = "Pattern\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [patt](patt) module"]
+pub type PATT = crate::Reg<u16, _PATT>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PATT;
+#[doc = "`read()` method returns [patt::R](patt::R) reader structure"]
+impl crate::Readable for PATT {}
+#[doc = "`write(|w| ..)` method takes [patt::W](patt::W) writer structure"]
+impl crate::Writable for PATT {}
+#[doc = "Pattern"]
+pub mod patt;
+#[doc = "Waveform Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [wave](wave) module"]
+pub type WAVE = crate::Reg<u32, _WAVE>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WAVE;
+#[doc = "`read()` method returns [wave::R](wave::R) reader structure"]
+impl crate::Readable for WAVE {}
+#[doc = "`write(|w| ..)` method takes [wave::W](wave::W) writer structure"]
+impl crate::Writable for WAVE {}
+#[doc = "Waveform Control"]
+pub mod wave;
+#[doc = "Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [per](per) module"]
+pub type PER = crate::Reg<u32, _PER>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PER;
+#[doc = "`read()` method returns [per::R](per::R) reader structure"]
+impl crate::Readable for PER {}
+#[doc = "`write(|w| ..)` method takes [per::W](per::W) writer structure"]
+impl crate::Writable for PER {}
+#[doc = "Period"]
+pub mod per;
+#[doc = "Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [per_dith4](per_dith4) module"]
+pub type PER_DITH4 = crate::Reg<u32, _PER_DITH4>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PER_DITH4;
+#[doc = "`read()` method returns [per_dith4::R](per_dith4::R) reader structure"]
+impl crate::Readable for PER_DITH4 {}
+#[doc = "`write(|w| ..)` method takes [per_dith4::W](per_dith4::W) writer structure"]
+impl crate::Writable for PER_DITH4 {}
+#[doc = "Period"]
+pub mod per_dith4;
+#[doc = "Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [per_dith5](per_dith5) module"]
+pub type PER_DITH5 = crate::Reg<u32, _PER_DITH5>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PER_DITH5;
+#[doc = "`read()` method returns [per_dith5::R](per_dith5::R) reader structure"]
+impl crate::Readable for PER_DITH5 {}
+#[doc = "`write(|w| ..)` method takes [per_dith5::W](per_dith5::W) writer structure"]
+impl crate::Writable for PER_DITH5 {}
+#[doc = "Period"]
+pub mod per_dith5;
+#[doc = "Period\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [per_dith6](per_dith6) module"]
+pub type PER_DITH6 = crate::Reg<u32, _PER_DITH6>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PER_DITH6;
+#[doc = "`read()` method returns [per_dith6::R](per_dith6::R) reader structure"]
+impl crate::Readable for PER_DITH6 {}
+#[doc = "`write(|w| ..)` method takes [per_dith6::W](per_dith6::W) writer structure"]
+impl crate::Writable for PER_DITH6 {}
+#[doc = "Period"]
+pub mod per_dith6;
+#[doc = "Compare and Capture\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc](cc) module"]
+pub type CC = crate::Reg<u32, _CC>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CC;
+#[doc = "`read()` method returns [cc::R](cc::R) reader structure"]
+impl crate::Readable for CC {}
+#[doc = "`write(|w| ..)` method takes [cc::W](cc::W) writer structure"]
+impl crate::Writable for CC {}
+#[doc = "Compare and Capture"]
+pub mod cc;
+#[doc = "Compare and Capture\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc_dith4](cc_dith4) module"]
+pub type CC_DITH4 = crate::Reg<u32, _CC_DITH4>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CC_DITH4;
+#[doc = "`read()` method returns [cc_dith4::R](cc_dith4::R) reader structure"]
+impl crate::Readable for CC_DITH4 {}
+#[doc = "`write(|w| ..)` method takes [cc_dith4::W](cc_dith4::W) writer structure"]
+impl crate::Writable for CC_DITH4 {}
+#[doc = "Compare and Capture"]
+pub mod cc_dith4;
+#[doc = "Compare and Capture\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc_dith5](cc_dith5) module"]
+pub type CC_DITH5 = crate::Reg<u32, _CC_DITH5>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CC_DITH5;
+#[doc = "`read()` method returns [cc_dith5::R](cc_dith5::R) reader structure"]
+impl crate::Readable for CC_DITH5 {}
+#[doc = "`write(|w| ..)` method takes [cc_dith5::W](cc_dith5::W) writer structure"]
+impl crate::Writable for CC_DITH5 {}
+#[doc = "Compare and Capture"]
+pub mod cc_dith5;
+#[doc = "Compare and Capture\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [cc_dith6](cc_dith6) module"]
+pub type CC_DITH6 = crate::Reg<u32, _CC_DITH6>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CC_DITH6;
+#[doc = "`read()` method returns [cc_dith6::R](cc_dith6::R) reader structure"]
+impl crate::Readable for CC_DITH6 {}
+#[doc = "`write(|w| ..)` method takes [cc_dith6::W](cc_dith6::W) writer structure"]
+impl crate::Writable for CC_DITH6 {}
+#[doc = "Compare and Capture"]
+pub mod cc_dith6;
+#[doc = "Pattern Buffer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [pattb](pattb) module"]
+pub type PATTB = crate::Reg<u16, _PATTB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PATTB;
+#[doc = "`read()` method returns [pattb::R](pattb::R) reader structure"]
+impl crate::Readable for PATTB {}
+#[doc = "`write(|w| ..)` method takes [pattb::W](pattb::W) writer structure"]
+impl crate::Writable for PATTB {}
+#[doc = "Pattern Buffer"]
+pub mod pattb;
+#[doc = "Waveform Control Buffer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [waveb](waveb) module"]
+pub type WAVEB = crate::Reg<u32, _WAVEB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WAVEB;
+#[doc = "`read()` method returns [waveb::R](waveb::R) reader structure"]
+impl crate::Readable for WAVEB {}
+#[doc = "`write(|w| ..)` method takes [waveb::W](waveb::W) writer structure"]
+impl crate::Writable for WAVEB {}
+#[doc = "Waveform Control Buffer"]
+pub mod waveb;
+#[doc = "Period Buffer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [perb](perb) module"]
+pub type PERB = crate::Reg<u32, _PERB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PERB;
+#[doc = "`read()` method returns [perb::R](perb::R) reader structure"]
+impl crate::Readable for PERB {}
+#[doc = "`write(|w| ..)` method takes [perb::W](perb::W) writer structure"]
+impl crate::Writable for PERB {}
+#[doc = "Period Buffer"]
+pub mod perb;
+#[doc = "Period Buffer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [perb_dith4](perb_dith4) module"]
+pub type PERB_DITH4 = crate::Reg<u32, _PERB_DITH4>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PERB_DITH4;
+#[doc = "`read()` method returns [perb_dith4::R](perb_dith4::R) reader structure"]
+impl crate::Readable for PERB_DITH4 {}
+#[doc = "`write(|w| ..)` method takes [perb_dith4::W](perb_dith4::W) writer structure"]
+impl crate::Writable for PERB_DITH4 {}
+#[doc = "Period Buffer"]
+pub mod perb_dith4;
+#[doc = "Period Buffer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [perb_dith5](perb_dith5) module"]
+pub type PERB_DITH5 = crate::Reg<u32, _PERB_DITH5>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PERB_DITH5;
+#[doc = "`read()` method returns [perb_dith5::R](perb_dith5::R) reader structure"]
+impl crate::Readable for PERB_DITH5 {}
+#[doc = "`write(|w| ..)` method takes [perb_dith5::W](perb_dith5::W) writer structure"]
+impl crate::Writable for PERB_DITH5 {}
+#[doc = "Period Buffer"]
+pub mod perb_dith5;
+#[doc = "Period Buffer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [perb_dith6](perb_dith6) module"]
+pub type PERB_DITH6 = crate::Reg<u32, _PERB_DITH6>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PERB_DITH6;
+#[doc = "`read()` method returns [perb_dith6::R](perb_dith6::R) reader structure"]
+impl crate::Readable for PERB_DITH6 {}
+#[doc = "`write(|w| ..)` method takes [perb_dith6::W](perb_dith6::W) writer structure"]
+impl crate::Writable for PERB_DITH6 {}
+#[doc = "Period Buffer"]
+pub mod perb_dith6;
+#[doc = "Compare and Capture Buffer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ccb](ccb) module"]
+pub type CCB = crate::Reg<u32, _CCB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CCB;
+#[doc = "`read()` method returns [ccb::R](ccb::R) reader structure"]
+impl crate::Readable for CCB {}
+#[doc = "`write(|w| ..)` method takes [ccb::W](ccb::W) writer structure"]
+impl crate::Writable for CCB {}
+#[doc = "Compare and Capture Buffer"]
+pub mod ccb;
+#[doc = "Compare and Capture Buffer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ccb_dith4](ccb_dith4) module"]
+pub type CCB_DITH4 = crate::Reg<u32, _CCB_DITH4>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CCB_DITH4;
+#[doc = "`read()` method returns [ccb_dith4::R](ccb_dith4::R) reader structure"]
+impl crate::Readable for CCB_DITH4 {}
+#[doc = "`write(|w| ..)` method takes [ccb_dith4::W](ccb_dith4::W) writer structure"]
+impl crate::Writable for CCB_DITH4 {}
+#[doc = "Compare and Capture Buffer"]
+pub mod ccb_dith4;
+#[doc = "Compare and Capture Buffer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ccb_dith5](ccb_dith5) module"]
+pub type CCB_DITH5 = crate::Reg<u32, _CCB_DITH5>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CCB_DITH5;
+#[doc = "`read()` method returns [ccb_dith5::R](ccb_dith5::R) reader structure"]
+impl crate::Readable for CCB_DITH5 {}
+#[doc = "`write(|w| ..)` method takes [ccb_dith5::W](ccb_dith5::W) writer structure"]
+impl crate::Writable for CCB_DITH5 {}
+#[doc = "Compare and Capture Buffer"]
+pub mod ccb_dith5;
+#[doc = "Compare and Capture Buffer\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ccb_dith6](ccb_dith6) module"]
+pub type CCB_DITH6 = crate::Reg<u32, _CCB_DITH6>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CCB_DITH6;
+#[doc = "`read()` method returns [ccb_dith6::R](ccb_dith6::R) reader structure"]
+impl crate::Readable for CCB_DITH6 {}
+#[doc = "`write(|w| ..)` method takes [ccb_dith6::W](ccb_dith6::W) writer structure"]
+impl crate::Writable for CCB_DITH6 {}
+#[doc = "Compare and Capture Buffer"]
+pub mod ccb_dith6;

--- a/pac/atsamd11c14a/src/tcc0/cc.rs
+++ b/pac/atsamd11c14a/src/tcc0/cc.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register CC%s"]
+pub type R = crate::R<u32, super::CC>;
+#[doc = "Writer for register CC%s"]
+pub type W = crate::W<u32, super::CC>;
+#[doc = "Register CC%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::CC {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CC`"]
+pub type CC_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `CC`"]
+pub struct CC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CC_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x00ff_ffff) | ((value as u32) & 0x00ff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:23 - Channel Compare/Capture Value"]
+    #[inline(always)]
+    pub fn cc(&self) -> CC_R {
+        CC_R::new((self.bits & 0x00ff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:23 - Channel Compare/Capture Value"]
+    #[inline(always)]
+    pub fn cc(&mut self) -> CC_W {
+        CC_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/cc_dith4.rs
+++ b/pac/atsamd11c14a/src/tcc0/cc_dith4.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register CC%s_DITH4"]
+pub type R = crate::R<u32, super::CC_DITH4>;
+#[doc = "Writer for register CC%s_DITH4"]
+pub type W = crate::W<u32, super::CC_DITH4>;
+#[doc = "Register CC%s_DITH4 `reset()`'s with value 0"]
+impl crate::ResetValue for super::CC_DITH4 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DITHERCY`"]
+pub type DITHERCY_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DITHERCY`"]
+pub struct DITHERCY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DITHERCY_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0f) | ((value as u32) & 0x0f);
+        self.w
+    }
+}
+#[doc = "Reader of field `CC`"]
+pub type CC_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `CC`"]
+pub struct CC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CC_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x000f_ffff << 4)) | (((value as u32) & 0x000f_ffff) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:3 - Dithering Cycle Number"]
+    #[inline(always)]
+    pub fn dithercy(&self) -> DITHERCY_R {
+        DITHERCY_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:23 - Channel Compare/Capture Value"]
+    #[inline(always)]
+    pub fn cc(&self) -> CC_R {
+        CC_R::new(((self.bits >> 4) & 0x000f_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Dithering Cycle Number"]
+    #[inline(always)]
+    pub fn dithercy(&mut self) -> DITHERCY_W {
+        DITHERCY_W { w: self }
+    }
+    #[doc = "Bits 4:23 - Channel Compare/Capture Value"]
+    #[inline(always)]
+    pub fn cc(&mut self) -> CC_W {
+        CC_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/cc_dith5.rs
+++ b/pac/atsamd11c14a/src/tcc0/cc_dith5.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register CC%s_DITH5"]
+pub type R = crate::R<u32, super::CC_DITH5>;
+#[doc = "Writer for register CC%s_DITH5"]
+pub type W = crate::W<u32, super::CC_DITH5>;
+#[doc = "Register CC%s_DITH5 `reset()`'s with value 0"]
+impl crate::ResetValue for super::CC_DITH5 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DITHERCY`"]
+pub type DITHERCY_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DITHERCY`"]
+pub struct DITHERCY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DITHERCY_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x1f) | ((value as u32) & 0x1f);
+        self.w
+    }
+}
+#[doc = "Reader of field `CC`"]
+pub type CC_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `CC`"]
+pub struct CC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CC_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0007_ffff << 5)) | (((value as u32) & 0x0007_ffff) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:4 - Dithering Cycle Number"]
+    #[inline(always)]
+    pub fn dithercy(&self) -> DITHERCY_R {
+        DITHERCY_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bits 5:23 - Channel Compare/Capture Value"]
+    #[inline(always)]
+    pub fn cc(&self) -> CC_R {
+        CC_R::new(((self.bits >> 5) & 0x0007_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - Dithering Cycle Number"]
+    #[inline(always)]
+    pub fn dithercy(&mut self) -> DITHERCY_W {
+        DITHERCY_W { w: self }
+    }
+    #[doc = "Bits 5:23 - Channel Compare/Capture Value"]
+    #[inline(always)]
+    pub fn cc(&mut self) -> CC_W {
+        CC_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/cc_dith6.rs
+++ b/pac/atsamd11c14a/src/tcc0/cc_dith6.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register CC%s_DITH6"]
+pub type R = crate::R<u32, super::CC_DITH6>;
+#[doc = "Writer for register CC%s_DITH6"]
+pub type W = crate::W<u32, super::CC_DITH6>;
+#[doc = "Register CC%s_DITH6 `reset()`'s with value 0"]
+impl crate::ResetValue for super::CC_DITH6 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DITHERCY`"]
+pub type DITHERCY_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DITHERCY`"]
+pub struct DITHERCY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DITHERCY_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x3f) | ((value as u32) & 0x3f);
+        self.w
+    }
+}
+#[doc = "Reader of field `CC`"]
+pub type CC_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `CC`"]
+pub struct CC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CC_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0003_ffff << 6)) | (((value as u32) & 0x0003_ffff) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:5 - Dithering Cycle Number"]
+    #[inline(always)]
+    pub fn dithercy(&self) -> DITHERCY_R {
+        DITHERCY_R::new((self.bits & 0x3f) as u8)
+    }
+    #[doc = "Bits 6:23 - Channel Compare/Capture Value"]
+    #[inline(always)]
+    pub fn cc(&self) -> CC_R {
+        CC_R::new(((self.bits >> 6) & 0x0003_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:5 - Dithering Cycle Number"]
+    #[inline(always)]
+    pub fn dithercy(&mut self) -> DITHERCY_W {
+        DITHERCY_W { w: self }
+    }
+    #[doc = "Bits 6:23 - Channel Compare/Capture Value"]
+    #[inline(always)]
+    pub fn cc(&mut self) -> CC_W {
+        CC_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/ccb.rs
+++ b/pac/atsamd11c14a/src/tcc0/ccb.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register CCB%s"]
+pub type R = crate::R<u32, super::CCB>;
+#[doc = "Writer for register CCB%s"]
+pub type W = crate::W<u32, super::CCB>;
+#[doc = "Register CCB%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::CCB {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CCB`"]
+pub type CCB_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `CCB`"]
+pub struct CCB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CCB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x00ff_ffff) | ((value as u32) & 0x00ff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:23 - Channel Compare/Capture Buffer Value"]
+    #[inline(always)]
+    pub fn ccb(&self) -> CCB_R {
+        CCB_R::new((self.bits & 0x00ff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:23 - Channel Compare/Capture Buffer Value"]
+    #[inline(always)]
+    pub fn ccb(&mut self) -> CCB_W {
+        CCB_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/ccb_dith4.rs
+++ b/pac/atsamd11c14a/src/tcc0/ccb_dith4.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register CCB%s_DITH4"]
+pub type R = crate::R<u32, super::CCB_DITH4>;
+#[doc = "Writer for register CCB%s_DITH4"]
+pub type W = crate::W<u32, super::CCB_DITH4>;
+#[doc = "Register CCB%s_DITH4 `reset()`'s with value 0"]
+impl crate::ResetValue for super::CCB_DITH4 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DITHERCYB`"]
+pub type DITHERCYB_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DITHERCYB`"]
+pub struct DITHERCYB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DITHERCYB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0f) | ((value as u32) & 0x0f);
+        self.w
+    }
+}
+#[doc = "Reader of field `CCB`"]
+pub type CCB_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `CCB`"]
+pub struct CCB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CCB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x000f_ffff << 4)) | (((value as u32) & 0x000f_ffff) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:3 - Dithering Buffer Cycle Number"]
+    #[inline(always)]
+    pub fn dithercyb(&self) -> DITHERCYB_R {
+        DITHERCYB_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:23 - Channel Compare/Capture Buffer Value"]
+    #[inline(always)]
+    pub fn ccb(&self) -> CCB_R {
+        CCB_R::new(((self.bits >> 4) & 0x000f_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Dithering Buffer Cycle Number"]
+    #[inline(always)]
+    pub fn dithercyb(&mut self) -> DITHERCYB_W {
+        DITHERCYB_W { w: self }
+    }
+    #[doc = "Bits 4:23 - Channel Compare/Capture Buffer Value"]
+    #[inline(always)]
+    pub fn ccb(&mut self) -> CCB_W {
+        CCB_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/ccb_dith5.rs
+++ b/pac/atsamd11c14a/src/tcc0/ccb_dith5.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register CCB%s_DITH5"]
+pub type R = crate::R<u32, super::CCB_DITH5>;
+#[doc = "Writer for register CCB%s_DITH5"]
+pub type W = crate::W<u32, super::CCB_DITH5>;
+#[doc = "Register CCB%s_DITH5 `reset()`'s with value 0"]
+impl crate::ResetValue for super::CCB_DITH5 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DITHERCYB`"]
+pub type DITHERCYB_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DITHERCYB`"]
+pub struct DITHERCYB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DITHERCYB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x1f) | ((value as u32) & 0x1f);
+        self.w
+    }
+}
+#[doc = "Reader of field `CCB`"]
+pub type CCB_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `CCB`"]
+pub struct CCB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CCB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0007_ffff << 5)) | (((value as u32) & 0x0007_ffff) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:4 - Dithering Buffer Cycle Number"]
+    #[inline(always)]
+    pub fn dithercyb(&self) -> DITHERCYB_R {
+        DITHERCYB_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bits 5:23 - Channel Compare/Capture Buffer Value"]
+    #[inline(always)]
+    pub fn ccb(&self) -> CCB_R {
+        CCB_R::new(((self.bits >> 5) & 0x0007_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - Dithering Buffer Cycle Number"]
+    #[inline(always)]
+    pub fn dithercyb(&mut self) -> DITHERCYB_W {
+        DITHERCYB_W { w: self }
+    }
+    #[doc = "Bits 5:23 - Channel Compare/Capture Buffer Value"]
+    #[inline(always)]
+    pub fn ccb(&mut self) -> CCB_W {
+        CCB_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/ccb_dith6.rs
+++ b/pac/atsamd11c14a/src/tcc0/ccb_dith6.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register CCB%s_DITH6"]
+pub type R = crate::R<u32, super::CCB_DITH6>;
+#[doc = "Writer for register CCB%s_DITH6"]
+pub type W = crate::W<u32, super::CCB_DITH6>;
+#[doc = "Register CCB%s_DITH6 `reset()`'s with value 0"]
+impl crate::ResetValue for super::CCB_DITH6 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DITHERCYB`"]
+pub type DITHERCYB_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DITHERCYB`"]
+pub struct DITHERCYB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DITHERCYB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x3f) | ((value as u32) & 0x3f);
+        self.w
+    }
+}
+#[doc = "Reader of field `CCB`"]
+pub type CCB_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `CCB`"]
+pub struct CCB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CCB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0003_ffff << 6)) | (((value as u32) & 0x0003_ffff) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:5 - Dithering Buffer Cycle Number"]
+    #[inline(always)]
+    pub fn dithercyb(&self) -> DITHERCYB_R {
+        DITHERCYB_R::new((self.bits & 0x3f) as u8)
+    }
+    #[doc = "Bits 6:23 - Channel Compare/Capture Buffer Value"]
+    #[inline(always)]
+    pub fn ccb(&self) -> CCB_R {
+        CCB_R::new(((self.bits >> 6) & 0x0003_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:5 - Dithering Buffer Cycle Number"]
+    #[inline(always)]
+    pub fn dithercyb(&mut self) -> DITHERCYB_W {
+        DITHERCYB_W { w: self }
+    }
+    #[doc = "Bits 6:23 - Channel Compare/Capture Buffer Value"]
+    #[inline(always)]
+    pub fn ccb(&mut self) -> CCB_W {
+        CCB_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/count.rs
+++ b/pac/atsamd11c14a/src/tcc0/count.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register COUNT"]
+pub type R = crate::R<u32, super::COUNT>;
+#[doc = "Writer for register COUNT"]
+pub type W = crate::W<u32, super::COUNT>;
+#[doc = "Register COUNT `reset()`'s with value 0"]
+impl crate::ResetValue for super::COUNT {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `COUNT`"]
+pub type COUNT_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `COUNT`"]
+pub struct COUNT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COUNT_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x00ff_ffff) | ((value as u32) & 0x00ff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:23 - Counter Value"]
+    #[inline(always)]
+    pub fn count(&self) -> COUNT_R {
+        COUNT_R::new((self.bits & 0x00ff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:23 - Counter Value"]
+    #[inline(always)]
+    pub fn count(&mut self) -> COUNT_W {
+        COUNT_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/count_dith4.rs
+++ b/pac/atsamd11c14a/src/tcc0/count_dith4.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register COUNT_DITH4"]
+pub type R = crate::R<u32, super::COUNT_DITH4>;
+#[doc = "Writer for register COUNT_DITH4"]
+pub type W = crate::W<u32, super::COUNT_DITH4>;
+#[doc = "Register COUNT_DITH4 `reset()`'s with value 0"]
+impl crate::ResetValue for super::COUNT_DITH4 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `COUNT`"]
+pub type COUNT_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `COUNT`"]
+pub struct COUNT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COUNT_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x000f_ffff << 4)) | (((value as u32) & 0x000f_ffff) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 4:23 - Counter Value"]
+    #[inline(always)]
+    pub fn count(&self) -> COUNT_R {
+        COUNT_R::new(((self.bits >> 4) & 0x000f_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 4:23 - Counter Value"]
+    #[inline(always)]
+    pub fn count(&mut self) -> COUNT_W {
+        COUNT_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/count_dith5.rs
+++ b/pac/atsamd11c14a/src/tcc0/count_dith5.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register COUNT_DITH5"]
+pub type R = crate::R<u32, super::COUNT_DITH5>;
+#[doc = "Writer for register COUNT_DITH5"]
+pub type W = crate::W<u32, super::COUNT_DITH5>;
+#[doc = "Register COUNT_DITH5 `reset()`'s with value 0"]
+impl crate::ResetValue for super::COUNT_DITH5 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `COUNT`"]
+pub type COUNT_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `COUNT`"]
+pub struct COUNT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COUNT_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0007_ffff << 5)) | (((value as u32) & 0x0007_ffff) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 5:23 - Counter Value"]
+    #[inline(always)]
+    pub fn count(&self) -> COUNT_R {
+        COUNT_R::new(((self.bits >> 5) & 0x0007_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 5:23 - Counter Value"]
+    #[inline(always)]
+    pub fn count(&mut self) -> COUNT_W {
+        COUNT_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/count_dith6.rs
+++ b/pac/atsamd11c14a/src/tcc0/count_dith6.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register COUNT_DITH6"]
+pub type R = crate::R<u32, super::COUNT_DITH6>;
+#[doc = "Writer for register COUNT_DITH6"]
+pub type W = crate::W<u32, super::COUNT_DITH6>;
+#[doc = "Register COUNT_DITH6 `reset()`'s with value 0"]
+impl crate::ResetValue for super::COUNT_DITH6 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `COUNT`"]
+pub type COUNT_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `COUNT`"]
+pub struct COUNT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> COUNT_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0003_ffff << 6)) | (((value as u32) & 0x0003_ffff) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 6:23 - Counter Value"]
+    #[inline(always)]
+    pub fn count(&self) -> COUNT_R {
+        COUNT_R::new(((self.bits >> 6) & 0x0003_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 6:23 - Counter Value"]
+    #[inline(always)]
+    pub fn count(&mut self) -> COUNT_W {
+        COUNT_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/ctrla.rs
+++ b/pac/atsamd11c14a/src/tcc0/ctrla.rs
@@ -1,0 +1,650 @@
+#[doc = "Reader of register CTRLA"]
+pub type R = crate::R<u32, super::CTRLA>;
+#[doc = "Writer for register CTRLA"]
+pub type W = crate::W<u32, super::CTRLA>;
+#[doc = "Register CTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLA {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Enhanced Resolution\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum RESOLUTION_A {
+    #[doc = "0: Dithering is disabled"]
+    NONE,
+    #[doc = "1: Dithering is done every 16 PWM frames"]
+    DITH4,
+    #[doc = "2: Dithering is done every 32 PWM frames"]
+    DITH5,
+    #[doc = "3: Dithering is done every 64 PWM frames"]
+    DITH6,
+}
+impl From<RESOLUTION_A> for u8 {
+    #[inline(always)]
+    fn from(variant: RESOLUTION_A) -> Self {
+        match variant {
+            RESOLUTION_A::NONE => 0,
+            RESOLUTION_A::DITH4 => 1,
+            RESOLUTION_A::DITH5 => 2,
+            RESOLUTION_A::DITH6 => 3,
+        }
+    }
+}
+#[doc = "Reader of field `RESOLUTION`"]
+pub type RESOLUTION_R = crate::R<u8, RESOLUTION_A>;
+impl RESOLUTION_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> RESOLUTION_A {
+        match self.bits {
+            0 => RESOLUTION_A::NONE,
+            1 => RESOLUTION_A::DITH4,
+            2 => RESOLUTION_A::DITH5,
+            3 => RESOLUTION_A::DITH6,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == RESOLUTION_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `DITH4`"]
+    #[inline(always)]
+    pub fn is_dith4(&self) -> bool {
+        *self == RESOLUTION_A::DITH4
+    }
+    #[doc = "Checks if the value of the field is `DITH5`"]
+    #[inline(always)]
+    pub fn is_dith5(&self) -> bool {
+        *self == RESOLUTION_A::DITH5
+    }
+    #[doc = "Checks if the value of the field is `DITH6`"]
+    #[inline(always)]
+    pub fn is_dith6(&self) -> bool {
+        *self == RESOLUTION_A::DITH6
+    }
+}
+#[doc = "Write proxy for field `RESOLUTION`"]
+pub struct RESOLUTION_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RESOLUTION_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: RESOLUTION_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Dithering is disabled"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(RESOLUTION_A::NONE)
+    }
+    #[doc = "Dithering is done every 16 PWM frames"]
+    #[inline(always)]
+    pub fn dith4(self) -> &'a mut W {
+        self.variant(RESOLUTION_A::DITH4)
+    }
+    #[doc = "Dithering is done every 32 PWM frames"]
+    #[inline(always)]
+    pub fn dith5(self) -> &'a mut W {
+        self.variant(RESOLUTION_A::DITH5)
+    }
+    #[doc = "Dithering is done every 64 PWM frames"]
+    #[inline(always)]
+    pub fn dith6(self) -> &'a mut W {
+        self.variant(RESOLUTION_A::DITH6)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 5)) | (((value as u32) & 0x03) << 5);
+        self.w
+    }
+}
+#[doc = "Prescaler\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PRESCALER_A {
+    #[doc = "0: No division"]
+    DIV1,
+    #[doc = "1: Divide by 2"]
+    DIV2,
+    #[doc = "2: Divide by 4"]
+    DIV4,
+    #[doc = "3: Divide by 8"]
+    DIV8,
+    #[doc = "4: Divide by 16"]
+    DIV16,
+    #[doc = "5: Divide by 64"]
+    DIV64,
+    #[doc = "6: Divide by 256"]
+    DIV256,
+    #[doc = "7: Divide by 1024"]
+    DIV1024,
+}
+impl From<PRESCALER_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PRESCALER_A) -> Self {
+        match variant {
+            PRESCALER_A::DIV1 => 0,
+            PRESCALER_A::DIV2 => 1,
+            PRESCALER_A::DIV4 => 2,
+            PRESCALER_A::DIV8 => 3,
+            PRESCALER_A::DIV16 => 4,
+            PRESCALER_A::DIV64 => 5,
+            PRESCALER_A::DIV256 => 6,
+            PRESCALER_A::DIV1024 => 7,
+        }
+    }
+}
+#[doc = "Reader of field `PRESCALER`"]
+pub type PRESCALER_R = crate::R<u8, PRESCALER_A>;
+impl PRESCALER_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> PRESCALER_A {
+        match self.bits {
+            0 => PRESCALER_A::DIV1,
+            1 => PRESCALER_A::DIV2,
+            2 => PRESCALER_A::DIV4,
+            3 => PRESCALER_A::DIV8,
+            4 => PRESCALER_A::DIV16,
+            5 => PRESCALER_A::DIV64,
+            6 => PRESCALER_A::DIV256,
+            7 => PRESCALER_A::DIV1024,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DIV1`"]
+    #[inline(always)]
+    pub fn is_div1(&self) -> bool {
+        *self == PRESCALER_A::DIV1
+    }
+    #[doc = "Checks if the value of the field is `DIV2`"]
+    #[inline(always)]
+    pub fn is_div2(&self) -> bool {
+        *self == PRESCALER_A::DIV2
+    }
+    #[doc = "Checks if the value of the field is `DIV4`"]
+    #[inline(always)]
+    pub fn is_div4(&self) -> bool {
+        *self == PRESCALER_A::DIV4
+    }
+    #[doc = "Checks if the value of the field is `DIV8`"]
+    #[inline(always)]
+    pub fn is_div8(&self) -> bool {
+        *self == PRESCALER_A::DIV8
+    }
+    #[doc = "Checks if the value of the field is `DIV16`"]
+    #[inline(always)]
+    pub fn is_div16(&self) -> bool {
+        *self == PRESCALER_A::DIV16
+    }
+    #[doc = "Checks if the value of the field is `DIV64`"]
+    #[inline(always)]
+    pub fn is_div64(&self) -> bool {
+        *self == PRESCALER_A::DIV64
+    }
+    #[doc = "Checks if the value of the field is `DIV256`"]
+    #[inline(always)]
+    pub fn is_div256(&self) -> bool {
+        *self == PRESCALER_A::DIV256
+    }
+    #[doc = "Checks if the value of the field is `DIV1024`"]
+    #[inline(always)]
+    pub fn is_div1024(&self) -> bool {
+        *self == PRESCALER_A::DIV1024
+    }
+}
+#[doc = "Write proxy for field `PRESCALER`"]
+pub struct PRESCALER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PRESCALER_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PRESCALER_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "No division"]
+    #[inline(always)]
+    pub fn div1(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV1)
+    }
+    #[doc = "Divide by 2"]
+    #[inline(always)]
+    pub fn div2(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV2)
+    }
+    #[doc = "Divide by 4"]
+    #[inline(always)]
+    pub fn div4(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV4)
+    }
+    #[doc = "Divide by 8"]
+    #[inline(always)]
+    pub fn div8(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV8)
+    }
+    #[doc = "Divide by 16"]
+    #[inline(always)]
+    pub fn div16(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV16)
+    }
+    #[doc = "Divide by 64"]
+    #[inline(always)]
+    pub fn div64(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV64)
+    }
+    #[doc = "Divide by 256"]
+    #[inline(always)]
+    pub fn div256(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV256)
+    }
+    #[doc = "Divide by 1024"]
+    #[inline(always)]
+    pub fn div1024(self) -> &'a mut W {
+        self.variant(PRESCALER_A::DIV1024)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 8)) | (((value as u32) & 0x07) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Prescaler and Counter Synchronization Selection\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PRESCSYNC_A {
+    #[doc = "0: Reload or reset counter on next GCLK"]
+    GCLK,
+    #[doc = "1: Reload or reset counter on next prescaler clock"]
+    PRESC,
+    #[doc = "2: Reload or reset counter on next GCLK and reset prescaler counter"]
+    RESYNC,
+}
+impl From<PRESCSYNC_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PRESCSYNC_A) -> Self {
+        match variant {
+            PRESCSYNC_A::GCLK => 0,
+            PRESCSYNC_A::PRESC => 1,
+            PRESCSYNC_A::RESYNC => 2,
+        }
+    }
+}
+#[doc = "Reader of field `PRESCSYNC`"]
+pub type PRESCSYNC_R = crate::R<u8, PRESCSYNC_A>;
+impl PRESCSYNC_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, PRESCSYNC_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(PRESCSYNC_A::GCLK),
+            1 => Val(PRESCSYNC_A::PRESC),
+            2 => Val(PRESCSYNC_A::RESYNC),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `GCLK`"]
+    #[inline(always)]
+    pub fn is_gclk(&self) -> bool {
+        *self == PRESCSYNC_A::GCLK
+    }
+    #[doc = "Checks if the value of the field is `PRESC`"]
+    #[inline(always)]
+    pub fn is_presc(&self) -> bool {
+        *self == PRESCSYNC_A::PRESC
+    }
+    #[doc = "Checks if the value of the field is `RESYNC`"]
+    #[inline(always)]
+    pub fn is_resync(&self) -> bool {
+        *self == PRESCSYNC_A::RESYNC
+    }
+}
+#[doc = "Write proxy for field `PRESCSYNC`"]
+pub struct PRESCSYNC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PRESCSYNC_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PRESCSYNC_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Reload or reset counter on next GCLK"]
+    #[inline(always)]
+    pub fn gclk(self) -> &'a mut W {
+        self.variant(PRESCSYNC_A::GCLK)
+    }
+    #[doc = "Reload or reset counter on next prescaler clock"]
+    #[inline(always)]
+    pub fn presc(self) -> &'a mut W {
+        self.variant(PRESCSYNC_A::PRESC)
+    }
+    #[doc = "Reload or reset counter on next GCLK and reset prescaler counter"]
+    #[inline(always)]
+    pub fn resync(self) -> &'a mut W {
+        self.variant(PRESCSYNC_A::RESYNC)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 12)) | (((value as u32) & 0x03) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `ALOCK`"]
+pub type ALOCK_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ALOCK`"]
+pub struct ALOCK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ALOCK_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u32) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `CPTEN0`"]
+pub type CPTEN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CPTEN0`"]
+pub struct CPTEN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CPTEN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 24)) | (((value as u32) & 0x01) << 24);
+        self.w
+    }
+}
+#[doc = "Reader of field `CPTEN1`"]
+pub type CPTEN1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CPTEN1`"]
+pub struct CPTEN1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CPTEN1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 25)) | (((value as u32) & 0x01) << 25);
+        self.w
+    }
+}
+#[doc = "Reader of field `CPTEN2`"]
+pub type CPTEN2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CPTEN2`"]
+pub struct CPTEN2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CPTEN2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 26)) | (((value as u32) & 0x01) << 26);
+        self.w
+    }
+}
+#[doc = "Reader of field `CPTEN3`"]
+pub type CPTEN3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CPTEN3`"]
+pub struct CPTEN3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CPTEN3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 27)) | (((value as u32) & 0x01) << 27);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 5:6 - Enhanced Resolution"]
+    #[inline(always)]
+    pub fn resolution(&self) -> RESOLUTION_R {
+        RESOLUTION_R::new(((self.bits >> 5) & 0x03) as u8)
+    }
+    #[doc = "Bits 8:10 - Prescaler"]
+    #[inline(always)]
+    pub fn prescaler(&self) -> PRESCALER_R {
+        PRESCALER_R::new(((self.bits >> 8) & 0x07) as u8)
+    }
+    #[doc = "Bit 11 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bits 12:13 - Prescaler and Counter Synchronization Selection"]
+    #[inline(always)]
+    pub fn prescsync(&self) -> PRESCSYNC_R {
+        PRESCSYNC_R::new(((self.bits >> 12) & 0x03) as u8)
+    }
+    #[doc = "Bit 14 - Auto Lock"]
+    #[inline(always)]
+    pub fn alock(&self) -> ALOCK_R {
+        ALOCK_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 24 - Capture Channel 0 Enable"]
+    #[inline(always)]
+    pub fn cpten0(&self) -> CPTEN0_R {
+        CPTEN0_R::new(((self.bits >> 24) & 0x01) != 0)
+    }
+    #[doc = "Bit 25 - Capture Channel 1 Enable"]
+    #[inline(always)]
+    pub fn cpten1(&self) -> CPTEN1_R {
+        CPTEN1_R::new(((self.bits >> 25) & 0x01) != 0)
+    }
+    #[doc = "Bit 26 - Capture Channel 2 Enable"]
+    #[inline(always)]
+    pub fn cpten2(&self) -> CPTEN2_R {
+        CPTEN2_R::new(((self.bits >> 26) & 0x01) != 0)
+    }
+    #[doc = "Bit 27 - Capture Channel 3 Enable"]
+    #[inline(always)]
+    pub fn cpten3(&self) -> CPTEN3_R {
+        CPTEN3_R::new(((self.bits >> 27) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bits 5:6 - Enhanced Resolution"]
+    #[inline(always)]
+    pub fn resolution(&mut self) -> RESOLUTION_W {
+        RESOLUTION_W { w: self }
+    }
+    #[doc = "Bits 8:10 - Prescaler"]
+    #[inline(always)]
+    pub fn prescaler(&mut self) -> PRESCALER_W {
+        PRESCALER_W { w: self }
+    }
+    #[doc = "Bit 11 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bits 12:13 - Prescaler and Counter Synchronization Selection"]
+    #[inline(always)]
+    pub fn prescsync(&mut self) -> PRESCSYNC_W {
+        PRESCSYNC_W { w: self }
+    }
+    #[doc = "Bit 14 - Auto Lock"]
+    #[inline(always)]
+    pub fn alock(&mut self) -> ALOCK_W {
+        ALOCK_W { w: self }
+    }
+    #[doc = "Bit 24 - Capture Channel 0 Enable"]
+    #[inline(always)]
+    pub fn cpten0(&mut self) -> CPTEN0_W {
+        CPTEN0_W { w: self }
+    }
+    #[doc = "Bit 25 - Capture Channel 1 Enable"]
+    #[inline(always)]
+    pub fn cpten1(&mut self) -> CPTEN1_W {
+        CPTEN1_W { w: self }
+    }
+    #[doc = "Bit 26 - Capture Channel 2 Enable"]
+    #[inline(always)]
+    pub fn cpten2(&mut self) -> CPTEN2_W {
+        CPTEN2_W { w: self }
+    }
+    #[doc = "Bit 27 - Capture Channel 3 Enable"]
+    #[inline(always)]
+    pub fn cpten3(&mut self) -> CPTEN3_W {
+        CPTEN3_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/ctrlbclr.rs
+++ b/pac/atsamd11c14a/src/tcc0/ctrlbclr.rs
@@ -1,0 +1,345 @@
+#[doc = "Reader of register CTRLBCLR"]
+pub type R = crate::R<u8, super::CTRLBCLR>;
+#[doc = "Writer for register CTRLBCLR"]
+pub type W = crate::W<u8, super::CTRLBCLR>;
+#[doc = "Register CTRLBCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLBCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DIR`"]
+pub type DIR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DIR`"]
+pub struct DIR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `LUPD`"]
+pub type LUPD_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LUPD`"]
+pub struct LUPD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LUPD_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `ONESHOT`"]
+pub type ONESHOT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ONESHOT`"]
+pub struct ONESHOT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ONESHOT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Ramp Index Command\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum IDXCMD_A {
+    #[doc = "0: Command disabled: Index toggles between cycles A and B"]
+    DISABLE,
+    #[doc = "1: Set index: cycle B will be forced in the next cycle"]
+    SET,
+    #[doc = "2: Clear index: cycle A will be forced in the next cycle"]
+    CLEAR,
+    #[doc = "3: Hold index: the next cycle will be the same as the current cycle"]
+    HOLD,
+}
+impl From<IDXCMD_A> for u8 {
+    #[inline(always)]
+    fn from(variant: IDXCMD_A) -> Self {
+        match variant {
+            IDXCMD_A::DISABLE => 0,
+            IDXCMD_A::SET => 1,
+            IDXCMD_A::CLEAR => 2,
+            IDXCMD_A::HOLD => 3,
+        }
+    }
+}
+#[doc = "Reader of field `IDXCMD`"]
+pub type IDXCMD_R = crate::R<u8, IDXCMD_A>;
+impl IDXCMD_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> IDXCMD_A {
+        match self.bits {
+            0 => IDXCMD_A::DISABLE,
+            1 => IDXCMD_A::SET,
+            2 => IDXCMD_A::CLEAR,
+            3 => IDXCMD_A::HOLD,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[inline(always)]
+    pub fn is_disable(&self) -> bool {
+        *self == IDXCMD_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `SET`"]
+    #[inline(always)]
+    pub fn is_set(&self) -> bool {
+        *self == IDXCMD_A::SET
+    }
+    #[doc = "Checks if the value of the field is `CLEAR`"]
+    #[inline(always)]
+    pub fn is_clear(&self) -> bool {
+        *self == IDXCMD_A::CLEAR
+    }
+    #[doc = "Checks if the value of the field is `HOLD`"]
+    #[inline(always)]
+    pub fn is_hold(&self) -> bool {
+        *self == IDXCMD_A::HOLD
+    }
+}
+#[doc = "Write proxy for field `IDXCMD`"]
+pub struct IDXCMD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> IDXCMD_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: IDXCMD_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Command disabled: Index toggles between cycles A and B"]
+    #[inline(always)]
+    pub fn disable(self) -> &'a mut W {
+        self.variant(IDXCMD_A::DISABLE)
+    }
+    #[doc = "Set index: cycle B will be forced in the next cycle"]
+    #[inline(always)]
+    pub fn set(self) -> &'a mut W {
+        self.variant(IDXCMD_A::SET)
+    }
+    #[doc = "Clear index: cycle A will be forced in the next cycle"]
+    #[inline(always)]
+    pub fn clear(self) -> &'a mut W {
+        self.variant(IDXCMD_A::CLEAR)
+    }
+    #[doc = "Hold index: the next cycle will be the same as the current cycle"]
+    #[inline(always)]
+    pub fn hold(self) -> &'a mut W {
+        self.variant(IDXCMD_A::HOLD)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 3)) | (((value as u8) & 0x03) << 3);
+        self.w
+    }
+}
+#[doc = "TCC Command\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CMD_A {
+    #[doc = "0: No action"]
+    NONE,
+    #[doc = "1: Clear start, restart or retrigger"]
+    RETRIGGER,
+    #[doc = "2: Force stop"]
+    STOP,
+    #[doc = "3: Force update or double buffered registers"]
+    UPDATE,
+    #[doc = "4: Force COUNT read synchronization"]
+    READSYNC,
+}
+impl From<CMD_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CMD_A) -> Self {
+        match variant {
+            CMD_A::NONE => 0,
+            CMD_A::RETRIGGER => 1,
+            CMD_A::STOP => 2,
+            CMD_A::UPDATE => 3,
+            CMD_A::READSYNC => 4,
+        }
+    }
+}
+#[doc = "Reader of field `CMD`"]
+pub type CMD_R = crate::R<u8, CMD_A>;
+impl CMD_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, CMD_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(CMD_A::NONE),
+            1 => Val(CMD_A::RETRIGGER),
+            2 => Val(CMD_A::STOP),
+            3 => Val(CMD_A::UPDATE),
+            4 => Val(CMD_A::READSYNC),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == CMD_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RETRIGGER`"]
+    #[inline(always)]
+    pub fn is_retrigger(&self) -> bool {
+        *self == CMD_A::RETRIGGER
+    }
+    #[doc = "Checks if the value of the field is `STOP`"]
+    #[inline(always)]
+    pub fn is_stop(&self) -> bool {
+        *self == CMD_A::STOP
+    }
+    #[doc = "Checks if the value of the field is `UPDATE`"]
+    #[inline(always)]
+    pub fn is_update(&self) -> bool {
+        *self == CMD_A::UPDATE
+    }
+    #[doc = "Checks if the value of the field is `READSYNC`"]
+    #[inline(always)]
+    pub fn is_readsync(&self) -> bool {
+        *self == CMD_A::READSYNC
+    }
+}
+#[doc = "Write proxy for field `CMD`"]
+pub struct CMD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMD_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CMD_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No action"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(CMD_A::NONE)
+    }
+    #[doc = "Clear start, restart or retrigger"]
+    #[inline(always)]
+    pub fn retrigger(self) -> &'a mut W {
+        self.variant(CMD_A::RETRIGGER)
+    }
+    #[doc = "Force stop"]
+    #[inline(always)]
+    pub fn stop(self) -> &'a mut W {
+        self.variant(CMD_A::STOP)
+    }
+    #[doc = "Force update or double buffered registers"]
+    #[inline(always)]
+    pub fn update(self) -> &'a mut W {
+        self.variant(CMD_A::UPDATE)
+    }
+    #[doc = "Force COUNT read synchronization"]
+    #[inline(always)]
+    pub fn readsync(self) -> &'a mut W {
+        self.variant(CMD_A::READSYNC)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 5)) | (((value as u8) & 0x07) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&self) -> DIR_R {
+        DIR_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Lock Update"]
+    #[inline(always)]
+    pub fn lupd(&self) -> LUPD_R {
+        LUPD_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&self) -> ONESHOT_R {
+        ONESHOT_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bits 3:4 - Ramp Index Command"]
+    #[inline(always)]
+    pub fn idxcmd(&self) -> IDXCMD_R {
+        IDXCMD_R::new(((self.bits >> 3) & 0x03) as u8)
+    }
+    #[doc = "Bits 5:7 - TCC Command"]
+    #[inline(always)]
+    pub fn cmd(&self) -> CMD_R {
+        CMD_R::new(((self.bits >> 5) & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&mut self) -> DIR_W {
+        DIR_W { w: self }
+    }
+    #[doc = "Bit 1 - Lock Update"]
+    #[inline(always)]
+    pub fn lupd(&mut self) -> LUPD_W {
+        LUPD_W { w: self }
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&mut self) -> ONESHOT_W {
+        ONESHOT_W { w: self }
+    }
+    #[doc = "Bits 3:4 - Ramp Index Command"]
+    #[inline(always)]
+    pub fn idxcmd(&mut self) -> IDXCMD_W {
+        IDXCMD_W { w: self }
+    }
+    #[doc = "Bits 5:7 - TCC Command"]
+    #[inline(always)]
+    pub fn cmd(&mut self) -> CMD_W {
+        CMD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/ctrlbset.rs
+++ b/pac/atsamd11c14a/src/tcc0/ctrlbset.rs
@@ -1,0 +1,345 @@
+#[doc = "Reader of register CTRLBSET"]
+pub type R = crate::R<u8, super::CTRLBSET>;
+#[doc = "Writer for register CTRLBSET"]
+pub type W = crate::W<u8, super::CTRLBSET>;
+#[doc = "Register CTRLBSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLBSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DIR`"]
+pub type DIR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DIR`"]
+pub struct DIR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DIR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `LUPD`"]
+pub type LUPD_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LUPD`"]
+pub struct LUPD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LUPD_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `ONESHOT`"]
+pub type ONESHOT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ONESHOT`"]
+pub struct ONESHOT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ONESHOT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Ramp Index Command\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum IDXCMD_A {
+    #[doc = "0: Command disabled: Index toggles between cycles A and B"]
+    DISABLE,
+    #[doc = "1: Set index: cycle B will be forced in the next cycle"]
+    SET,
+    #[doc = "2: Clear index: cycle A will be forced in the next cycle"]
+    CLEAR,
+    #[doc = "3: Hold index: the next cycle will be the same as the current cycle"]
+    HOLD,
+}
+impl From<IDXCMD_A> for u8 {
+    #[inline(always)]
+    fn from(variant: IDXCMD_A) -> Self {
+        match variant {
+            IDXCMD_A::DISABLE => 0,
+            IDXCMD_A::SET => 1,
+            IDXCMD_A::CLEAR => 2,
+            IDXCMD_A::HOLD => 3,
+        }
+    }
+}
+#[doc = "Reader of field `IDXCMD`"]
+pub type IDXCMD_R = crate::R<u8, IDXCMD_A>;
+impl IDXCMD_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> IDXCMD_A {
+        match self.bits {
+            0 => IDXCMD_A::DISABLE,
+            1 => IDXCMD_A::SET,
+            2 => IDXCMD_A::CLEAR,
+            3 => IDXCMD_A::HOLD,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[inline(always)]
+    pub fn is_disable(&self) -> bool {
+        *self == IDXCMD_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `SET`"]
+    #[inline(always)]
+    pub fn is_set(&self) -> bool {
+        *self == IDXCMD_A::SET
+    }
+    #[doc = "Checks if the value of the field is `CLEAR`"]
+    #[inline(always)]
+    pub fn is_clear(&self) -> bool {
+        *self == IDXCMD_A::CLEAR
+    }
+    #[doc = "Checks if the value of the field is `HOLD`"]
+    #[inline(always)]
+    pub fn is_hold(&self) -> bool {
+        *self == IDXCMD_A::HOLD
+    }
+}
+#[doc = "Write proxy for field `IDXCMD`"]
+pub struct IDXCMD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> IDXCMD_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: IDXCMD_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Command disabled: Index toggles between cycles A and B"]
+    #[inline(always)]
+    pub fn disable(self) -> &'a mut W {
+        self.variant(IDXCMD_A::DISABLE)
+    }
+    #[doc = "Set index: cycle B will be forced in the next cycle"]
+    #[inline(always)]
+    pub fn set(self) -> &'a mut W {
+        self.variant(IDXCMD_A::SET)
+    }
+    #[doc = "Clear index: cycle A will be forced in the next cycle"]
+    #[inline(always)]
+    pub fn clear(self) -> &'a mut W {
+        self.variant(IDXCMD_A::CLEAR)
+    }
+    #[doc = "Hold index: the next cycle will be the same as the current cycle"]
+    #[inline(always)]
+    pub fn hold(self) -> &'a mut W {
+        self.variant(IDXCMD_A::HOLD)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 3)) | (((value as u8) & 0x03) << 3);
+        self.w
+    }
+}
+#[doc = "TCC Command\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CMD_A {
+    #[doc = "0: No action"]
+    NONE,
+    #[doc = "1: Clear start, restart or retrigger"]
+    RETRIGGER,
+    #[doc = "2: Force stop"]
+    STOP,
+    #[doc = "3: Force update or double buffered registers"]
+    UPDATE,
+    #[doc = "4: Force COUNT read synchronization"]
+    READSYNC,
+}
+impl From<CMD_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CMD_A) -> Self {
+        match variant {
+            CMD_A::NONE => 0,
+            CMD_A::RETRIGGER => 1,
+            CMD_A::STOP => 2,
+            CMD_A::UPDATE => 3,
+            CMD_A::READSYNC => 4,
+        }
+    }
+}
+#[doc = "Reader of field `CMD`"]
+pub type CMD_R = crate::R<u8, CMD_A>;
+impl CMD_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, CMD_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(CMD_A::NONE),
+            1 => Val(CMD_A::RETRIGGER),
+            2 => Val(CMD_A::STOP),
+            3 => Val(CMD_A::UPDATE),
+            4 => Val(CMD_A::READSYNC),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NONE`"]
+    #[inline(always)]
+    pub fn is_none(&self) -> bool {
+        *self == CMD_A::NONE
+    }
+    #[doc = "Checks if the value of the field is `RETRIGGER`"]
+    #[inline(always)]
+    pub fn is_retrigger(&self) -> bool {
+        *self == CMD_A::RETRIGGER
+    }
+    #[doc = "Checks if the value of the field is `STOP`"]
+    #[inline(always)]
+    pub fn is_stop(&self) -> bool {
+        *self == CMD_A::STOP
+    }
+    #[doc = "Checks if the value of the field is `UPDATE`"]
+    #[inline(always)]
+    pub fn is_update(&self) -> bool {
+        *self == CMD_A::UPDATE
+    }
+    #[doc = "Checks if the value of the field is `READSYNC`"]
+    #[inline(always)]
+    pub fn is_readsync(&self) -> bool {
+        *self == CMD_A::READSYNC
+    }
+}
+#[doc = "Write proxy for field `CMD`"]
+pub struct CMD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CMD_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CMD_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "No action"]
+    #[inline(always)]
+    pub fn none(self) -> &'a mut W {
+        self.variant(CMD_A::NONE)
+    }
+    #[doc = "Clear start, restart or retrigger"]
+    #[inline(always)]
+    pub fn retrigger(self) -> &'a mut W {
+        self.variant(CMD_A::RETRIGGER)
+    }
+    #[doc = "Force stop"]
+    #[inline(always)]
+    pub fn stop(self) -> &'a mut W {
+        self.variant(CMD_A::STOP)
+    }
+    #[doc = "Force update or double buffered registers"]
+    #[inline(always)]
+    pub fn update(self) -> &'a mut W {
+        self.variant(CMD_A::UPDATE)
+    }
+    #[doc = "Force COUNT read synchronization"]
+    #[inline(always)]
+    pub fn readsync(self) -> &'a mut W {
+        self.variant(CMD_A::READSYNC)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 5)) | (((value as u8) & 0x07) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&self) -> DIR_R {
+        DIR_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Lock Update"]
+    #[inline(always)]
+    pub fn lupd(&self) -> LUPD_R {
+        LUPD_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&self) -> ONESHOT_R {
+        ONESHOT_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bits 3:4 - Ramp Index Command"]
+    #[inline(always)]
+    pub fn idxcmd(&self) -> IDXCMD_R {
+        IDXCMD_R::new(((self.bits >> 3) & 0x03) as u8)
+    }
+    #[doc = "Bits 5:7 - TCC Command"]
+    #[inline(always)]
+    pub fn cmd(&self) -> CMD_R {
+        CMD_R::new(((self.bits >> 5) & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Counter Direction"]
+    #[inline(always)]
+    pub fn dir(&mut self) -> DIR_W {
+        DIR_W { w: self }
+    }
+    #[doc = "Bit 1 - Lock Update"]
+    #[inline(always)]
+    pub fn lupd(&mut self) -> LUPD_W {
+        LUPD_W { w: self }
+    }
+    #[doc = "Bit 2 - One-Shot"]
+    #[inline(always)]
+    pub fn oneshot(&mut self) -> ONESHOT_W {
+        ONESHOT_W { w: self }
+    }
+    #[doc = "Bits 3:4 - Ramp Index Command"]
+    #[inline(always)]
+    pub fn idxcmd(&mut self) -> IDXCMD_W {
+        IDXCMD_W { w: self }
+    }
+    #[doc = "Bits 5:7 - TCC Command"]
+    #[inline(always)]
+    pub fn cmd(&mut self) -> CMD_W {
+        CMD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/dbgctrl.rs
+++ b/pac/atsamd11c14a/src/tcc0/dbgctrl.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register DBGCTRL"]
+pub type R = crate::R<u8, super::DBGCTRL>;
+#[doc = "Writer for register DBGCTRL"]
+pub type W = crate::W<u8, super::DBGCTRL>;
+#[doc = "Register DBGCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::DBGCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DBGRUN`"]
+pub type DBGRUN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DBGRUN`"]
+pub struct DBGRUN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DBGRUN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `FDDBD`"]
+pub type FDDBD_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FDDBD`"]
+pub struct FDDBD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FDDBD_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Debug Running Mode"]
+    #[inline(always)]
+    pub fn dbgrun(&self) -> DBGRUN_R {
+        DBGRUN_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Fault Detection on Debug Break Detection"]
+    #[inline(always)]
+    pub fn fddbd(&self) -> FDDBD_R {
+        FDDBD_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Debug Running Mode"]
+    #[inline(always)]
+    pub fn dbgrun(&mut self) -> DBGRUN_W {
+        DBGRUN_W { w: self }
+    }
+    #[doc = "Bit 2 - Fault Detection on Debug Break Detection"]
+    #[inline(always)]
+    pub fn fddbd(&mut self) -> FDDBD_W {
+        FDDBD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/drvctrl.rs
+++ b/pac/atsamd11c14a/src/tcc0/drvctrl.rs
@@ -1,0 +1,880 @@
+#[doc = "Reader of register DRVCTRL"]
+pub type R = crate::R<u32, super::DRVCTRL>;
+#[doc = "Writer for register DRVCTRL"]
+pub type W = crate::W<u32, super::DRVCTRL>;
+#[doc = "Register DRVCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::DRVCTRL {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `NRE0`"]
+pub type NRE0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRE0`"]
+pub struct NRE0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRE0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `NRE1`"]
+pub type NRE1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRE1`"]
+pub struct NRE1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRE1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `NRE2`"]
+pub type NRE2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRE2`"]
+pub struct NRE2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRE2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `NRE3`"]
+pub type NRE3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRE3`"]
+pub struct NRE3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRE3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `NRE4`"]
+pub type NRE4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRE4`"]
+pub struct NRE4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRE4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `NRE5`"]
+pub type NRE5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRE5`"]
+pub struct NRE5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRE5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `NRE6`"]
+pub type NRE6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRE6`"]
+pub struct NRE6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRE6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `NRE7`"]
+pub type NRE7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRE7`"]
+pub struct NRE7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRE7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `NRV0`"]
+pub type NRV0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRV0`"]
+pub struct NRV0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRV0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `NRV1`"]
+pub type NRV1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRV1`"]
+pub struct NRV1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRV1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `NRV2`"]
+pub type NRV2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRV2`"]
+pub struct NRV2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRV2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u32) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `NRV3`"]
+pub type NRV3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRV3`"]
+pub struct NRV3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRV3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `NRV4`"]
+pub type NRV4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRV4`"]
+pub struct NRV4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRV4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u32) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `NRV5`"]
+pub type NRV5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRV5`"]
+pub struct NRV5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRV5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u32) & 0x01) << 13);
+        self.w
+    }
+}
+#[doc = "Reader of field `NRV6`"]
+pub type NRV6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRV6`"]
+pub struct NRV6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRV6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u32) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `NRV7`"]
+pub type NRV7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NRV7`"]
+pub struct NRV7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NRV7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Reader of field `INVEN0`"]
+pub type INVEN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INVEN0`"]
+pub struct INVEN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INVEN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `INVEN1`"]
+pub type INVEN1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INVEN1`"]
+pub struct INVEN1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INVEN1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
+#[doc = "Reader of field `INVEN2`"]
+pub type INVEN2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INVEN2`"]
+pub struct INVEN2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INVEN2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 18)) | (((value as u32) & 0x01) << 18);
+        self.w
+    }
+}
+#[doc = "Reader of field `INVEN3`"]
+pub type INVEN3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INVEN3`"]
+pub struct INVEN3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INVEN3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 19)) | (((value as u32) & 0x01) << 19);
+        self.w
+    }
+}
+#[doc = "Reader of field `INVEN4`"]
+pub type INVEN4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INVEN4`"]
+pub struct INVEN4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INVEN4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 20)) | (((value as u32) & 0x01) << 20);
+        self.w
+    }
+}
+#[doc = "Reader of field `INVEN5`"]
+pub type INVEN5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INVEN5`"]
+pub struct INVEN5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INVEN5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 21)) | (((value as u32) & 0x01) << 21);
+        self.w
+    }
+}
+#[doc = "Reader of field `INVEN6`"]
+pub type INVEN6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INVEN6`"]
+pub struct INVEN6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INVEN6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 22)) | (((value as u32) & 0x01) << 22);
+        self.w
+    }
+}
+#[doc = "Reader of field `INVEN7`"]
+pub type INVEN7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INVEN7`"]
+pub struct INVEN7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INVEN7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 23)) | (((value as u32) & 0x01) << 23);
+        self.w
+    }
+}
+#[doc = "Reader of field `FILTERVAL0`"]
+pub type FILTERVAL0_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `FILTERVAL0`"]
+pub struct FILTERVAL0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FILTERVAL0_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 24)) | (((value as u32) & 0x0f) << 24);
+        self.w
+    }
+}
+#[doc = "Reader of field `FILTERVAL1`"]
+pub type FILTERVAL1_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `FILTERVAL1`"]
+pub struct FILTERVAL1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FILTERVAL1_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 28)) | (((value as u32) & 0x0f) << 28);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Non-Recoverable State 0 Output Enable"]
+    #[inline(always)]
+    pub fn nre0(&self) -> NRE0_R {
+        NRE0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Non-Recoverable State 1 Output Enable"]
+    #[inline(always)]
+    pub fn nre1(&self) -> NRE1_R {
+        NRE1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Non-Recoverable State 2 Output Enable"]
+    #[inline(always)]
+    pub fn nre2(&self) -> NRE2_R {
+        NRE2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Non-Recoverable State 3 Output Enable"]
+    #[inline(always)]
+    pub fn nre3(&self) -> NRE3_R {
+        NRE3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Non-Recoverable State 4 Output Enable"]
+    #[inline(always)]
+    pub fn nre4(&self) -> NRE4_R {
+        NRE4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Non-Recoverable State 5 Output Enable"]
+    #[inline(always)]
+    pub fn nre5(&self) -> NRE5_R {
+        NRE5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Non-Recoverable State 6 Output Enable"]
+    #[inline(always)]
+    pub fn nre6(&self) -> NRE6_R {
+        NRE6_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Non-Recoverable State 7 Output Enable"]
+    #[inline(always)]
+    pub fn nre7(&self) -> NRE7_R {
+        NRE7_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Non-Recoverable State 0 Output Value"]
+    #[inline(always)]
+    pub fn nrv0(&self) -> NRV0_R {
+        NRV0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Non-Recoverable State 1 Output Value"]
+    #[inline(always)]
+    pub fn nrv1(&self) -> NRV1_R {
+        NRV1_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Non-Recoverable State 2 Output Value"]
+    #[inline(always)]
+    pub fn nrv2(&self) -> NRV2_R {
+        NRV2_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Non-Recoverable State 3 Output Value"]
+    #[inline(always)]
+    pub fn nrv3(&self) -> NRV3_R {
+        NRV3_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - Non-Recoverable State 4 Output Value"]
+    #[inline(always)]
+    pub fn nrv4(&self) -> NRV4_R {
+        NRV4_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Non-Recoverable State 5 Output Value"]
+    #[inline(always)]
+    pub fn nrv5(&self) -> NRV5_R {
+        NRV5_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+    #[doc = "Bit 14 - Non-Recoverable State 6 Output Value"]
+    #[inline(always)]
+    pub fn nrv6(&self) -> NRV6_R {
+        NRV6_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Non-Recoverable State 7 Output Value"]
+    #[inline(always)]
+    pub fn nrv7(&self) -> NRV7_R {
+        NRV7_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - Output Waveform 0 Inversion"]
+    #[inline(always)]
+    pub fn inven0(&self) -> INVEN0_R {
+        INVEN0_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bit 17 - Output Waveform 1 Inversion"]
+    #[inline(always)]
+    pub fn inven1(&self) -> INVEN1_R {
+        INVEN1_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+    #[doc = "Bit 18 - Output Waveform 2 Inversion"]
+    #[inline(always)]
+    pub fn inven2(&self) -> INVEN2_R {
+        INVEN2_R::new(((self.bits >> 18) & 0x01) != 0)
+    }
+    #[doc = "Bit 19 - Output Waveform 3 Inversion"]
+    #[inline(always)]
+    pub fn inven3(&self) -> INVEN3_R {
+        INVEN3_R::new(((self.bits >> 19) & 0x01) != 0)
+    }
+    #[doc = "Bit 20 - Output Waveform 4 Inversion"]
+    #[inline(always)]
+    pub fn inven4(&self) -> INVEN4_R {
+        INVEN4_R::new(((self.bits >> 20) & 0x01) != 0)
+    }
+    #[doc = "Bit 21 - Output Waveform 5 Inversion"]
+    #[inline(always)]
+    pub fn inven5(&self) -> INVEN5_R {
+        INVEN5_R::new(((self.bits >> 21) & 0x01) != 0)
+    }
+    #[doc = "Bit 22 - Output Waveform 6 Inversion"]
+    #[inline(always)]
+    pub fn inven6(&self) -> INVEN6_R {
+        INVEN6_R::new(((self.bits >> 22) & 0x01) != 0)
+    }
+    #[doc = "Bit 23 - Output Waveform 7 Inversion"]
+    #[inline(always)]
+    pub fn inven7(&self) -> INVEN7_R {
+        INVEN7_R::new(((self.bits >> 23) & 0x01) != 0)
+    }
+    #[doc = "Bits 24:27 - Non-Recoverable Fault Input 0 Filter Value"]
+    #[inline(always)]
+    pub fn filterval0(&self) -> FILTERVAL0_R {
+        FILTERVAL0_R::new(((self.bits >> 24) & 0x0f) as u8)
+    }
+    #[doc = "Bits 28:31 - Non-Recoverable Fault Input 1 Filter Value"]
+    #[inline(always)]
+    pub fn filterval1(&self) -> FILTERVAL1_R {
+        FILTERVAL1_R::new(((self.bits >> 28) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Non-Recoverable State 0 Output Enable"]
+    #[inline(always)]
+    pub fn nre0(&mut self) -> NRE0_W {
+        NRE0_W { w: self }
+    }
+    #[doc = "Bit 1 - Non-Recoverable State 1 Output Enable"]
+    #[inline(always)]
+    pub fn nre1(&mut self) -> NRE1_W {
+        NRE1_W { w: self }
+    }
+    #[doc = "Bit 2 - Non-Recoverable State 2 Output Enable"]
+    #[inline(always)]
+    pub fn nre2(&mut self) -> NRE2_W {
+        NRE2_W { w: self }
+    }
+    #[doc = "Bit 3 - Non-Recoverable State 3 Output Enable"]
+    #[inline(always)]
+    pub fn nre3(&mut self) -> NRE3_W {
+        NRE3_W { w: self }
+    }
+    #[doc = "Bit 4 - Non-Recoverable State 4 Output Enable"]
+    #[inline(always)]
+    pub fn nre4(&mut self) -> NRE4_W {
+        NRE4_W { w: self }
+    }
+    #[doc = "Bit 5 - Non-Recoverable State 5 Output Enable"]
+    #[inline(always)]
+    pub fn nre5(&mut self) -> NRE5_W {
+        NRE5_W { w: self }
+    }
+    #[doc = "Bit 6 - Non-Recoverable State 6 Output Enable"]
+    #[inline(always)]
+    pub fn nre6(&mut self) -> NRE6_W {
+        NRE6_W { w: self }
+    }
+    #[doc = "Bit 7 - Non-Recoverable State 7 Output Enable"]
+    #[inline(always)]
+    pub fn nre7(&mut self) -> NRE7_W {
+        NRE7_W { w: self }
+    }
+    #[doc = "Bit 8 - Non-Recoverable State 0 Output Value"]
+    #[inline(always)]
+    pub fn nrv0(&mut self) -> NRV0_W {
+        NRV0_W { w: self }
+    }
+    #[doc = "Bit 9 - Non-Recoverable State 1 Output Value"]
+    #[inline(always)]
+    pub fn nrv1(&mut self) -> NRV1_W {
+        NRV1_W { w: self }
+    }
+    #[doc = "Bit 10 - Non-Recoverable State 2 Output Value"]
+    #[inline(always)]
+    pub fn nrv2(&mut self) -> NRV2_W {
+        NRV2_W { w: self }
+    }
+    #[doc = "Bit 11 - Non-Recoverable State 3 Output Value"]
+    #[inline(always)]
+    pub fn nrv3(&mut self) -> NRV3_W {
+        NRV3_W { w: self }
+    }
+    #[doc = "Bit 12 - Non-Recoverable State 4 Output Value"]
+    #[inline(always)]
+    pub fn nrv4(&mut self) -> NRV4_W {
+        NRV4_W { w: self }
+    }
+    #[doc = "Bit 13 - Non-Recoverable State 5 Output Value"]
+    #[inline(always)]
+    pub fn nrv5(&mut self) -> NRV5_W {
+        NRV5_W { w: self }
+    }
+    #[doc = "Bit 14 - Non-Recoverable State 6 Output Value"]
+    #[inline(always)]
+    pub fn nrv6(&mut self) -> NRV6_W {
+        NRV6_W { w: self }
+    }
+    #[doc = "Bit 15 - Non-Recoverable State 7 Output Value"]
+    #[inline(always)]
+    pub fn nrv7(&mut self) -> NRV7_W {
+        NRV7_W { w: self }
+    }
+    #[doc = "Bit 16 - Output Waveform 0 Inversion"]
+    #[inline(always)]
+    pub fn inven0(&mut self) -> INVEN0_W {
+        INVEN0_W { w: self }
+    }
+    #[doc = "Bit 17 - Output Waveform 1 Inversion"]
+    #[inline(always)]
+    pub fn inven1(&mut self) -> INVEN1_W {
+        INVEN1_W { w: self }
+    }
+    #[doc = "Bit 18 - Output Waveform 2 Inversion"]
+    #[inline(always)]
+    pub fn inven2(&mut self) -> INVEN2_W {
+        INVEN2_W { w: self }
+    }
+    #[doc = "Bit 19 - Output Waveform 3 Inversion"]
+    #[inline(always)]
+    pub fn inven3(&mut self) -> INVEN3_W {
+        INVEN3_W { w: self }
+    }
+    #[doc = "Bit 20 - Output Waveform 4 Inversion"]
+    #[inline(always)]
+    pub fn inven4(&mut self) -> INVEN4_W {
+        INVEN4_W { w: self }
+    }
+    #[doc = "Bit 21 - Output Waveform 5 Inversion"]
+    #[inline(always)]
+    pub fn inven5(&mut self) -> INVEN5_W {
+        INVEN5_W { w: self }
+    }
+    #[doc = "Bit 22 - Output Waveform 6 Inversion"]
+    #[inline(always)]
+    pub fn inven6(&mut self) -> INVEN6_W {
+        INVEN6_W { w: self }
+    }
+    #[doc = "Bit 23 - Output Waveform 7 Inversion"]
+    #[inline(always)]
+    pub fn inven7(&mut self) -> INVEN7_W {
+        INVEN7_W { w: self }
+    }
+    #[doc = "Bits 24:27 - Non-Recoverable Fault Input 0 Filter Value"]
+    #[inline(always)]
+    pub fn filterval0(&mut self) -> FILTERVAL0_W {
+        FILTERVAL0_W { w: self }
+    }
+    #[doc = "Bits 28:31 - Non-Recoverable Fault Input 1 Filter Value"]
+    #[inline(always)]
+    pub fn filterval1(&mut self) -> FILTERVAL1_W {
+        FILTERVAL1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/evctrl.rs
+++ b/pac/atsamd11c14a/src/tcc0/evctrl.rs
@@ -1,0 +1,944 @@
+#[doc = "Reader of register EVCTRL"]
+pub type R = crate::R<u32, super::EVCTRL>;
+#[doc = "Writer for register EVCTRL"]
+pub type W = crate::W<u32, super::EVCTRL>;
+#[doc = "Register EVCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::EVCTRL {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Timer/counter Input Event0 Action\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum EVACT0_A {
+    #[doc = "0: Event action disabled"]
+    OFF,
+    #[doc = "1: Start, restart or re-trigger counter on event"]
+    RETRIGGER,
+    #[doc = "2: Count on event"]
+    COUNTEV,
+    #[doc = "3: Start counter on event"]
+    START,
+    #[doc = "4: Increment counter on event"]
+    INC,
+    #[doc = "5: Count on active state of asynchronous event"]
+    COUNT,
+    #[doc = "7: Non-recoverable fault"]
+    FAULT,
+}
+impl From<EVACT0_A> for u8 {
+    #[inline(always)]
+    fn from(variant: EVACT0_A) -> Self {
+        match variant {
+            EVACT0_A::OFF => 0,
+            EVACT0_A::RETRIGGER => 1,
+            EVACT0_A::COUNTEV => 2,
+            EVACT0_A::START => 3,
+            EVACT0_A::INC => 4,
+            EVACT0_A::COUNT => 5,
+            EVACT0_A::FAULT => 7,
+        }
+    }
+}
+#[doc = "Reader of field `EVACT0`"]
+pub type EVACT0_R = crate::R<u8, EVACT0_A>;
+impl EVACT0_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, EVACT0_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(EVACT0_A::OFF),
+            1 => Val(EVACT0_A::RETRIGGER),
+            2 => Val(EVACT0_A::COUNTEV),
+            3 => Val(EVACT0_A::START),
+            4 => Val(EVACT0_A::INC),
+            5 => Val(EVACT0_A::COUNT),
+            7 => Val(EVACT0_A::FAULT),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `OFF`"]
+    #[inline(always)]
+    pub fn is_off(&self) -> bool {
+        *self == EVACT0_A::OFF
+    }
+    #[doc = "Checks if the value of the field is `RETRIGGER`"]
+    #[inline(always)]
+    pub fn is_retrigger(&self) -> bool {
+        *self == EVACT0_A::RETRIGGER
+    }
+    #[doc = "Checks if the value of the field is `COUNTEV`"]
+    #[inline(always)]
+    pub fn is_countev(&self) -> bool {
+        *self == EVACT0_A::COUNTEV
+    }
+    #[doc = "Checks if the value of the field is `START`"]
+    #[inline(always)]
+    pub fn is_start(&self) -> bool {
+        *self == EVACT0_A::START
+    }
+    #[doc = "Checks if the value of the field is `INC`"]
+    #[inline(always)]
+    pub fn is_inc(&self) -> bool {
+        *self == EVACT0_A::INC
+    }
+    #[doc = "Checks if the value of the field is `COUNT`"]
+    #[inline(always)]
+    pub fn is_count(&self) -> bool {
+        *self == EVACT0_A::COUNT
+    }
+    #[doc = "Checks if the value of the field is `FAULT`"]
+    #[inline(always)]
+    pub fn is_fault(&self) -> bool {
+        *self == EVACT0_A::FAULT
+    }
+}
+#[doc = "Write proxy for field `EVACT0`"]
+pub struct EVACT0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVACT0_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: EVACT0_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Event action disabled"]
+    #[inline(always)]
+    pub fn off(self) -> &'a mut W {
+        self.variant(EVACT0_A::OFF)
+    }
+    #[doc = "Start, restart or re-trigger counter on event"]
+    #[inline(always)]
+    pub fn retrigger(self) -> &'a mut W {
+        self.variant(EVACT0_A::RETRIGGER)
+    }
+    #[doc = "Count on event"]
+    #[inline(always)]
+    pub fn countev(self) -> &'a mut W {
+        self.variant(EVACT0_A::COUNTEV)
+    }
+    #[doc = "Start counter on event"]
+    #[inline(always)]
+    pub fn start(self) -> &'a mut W {
+        self.variant(EVACT0_A::START)
+    }
+    #[doc = "Increment counter on event"]
+    #[inline(always)]
+    pub fn inc(self) -> &'a mut W {
+        self.variant(EVACT0_A::INC)
+    }
+    #[doc = "Count on active state of asynchronous event"]
+    #[inline(always)]
+    pub fn count(self) -> &'a mut W {
+        self.variant(EVACT0_A::COUNT)
+    }
+    #[doc = "Non-recoverable fault"]
+    #[inline(always)]
+    pub fn fault(self) -> &'a mut W {
+        self.variant(EVACT0_A::FAULT)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u32) & 0x07);
+        self.w
+    }
+}
+#[doc = "Timer/counter Input Event1 Action\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum EVACT1_A {
+    #[doc = "0: Event action disabled"]
+    OFF,
+    #[doc = "1: Re-trigger counter on event"]
+    RETRIGGER,
+    #[doc = "2: Direction control"]
+    DIR,
+    #[doc = "3: Stop counter on event"]
+    STOP,
+    #[doc = "4: Decrement counter on event"]
+    DEC,
+    #[doc = "5: Period capture value in CC0 register, pulse width capture value in CC1 register"]
+    PPW,
+    #[doc = "6: Period capture value in CC1 register, pulse width capture value in CC0 register"]
+    PWP,
+    #[doc = "7: Non-recoverable fault"]
+    FAULT,
+}
+impl From<EVACT1_A> for u8 {
+    #[inline(always)]
+    fn from(variant: EVACT1_A) -> Self {
+        match variant {
+            EVACT1_A::OFF => 0,
+            EVACT1_A::RETRIGGER => 1,
+            EVACT1_A::DIR => 2,
+            EVACT1_A::STOP => 3,
+            EVACT1_A::DEC => 4,
+            EVACT1_A::PPW => 5,
+            EVACT1_A::PWP => 6,
+            EVACT1_A::FAULT => 7,
+        }
+    }
+}
+#[doc = "Reader of field `EVACT1`"]
+pub type EVACT1_R = crate::R<u8, EVACT1_A>;
+impl EVACT1_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> EVACT1_A {
+        match self.bits {
+            0 => EVACT1_A::OFF,
+            1 => EVACT1_A::RETRIGGER,
+            2 => EVACT1_A::DIR,
+            3 => EVACT1_A::STOP,
+            4 => EVACT1_A::DEC,
+            5 => EVACT1_A::PPW,
+            6 => EVACT1_A::PWP,
+            7 => EVACT1_A::FAULT,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `OFF`"]
+    #[inline(always)]
+    pub fn is_off(&self) -> bool {
+        *self == EVACT1_A::OFF
+    }
+    #[doc = "Checks if the value of the field is `RETRIGGER`"]
+    #[inline(always)]
+    pub fn is_retrigger(&self) -> bool {
+        *self == EVACT1_A::RETRIGGER
+    }
+    #[doc = "Checks if the value of the field is `DIR`"]
+    #[inline(always)]
+    pub fn is_dir(&self) -> bool {
+        *self == EVACT1_A::DIR
+    }
+    #[doc = "Checks if the value of the field is `STOP`"]
+    #[inline(always)]
+    pub fn is_stop(&self) -> bool {
+        *self == EVACT1_A::STOP
+    }
+    #[doc = "Checks if the value of the field is `DEC`"]
+    #[inline(always)]
+    pub fn is_dec(&self) -> bool {
+        *self == EVACT1_A::DEC
+    }
+    #[doc = "Checks if the value of the field is `PPW`"]
+    #[inline(always)]
+    pub fn is_ppw(&self) -> bool {
+        *self == EVACT1_A::PPW
+    }
+    #[doc = "Checks if the value of the field is `PWP`"]
+    #[inline(always)]
+    pub fn is_pwp(&self) -> bool {
+        *self == EVACT1_A::PWP
+    }
+    #[doc = "Checks if the value of the field is `FAULT`"]
+    #[inline(always)]
+    pub fn is_fault(&self) -> bool {
+        *self == EVACT1_A::FAULT
+    }
+}
+#[doc = "Write proxy for field `EVACT1`"]
+pub struct EVACT1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EVACT1_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: EVACT1_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Event action disabled"]
+    #[inline(always)]
+    pub fn off(self) -> &'a mut W {
+        self.variant(EVACT1_A::OFF)
+    }
+    #[doc = "Re-trigger counter on event"]
+    #[inline(always)]
+    pub fn retrigger(self) -> &'a mut W {
+        self.variant(EVACT1_A::RETRIGGER)
+    }
+    #[doc = "Direction control"]
+    #[inline(always)]
+    pub fn dir(self) -> &'a mut W {
+        self.variant(EVACT1_A::DIR)
+    }
+    #[doc = "Stop counter on event"]
+    #[inline(always)]
+    pub fn stop(self) -> &'a mut W {
+        self.variant(EVACT1_A::STOP)
+    }
+    #[doc = "Decrement counter on event"]
+    #[inline(always)]
+    pub fn dec(self) -> &'a mut W {
+        self.variant(EVACT1_A::DEC)
+    }
+    #[doc = "Period capture value in CC0 register, pulse width capture value in CC1 register"]
+    #[inline(always)]
+    pub fn ppw(self) -> &'a mut W {
+        self.variant(EVACT1_A::PPW)
+    }
+    #[doc = "Period capture value in CC1 register, pulse width capture value in CC0 register"]
+    #[inline(always)]
+    pub fn pwp(self) -> &'a mut W {
+        self.variant(EVACT1_A::PWP)
+    }
+    #[doc = "Non-recoverable fault"]
+    #[inline(always)]
+    pub fn fault(self) -> &'a mut W {
+        self.variant(EVACT1_A::FAULT)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 3)) | (((value as u32) & 0x07) << 3);
+        self.w
+    }
+}
+#[doc = "Timer/counter Output Event Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CNTSEL_A {
+    #[doc = "0: An interrupt/event is generated when a new counter cycle starts"]
+    START,
+    #[doc = "1: An interrupt/event is generated when a counter cycle ends"]
+    END,
+    #[doc = "2: An interrupt/event is generated when a counter cycle ends, except for the first and last cycles"]
+    BETWEEN,
+    #[doc = "3: An interrupt/event is generated when a new counter cycle starts or a counter cycle ends"]
+    BOUNDARY,
+}
+impl From<CNTSEL_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CNTSEL_A) -> Self {
+        match variant {
+            CNTSEL_A::START => 0,
+            CNTSEL_A::END => 1,
+            CNTSEL_A::BETWEEN => 2,
+            CNTSEL_A::BOUNDARY => 3,
+        }
+    }
+}
+#[doc = "Reader of field `CNTSEL`"]
+pub type CNTSEL_R = crate::R<u8, CNTSEL_A>;
+impl CNTSEL_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> CNTSEL_A {
+        match self.bits {
+            0 => CNTSEL_A::START,
+            1 => CNTSEL_A::END,
+            2 => CNTSEL_A::BETWEEN,
+            3 => CNTSEL_A::BOUNDARY,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `START`"]
+    #[inline(always)]
+    pub fn is_start(&self) -> bool {
+        *self == CNTSEL_A::START
+    }
+    #[doc = "Checks if the value of the field is `END`"]
+    #[inline(always)]
+    pub fn is_end(&self) -> bool {
+        *self == CNTSEL_A::END
+    }
+    #[doc = "Checks if the value of the field is `BETWEEN`"]
+    #[inline(always)]
+    pub fn is_between(&self) -> bool {
+        *self == CNTSEL_A::BETWEEN
+    }
+    #[doc = "Checks if the value of the field is `BOUNDARY`"]
+    #[inline(always)]
+    pub fn is_boundary(&self) -> bool {
+        *self == CNTSEL_A::BOUNDARY
+    }
+}
+#[doc = "Write proxy for field `CNTSEL`"]
+pub struct CNTSEL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CNTSEL_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CNTSEL_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "An interrupt/event is generated when a new counter cycle starts"]
+    #[inline(always)]
+    pub fn start(self) -> &'a mut W {
+        self.variant(CNTSEL_A::START)
+    }
+    #[doc = "An interrupt/event is generated when a counter cycle ends"]
+    #[inline(always)]
+    pub fn end(self) -> &'a mut W {
+        self.variant(CNTSEL_A::END)
+    }
+    #[doc = "An interrupt/event is generated when a counter cycle ends, except for the first and last cycles"]
+    #[inline(always)]
+    pub fn between(self) -> &'a mut W {
+        self.variant(CNTSEL_A::BETWEEN)
+    }
+    #[doc = "An interrupt/event is generated when a new counter cycle starts or a counter cycle ends"]
+    #[inline(always)]
+    pub fn boundary(self) -> &'a mut W {
+        self.variant(CNTSEL_A::BOUNDARY)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 6)) | (((value as u32) & 0x03) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `OVFEO`"]
+pub type OVFEO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVFEO`"]
+pub struct OVFEO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVFEO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `TRGEO`"]
+pub type TRGEO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRGEO`"]
+pub struct TRGEO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRGEO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `CNTEO`"]
+pub type CNTEO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CNTEO`"]
+pub struct CNTEO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CNTEO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u32) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `TCINV0`"]
+pub type TCINV0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TCINV0`"]
+pub struct TCINV0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TCINV0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u32) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `TCINV1`"]
+pub type TCINV1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TCINV1`"]
+pub struct TCINV1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TCINV1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u32) & 0x01) << 13);
+        self.w
+    }
+}
+#[doc = "Reader of field `TCEI0`"]
+pub type TCEI0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TCEI0`"]
+pub struct TCEI0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TCEI0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u32) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `TCEI1`"]
+pub type TCEI1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TCEI1`"]
+pub struct TCEI1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TCEI1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Reader of field `MCEI0`"]
+pub type MCEI0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MCEI0`"]
+pub struct MCEI0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MCEI0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `MCEI1`"]
+pub type MCEI1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MCEI1`"]
+pub struct MCEI1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MCEI1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
+#[doc = "Reader of field `MCEI2`"]
+pub type MCEI2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MCEI2`"]
+pub struct MCEI2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MCEI2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 18)) | (((value as u32) & 0x01) << 18);
+        self.w
+    }
+}
+#[doc = "Reader of field `MCEI3`"]
+pub type MCEI3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MCEI3`"]
+pub struct MCEI3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MCEI3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 19)) | (((value as u32) & 0x01) << 19);
+        self.w
+    }
+}
+#[doc = "Reader of field `MCEO0`"]
+pub type MCEO0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MCEO0`"]
+pub struct MCEO0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MCEO0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 24)) | (((value as u32) & 0x01) << 24);
+        self.w
+    }
+}
+#[doc = "Reader of field `MCEO1`"]
+pub type MCEO1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MCEO1`"]
+pub struct MCEO1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MCEO1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 25)) | (((value as u32) & 0x01) << 25);
+        self.w
+    }
+}
+#[doc = "Reader of field `MCEO2`"]
+pub type MCEO2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MCEO2`"]
+pub struct MCEO2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MCEO2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 26)) | (((value as u32) & 0x01) << 26);
+        self.w
+    }
+}
+#[doc = "Reader of field `MCEO3`"]
+pub type MCEO3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MCEO3`"]
+pub struct MCEO3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MCEO3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 27)) | (((value as u32) & 0x01) << 27);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Timer/counter Input Event0 Action"]
+    #[inline(always)]
+    pub fn evact0(&self) -> EVACT0_R {
+        EVACT0_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bits 3:5 - Timer/counter Input Event1 Action"]
+    #[inline(always)]
+    pub fn evact1(&self) -> EVACT1_R {
+        EVACT1_R::new(((self.bits >> 3) & 0x07) as u8)
+    }
+    #[doc = "Bits 6:7 - Timer/counter Output Event Mode"]
+    #[inline(always)]
+    pub fn cntsel(&self) -> CNTSEL_R {
+        CNTSEL_R::new(((self.bits >> 6) & 0x03) as u8)
+    }
+    #[doc = "Bit 8 - Overflow/Underflow Output Event Enable"]
+    #[inline(always)]
+    pub fn ovfeo(&self) -> OVFEO_R {
+        OVFEO_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Retrigger Output Event Enable"]
+    #[inline(always)]
+    pub fn trgeo(&self) -> TRGEO_R {
+        TRGEO_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Timer/counter Output Event Enable"]
+    #[inline(always)]
+    pub fn cnteo(&self) -> CNTEO_R {
+        CNTEO_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - Inverted Event 0 Input Enable"]
+    #[inline(always)]
+    pub fn tcinv0(&self) -> TCINV0_R {
+        TCINV0_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Inverted Event 1 Input Enable"]
+    #[inline(always)]
+    pub fn tcinv1(&self) -> TCINV1_R {
+        TCINV1_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+    #[doc = "Bit 14 - Timer/counter Event 0 Input Enable"]
+    #[inline(always)]
+    pub fn tcei0(&self) -> TCEI0_R {
+        TCEI0_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Timer/counter Event 1 Input Enable"]
+    #[inline(always)]
+    pub fn tcei1(&self) -> TCEI1_R {
+        TCEI1_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - Match or Capture Channel 0 Event Input Enable"]
+    #[inline(always)]
+    pub fn mcei0(&self) -> MCEI0_R {
+        MCEI0_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bit 17 - Match or Capture Channel 1 Event Input Enable"]
+    #[inline(always)]
+    pub fn mcei1(&self) -> MCEI1_R {
+        MCEI1_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+    #[doc = "Bit 18 - Match or Capture Channel 2 Event Input Enable"]
+    #[inline(always)]
+    pub fn mcei2(&self) -> MCEI2_R {
+        MCEI2_R::new(((self.bits >> 18) & 0x01) != 0)
+    }
+    #[doc = "Bit 19 - Match or Capture Channel 3 Event Input Enable"]
+    #[inline(always)]
+    pub fn mcei3(&self) -> MCEI3_R {
+        MCEI3_R::new(((self.bits >> 19) & 0x01) != 0)
+    }
+    #[doc = "Bit 24 - Match or Capture Channel 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo0(&self) -> MCEO0_R {
+        MCEO0_R::new(((self.bits >> 24) & 0x01) != 0)
+    }
+    #[doc = "Bit 25 - Match or Capture Channel 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo1(&self) -> MCEO1_R {
+        MCEO1_R::new(((self.bits >> 25) & 0x01) != 0)
+    }
+    #[doc = "Bit 26 - Match or Capture Channel 2 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo2(&self) -> MCEO2_R {
+        MCEO2_R::new(((self.bits >> 26) & 0x01) != 0)
+    }
+    #[doc = "Bit 27 - Match or Capture Channel 3 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo3(&self) -> MCEO3_R {
+        MCEO3_R::new(((self.bits >> 27) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Timer/counter Input Event0 Action"]
+    #[inline(always)]
+    pub fn evact0(&mut self) -> EVACT0_W {
+        EVACT0_W { w: self }
+    }
+    #[doc = "Bits 3:5 - Timer/counter Input Event1 Action"]
+    #[inline(always)]
+    pub fn evact1(&mut self) -> EVACT1_W {
+        EVACT1_W { w: self }
+    }
+    #[doc = "Bits 6:7 - Timer/counter Output Event Mode"]
+    #[inline(always)]
+    pub fn cntsel(&mut self) -> CNTSEL_W {
+        CNTSEL_W { w: self }
+    }
+    #[doc = "Bit 8 - Overflow/Underflow Output Event Enable"]
+    #[inline(always)]
+    pub fn ovfeo(&mut self) -> OVFEO_W {
+        OVFEO_W { w: self }
+    }
+    #[doc = "Bit 9 - Retrigger Output Event Enable"]
+    #[inline(always)]
+    pub fn trgeo(&mut self) -> TRGEO_W {
+        TRGEO_W { w: self }
+    }
+    #[doc = "Bit 10 - Timer/counter Output Event Enable"]
+    #[inline(always)]
+    pub fn cnteo(&mut self) -> CNTEO_W {
+        CNTEO_W { w: self }
+    }
+    #[doc = "Bit 12 - Inverted Event 0 Input Enable"]
+    #[inline(always)]
+    pub fn tcinv0(&mut self) -> TCINV0_W {
+        TCINV0_W { w: self }
+    }
+    #[doc = "Bit 13 - Inverted Event 1 Input Enable"]
+    #[inline(always)]
+    pub fn tcinv1(&mut self) -> TCINV1_W {
+        TCINV1_W { w: self }
+    }
+    #[doc = "Bit 14 - Timer/counter Event 0 Input Enable"]
+    #[inline(always)]
+    pub fn tcei0(&mut self) -> TCEI0_W {
+        TCEI0_W { w: self }
+    }
+    #[doc = "Bit 15 - Timer/counter Event 1 Input Enable"]
+    #[inline(always)]
+    pub fn tcei1(&mut self) -> TCEI1_W {
+        TCEI1_W { w: self }
+    }
+    #[doc = "Bit 16 - Match or Capture Channel 0 Event Input Enable"]
+    #[inline(always)]
+    pub fn mcei0(&mut self) -> MCEI0_W {
+        MCEI0_W { w: self }
+    }
+    #[doc = "Bit 17 - Match or Capture Channel 1 Event Input Enable"]
+    #[inline(always)]
+    pub fn mcei1(&mut self) -> MCEI1_W {
+        MCEI1_W { w: self }
+    }
+    #[doc = "Bit 18 - Match or Capture Channel 2 Event Input Enable"]
+    #[inline(always)]
+    pub fn mcei2(&mut self) -> MCEI2_W {
+        MCEI2_W { w: self }
+    }
+    #[doc = "Bit 19 - Match or Capture Channel 3 Event Input Enable"]
+    #[inline(always)]
+    pub fn mcei3(&mut self) -> MCEI3_W {
+        MCEI3_W { w: self }
+    }
+    #[doc = "Bit 24 - Match or Capture Channel 0 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo0(&mut self) -> MCEO0_W {
+        MCEO0_W { w: self }
+    }
+    #[doc = "Bit 25 - Match or Capture Channel 1 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo1(&mut self) -> MCEO1_W {
+        MCEO1_W { w: self }
+    }
+    #[doc = "Bit 26 - Match or Capture Channel 2 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo2(&mut self) -> MCEO2_W {
+        MCEO2_W { w: self }
+    }
+    #[doc = "Bit 27 - Match or Capture Channel 3 Event Output Enable"]
+    #[inline(always)]
+    pub fn mceo3(&mut self) -> MCEO3_W {
+        MCEO3_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/fctrla.rs
+++ b/pac/atsamd11c14a/src/tcc0/fctrla.rs
@@ -1,0 +1,791 @@
+#[doc = "Reader of register FCTRLA"]
+pub type R = crate::R<u32, super::FCTRLA>;
+#[doc = "Writer for register FCTRLA"]
+pub type W = crate::W<u32, super::FCTRLA>;
+#[doc = "Register FCTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::FCTRLA {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Fault A Source\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SRC_A {
+    #[doc = "0: Fault input disabled"]
+    DISABLE,
+    #[doc = "1: MCEx (x=0,1) event input"]
+    ENABLE,
+    #[doc = "2: Inverted MCEx (x=0,1) event input"]
+    INVERT,
+    #[doc = "3: Alternate fault (A or B) state at the end of the previous period"]
+    ALTFAULT,
+}
+impl From<SRC_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SRC_A) -> Self {
+        match variant {
+            SRC_A::DISABLE => 0,
+            SRC_A::ENABLE => 1,
+            SRC_A::INVERT => 2,
+            SRC_A::ALTFAULT => 3,
+        }
+    }
+}
+#[doc = "Reader of field `SRC`"]
+pub type SRC_R = crate::R<u8, SRC_A>;
+impl SRC_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> SRC_A {
+        match self.bits {
+            0 => SRC_A::DISABLE,
+            1 => SRC_A::ENABLE,
+            2 => SRC_A::INVERT,
+            3 => SRC_A::ALTFAULT,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[inline(always)]
+    pub fn is_disable(&self) -> bool {
+        *self == SRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[inline(always)]
+    pub fn is_enable(&self) -> bool {
+        *self == SRC_A::ENABLE
+    }
+    #[doc = "Checks if the value of the field is `INVERT`"]
+    #[inline(always)]
+    pub fn is_invert(&self) -> bool {
+        *self == SRC_A::INVERT
+    }
+    #[doc = "Checks if the value of the field is `ALTFAULT`"]
+    #[inline(always)]
+    pub fn is_altfault(&self) -> bool {
+        *self == SRC_A::ALTFAULT
+    }
+}
+#[doc = "Write proxy for field `SRC`"]
+pub struct SRC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SRC_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SRC_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Fault input disabled"]
+    #[inline(always)]
+    pub fn disable(self) -> &'a mut W {
+        self.variant(SRC_A::DISABLE)
+    }
+    #[doc = "MCEx (x=0,1) event input"]
+    #[inline(always)]
+    pub fn enable(self) -> &'a mut W {
+        self.variant(SRC_A::ENABLE)
+    }
+    #[doc = "Inverted MCEx (x=0,1) event input"]
+    #[inline(always)]
+    pub fn invert(self) -> &'a mut W {
+        self.variant(SRC_A::INVERT)
+    }
+    #[doc = "Alternate fault (A or B) state at the end of the previous period"]
+    #[inline(always)]
+    pub fn altfault(self) -> &'a mut W {
+        self.variant(SRC_A::ALTFAULT)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x03) | ((value as u32) & 0x03);
+        self.w
+    }
+}
+#[doc = "Reader of field `KEEP`"]
+pub type KEEP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `KEEP`"]
+pub struct KEEP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> KEEP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `QUAL`"]
+pub type QUAL_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `QUAL`"]
+pub struct QUAL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> QUAL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Fault A Blanking Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BLANK_A {
+    #[doc = "0: Blanking applied from start of ramp"]
+    START,
+    #[doc = "1: Blanking applied from rising edge of the output waveform"]
+    RISE,
+    #[doc = "2: Blanking applied from falling edge of the output waveform"]
+    FALL,
+    #[doc = "3: Blanking applied from each toggle of the output waveform"]
+    BOTH,
+}
+impl From<BLANK_A> for u8 {
+    #[inline(always)]
+    fn from(variant: BLANK_A) -> Self {
+        match variant {
+            BLANK_A::START => 0,
+            BLANK_A::RISE => 1,
+            BLANK_A::FALL => 2,
+            BLANK_A::BOTH => 3,
+        }
+    }
+}
+#[doc = "Reader of field `BLANK`"]
+pub type BLANK_R = crate::R<u8, BLANK_A>;
+impl BLANK_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> BLANK_A {
+        match self.bits {
+            0 => BLANK_A::START,
+            1 => BLANK_A::RISE,
+            2 => BLANK_A::FALL,
+            3 => BLANK_A::BOTH,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `START`"]
+    #[inline(always)]
+    pub fn is_start(&self) -> bool {
+        *self == BLANK_A::START
+    }
+    #[doc = "Checks if the value of the field is `RISE`"]
+    #[inline(always)]
+    pub fn is_rise(&self) -> bool {
+        *self == BLANK_A::RISE
+    }
+    #[doc = "Checks if the value of the field is `FALL`"]
+    #[inline(always)]
+    pub fn is_fall(&self) -> bool {
+        *self == BLANK_A::FALL
+    }
+    #[doc = "Checks if the value of the field is `BOTH`"]
+    #[inline(always)]
+    pub fn is_both(&self) -> bool {
+        *self == BLANK_A::BOTH
+    }
+}
+#[doc = "Write proxy for field `BLANK`"]
+pub struct BLANK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BLANK_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: BLANK_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Blanking applied from start of ramp"]
+    #[inline(always)]
+    pub fn start(self) -> &'a mut W {
+        self.variant(BLANK_A::START)
+    }
+    #[doc = "Blanking applied from rising edge of the output waveform"]
+    #[inline(always)]
+    pub fn rise(self) -> &'a mut W {
+        self.variant(BLANK_A::RISE)
+    }
+    #[doc = "Blanking applied from falling edge of the output waveform"]
+    #[inline(always)]
+    pub fn fall(self) -> &'a mut W {
+        self.variant(BLANK_A::FALL)
+    }
+    #[doc = "Blanking applied from each toggle of the output waveform"]
+    #[inline(always)]
+    pub fn both(self) -> &'a mut W {
+        self.variant(BLANK_A::BOTH)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 5)) | (((value as u32) & 0x03) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `RESTART`"]
+pub type RESTART_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RESTART`"]
+pub struct RESTART_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RESTART_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Fault A Halt Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum HALT_A {
+    #[doc = "0: Halt action disabled"]
+    DISABLE,
+    #[doc = "1: Hardware halt action"]
+    HW,
+    #[doc = "2: Software halt action"]
+    SW,
+    #[doc = "3: Non-recoverable fault"]
+    NR,
+}
+impl From<HALT_A> for u8 {
+    #[inline(always)]
+    fn from(variant: HALT_A) -> Self {
+        match variant {
+            HALT_A::DISABLE => 0,
+            HALT_A::HW => 1,
+            HALT_A::SW => 2,
+            HALT_A::NR => 3,
+        }
+    }
+}
+#[doc = "Reader of field `HALT`"]
+pub type HALT_R = crate::R<u8, HALT_A>;
+impl HALT_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> HALT_A {
+        match self.bits {
+            0 => HALT_A::DISABLE,
+            1 => HALT_A::HW,
+            2 => HALT_A::SW,
+            3 => HALT_A::NR,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[inline(always)]
+    pub fn is_disable(&self) -> bool {
+        *self == HALT_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `HW`"]
+    #[inline(always)]
+    pub fn is_hw(&self) -> bool {
+        *self == HALT_A::HW
+    }
+    #[doc = "Checks if the value of the field is `SW`"]
+    #[inline(always)]
+    pub fn is_sw(&self) -> bool {
+        *self == HALT_A::SW
+    }
+    #[doc = "Checks if the value of the field is `NR`"]
+    #[inline(always)]
+    pub fn is_nr(&self) -> bool {
+        *self == HALT_A::NR
+    }
+}
+#[doc = "Write proxy for field `HALT`"]
+pub struct HALT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HALT_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: HALT_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Halt action disabled"]
+    #[inline(always)]
+    pub fn disable(self) -> &'a mut W {
+        self.variant(HALT_A::DISABLE)
+    }
+    #[doc = "Hardware halt action"]
+    #[inline(always)]
+    pub fn hw(self) -> &'a mut W {
+        self.variant(HALT_A::HW)
+    }
+    #[doc = "Software halt action"]
+    #[inline(always)]
+    pub fn sw(self) -> &'a mut W {
+        self.variant(HALT_A::SW)
+    }
+    #[doc = "Non-recoverable fault"]
+    #[inline(always)]
+    pub fn nr(self) -> &'a mut W {
+        self.variant(HALT_A::NR)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 8)) | (((value as u32) & 0x03) << 8);
+        self.w
+    }
+}
+#[doc = "Fault A Capture Channel\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CHSEL_A {
+    #[doc = "0: Capture value stored in channel 0"]
+    CC0,
+    #[doc = "1: Capture value stored in channel 1"]
+    CC1,
+    #[doc = "2: Capture value stored in channel 2"]
+    CC2,
+    #[doc = "3: Capture value stored in channel 3"]
+    CC3,
+}
+impl From<CHSEL_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CHSEL_A) -> Self {
+        match variant {
+            CHSEL_A::CC0 => 0,
+            CHSEL_A::CC1 => 1,
+            CHSEL_A::CC2 => 2,
+            CHSEL_A::CC3 => 3,
+        }
+    }
+}
+#[doc = "Reader of field `CHSEL`"]
+pub type CHSEL_R = crate::R<u8, CHSEL_A>;
+impl CHSEL_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> CHSEL_A {
+        match self.bits {
+            0 => CHSEL_A::CC0,
+            1 => CHSEL_A::CC1,
+            2 => CHSEL_A::CC2,
+            3 => CHSEL_A::CC3,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `CC0`"]
+    #[inline(always)]
+    pub fn is_cc0(&self) -> bool {
+        *self == CHSEL_A::CC0
+    }
+    #[doc = "Checks if the value of the field is `CC1`"]
+    #[inline(always)]
+    pub fn is_cc1(&self) -> bool {
+        *self == CHSEL_A::CC1
+    }
+    #[doc = "Checks if the value of the field is `CC2`"]
+    #[inline(always)]
+    pub fn is_cc2(&self) -> bool {
+        *self == CHSEL_A::CC2
+    }
+    #[doc = "Checks if the value of the field is `CC3`"]
+    #[inline(always)]
+    pub fn is_cc3(&self) -> bool {
+        *self == CHSEL_A::CC3
+    }
+}
+#[doc = "Write proxy for field `CHSEL`"]
+pub struct CHSEL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CHSEL_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CHSEL_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Capture value stored in channel 0"]
+    #[inline(always)]
+    pub fn cc0(self) -> &'a mut W {
+        self.variant(CHSEL_A::CC0)
+    }
+    #[doc = "Capture value stored in channel 1"]
+    #[inline(always)]
+    pub fn cc1(self) -> &'a mut W {
+        self.variant(CHSEL_A::CC1)
+    }
+    #[doc = "Capture value stored in channel 2"]
+    #[inline(always)]
+    pub fn cc2(self) -> &'a mut W {
+        self.variant(CHSEL_A::CC2)
+    }
+    #[doc = "Capture value stored in channel 3"]
+    #[inline(always)]
+    pub fn cc3(self) -> &'a mut W {
+        self.variant(CHSEL_A::CC3)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 10)) | (((value as u32) & 0x03) << 10);
+        self.w
+    }
+}
+#[doc = "Fault A Capture Action\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CAPTURE_A {
+    #[doc = "0: No capture"]
+    DISABLE,
+    #[doc = "1: Capture on fault"]
+    CAPT,
+    #[doc = "2: Minimum capture"]
+    CAPTMIN,
+    #[doc = "3: Maximum capture"]
+    CAPTMAX,
+    #[doc = "4: Minimum local detection"]
+    LOCMIN,
+    #[doc = "5: Maximum local detection"]
+    LOCMAX,
+    #[doc = "6: Minimum and maximum local detection"]
+    DERIV0,
+    #[doc = "7: Capture with ramp index as MSB value"]
+    CAPTMARK,
+}
+impl From<CAPTURE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CAPTURE_A) -> Self {
+        match variant {
+            CAPTURE_A::DISABLE => 0,
+            CAPTURE_A::CAPT => 1,
+            CAPTURE_A::CAPTMIN => 2,
+            CAPTURE_A::CAPTMAX => 3,
+            CAPTURE_A::LOCMIN => 4,
+            CAPTURE_A::LOCMAX => 5,
+            CAPTURE_A::DERIV0 => 6,
+            CAPTURE_A::CAPTMARK => 7,
+        }
+    }
+}
+#[doc = "Reader of field `CAPTURE`"]
+pub type CAPTURE_R = crate::R<u8, CAPTURE_A>;
+impl CAPTURE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> CAPTURE_A {
+        match self.bits {
+            0 => CAPTURE_A::DISABLE,
+            1 => CAPTURE_A::CAPT,
+            2 => CAPTURE_A::CAPTMIN,
+            3 => CAPTURE_A::CAPTMAX,
+            4 => CAPTURE_A::LOCMIN,
+            5 => CAPTURE_A::LOCMAX,
+            6 => CAPTURE_A::DERIV0,
+            7 => CAPTURE_A::CAPTMARK,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[inline(always)]
+    pub fn is_disable(&self) -> bool {
+        *self == CAPTURE_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `CAPT`"]
+    #[inline(always)]
+    pub fn is_capt(&self) -> bool {
+        *self == CAPTURE_A::CAPT
+    }
+    #[doc = "Checks if the value of the field is `CAPTMIN`"]
+    #[inline(always)]
+    pub fn is_captmin(&self) -> bool {
+        *self == CAPTURE_A::CAPTMIN
+    }
+    #[doc = "Checks if the value of the field is `CAPTMAX`"]
+    #[inline(always)]
+    pub fn is_captmax(&self) -> bool {
+        *self == CAPTURE_A::CAPTMAX
+    }
+    #[doc = "Checks if the value of the field is `LOCMIN`"]
+    #[inline(always)]
+    pub fn is_locmin(&self) -> bool {
+        *self == CAPTURE_A::LOCMIN
+    }
+    #[doc = "Checks if the value of the field is `LOCMAX`"]
+    #[inline(always)]
+    pub fn is_locmax(&self) -> bool {
+        *self == CAPTURE_A::LOCMAX
+    }
+    #[doc = "Checks if the value of the field is `DERIV0`"]
+    #[inline(always)]
+    pub fn is_deriv0(&self) -> bool {
+        *self == CAPTURE_A::DERIV0
+    }
+    #[doc = "Checks if the value of the field is `CAPTMARK`"]
+    #[inline(always)]
+    pub fn is_captmark(&self) -> bool {
+        *self == CAPTURE_A::CAPTMARK
+    }
+}
+#[doc = "Write proxy for field `CAPTURE`"]
+pub struct CAPTURE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CAPTURE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CAPTURE_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "No capture"]
+    #[inline(always)]
+    pub fn disable(self) -> &'a mut W {
+        self.variant(CAPTURE_A::DISABLE)
+    }
+    #[doc = "Capture on fault"]
+    #[inline(always)]
+    pub fn capt(self) -> &'a mut W {
+        self.variant(CAPTURE_A::CAPT)
+    }
+    #[doc = "Minimum capture"]
+    #[inline(always)]
+    pub fn captmin(self) -> &'a mut W {
+        self.variant(CAPTURE_A::CAPTMIN)
+    }
+    #[doc = "Maximum capture"]
+    #[inline(always)]
+    pub fn captmax(self) -> &'a mut W {
+        self.variant(CAPTURE_A::CAPTMAX)
+    }
+    #[doc = "Minimum local detection"]
+    #[inline(always)]
+    pub fn locmin(self) -> &'a mut W {
+        self.variant(CAPTURE_A::LOCMIN)
+    }
+    #[doc = "Maximum local detection"]
+    #[inline(always)]
+    pub fn locmax(self) -> &'a mut W {
+        self.variant(CAPTURE_A::LOCMAX)
+    }
+    #[doc = "Minimum and maximum local detection"]
+    #[inline(always)]
+    pub fn deriv0(self) -> &'a mut W {
+        self.variant(CAPTURE_A::DERIV0)
+    }
+    #[doc = "Capture with ramp index as MSB value"]
+    #[inline(always)]
+    pub fn captmark(self) -> &'a mut W {
+        self.variant(CAPTURE_A::CAPTMARK)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 12)) | (((value as u32) & 0x07) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `BLANKPRESC`"]
+pub type BLANKPRESC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BLANKPRESC`"]
+pub struct BLANKPRESC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BLANKPRESC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Reader of field `BLANKVAL`"]
+pub type BLANKVAL_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `BLANKVAL`"]
+pub struct BLANKVAL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BLANKVAL_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0xff << 16)) | (((value as u32) & 0xff) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `FILTERVAL`"]
+pub type FILTERVAL_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `FILTERVAL`"]
+pub struct FILTERVAL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FILTERVAL_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 24)) | (((value as u32) & 0x0f) << 24);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:1 - Fault A Source"]
+    #[inline(always)]
+    pub fn src(&self) -> SRC_R {
+        SRC_R::new((self.bits & 0x03) as u8)
+    }
+    #[doc = "Bit 3 - Fault A Keeper"]
+    #[inline(always)]
+    pub fn keep(&self) -> KEEP_R {
+        KEEP_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Fault A Qualification"]
+    #[inline(always)]
+    pub fn qual(&self) -> QUAL_R {
+        QUAL_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bits 5:6 - Fault A Blanking Mode"]
+    #[inline(always)]
+    pub fn blank(&self) -> BLANK_R {
+        BLANK_R::new(((self.bits >> 5) & 0x03) as u8)
+    }
+    #[doc = "Bit 7 - Fault A Restart"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bits 8:9 - Fault A Halt Mode"]
+    #[inline(always)]
+    pub fn halt(&self) -> HALT_R {
+        HALT_R::new(((self.bits >> 8) & 0x03) as u8)
+    }
+    #[doc = "Bits 10:11 - Fault A Capture Channel"]
+    #[inline(always)]
+    pub fn chsel(&self) -> CHSEL_R {
+        CHSEL_R::new(((self.bits >> 10) & 0x03) as u8)
+    }
+    #[doc = "Bits 12:14 - Fault A Capture Action"]
+    #[inline(always)]
+    pub fn capture(&self) -> CAPTURE_R {
+        CAPTURE_R::new(((self.bits >> 12) & 0x07) as u8)
+    }
+    #[doc = "Bit 15 - Fault A Blanking Prescaler"]
+    #[inline(always)]
+    pub fn blankpresc(&self) -> BLANKPRESC_R {
+        BLANKPRESC_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bits 16:23 - Fault A Blanking Time"]
+    #[inline(always)]
+    pub fn blankval(&self) -> BLANKVAL_R {
+        BLANKVAL_R::new(((self.bits >> 16) & 0xff) as u8)
+    }
+    #[doc = "Bits 24:27 - Fault A Filter Value"]
+    #[inline(always)]
+    pub fn filterval(&self) -> FILTERVAL_R {
+        FILTERVAL_R::new(((self.bits >> 24) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:1 - Fault A Source"]
+    #[inline(always)]
+    pub fn src(&mut self) -> SRC_W {
+        SRC_W { w: self }
+    }
+    #[doc = "Bit 3 - Fault A Keeper"]
+    #[inline(always)]
+    pub fn keep(&mut self) -> KEEP_W {
+        KEEP_W { w: self }
+    }
+    #[doc = "Bit 4 - Fault A Qualification"]
+    #[inline(always)]
+    pub fn qual(&mut self) -> QUAL_W {
+        QUAL_W { w: self }
+    }
+    #[doc = "Bits 5:6 - Fault A Blanking Mode"]
+    #[inline(always)]
+    pub fn blank(&mut self) -> BLANK_W {
+        BLANK_W { w: self }
+    }
+    #[doc = "Bit 7 - Fault A Restart"]
+    #[inline(always)]
+    pub fn restart(&mut self) -> RESTART_W {
+        RESTART_W { w: self }
+    }
+    #[doc = "Bits 8:9 - Fault A Halt Mode"]
+    #[inline(always)]
+    pub fn halt(&mut self) -> HALT_W {
+        HALT_W { w: self }
+    }
+    #[doc = "Bits 10:11 - Fault A Capture Channel"]
+    #[inline(always)]
+    pub fn chsel(&mut self) -> CHSEL_W {
+        CHSEL_W { w: self }
+    }
+    #[doc = "Bits 12:14 - Fault A Capture Action"]
+    #[inline(always)]
+    pub fn capture(&mut self) -> CAPTURE_W {
+        CAPTURE_W { w: self }
+    }
+    #[doc = "Bit 15 - Fault A Blanking Prescaler"]
+    #[inline(always)]
+    pub fn blankpresc(&mut self) -> BLANKPRESC_W {
+        BLANKPRESC_W { w: self }
+    }
+    #[doc = "Bits 16:23 - Fault A Blanking Time"]
+    #[inline(always)]
+    pub fn blankval(&mut self) -> BLANKVAL_W {
+        BLANKVAL_W { w: self }
+    }
+    #[doc = "Bits 24:27 - Fault A Filter Value"]
+    #[inline(always)]
+    pub fn filterval(&mut self) -> FILTERVAL_W {
+        FILTERVAL_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/fctrlb.rs
+++ b/pac/atsamd11c14a/src/tcc0/fctrlb.rs
@@ -1,0 +1,791 @@
+#[doc = "Reader of register FCTRLB"]
+pub type R = crate::R<u32, super::FCTRLB>;
+#[doc = "Writer for register FCTRLB"]
+pub type W = crate::W<u32, super::FCTRLB>;
+#[doc = "Register FCTRLB `reset()`'s with value 0"]
+impl crate::ResetValue for super::FCTRLB {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Fault B Source\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SRC_A {
+    #[doc = "0: Fault input disabled"]
+    DISABLE,
+    #[doc = "1: MCEx (x=0,1) event input"]
+    ENABLE,
+    #[doc = "2: Inverted MCEx (x=0,1) event input"]
+    INVERT,
+    #[doc = "3: Alternate fault (A or B) state at the end of the previous period"]
+    ALTFAULT,
+}
+impl From<SRC_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SRC_A) -> Self {
+        match variant {
+            SRC_A::DISABLE => 0,
+            SRC_A::ENABLE => 1,
+            SRC_A::INVERT => 2,
+            SRC_A::ALTFAULT => 3,
+        }
+    }
+}
+#[doc = "Reader of field `SRC`"]
+pub type SRC_R = crate::R<u8, SRC_A>;
+impl SRC_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> SRC_A {
+        match self.bits {
+            0 => SRC_A::DISABLE,
+            1 => SRC_A::ENABLE,
+            2 => SRC_A::INVERT,
+            3 => SRC_A::ALTFAULT,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[inline(always)]
+    pub fn is_disable(&self) -> bool {
+        *self == SRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `ENABLE`"]
+    #[inline(always)]
+    pub fn is_enable(&self) -> bool {
+        *self == SRC_A::ENABLE
+    }
+    #[doc = "Checks if the value of the field is `INVERT`"]
+    #[inline(always)]
+    pub fn is_invert(&self) -> bool {
+        *self == SRC_A::INVERT
+    }
+    #[doc = "Checks if the value of the field is `ALTFAULT`"]
+    #[inline(always)]
+    pub fn is_altfault(&self) -> bool {
+        *self == SRC_A::ALTFAULT
+    }
+}
+#[doc = "Write proxy for field `SRC`"]
+pub struct SRC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SRC_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SRC_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Fault input disabled"]
+    #[inline(always)]
+    pub fn disable(self) -> &'a mut W {
+        self.variant(SRC_A::DISABLE)
+    }
+    #[doc = "MCEx (x=0,1) event input"]
+    #[inline(always)]
+    pub fn enable(self) -> &'a mut W {
+        self.variant(SRC_A::ENABLE)
+    }
+    #[doc = "Inverted MCEx (x=0,1) event input"]
+    #[inline(always)]
+    pub fn invert(self) -> &'a mut W {
+        self.variant(SRC_A::INVERT)
+    }
+    #[doc = "Alternate fault (A or B) state at the end of the previous period"]
+    #[inline(always)]
+    pub fn altfault(self) -> &'a mut W {
+        self.variant(SRC_A::ALTFAULT)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x03) | ((value as u32) & 0x03);
+        self.w
+    }
+}
+#[doc = "Reader of field `KEEP`"]
+pub type KEEP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `KEEP`"]
+pub struct KEEP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> KEEP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `QUAL`"]
+pub type QUAL_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `QUAL`"]
+pub struct QUAL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> QUAL_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u32) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Fault B Blanking Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum BLANK_A {
+    #[doc = "0: Blanking applied from start of ramp"]
+    START,
+    #[doc = "1: Blanking applied from rising edge of the output waveform"]
+    RISE,
+    #[doc = "2: Blanking applied from falling edge of the output waveform"]
+    FALL,
+    #[doc = "3: Blanking applied from each toggle of the output waveform"]
+    BOTH,
+}
+impl From<BLANK_A> for u8 {
+    #[inline(always)]
+    fn from(variant: BLANK_A) -> Self {
+        match variant {
+            BLANK_A::START => 0,
+            BLANK_A::RISE => 1,
+            BLANK_A::FALL => 2,
+            BLANK_A::BOTH => 3,
+        }
+    }
+}
+#[doc = "Reader of field `BLANK`"]
+pub type BLANK_R = crate::R<u8, BLANK_A>;
+impl BLANK_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> BLANK_A {
+        match self.bits {
+            0 => BLANK_A::START,
+            1 => BLANK_A::RISE,
+            2 => BLANK_A::FALL,
+            3 => BLANK_A::BOTH,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `START`"]
+    #[inline(always)]
+    pub fn is_start(&self) -> bool {
+        *self == BLANK_A::START
+    }
+    #[doc = "Checks if the value of the field is `RISE`"]
+    #[inline(always)]
+    pub fn is_rise(&self) -> bool {
+        *self == BLANK_A::RISE
+    }
+    #[doc = "Checks if the value of the field is `FALL`"]
+    #[inline(always)]
+    pub fn is_fall(&self) -> bool {
+        *self == BLANK_A::FALL
+    }
+    #[doc = "Checks if the value of the field is `BOTH`"]
+    #[inline(always)]
+    pub fn is_both(&self) -> bool {
+        *self == BLANK_A::BOTH
+    }
+}
+#[doc = "Write proxy for field `BLANK`"]
+pub struct BLANK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BLANK_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: BLANK_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Blanking applied from start of ramp"]
+    #[inline(always)]
+    pub fn start(self) -> &'a mut W {
+        self.variant(BLANK_A::START)
+    }
+    #[doc = "Blanking applied from rising edge of the output waveform"]
+    #[inline(always)]
+    pub fn rise(self) -> &'a mut W {
+        self.variant(BLANK_A::RISE)
+    }
+    #[doc = "Blanking applied from falling edge of the output waveform"]
+    #[inline(always)]
+    pub fn fall(self) -> &'a mut W {
+        self.variant(BLANK_A::FALL)
+    }
+    #[doc = "Blanking applied from each toggle of the output waveform"]
+    #[inline(always)]
+    pub fn both(self) -> &'a mut W {
+        self.variant(BLANK_A::BOTH)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 5)) | (((value as u32) & 0x03) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `RESTART`"]
+pub type RESTART_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RESTART`"]
+pub struct RESTART_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RESTART_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Fault B Halt Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum HALT_A {
+    #[doc = "0: Halt action disabled"]
+    DISABLE,
+    #[doc = "1: Hardware halt action"]
+    HW,
+    #[doc = "2: Software halt action"]
+    SW,
+    #[doc = "3: Non-recoverable fault"]
+    NR,
+}
+impl From<HALT_A> for u8 {
+    #[inline(always)]
+    fn from(variant: HALT_A) -> Self {
+        match variant {
+            HALT_A::DISABLE => 0,
+            HALT_A::HW => 1,
+            HALT_A::SW => 2,
+            HALT_A::NR => 3,
+        }
+    }
+}
+#[doc = "Reader of field `HALT`"]
+pub type HALT_R = crate::R<u8, HALT_A>;
+impl HALT_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> HALT_A {
+        match self.bits {
+            0 => HALT_A::DISABLE,
+            1 => HALT_A::HW,
+            2 => HALT_A::SW,
+            3 => HALT_A::NR,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[inline(always)]
+    pub fn is_disable(&self) -> bool {
+        *self == HALT_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `HW`"]
+    #[inline(always)]
+    pub fn is_hw(&self) -> bool {
+        *self == HALT_A::HW
+    }
+    #[doc = "Checks if the value of the field is `SW`"]
+    #[inline(always)]
+    pub fn is_sw(&self) -> bool {
+        *self == HALT_A::SW
+    }
+    #[doc = "Checks if the value of the field is `NR`"]
+    #[inline(always)]
+    pub fn is_nr(&self) -> bool {
+        *self == HALT_A::NR
+    }
+}
+#[doc = "Write proxy for field `HALT`"]
+pub struct HALT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> HALT_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: HALT_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Halt action disabled"]
+    #[inline(always)]
+    pub fn disable(self) -> &'a mut W {
+        self.variant(HALT_A::DISABLE)
+    }
+    #[doc = "Hardware halt action"]
+    #[inline(always)]
+    pub fn hw(self) -> &'a mut W {
+        self.variant(HALT_A::HW)
+    }
+    #[doc = "Software halt action"]
+    #[inline(always)]
+    pub fn sw(self) -> &'a mut W {
+        self.variant(HALT_A::SW)
+    }
+    #[doc = "Non-recoverable fault"]
+    #[inline(always)]
+    pub fn nr(self) -> &'a mut W {
+        self.variant(HALT_A::NR)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 8)) | (((value as u32) & 0x03) << 8);
+        self.w
+    }
+}
+#[doc = "Fault B Capture Channel\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CHSEL_A {
+    #[doc = "0: Capture value stored in channel 0"]
+    CC0,
+    #[doc = "1: Capture value stored in channel 1"]
+    CC1,
+    #[doc = "2: Capture value stored in channel 2"]
+    CC2,
+    #[doc = "3: Capture value stored in channel 3"]
+    CC3,
+}
+impl From<CHSEL_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CHSEL_A) -> Self {
+        match variant {
+            CHSEL_A::CC0 => 0,
+            CHSEL_A::CC1 => 1,
+            CHSEL_A::CC2 => 2,
+            CHSEL_A::CC3 => 3,
+        }
+    }
+}
+#[doc = "Reader of field `CHSEL`"]
+pub type CHSEL_R = crate::R<u8, CHSEL_A>;
+impl CHSEL_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> CHSEL_A {
+        match self.bits {
+            0 => CHSEL_A::CC0,
+            1 => CHSEL_A::CC1,
+            2 => CHSEL_A::CC2,
+            3 => CHSEL_A::CC3,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `CC0`"]
+    #[inline(always)]
+    pub fn is_cc0(&self) -> bool {
+        *self == CHSEL_A::CC0
+    }
+    #[doc = "Checks if the value of the field is `CC1`"]
+    #[inline(always)]
+    pub fn is_cc1(&self) -> bool {
+        *self == CHSEL_A::CC1
+    }
+    #[doc = "Checks if the value of the field is `CC2`"]
+    #[inline(always)]
+    pub fn is_cc2(&self) -> bool {
+        *self == CHSEL_A::CC2
+    }
+    #[doc = "Checks if the value of the field is `CC3`"]
+    #[inline(always)]
+    pub fn is_cc3(&self) -> bool {
+        *self == CHSEL_A::CC3
+    }
+}
+#[doc = "Write proxy for field `CHSEL`"]
+pub struct CHSEL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CHSEL_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CHSEL_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "Capture value stored in channel 0"]
+    #[inline(always)]
+    pub fn cc0(self) -> &'a mut W {
+        self.variant(CHSEL_A::CC0)
+    }
+    #[doc = "Capture value stored in channel 1"]
+    #[inline(always)]
+    pub fn cc1(self) -> &'a mut W {
+        self.variant(CHSEL_A::CC1)
+    }
+    #[doc = "Capture value stored in channel 2"]
+    #[inline(always)]
+    pub fn cc2(self) -> &'a mut W {
+        self.variant(CHSEL_A::CC2)
+    }
+    #[doc = "Capture value stored in channel 3"]
+    #[inline(always)]
+    pub fn cc3(self) -> &'a mut W {
+        self.variant(CHSEL_A::CC3)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 10)) | (((value as u32) & 0x03) << 10);
+        self.w
+    }
+}
+#[doc = "Fault B Capture Action\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CAPTURE_A {
+    #[doc = "0: No capture"]
+    DISABLE,
+    #[doc = "1: Capture on fault"]
+    CAPT,
+    #[doc = "2: Minimum capture"]
+    CAPTMIN,
+    #[doc = "3: Maximum capture"]
+    CAPTMAX,
+    #[doc = "4: Minimum local detection"]
+    LOCMIN,
+    #[doc = "5: Maximum local detection"]
+    LOCMAX,
+    #[doc = "6: Minimum and maximum local detection"]
+    DERIV0,
+    #[doc = "7: Capture with ramp index as MSB value"]
+    CAPTMARK,
+}
+impl From<CAPTURE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: CAPTURE_A) -> Self {
+        match variant {
+            CAPTURE_A::DISABLE => 0,
+            CAPTURE_A::CAPT => 1,
+            CAPTURE_A::CAPTMIN => 2,
+            CAPTURE_A::CAPTMAX => 3,
+            CAPTURE_A::LOCMIN => 4,
+            CAPTURE_A::LOCMAX => 5,
+            CAPTURE_A::DERIV0 => 6,
+            CAPTURE_A::CAPTMARK => 7,
+        }
+    }
+}
+#[doc = "Reader of field `CAPTURE`"]
+pub type CAPTURE_R = crate::R<u8, CAPTURE_A>;
+impl CAPTURE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> CAPTURE_A {
+        match self.bits {
+            0 => CAPTURE_A::DISABLE,
+            1 => CAPTURE_A::CAPT,
+            2 => CAPTURE_A::CAPTMIN,
+            3 => CAPTURE_A::CAPTMAX,
+            4 => CAPTURE_A::LOCMIN,
+            5 => CAPTURE_A::LOCMAX,
+            6 => CAPTURE_A::DERIV0,
+            7 => CAPTURE_A::CAPTMARK,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DISABLE`"]
+    #[inline(always)]
+    pub fn is_disable(&self) -> bool {
+        *self == CAPTURE_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `CAPT`"]
+    #[inline(always)]
+    pub fn is_capt(&self) -> bool {
+        *self == CAPTURE_A::CAPT
+    }
+    #[doc = "Checks if the value of the field is `CAPTMIN`"]
+    #[inline(always)]
+    pub fn is_captmin(&self) -> bool {
+        *self == CAPTURE_A::CAPTMIN
+    }
+    #[doc = "Checks if the value of the field is `CAPTMAX`"]
+    #[inline(always)]
+    pub fn is_captmax(&self) -> bool {
+        *self == CAPTURE_A::CAPTMAX
+    }
+    #[doc = "Checks if the value of the field is `LOCMIN`"]
+    #[inline(always)]
+    pub fn is_locmin(&self) -> bool {
+        *self == CAPTURE_A::LOCMIN
+    }
+    #[doc = "Checks if the value of the field is `LOCMAX`"]
+    #[inline(always)]
+    pub fn is_locmax(&self) -> bool {
+        *self == CAPTURE_A::LOCMAX
+    }
+    #[doc = "Checks if the value of the field is `DERIV0`"]
+    #[inline(always)]
+    pub fn is_deriv0(&self) -> bool {
+        *self == CAPTURE_A::DERIV0
+    }
+    #[doc = "Checks if the value of the field is `CAPTMARK`"]
+    #[inline(always)]
+    pub fn is_captmark(&self) -> bool {
+        *self == CAPTURE_A::CAPTMARK
+    }
+}
+#[doc = "Write proxy for field `CAPTURE`"]
+pub struct CAPTURE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CAPTURE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CAPTURE_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "No capture"]
+    #[inline(always)]
+    pub fn disable(self) -> &'a mut W {
+        self.variant(CAPTURE_A::DISABLE)
+    }
+    #[doc = "Capture on fault"]
+    #[inline(always)]
+    pub fn capt(self) -> &'a mut W {
+        self.variant(CAPTURE_A::CAPT)
+    }
+    #[doc = "Minimum capture"]
+    #[inline(always)]
+    pub fn captmin(self) -> &'a mut W {
+        self.variant(CAPTURE_A::CAPTMIN)
+    }
+    #[doc = "Maximum capture"]
+    #[inline(always)]
+    pub fn captmax(self) -> &'a mut W {
+        self.variant(CAPTURE_A::CAPTMAX)
+    }
+    #[doc = "Minimum local detection"]
+    #[inline(always)]
+    pub fn locmin(self) -> &'a mut W {
+        self.variant(CAPTURE_A::LOCMIN)
+    }
+    #[doc = "Maximum local detection"]
+    #[inline(always)]
+    pub fn locmax(self) -> &'a mut W {
+        self.variant(CAPTURE_A::LOCMAX)
+    }
+    #[doc = "Minimum and maximum local detection"]
+    #[inline(always)]
+    pub fn deriv0(self) -> &'a mut W {
+        self.variant(CAPTURE_A::DERIV0)
+    }
+    #[doc = "Capture with ramp index as MSB value"]
+    #[inline(always)]
+    pub fn captmark(self) -> &'a mut W {
+        self.variant(CAPTURE_A::CAPTMARK)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 12)) | (((value as u32) & 0x07) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `BLANKPRESC`"]
+pub type BLANKPRESC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `BLANKPRESC`"]
+pub struct BLANKPRESC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BLANKPRESC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Reader of field `BLANKVAL`"]
+pub type BLANKVAL_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `BLANKVAL`"]
+pub struct BLANKVAL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BLANKVAL_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0xff << 16)) | (((value as u32) & 0xff) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `FILTERVAL`"]
+pub type FILTERVAL_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `FILTERVAL`"]
+pub struct FILTERVAL_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FILTERVAL_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 24)) | (((value as u32) & 0x0f) << 24);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:1 - Fault B Source"]
+    #[inline(always)]
+    pub fn src(&self) -> SRC_R {
+        SRC_R::new((self.bits & 0x03) as u8)
+    }
+    #[doc = "Bit 3 - Fault B Keeper"]
+    #[inline(always)]
+    pub fn keep(&self) -> KEEP_R {
+        KEEP_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Fault B Qualification"]
+    #[inline(always)]
+    pub fn qual(&self) -> QUAL_R {
+        QUAL_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bits 5:6 - Fault B Blanking Mode"]
+    #[inline(always)]
+    pub fn blank(&self) -> BLANK_R {
+        BLANK_R::new(((self.bits >> 5) & 0x03) as u8)
+    }
+    #[doc = "Bit 7 - Fault B Restart"]
+    #[inline(always)]
+    pub fn restart(&self) -> RESTART_R {
+        RESTART_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bits 8:9 - Fault B Halt Mode"]
+    #[inline(always)]
+    pub fn halt(&self) -> HALT_R {
+        HALT_R::new(((self.bits >> 8) & 0x03) as u8)
+    }
+    #[doc = "Bits 10:11 - Fault B Capture Channel"]
+    #[inline(always)]
+    pub fn chsel(&self) -> CHSEL_R {
+        CHSEL_R::new(((self.bits >> 10) & 0x03) as u8)
+    }
+    #[doc = "Bits 12:14 - Fault B Capture Action"]
+    #[inline(always)]
+    pub fn capture(&self) -> CAPTURE_R {
+        CAPTURE_R::new(((self.bits >> 12) & 0x07) as u8)
+    }
+    #[doc = "Bit 15 - Fault B Blanking Prescaler"]
+    #[inline(always)]
+    pub fn blankpresc(&self) -> BLANKPRESC_R {
+        BLANKPRESC_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bits 16:23 - Fault B Blanking Time"]
+    #[inline(always)]
+    pub fn blankval(&self) -> BLANKVAL_R {
+        BLANKVAL_R::new(((self.bits >> 16) & 0xff) as u8)
+    }
+    #[doc = "Bits 24:27 - Fault B Filter Value"]
+    #[inline(always)]
+    pub fn filterval(&self) -> FILTERVAL_R {
+        FILTERVAL_R::new(((self.bits >> 24) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:1 - Fault B Source"]
+    #[inline(always)]
+    pub fn src(&mut self) -> SRC_W {
+        SRC_W { w: self }
+    }
+    #[doc = "Bit 3 - Fault B Keeper"]
+    #[inline(always)]
+    pub fn keep(&mut self) -> KEEP_W {
+        KEEP_W { w: self }
+    }
+    #[doc = "Bit 4 - Fault B Qualification"]
+    #[inline(always)]
+    pub fn qual(&mut self) -> QUAL_W {
+        QUAL_W { w: self }
+    }
+    #[doc = "Bits 5:6 - Fault B Blanking Mode"]
+    #[inline(always)]
+    pub fn blank(&mut self) -> BLANK_W {
+        BLANK_W { w: self }
+    }
+    #[doc = "Bit 7 - Fault B Restart"]
+    #[inline(always)]
+    pub fn restart(&mut self) -> RESTART_W {
+        RESTART_W { w: self }
+    }
+    #[doc = "Bits 8:9 - Fault B Halt Mode"]
+    #[inline(always)]
+    pub fn halt(&mut self) -> HALT_W {
+        HALT_W { w: self }
+    }
+    #[doc = "Bits 10:11 - Fault B Capture Channel"]
+    #[inline(always)]
+    pub fn chsel(&mut self) -> CHSEL_W {
+        CHSEL_W { w: self }
+    }
+    #[doc = "Bits 12:14 - Fault B Capture Action"]
+    #[inline(always)]
+    pub fn capture(&mut self) -> CAPTURE_W {
+        CAPTURE_W { w: self }
+    }
+    #[doc = "Bit 15 - Fault B Blanking Prescaler"]
+    #[inline(always)]
+    pub fn blankpresc(&mut self) -> BLANKPRESC_W {
+        BLANKPRESC_W { w: self }
+    }
+    #[doc = "Bits 16:23 - Fault B Blanking Time"]
+    #[inline(always)]
+    pub fn blankval(&mut self) -> BLANKVAL_W {
+        BLANKVAL_W { w: self }
+    }
+    #[doc = "Bits 24:27 - Fault B Filter Value"]
+    #[inline(always)]
+    pub fn filterval(&mut self) -> FILTERVAL_W {
+        FILTERVAL_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/intenclr.rs
+++ b/pac/atsamd11c14a/src/tcc0/intenclr.rs
@@ -1,0 +1,458 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u32, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u32, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `TRG`"]
+pub type TRG_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRG`"]
+pub struct TRG_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRG_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `CNT`"]
+pub type CNT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CNT`"]
+pub struct CNT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CNT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERR`"]
+pub type ERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERR`"]
+pub struct ERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFS`"]
+pub type DFS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFS`"]
+pub struct DFS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULTA`"]
+pub type FAULTA_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULTA`"]
+pub struct FAULTA_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULTA_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u32) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULTB`"]
+pub type FAULTB_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULTB`"]
+pub struct FAULTB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULTB_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u32) & 0x01) << 13);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULT0`"]
+pub type FAULT0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULT0`"]
+pub struct FAULT0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULT0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u32) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULT1`"]
+pub type FAULT1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULT1`"]
+pub struct FAULT1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULT1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC0`"]
+pub type MC0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC0`"]
+pub struct MC0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC1`"]
+pub type MC1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC1`"]
+pub struct MC1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC2`"]
+pub type MC2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC2`"]
+pub struct MC2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 18)) | (((value as u32) & 0x01) << 18);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC3`"]
+pub type MC3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC3`"]
+pub struct MC3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 19)) | (((value as u32) & 0x01) << 19);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Retrigger Interrupt Enable"]
+    #[inline(always)]
+    pub fn trg(&self) -> TRG_R {
+        TRG_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Counter Interrupt Enable"]
+    #[inline(always)]
+    pub fn cnt(&self) -> CNT_R {
+        CNT_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&self) -> ERR_R {
+        ERR_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Non-Recoverable Debug Fault Interrupt Enable"]
+    #[inline(always)]
+    pub fn dfs(&self) -> DFS_R {
+        DFS_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - Recoverable Fault A Interrupt Enable"]
+    #[inline(always)]
+    pub fn faulta(&self) -> FAULTA_R {
+        FAULTA_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Recoverable Fault B Interrupt Enable"]
+    #[inline(always)]
+    pub fn faultb(&self) -> FAULTB_R {
+        FAULTB_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+    #[doc = "Bit 14 - Non-Recoverable Fault 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn fault0(&self) -> FAULT0_R {
+        FAULT0_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Non-Recoverable Fault 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn fault1(&self) -> FAULT1_R {
+        FAULT1_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&self) -> MC0_R {
+        MC0_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bit 17 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&self) -> MC1_R {
+        MC1_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+    #[doc = "Bit 18 - Match or Capture Channel 2 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc2(&self) -> MC2_R {
+        MC2_R::new(((self.bits >> 18) & 0x01) != 0)
+    }
+    #[doc = "Bit 19 - Match or Capture Channel 3 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc3(&self) -> MC3_R {
+        MC3_R::new(((self.bits >> 19) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+    #[doc = "Bit 1 - Retrigger Interrupt Enable"]
+    #[inline(always)]
+    pub fn trg(&mut self) -> TRG_W {
+        TRG_W { w: self }
+    }
+    #[doc = "Bit 2 - Counter Interrupt Enable"]
+    #[inline(always)]
+    pub fn cnt(&mut self) -> CNT_W {
+        CNT_W { w: self }
+    }
+    #[doc = "Bit 3 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&mut self) -> ERR_W {
+        ERR_W { w: self }
+    }
+    #[doc = "Bit 11 - Non-Recoverable Debug Fault Interrupt Enable"]
+    #[inline(always)]
+    pub fn dfs(&mut self) -> DFS_W {
+        DFS_W { w: self }
+    }
+    #[doc = "Bit 12 - Recoverable Fault A Interrupt Enable"]
+    #[inline(always)]
+    pub fn faulta(&mut self) -> FAULTA_W {
+        FAULTA_W { w: self }
+    }
+    #[doc = "Bit 13 - Recoverable Fault B Interrupt Enable"]
+    #[inline(always)]
+    pub fn faultb(&mut self) -> FAULTB_W {
+        FAULTB_W { w: self }
+    }
+    #[doc = "Bit 14 - Non-Recoverable Fault 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn fault0(&mut self) -> FAULT0_W {
+        FAULT0_W { w: self }
+    }
+    #[doc = "Bit 15 - Non-Recoverable Fault 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn fault1(&mut self) -> FAULT1_W {
+        FAULT1_W { w: self }
+    }
+    #[doc = "Bit 16 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&mut self) -> MC0_W {
+        MC0_W { w: self }
+    }
+    #[doc = "Bit 17 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&mut self) -> MC1_W {
+        MC1_W { w: self }
+    }
+    #[doc = "Bit 18 - Match or Capture Channel 2 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc2(&mut self) -> MC2_W {
+        MC2_W { w: self }
+    }
+    #[doc = "Bit 19 - Match or Capture Channel 3 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc3(&mut self) -> MC3_W {
+        MC3_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/intenset.rs
+++ b/pac/atsamd11c14a/src/tcc0/intenset.rs
@@ -1,0 +1,458 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u32, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u32, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `TRG`"]
+pub type TRG_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRG`"]
+pub struct TRG_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRG_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `CNT`"]
+pub type CNT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CNT`"]
+pub struct CNT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CNT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERR`"]
+pub type ERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERR`"]
+pub struct ERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFS`"]
+pub type DFS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFS`"]
+pub struct DFS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULTA`"]
+pub type FAULTA_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULTA`"]
+pub struct FAULTA_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULTA_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u32) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULTB`"]
+pub type FAULTB_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULTB`"]
+pub struct FAULTB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULTB_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u32) & 0x01) << 13);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULT0`"]
+pub type FAULT0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULT0`"]
+pub struct FAULT0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULT0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u32) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULT1`"]
+pub type FAULT1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULT1`"]
+pub struct FAULT1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULT1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC0`"]
+pub type MC0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC0`"]
+pub struct MC0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC1`"]
+pub type MC1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC1`"]
+pub struct MC1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC2`"]
+pub type MC2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC2`"]
+pub struct MC2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 18)) | (((value as u32) & 0x01) << 18);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC3`"]
+pub type MC3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC3`"]
+pub struct MC3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 19)) | (((value as u32) & 0x01) << 19);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Retrigger Interrupt Enable"]
+    #[inline(always)]
+    pub fn trg(&self) -> TRG_R {
+        TRG_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Counter Interrupt Enable"]
+    #[inline(always)]
+    pub fn cnt(&self) -> CNT_R {
+        CNT_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&self) -> ERR_R {
+        ERR_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Non-Recoverable Debug Fault Interrupt Enable"]
+    #[inline(always)]
+    pub fn dfs(&self) -> DFS_R {
+        DFS_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - Recoverable Fault A Interrupt Enable"]
+    #[inline(always)]
+    pub fn faulta(&self) -> FAULTA_R {
+        FAULTA_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Recoverable Fault B Interrupt Enable"]
+    #[inline(always)]
+    pub fn faultb(&self) -> FAULTB_R {
+        FAULTB_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+    #[doc = "Bit 14 - Non-Recoverable Fault 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn fault0(&self) -> FAULT0_R {
+        FAULT0_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Non-Recoverable Fault 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn fault1(&self) -> FAULT1_R {
+        FAULT1_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&self) -> MC0_R {
+        MC0_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bit 17 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&self) -> MC1_R {
+        MC1_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+    #[doc = "Bit 18 - Match or Capture Channel 2 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc2(&self) -> MC2_R {
+        MC2_R::new(((self.bits >> 18) & 0x01) != 0)
+    }
+    #[doc = "Bit 19 - Match or Capture Channel 3 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc3(&self) -> MC3_R {
+        MC3_R::new(((self.bits >> 19) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Overflow Interrupt Enable"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+    #[doc = "Bit 1 - Retrigger Interrupt Enable"]
+    #[inline(always)]
+    pub fn trg(&mut self) -> TRG_W {
+        TRG_W { w: self }
+    }
+    #[doc = "Bit 2 - Counter Interrupt Enable"]
+    #[inline(always)]
+    pub fn cnt(&mut self) -> CNT_W {
+        CNT_W { w: self }
+    }
+    #[doc = "Bit 3 - Error Interrupt Enable"]
+    #[inline(always)]
+    pub fn err(&mut self) -> ERR_W {
+        ERR_W { w: self }
+    }
+    #[doc = "Bit 11 - Non-Recoverable Debug Fault Interrupt Enable"]
+    #[inline(always)]
+    pub fn dfs(&mut self) -> DFS_W {
+        DFS_W { w: self }
+    }
+    #[doc = "Bit 12 - Recoverable Fault A Interrupt Enable"]
+    #[inline(always)]
+    pub fn faulta(&mut self) -> FAULTA_W {
+        FAULTA_W { w: self }
+    }
+    #[doc = "Bit 13 - Recoverable Fault B Interrupt Enable"]
+    #[inline(always)]
+    pub fn faultb(&mut self) -> FAULTB_W {
+        FAULTB_W { w: self }
+    }
+    #[doc = "Bit 14 - Non-Recoverable Fault 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn fault0(&mut self) -> FAULT0_W {
+        FAULT0_W { w: self }
+    }
+    #[doc = "Bit 15 - Non-Recoverable Fault 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn fault1(&mut self) -> FAULT1_W {
+        FAULT1_W { w: self }
+    }
+    #[doc = "Bit 16 - Match or Capture Channel 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc0(&mut self) -> MC0_W {
+        MC0_W { w: self }
+    }
+    #[doc = "Bit 17 - Match or Capture Channel 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc1(&mut self) -> MC1_W {
+        MC1_W { w: self }
+    }
+    #[doc = "Bit 18 - Match or Capture Channel 2 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc2(&mut self) -> MC2_W {
+        MC2_W { w: self }
+    }
+    #[doc = "Bit 19 - Match or Capture Channel 3 Interrupt Enable"]
+    #[inline(always)]
+    pub fn mc3(&mut self) -> MC3_W {
+        MC3_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/intflag.rs
+++ b/pac/atsamd11c14a/src/tcc0/intflag.rs
@@ -1,0 +1,458 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u32, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u32, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OVF`"]
+pub type OVF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OVF`"]
+pub struct OVF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OVF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u32) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `TRG`"]
+pub type TRG_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRG`"]
+pub struct TRG_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRG_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u32) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `CNT`"]
+pub type CNT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CNT`"]
+pub struct CNT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CNT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u32) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `ERR`"]
+pub type ERR_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ERR`"]
+pub struct ERR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ERR_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `DFS`"]
+pub type DFS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFS`"]
+pub struct DFS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULTA`"]
+pub type FAULTA_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULTA`"]
+pub struct FAULTA_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULTA_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u32) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULTB`"]
+pub type FAULTB_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULTB`"]
+pub struct FAULTB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULTB_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u32) & 0x01) << 13);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULT0`"]
+pub type FAULT0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULT0`"]
+pub struct FAULT0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULT0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u32) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULT1`"]
+pub type FAULT1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULT1`"]
+pub struct FAULT1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULT1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC0`"]
+pub type MC0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC0`"]
+pub struct MC0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC1`"]
+pub type MC1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC1`"]
+pub struct MC1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC2`"]
+pub type MC2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC2`"]
+pub struct MC2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 18)) | (((value as u32) & 0x01) << 18);
+        self.w
+    }
+}
+#[doc = "Reader of field `MC3`"]
+pub type MC3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MC3`"]
+pub struct MC3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MC3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 19)) | (((value as u32) & 0x01) << 19);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Overflow"]
+    #[inline(always)]
+    pub fn ovf(&self) -> OVF_R {
+        OVF_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Retrigger"]
+    #[inline(always)]
+    pub fn trg(&self) -> TRG_R {
+        TRG_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Counter"]
+    #[inline(always)]
+    pub fn cnt(&self) -> CNT_R {
+        CNT_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Error"]
+    #[inline(always)]
+    pub fn err(&self) -> ERR_R {
+        ERR_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Non-Recoverable Debug Fault"]
+    #[inline(always)]
+    pub fn dfs(&self) -> DFS_R {
+        DFS_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - Recoverable Fault A"]
+    #[inline(always)]
+    pub fn faulta(&self) -> FAULTA_R {
+        FAULTA_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Recoverable Fault B"]
+    #[inline(always)]
+    pub fn faultb(&self) -> FAULTB_R {
+        FAULTB_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+    #[doc = "Bit 14 - Non-Recoverable Fault 0"]
+    #[inline(always)]
+    pub fn fault0(&self) -> FAULT0_R {
+        FAULT0_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Non-Recoverable Fault 1"]
+    #[inline(always)]
+    pub fn fault1(&self) -> FAULT1_R {
+        FAULT1_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - Match or Capture 0"]
+    #[inline(always)]
+    pub fn mc0(&self) -> MC0_R {
+        MC0_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bit 17 - Match or Capture 1"]
+    #[inline(always)]
+    pub fn mc1(&self) -> MC1_R {
+        MC1_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+    #[doc = "Bit 18 - Match or Capture 2"]
+    #[inline(always)]
+    pub fn mc2(&self) -> MC2_R {
+        MC2_R::new(((self.bits >> 18) & 0x01) != 0)
+    }
+    #[doc = "Bit 19 - Match or Capture 3"]
+    #[inline(always)]
+    pub fn mc3(&self) -> MC3_R {
+        MC3_R::new(((self.bits >> 19) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Overflow"]
+    #[inline(always)]
+    pub fn ovf(&mut self) -> OVF_W {
+        OVF_W { w: self }
+    }
+    #[doc = "Bit 1 - Retrigger"]
+    #[inline(always)]
+    pub fn trg(&mut self) -> TRG_W {
+        TRG_W { w: self }
+    }
+    #[doc = "Bit 2 - Counter"]
+    #[inline(always)]
+    pub fn cnt(&mut self) -> CNT_W {
+        CNT_W { w: self }
+    }
+    #[doc = "Bit 3 - Error"]
+    #[inline(always)]
+    pub fn err(&mut self) -> ERR_W {
+        ERR_W { w: self }
+    }
+    #[doc = "Bit 11 - Non-Recoverable Debug Fault"]
+    #[inline(always)]
+    pub fn dfs(&mut self) -> DFS_W {
+        DFS_W { w: self }
+    }
+    #[doc = "Bit 12 - Recoverable Fault A"]
+    #[inline(always)]
+    pub fn faulta(&mut self) -> FAULTA_W {
+        FAULTA_W { w: self }
+    }
+    #[doc = "Bit 13 - Recoverable Fault B"]
+    #[inline(always)]
+    pub fn faultb(&mut self) -> FAULTB_W {
+        FAULTB_W { w: self }
+    }
+    #[doc = "Bit 14 - Non-Recoverable Fault 0"]
+    #[inline(always)]
+    pub fn fault0(&mut self) -> FAULT0_W {
+        FAULT0_W { w: self }
+    }
+    #[doc = "Bit 15 - Non-Recoverable Fault 1"]
+    #[inline(always)]
+    pub fn fault1(&mut self) -> FAULT1_W {
+        FAULT1_W { w: self }
+    }
+    #[doc = "Bit 16 - Match or Capture 0"]
+    #[inline(always)]
+    pub fn mc0(&mut self) -> MC0_W {
+        MC0_W { w: self }
+    }
+    #[doc = "Bit 17 - Match or Capture 1"]
+    #[inline(always)]
+    pub fn mc1(&mut self) -> MC1_W {
+        MC1_W { w: self }
+    }
+    #[doc = "Bit 18 - Match or Capture 2"]
+    #[inline(always)]
+    pub fn mc2(&mut self) -> MC2_W {
+        MC2_W { w: self }
+    }
+    #[doc = "Bit 19 - Match or Capture 3"]
+    #[inline(always)]
+    pub fn mc3(&mut self) -> MC3_W {
+        MC3_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/patt.rs
+++ b/pac/atsamd11c14a/src/tcc0/patt.rs
@@ -1,0 +1,560 @@
+#[doc = "Reader of register PATT"]
+pub type R = crate::R<u16, super::PATT>;
+#[doc = "Writer for register PATT"]
+pub type W = crate::W<u16, super::PATT>;
+#[doc = "Register PATT `reset()`'s with value 0"]
+impl crate::ResetValue for super::PATT {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `PGE0`"]
+pub type PGE0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGE0`"]
+pub struct PGE0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGE0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGE1`"]
+pub type PGE1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGE1`"]
+pub struct PGE1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGE1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGE2`"]
+pub type PGE2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGE2`"]
+pub struct PGE2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGE2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGE3`"]
+pub type PGE3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGE3`"]
+pub struct PGE3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGE3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u16) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGE4`"]
+pub type PGE4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGE4`"]
+pub struct PGE4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGE4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGE5`"]
+pub type PGE5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGE5`"]
+pub struct PGE5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGE5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGE6`"]
+pub type PGE6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGE6`"]
+pub struct PGE6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGE6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGE7`"]
+pub type PGE7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGE7`"]
+pub struct PGE7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGE7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGV0`"]
+pub type PGV0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGV0`"]
+pub struct PGV0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGV0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGV1`"]
+pub type PGV1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGV1`"]
+pub struct PGV1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGV1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u16) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGV2`"]
+pub type PGV2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGV2`"]
+pub struct PGV2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGV2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u16) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGV3`"]
+pub type PGV3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGV3`"]
+pub struct PGV3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGV3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u16) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGV4`"]
+pub type PGV4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGV4`"]
+pub struct PGV4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGV4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u16) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGV5`"]
+pub type PGV5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGV5`"]
+pub struct PGV5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGV5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u16) & 0x01) << 13);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGV6`"]
+pub type PGV6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGV6`"]
+pub struct PGV6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGV6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u16) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGV7`"]
+pub type PGV7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGV7`"]
+pub struct PGV7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGV7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u16) & 0x01) << 15);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Pattern Generator 0 Output Enable"]
+    #[inline(always)]
+    pub fn pge0(&self) -> PGE0_R {
+        PGE0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Pattern Generator 1 Output Enable"]
+    #[inline(always)]
+    pub fn pge1(&self) -> PGE1_R {
+        PGE1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Pattern Generator 2 Output Enable"]
+    #[inline(always)]
+    pub fn pge2(&self) -> PGE2_R {
+        PGE2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Pattern Generator 3 Output Enable"]
+    #[inline(always)]
+    pub fn pge3(&self) -> PGE3_R {
+        PGE3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Pattern Generator 4 Output Enable"]
+    #[inline(always)]
+    pub fn pge4(&self) -> PGE4_R {
+        PGE4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Pattern Generator 5 Output Enable"]
+    #[inline(always)]
+    pub fn pge5(&self) -> PGE5_R {
+        PGE5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Pattern Generator 6 Output Enable"]
+    #[inline(always)]
+    pub fn pge6(&self) -> PGE6_R {
+        PGE6_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Pattern Generator 7 Output Enable"]
+    #[inline(always)]
+    pub fn pge7(&self) -> PGE7_R {
+        PGE7_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Pattern Generator 0 Output Value"]
+    #[inline(always)]
+    pub fn pgv0(&self) -> PGV0_R {
+        PGV0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Pattern Generator 1 Output Value"]
+    #[inline(always)]
+    pub fn pgv1(&self) -> PGV1_R {
+        PGV1_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Pattern Generator 2 Output Value"]
+    #[inline(always)]
+    pub fn pgv2(&self) -> PGV2_R {
+        PGV2_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Pattern Generator 3 Output Value"]
+    #[inline(always)]
+    pub fn pgv3(&self) -> PGV3_R {
+        PGV3_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - Pattern Generator 4 Output Value"]
+    #[inline(always)]
+    pub fn pgv4(&self) -> PGV4_R {
+        PGV4_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Pattern Generator 5 Output Value"]
+    #[inline(always)]
+    pub fn pgv5(&self) -> PGV5_R {
+        PGV5_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+    #[doc = "Bit 14 - Pattern Generator 6 Output Value"]
+    #[inline(always)]
+    pub fn pgv6(&self) -> PGV6_R {
+        PGV6_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Pattern Generator 7 Output Value"]
+    #[inline(always)]
+    pub fn pgv7(&self) -> PGV7_R {
+        PGV7_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Pattern Generator 0 Output Enable"]
+    #[inline(always)]
+    pub fn pge0(&mut self) -> PGE0_W {
+        PGE0_W { w: self }
+    }
+    #[doc = "Bit 1 - Pattern Generator 1 Output Enable"]
+    #[inline(always)]
+    pub fn pge1(&mut self) -> PGE1_W {
+        PGE1_W { w: self }
+    }
+    #[doc = "Bit 2 - Pattern Generator 2 Output Enable"]
+    #[inline(always)]
+    pub fn pge2(&mut self) -> PGE2_W {
+        PGE2_W { w: self }
+    }
+    #[doc = "Bit 3 - Pattern Generator 3 Output Enable"]
+    #[inline(always)]
+    pub fn pge3(&mut self) -> PGE3_W {
+        PGE3_W { w: self }
+    }
+    #[doc = "Bit 4 - Pattern Generator 4 Output Enable"]
+    #[inline(always)]
+    pub fn pge4(&mut self) -> PGE4_W {
+        PGE4_W { w: self }
+    }
+    #[doc = "Bit 5 - Pattern Generator 5 Output Enable"]
+    #[inline(always)]
+    pub fn pge5(&mut self) -> PGE5_W {
+        PGE5_W { w: self }
+    }
+    #[doc = "Bit 6 - Pattern Generator 6 Output Enable"]
+    #[inline(always)]
+    pub fn pge6(&mut self) -> PGE6_W {
+        PGE6_W { w: self }
+    }
+    #[doc = "Bit 7 - Pattern Generator 7 Output Enable"]
+    #[inline(always)]
+    pub fn pge7(&mut self) -> PGE7_W {
+        PGE7_W { w: self }
+    }
+    #[doc = "Bit 8 - Pattern Generator 0 Output Value"]
+    #[inline(always)]
+    pub fn pgv0(&mut self) -> PGV0_W {
+        PGV0_W { w: self }
+    }
+    #[doc = "Bit 9 - Pattern Generator 1 Output Value"]
+    #[inline(always)]
+    pub fn pgv1(&mut self) -> PGV1_W {
+        PGV1_W { w: self }
+    }
+    #[doc = "Bit 10 - Pattern Generator 2 Output Value"]
+    #[inline(always)]
+    pub fn pgv2(&mut self) -> PGV2_W {
+        PGV2_W { w: self }
+    }
+    #[doc = "Bit 11 - Pattern Generator 3 Output Value"]
+    #[inline(always)]
+    pub fn pgv3(&mut self) -> PGV3_W {
+        PGV3_W { w: self }
+    }
+    #[doc = "Bit 12 - Pattern Generator 4 Output Value"]
+    #[inline(always)]
+    pub fn pgv4(&mut self) -> PGV4_W {
+        PGV4_W { w: self }
+    }
+    #[doc = "Bit 13 - Pattern Generator 5 Output Value"]
+    #[inline(always)]
+    pub fn pgv5(&mut self) -> PGV5_W {
+        PGV5_W { w: self }
+    }
+    #[doc = "Bit 14 - Pattern Generator 6 Output Value"]
+    #[inline(always)]
+    pub fn pgv6(&mut self) -> PGV6_W {
+        PGV6_W { w: self }
+    }
+    #[doc = "Bit 15 - Pattern Generator 7 Output Value"]
+    #[inline(always)]
+    pub fn pgv7(&mut self) -> PGV7_W {
+        PGV7_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/pattb.rs
+++ b/pac/atsamd11c14a/src/tcc0/pattb.rs
@@ -1,0 +1,560 @@
+#[doc = "Reader of register PATTB"]
+pub type R = crate::R<u16, super::PATTB>;
+#[doc = "Writer for register PATTB"]
+pub type W = crate::W<u16, super::PATTB>;
+#[doc = "Register PATTB `reset()`'s with value 0"]
+impl crate::ResetValue for super::PATTB {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `PGEB0`"]
+pub type PGEB0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGEB0`"]
+pub struct PGEB0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGEB0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGEB1`"]
+pub type PGEB1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGEB1`"]
+pub struct PGEB1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGEB1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGEB2`"]
+pub type PGEB2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGEB2`"]
+pub struct PGEB2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGEB2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGEB3`"]
+pub type PGEB3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGEB3`"]
+pub struct PGEB3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGEB3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u16) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGEB4`"]
+pub type PGEB4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGEB4`"]
+pub struct PGEB4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGEB4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGEB5`"]
+pub type PGEB5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGEB5`"]
+pub struct PGEB5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGEB5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGEB6`"]
+pub type PGEB6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGEB6`"]
+pub struct PGEB6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGEB6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGEB7`"]
+pub type PGEB7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGEB7`"]
+pub struct PGEB7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGEB7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGVB0`"]
+pub type PGVB0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGVB0`"]
+pub struct PGVB0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGVB0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGVB1`"]
+pub type PGVB1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGVB1`"]
+pub struct PGVB1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGVB1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u16) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGVB2`"]
+pub type PGVB2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGVB2`"]
+pub struct PGVB2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGVB2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u16) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGVB3`"]
+pub type PGVB3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGVB3`"]
+pub struct PGVB3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGVB3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u16) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGVB4`"]
+pub type PGVB4_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGVB4`"]
+pub struct PGVB4_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGVB4_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u16) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGVB5`"]
+pub type PGVB5_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGVB5`"]
+pub struct PGVB5_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGVB5_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u16) & 0x01) << 13);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGVB6`"]
+pub type PGVB6_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGVB6`"]
+pub struct PGVB6_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGVB6_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u16) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `PGVB7`"]
+pub type PGVB7_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PGVB7`"]
+pub struct PGVB7_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PGVB7_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u16) & 0x01) << 15);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Pattern Generator 0 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb0(&self) -> PGEB0_R {
+        PGEB0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Pattern Generator 1 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb1(&self) -> PGEB1_R {
+        PGEB1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Pattern Generator 2 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb2(&self) -> PGEB2_R {
+        PGEB2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Pattern Generator 3 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb3(&self) -> PGEB3_R {
+        PGEB3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Pattern Generator 4 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb4(&self) -> PGEB4_R {
+        PGEB4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Pattern Generator 5 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb5(&self) -> PGEB5_R {
+        PGEB5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Pattern Generator 6 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb6(&self) -> PGEB6_R {
+        PGEB6_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Pattern Generator 7 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb7(&self) -> PGEB7_R {
+        PGEB7_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Pattern Generator 0 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb0(&self) -> PGVB0_R {
+        PGVB0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Pattern Generator 1 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb1(&self) -> PGVB1_R {
+        PGVB1_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Pattern Generator 2 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb2(&self) -> PGVB2_R {
+        PGVB2_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Pattern Generator 3 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb3(&self) -> PGVB3_R {
+        PGVB3_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - Pattern Generator 4 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb4(&self) -> PGVB4_R {
+        PGVB4_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Pattern Generator 5 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb5(&self) -> PGVB5_R {
+        PGVB5_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+    #[doc = "Bit 14 - Pattern Generator 6 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb6(&self) -> PGVB6_R {
+        PGVB6_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Pattern Generator 7 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb7(&self) -> PGVB7_R {
+        PGVB7_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Pattern Generator 0 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb0(&mut self) -> PGEB0_W {
+        PGEB0_W { w: self }
+    }
+    #[doc = "Bit 1 - Pattern Generator 1 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb1(&mut self) -> PGEB1_W {
+        PGEB1_W { w: self }
+    }
+    #[doc = "Bit 2 - Pattern Generator 2 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb2(&mut self) -> PGEB2_W {
+        PGEB2_W { w: self }
+    }
+    #[doc = "Bit 3 - Pattern Generator 3 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb3(&mut self) -> PGEB3_W {
+        PGEB3_W { w: self }
+    }
+    #[doc = "Bit 4 - Pattern Generator 4 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb4(&mut self) -> PGEB4_W {
+        PGEB4_W { w: self }
+    }
+    #[doc = "Bit 5 - Pattern Generator 5 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb5(&mut self) -> PGEB5_W {
+        PGEB5_W { w: self }
+    }
+    #[doc = "Bit 6 - Pattern Generator 6 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb6(&mut self) -> PGEB6_W {
+        PGEB6_W { w: self }
+    }
+    #[doc = "Bit 7 - Pattern Generator 7 Output Enable Buffer"]
+    #[inline(always)]
+    pub fn pgeb7(&mut self) -> PGEB7_W {
+        PGEB7_W { w: self }
+    }
+    #[doc = "Bit 8 - Pattern Generator 0 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb0(&mut self) -> PGVB0_W {
+        PGVB0_W { w: self }
+    }
+    #[doc = "Bit 9 - Pattern Generator 1 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb1(&mut self) -> PGVB1_W {
+        PGVB1_W { w: self }
+    }
+    #[doc = "Bit 10 - Pattern Generator 2 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb2(&mut self) -> PGVB2_W {
+        PGVB2_W { w: self }
+    }
+    #[doc = "Bit 11 - Pattern Generator 3 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb3(&mut self) -> PGVB3_W {
+        PGVB3_W { w: self }
+    }
+    #[doc = "Bit 12 - Pattern Generator 4 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb4(&mut self) -> PGVB4_W {
+        PGVB4_W { w: self }
+    }
+    #[doc = "Bit 13 - Pattern Generator 5 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb5(&mut self) -> PGVB5_W {
+        PGVB5_W { w: self }
+    }
+    #[doc = "Bit 14 - Pattern Generator 6 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb6(&mut self) -> PGVB6_W {
+        PGVB6_W { w: self }
+    }
+    #[doc = "Bit 15 - Pattern Generator 7 Output Enable"]
+    #[inline(always)]
+    pub fn pgvb7(&mut self) -> PGVB7_W {
+        PGVB7_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/per.rs
+++ b/pac/atsamd11c14a/src/tcc0/per.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register PER"]
+pub type R = crate::R<u32, super::PER>;
+#[doc = "Writer for register PER"]
+pub type W = crate::W<u32, super::PER>;
+#[doc = "Register PER `reset()`'s with value 0xffff_ffff"]
+impl crate::ResetValue for super::PER {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0xffff_ffff
+    }
+}
+#[doc = "Reader of field `PER`"]
+pub type PER_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `PER`"]
+pub struct PER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PER_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x00ff_ffff) | ((value as u32) & 0x00ff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:23 - Period Value"]
+    #[inline(always)]
+    pub fn per(&self) -> PER_R {
+        PER_R::new((self.bits & 0x00ff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:23 - Period Value"]
+    #[inline(always)]
+    pub fn per(&mut self) -> PER_W {
+        PER_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/per_dith4.rs
+++ b/pac/atsamd11c14a/src/tcc0/per_dith4.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register PER_DITH4"]
+pub type R = crate::R<u32, super::PER_DITH4>;
+#[doc = "Writer for register PER_DITH4"]
+pub type W = crate::W<u32, super::PER_DITH4>;
+#[doc = "Register PER_DITH4 `reset()`'s with value 0xffff_ffff"]
+impl crate::ResetValue for super::PER_DITH4 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0xffff_ffff
+    }
+}
+#[doc = "Reader of field `DITHERCY`"]
+pub type DITHERCY_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DITHERCY`"]
+pub struct DITHERCY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DITHERCY_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0f) | ((value as u32) & 0x0f);
+        self.w
+    }
+}
+#[doc = "Reader of field `PER`"]
+pub type PER_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `PER`"]
+pub struct PER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PER_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x000f_ffff << 4)) | (((value as u32) & 0x000f_ffff) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:3 - Dithering Cycle Number"]
+    #[inline(always)]
+    pub fn dithercy(&self) -> DITHERCY_R {
+        DITHERCY_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:23 - Period Value"]
+    #[inline(always)]
+    pub fn per(&self) -> PER_R {
+        PER_R::new(((self.bits >> 4) & 0x000f_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Dithering Cycle Number"]
+    #[inline(always)]
+    pub fn dithercy(&mut self) -> DITHERCY_W {
+        DITHERCY_W { w: self }
+    }
+    #[doc = "Bits 4:23 - Period Value"]
+    #[inline(always)]
+    pub fn per(&mut self) -> PER_W {
+        PER_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/per_dith5.rs
+++ b/pac/atsamd11c14a/src/tcc0/per_dith5.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register PER_DITH5"]
+pub type R = crate::R<u32, super::PER_DITH5>;
+#[doc = "Writer for register PER_DITH5"]
+pub type W = crate::W<u32, super::PER_DITH5>;
+#[doc = "Register PER_DITH5 `reset()`'s with value 0xffff_ffff"]
+impl crate::ResetValue for super::PER_DITH5 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0xffff_ffff
+    }
+}
+#[doc = "Reader of field `DITHERCY`"]
+pub type DITHERCY_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DITHERCY`"]
+pub struct DITHERCY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DITHERCY_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x1f) | ((value as u32) & 0x1f);
+        self.w
+    }
+}
+#[doc = "Reader of field `PER`"]
+pub type PER_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `PER`"]
+pub struct PER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PER_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0007_ffff << 5)) | (((value as u32) & 0x0007_ffff) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:4 - Dithering Cycle Number"]
+    #[inline(always)]
+    pub fn dithercy(&self) -> DITHERCY_R {
+        DITHERCY_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bits 5:23 - Period Value"]
+    #[inline(always)]
+    pub fn per(&self) -> PER_R {
+        PER_R::new(((self.bits >> 5) & 0x0007_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - Dithering Cycle Number"]
+    #[inline(always)]
+    pub fn dithercy(&mut self) -> DITHERCY_W {
+        DITHERCY_W { w: self }
+    }
+    #[doc = "Bits 5:23 - Period Value"]
+    #[inline(always)]
+    pub fn per(&mut self) -> PER_W {
+        PER_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/per_dith6.rs
+++ b/pac/atsamd11c14a/src/tcc0/per_dith6.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register PER_DITH6"]
+pub type R = crate::R<u32, super::PER_DITH6>;
+#[doc = "Writer for register PER_DITH6"]
+pub type W = crate::W<u32, super::PER_DITH6>;
+#[doc = "Register PER_DITH6 `reset()`'s with value 0xffff_ffff"]
+impl crate::ResetValue for super::PER_DITH6 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0xffff_ffff
+    }
+}
+#[doc = "Reader of field `DITHERCY`"]
+pub type DITHERCY_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DITHERCY`"]
+pub struct DITHERCY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DITHERCY_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x3f) | ((value as u32) & 0x3f);
+        self.w
+    }
+}
+#[doc = "Reader of field `PER`"]
+pub type PER_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `PER`"]
+pub struct PER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PER_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0003_ffff << 6)) | (((value as u32) & 0x0003_ffff) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:5 - Dithering Cycle Number"]
+    #[inline(always)]
+    pub fn dithercy(&self) -> DITHERCY_R {
+        DITHERCY_R::new((self.bits & 0x3f) as u8)
+    }
+    #[doc = "Bits 6:23 - Period Value"]
+    #[inline(always)]
+    pub fn per(&self) -> PER_R {
+        PER_R::new(((self.bits >> 6) & 0x0003_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:5 - Dithering Cycle Number"]
+    #[inline(always)]
+    pub fn dithercy(&mut self) -> DITHERCY_W {
+        DITHERCY_W { w: self }
+    }
+    #[doc = "Bits 6:23 - Period Value"]
+    #[inline(always)]
+    pub fn per(&mut self) -> PER_W {
+        PER_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/perb.rs
+++ b/pac/atsamd11c14a/src/tcc0/perb.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register PERB"]
+pub type R = crate::R<u32, super::PERB>;
+#[doc = "Writer for register PERB"]
+pub type W = crate::W<u32, super::PERB>;
+#[doc = "Register PERB `reset()`'s with value 0xffff_ffff"]
+impl crate::ResetValue for super::PERB {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0xffff_ffff
+    }
+}
+#[doc = "Reader of field `PERB`"]
+pub type PERB_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `PERB`"]
+pub struct PERB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PERB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x00ff_ffff) | ((value as u32) & 0x00ff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:23 - Period Buffer Value"]
+    #[inline(always)]
+    pub fn perb(&self) -> PERB_R {
+        PERB_R::new((self.bits & 0x00ff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:23 - Period Buffer Value"]
+    #[inline(always)]
+    pub fn perb(&mut self) -> PERB_W {
+        PERB_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/perb_dith4.rs
+++ b/pac/atsamd11c14a/src/tcc0/perb_dith4.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register PERB_DITH4"]
+pub type R = crate::R<u32, super::PERB_DITH4>;
+#[doc = "Writer for register PERB_DITH4"]
+pub type W = crate::W<u32, super::PERB_DITH4>;
+#[doc = "Register PERB_DITH4 `reset()`'s with value 0xffff_ffff"]
+impl crate::ResetValue for super::PERB_DITH4 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0xffff_ffff
+    }
+}
+#[doc = "Reader of field `DITHERCYB`"]
+pub type DITHERCYB_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DITHERCYB`"]
+pub struct DITHERCYB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DITHERCYB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0f) | ((value as u32) & 0x0f);
+        self.w
+    }
+}
+#[doc = "Reader of field `PERB`"]
+pub type PERB_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `PERB`"]
+pub struct PERB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PERB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x000f_ffff << 4)) | (((value as u32) & 0x000f_ffff) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:3 - Dithering Buffer Cycle Number"]
+    #[inline(always)]
+    pub fn dithercyb(&self) -> DITHERCYB_R {
+        DITHERCYB_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:23 - Period Buffer Value"]
+    #[inline(always)]
+    pub fn perb(&self) -> PERB_R {
+        PERB_R::new(((self.bits >> 4) & 0x000f_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Dithering Buffer Cycle Number"]
+    #[inline(always)]
+    pub fn dithercyb(&mut self) -> DITHERCYB_W {
+        DITHERCYB_W { w: self }
+    }
+    #[doc = "Bits 4:23 - Period Buffer Value"]
+    #[inline(always)]
+    pub fn perb(&mut self) -> PERB_W {
+        PERB_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/perb_dith5.rs
+++ b/pac/atsamd11c14a/src/tcc0/perb_dith5.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register PERB_DITH5"]
+pub type R = crate::R<u32, super::PERB_DITH5>;
+#[doc = "Writer for register PERB_DITH5"]
+pub type W = crate::W<u32, super::PERB_DITH5>;
+#[doc = "Register PERB_DITH5 `reset()`'s with value 0xffff_ffff"]
+impl crate::ResetValue for super::PERB_DITH5 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0xffff_ffff
+    }
+}
+#[doc = "Reader of field `DITHERCYB`"]
+pub type DITHERCYB_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DITHERCYB`"]
+pub struct DITHERCYB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DITHERCYB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x1f) | ((value as u32) & 0x1f);
+        self.w
+    }
+}
+#[doc = "Reader of field `PERB`"]
+pub type PERB_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `PERB`"]
+pub struct PERB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PERB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0007_ffff << 5)) | (((value as u32) & 0x0007_ffff) << 5);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:4 - Dithering Buffer Cycle Number"]
+    #[inline(always)]
+    pub fn dithercyb(&self) -> DITHERCYB_R {
+        DITHERCYB_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bits 5:23 - Period Buffer Value"]
+    #[inline(always)]
+    pub fn perb(&self) -> PERB_R {
+        PERB_R::new(((self.bits >> 5) & 0x0007_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - Dithering Buffer Cycle Number"]
+    #[inline(always)]
+    pub fn dithercyb(&mut self) -> DITHERCYB_W {
+        DITHERCYB_W { w: self }
+    }
+    #[doc = "Bits 5:23 - Period Buffer Value"]
+    #[inline(always)]
+    pub fn perb(&mut self) -> PERB_W {
+        PERB_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/perb_dith6.rs
+++ b/pac/atsamd11c14a/src/tcc0/perb_dith6.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register PERB_DITH6"]
+pub type R = crate::R<u32, super::PERB_DITH6>;
+#[doc = "Writer for register PERB_DITH6"]
+pub type W = crate::W<u32, super::PERB_DITH6>;
+#[doc = "Register PERB_DITH6 `reset()`'s with value 0xffff_ffff"]
+impl crate::ResetValue for super::PERB_DITH6 {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0xffff_ffff
+    }
+}
+#[doc = "Reader of field `DITHERCYB`"]
+pub type DITHERCYB_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DITHERCYB`"]
+pub struct DITHERCYB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DITHERCYB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x3f) | ((value as u32) & 0x3f);
+        self.w
+    }
+}
+#[doc = "Reader of field `PERB`"]
+pub type PERB_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `PERB`"]
+pub struct PERB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PERB_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0003_ffff << 6)) | (((value as u32) & 0x0003_ffff) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:5 - Dithering Buffer Cycle Number"]
+    #[inline(always)]
+    pub fn dithercyb(&self) -> DITHERCYB_R {
+        DITHERCYB_R::new((self.bits & 0x3f) as u8)
+    }
+    #[doc = "Bits 6:23 - Period Buffer Value"]
+    #[inline(always)]
+    pub fn perb(&self) -> PERB_R {
+        PERB_R::new(((self.bits >> 6) & 0x0003_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:5 - Dithering Buffer Cycle Number"]
+    #[inline(always)]
+    pub fn dithercyb(&mut self) -> DITHERCYB_W {
+        DITHERCYB_W { w: self }
+    }
+    #[doc = "Bits 6:23 - Period Buffer Value"]
+    #[inline(always)]
+    pub fn perb(&mut self) -> PERB_W {
+        PERB_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/status.rs
+++ b/pac/atsamd11c14a/src/tcc0/status.rs
@@ -1,0 +1,501 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u32, super::STATUS>;
+#[doc = "Writer for register STATUS"]
+pub type W = crate::W<u32, super::STATUS>;
+#[doc = "Register STATUS `reset()`'s with value 0x01"]
+impl crate::ResetValue for super::STATUS {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x01
+    }
+}
+#[doc = "Reader of field `STOP`"]
+pub type STOP_R = crate::R<bool, bool>;
+#[doc = "Reader of field `IDX`"]
+pub type IDX_R = crate::R<bool, bool>;
+#[doc = "Reader of field `DFS`"]
+pub type DFS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DFS`"]
+pub struct DFS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DFS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u32) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `SLAVE`"]
+pub type SLAVE_R = crate::R<bool, bool>;
+#[doc = "Reader of field `PATTBV`"]
+pub type PATTBV_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PATTBV`"]
+pub struct PATTBV_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PATTBV_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u32) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `WAVEBV`"]
+pub type WAVEBV_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WAVEBV`"]
+pub struct WAVEBV_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAVEBV_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u32) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `PERBV`"]
+pub type PERBV_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `PERBV`"]
+pub struct PERBV_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PERBV_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULTAIN`"]
+pub type FAULTAIN_R = crate::R<bool, bool>;
+#[doc = "Reader of field `FAULTBIN`"]
+pub type FAULTBIN_R = crate::R<bool, bool>;
+#[doc = "Reader of field `FAULT0IN`"]
+pub type FAULT0IN_R = crate::R<bool, bool>;
+#[doc = "Reader of field `FAULT1IN`"]
+pub type FAULT1IN_R = crate::R<bool, bool>;
+#[doc = "Reader of field `FAULTA`"]
+pub type FAULTA_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULTA`"]
+pub struct FAULTA_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULTA_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u32) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULTB`"]
+pub type FAULTB_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULTB`"]
+pub struct FAULTB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULTB_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u32) & 0x01) << 13);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULT0`"]
+pub type FAULT0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULT0`"]
+pub struct FAULT0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULT0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u32) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `FAULT1`"]
+pub type FAULT1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FAULT1`"]
+pub struct FAULT1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FAULT1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u32) & 0x01) << 15);
+        self.w
+    }
+}
+#[doc = "Reader of field `CCBV0`"]
+pub type CCBV0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CCBV0`"]
+pub struct CCBV0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CCBV0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `CCBV1`"]
+pub type CCBV1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CCBV1`"]
+pub struct CCBV1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CCBV1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
+#[doc = "Reader of field `CCBV2`"]
+pub type CCBV2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CCBV2`"]
+pub struct CCBV2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CCBV2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 18)) | (((value as u32) & 0x01) << 18);
+        self.w
+    }
+}
+#[doc = "Reader of field `CCBV3`"]
+pub type CCBV3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CCBV3`"]
+pub struct CCBV3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CCBV3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 19)) | (((value as u32) & 0x01) << 19);
+        self.w
+    }
+}
+#[doc = "Reader of field `CMP0`"]
+pub type CMP0_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CMP1`"]
+pub type CMP1_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CMP2`"]
+pub type CMP2_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CMP3`"]
+pub type CMP3_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Stop"]
+    #[inline(always)]
+    pub fn stop(&self) -> STOP_R {
+        STOP_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Ramp"]
+    #[inline(always)]
+    pub fn idx(&self) -> IDX_R {
+        IDX_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Non-Recoverable Debug Fault State"]
+    #[inline(always)]
+    pub fn dfs(&self) -> DFS_R {
+        DFS_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Slave"]
+    #[inline(always)]
+    pub fn slave(&self) -> SLAVE_R {
+        SLAVE_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Pattern Buffer Valid"]
+    #[inline(always)]
+    pub fn pattbv(&self) -> PATTBV_R {
+        PATTBV_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Wave Buffer Valid"]
+    #[inline(always)]
+    pub fn wavebv(&self) -> WAVEBV_R {
+        WAVEBV_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Period Buffer Valid"]
+    #[inline(always)]
+    pub fn perbv(&self) -> PERBV_R {
+        PERBV_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Recoverable Fault A Input"]
+    #[inline(always)]
+    pub fn faultain(&self) -> FAULTAIN_R {
+        FAULTAIN_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Recoverable Fault B Input"]
+    #[inline(always)]
+    pub fn faultbin(&self) -> FAULTBIN_R {
+        FAULTBIN_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Non-Recoverable Fault0 Input"]
+    #[inline(always)]
+    pub fn fault0in(&self) -> FAULT0IN_R {
+        FAULT0IN_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Non-Recoverable Fault1 Input"]
+    #[inline(always)]
+    pub fn fault1in(&self) -> FAULT1IN_R {
+        FAULT1IN_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - Recoverable Fault A State"]
+    #[inline(always)]
+    pub fn faulta(&self) -> FAULTA_R {
+        FAULTA_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - Recoverable Fault B State"]
+    #[inline(always)]
+    pub fn faultb(&self) -> FAULTB_R {
+        FAULTB_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+    #[doc = "Bit 14 - Non-Recoverable Fault 0 State"]
+    #[inline(always)]
+    pub fn fault0(&self) -> FAULT0_R {
+        FAULT0_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - Non-Recoverable Fault 1 State"]
+    #[inline(always)]
+    pub fn fault1(&self) -> FAULT1_R {
+        FAULT1_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - Compare Channel 0 Buffer Valid"]
+    #[inline(always)]
+    pub fn ccbv0(&self) -> CCBV0_R {
+        CCBV0_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bit 17 - Compare Channel 1 Buffer Valid"]
+    #[inline(always)]
+    pub fn ccbv1(&self) -> CCBV1_R {
+        CCBV1_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+    #[doc = "Bit 18 - Compare Channel 2 Buffer Valid"]
+    #[inline(always)]
+    pub fn ccbv2(&self) -> CCBV2_R {
+        CCBV2_R::new(((self.bits >> 18) & 0x01) != 0)
+    }
+    #[doc = "Bit 19 - Compare Channel 3 Buffer Valid"]
+    #[inline(always)]
+    pub fn ccbv3(&self) -> CCBV3_R {
+        CCBV3_R::new(((self.bits >> 19) & 0x01) != 0)
+    }
+    #[doc = "Bit 24 - Compare Channel 0 Value"]
+    #[inline(always)]
+    pub fn cmp0(&self) -> CMP0_R {
+        CMP0_R::new(((self.bits >> 24) & 0x01) != 0)
+    }
+    #[doc = "Bit 25 - Compare Channel 1 Value"]
+    #[inline(always)]
+    pub fn cmp1(&self) -> CMP1_R {
+        CMP1_R::new(((self.bits >> 25) & 0x01) != 0)
+    }
+    #[doc = "Bit 26 - Compare Channel 2 Value"]
+    #[inline(always)]
+    pub fn cmp2(&self) -> CMP2_R {
+        CMP2_R::new(((self.bits >> 26) & 0x01) != 0)
+    }
+    #[doc = "Bit 27 - Compare Channel 3 Value"]
+    #[inline(always)]
+    pub fn cmp3(&self) -> CMP3_R {
+        CMP3_R::new(((self.bits >> 27) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 3 - Non-Recoverable Debug Fault State"]
+    #[inline(always)]
+    pub fn dfs(&mut self) -> DFS_W {
+        DFS_W { w: self }
+    }
+    #[doc = "Bit 5 - Pattern Buffer Valid"]
+    #[inline(always)]
+    pub fn pattbv(&mut self) -> PATTBV_W {
+        PATTBV_W { w: self }
+    }
+    #[doc = "Bit 6 - Wave Buffer Valid"]
+    #[inline(always)]
+    pub fn wavebv(&mut self) -> WAVEBV_W {
+        WAVEBV_W { w: self }
+    }
+    #[doc = "Bit 7 - Period Buffer Valid"]
+    #[inline(always)]
+    pub fn perbv(&mut self) -> PERBV_W {
+        PERBV_W { w: self }
+    }
+    #[doc = "Bit 12 - Recoverable Fault A State"]
+    #[inline(always)]
+    pub fn faulta(&mut self) -> FAULTA_W {
+        FAULTA_W { w: self }
+    }
+    #[doc = "Bit 13 - Recoverable Fault B State"]
+    #[inline(always)]
+    pub fn faultb(&mut self) -> FAULTB_W {
+        FAULTB_W { w: self }
+    }
+    #[doc = "Bit 14 - Non-Recoverable Fault 0 State"]
+    #[inline(always)]
+    pub fn fault0(&mut self) -> FAULT0_W {
+        FAULT0_W { w: self }
+    }
+    #[doc = "Bit 15 - Non-Recoverable Fault 1 State"]
+    #[inline(always)]
+    pub fn fault1(&mut self) -> FAULT1_W {
+        FAULT1_W { w: self }
+    }
+    #[doc = "Bit 16 - Compare Channel 0 Buffer Valid"]
+    #[inline(always)]
+    pub fn ccbv0(&mut self) -> CCBV0_W {
+        CCBV0_W { w: self }
+    }
+    #[doc = "Bit 17 - Compare Channel 1 Buffer Valid"]
+    #[inline(always)]
+    pub fn ccbv1(&mut self) -> CCBV1_W {
+        CCBV1_W { w: self }
+    }
+    #[doc = "Bit 18 - Compare Channel 2 Buffer Valid"]
+    #[inline(always)]
+    pub fn ccbv2(&mut self) -> CCBV2_W {
+        CCBV2_W { w: self }
+    }
+    #[doc = "Bit 19 - Compare Channel 3 Buffer Valid"]
+    #[inline(always)]
+    pub fn ccbv3(&mut self) -> CCBV3_W {
+        CCBV3_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/syncbusy.rs
+++ b/pac/atsamd11c14a/src/tcc0/syncbusy.rs
@@ -1,0 +1,137 @@
+#[doc = "Reader of register SYNCBUSY"]
+pub type R = crate::R<u32, super::SYNCBUSY>;
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CTRLB`"]
+pub type CTRLB_R = crate::R<bool, bool>;
+#[doc = "Reader of field `STATUS`"]
+pub type STATUS_R = crate::R<bool, bool>;
+#[doc = "Reader of field `COUNT`"]
+pub type COUNT_R = crate::R<bool, bool>;
+#[doc = "Reader of field `PATT`"]
+pub type PATT_R = crate::R<bool, bool>;
+#[doc = "Reader of field `WAVE`"]
+pub type WAVE_R = crate::R<bool, bool>;
+#[doc = "Reader of field `PER`"]
+pub type PER_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CC0`"]
+pub type CC0_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CC1`"]
+pub type CC1_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CC2`"]
+pub type CC2_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CC3`"]
+pub type CC3_R = crate::R<bool, bool>;
+#[doc = "Reader of field `PATTB`"]
+pub type PATTB_R = crate::R<bool, bool>;
+#[doc = "Reader of field `WAVEB`"]
+pub type WAVEB_R = crate::R<bool, bool>;
+#[doc = "Reader of field `PERB`"]
+pub type PERB_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CCB0`"]
+pub type CCB0_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CCB1`"]
+pub type CCB1_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CCB2`"]
+pub type CCB2_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CCB3`"]
+pub type CCB3_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Swrst Busy"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Enable Busy"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Ctrlb Busy"]
+    #[inline(always)]
+    pub fn ctrlb(&self) -> CTRLB_R {
+        CTRLB_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Status Busy"]
+    #[inline(always)]
+    pub fn status(&self) -> STATUS_R {
+        STATUS_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Count Busy"]
+    #[inline(always)]
+    pub fn count(&self) -> COUNT_R {
+        COUNT_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Pattern Busy"]
+    #[inline(always)]
+    pub fn patt(&self) -> PATT_R {
+        PATT_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Wave Busy"]
+    #[inline(always)]
+    pub fn wave(&self) -> WAVE_R {
+        WAVE_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Period busy"]
+    #[inline(always)]
+    pub fn per(&self) -> PER_R {
+        PER_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Compare Channel 0 Busy"]
+    #[inline(always)]
+    pub fn cc0(&self) -> CC0_R {
+        CC0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Compare Channel 1 Busy"]
+    #[inline(always)]
+    pub fn cc1(&self) -> CC1_R {
+        CC1_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Compare Channel 2 Busy"]
+    #[inline(always)]
+    pub fn cc2(&self) -> CC2_R {
+        CC2_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Compare Channel 3 Busy"]
+    #[inline(always)]
+    pub fn cc3(&self) -> CC3_R {
+        CC3_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - Pattern Buffer Busy"]
+    #[inline(always)]
+    pub fn pattb(&self) -> PATTB_R {
+        PATTB_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bit 17 - Wave Buffer Busy"]
+    #[inline(always)]
+    pub fn waveb(&self) -> WAVEB_R {
+        WAVEB_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+    #[doc = "Bit 18 - Period Buffer Busy"]
+    #[inline(always)]
+    pub fn perb(&self) -> PERB_R {
+        PERB_R::new(((self.bits >> 18) & 0x01) != 0)
+    }
+    #[doc = "Bit 19 - Compare Channel Buffer 0 Busy"]
+    #[inline(always)]
+    pub fn ccb0(&self) -> CCB0_R {
+        CCB0_R::new(((self.bits >> 19) & 0x01) != 0)
+    }
+    #[doc = "Bit 20 - Compare Channel Buffer 1 Busy"]
+    #[inline(always)]
+    pub fn ccb1(&self) -> CCB1_R {
+        CCB1_R::new(((self.bits >> 20) & 0x01) != 0)
+    }
+    #[doc = "Bit 21 - Compare Channel Buffer 2 Busy"]
+    #[inline(always)]
+    pub fn ccb2(&self) -> CCB2_R {
+        CCB2_R::new(((self.bits >> 21) & 0x01) != 0)
+    }
+    #[doc = "Bit 22 - Compare Channel Buffer 3 Busy"]
+    #[inline(always)]
+    pub fn ccb3(&self) -> CCB3_R {
+        CCB3_R::new(((self.bits >> 22) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/wave.rs
+++ b/pac/atsamd11c14a/src/tcc0/wave.rs
@@ -1,0 +1,713 @@
+#[doc = "Reader of register WAVE"]
+pub type R = crate::R<u32, super::WAVE>;
+#[doc = "Writer for register WAVE"]
+pub type W = crate::W<u32, super::WAVE>;
+#[doc = "Register WAVE `reset()`'s with value 0"]
+impl crate::ResetValue for super::WAVE {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Waveform Generation\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum WAVEGEN_A {
+    #[doc = "0: Normal frequency"]
+    NFRQ,
+    #[doc = "1: Match frequency"]
+    MFRQ,
+    #[doc = "2: Normal PWM"]
+    NPWM,
+    #[doc = "4: Dual-slope critical"]
+    DSCRITICAL,
+    #[doc = "5: Dual-slope with interrupt/event condition when COUNT reaches ZERO"]
+    DSBOTTOM,
+    #[doc = "6: Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP"]
+    DSBOTH,
+    #[doc = "7: Dual-slope with interrupt/event condition when COUNT reaches TOP"]
+    DSTOP,
+}
+impl From<WAVEGEN_A> for u8 {
+    #[inline(always)]
+    fn from(variant: WAVEGEN_A) -> Self {
+        match variant {
+            WAVEGEN_A::NFRQ => 0,
+            WAVEGEN_A::MFRQ => 1,
+            WAVEGEN_A::NPWM => 2,
+            WAVEGEN_A::DSCRITICAL => 4,
+            WAVEGEN_A::DSBOTTOM => 5,
+            WAVEGEN_A::DSBOTH => 6,
+            WAVEGEN_A::DSTOP => 7,
+        }
+    }
+}
+#[doc = "Reader of field `WAVEGEN`"]
+pub type WAVEGEN_R = crate::R<u8, WAVEGEN_A>;
+impl WAVEGEN_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, WAVEGEN_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(WAVEGEN_A::NFRQ),
+            1 => Val(WAVEGEN_A::MFRQ),
+            2 => Val(WAVEGEN_A::NPWM),
+            4 => Val(WAVEGEN_A::DSCRITICAL),
+            5 => Val(WAVEGEN_A::DSBOTTOM),
+            6 => Val(WAVEGEN_A::DSBOTH),
+            7 => Val(WAVEGEN_A::DSTOP),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NFRQ`"]
+    #[inline(always)]
+    pub fn is_nfrq(&self) -> bool {
+        *self == WAVEGEN_A::NFRQ
+    }
+    #[doc = "Checks if the value of the field is `MFRQ`"]
+    #[inline(always)]
+    pub fn is_mfrq(&self) -> bool {
+        *self == WAVEGEN_A::MFRQ
+    }
+    #[doc = "Checks if the value of the field is `NPWM`"]
+    #[inline(always)]
+    pub fn is_npwm(&self) -> bool {
+        *self == WAVEGEN_A::NPWM
+    }
+    #[doc = "Checks if the value of the field is `DSCRITICAL`"]
+    #[inline(always)]
+    pub fn is_dscritical(&self) -> bool {
+        *self == WAVEGEN_A::DSCRITICAL
+    }
+    #[doc = "Checks if the value of the field is `DSBOTTOM`"]
+    #[inline(always)]
+    pub fn is_dsbottom(&self) -> bool {
+        *self == WAVEGEN_A::DSBOTTOM
+    }
+    #[doc = "Checks if the value of the field is `DSBOTH`"]
+    #[inline(always)]
+    pub fn is_dsboth(&self) -> bool {
+        *self == WAVEGEN_A::DSBOTH
+    }
+    #[doc = "Checks if the value of the field is `DSTOP`"]
+    #[inline(always)]
+    pub fn is_dstop(&self) -> bool {
+        *self == WAVEGEN_A::DSTOP
+    }
+}
+#[doc = "Write proxy for field `WAVEGEN`"]
+pub struct WAVEGEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAVEGEN_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: WAVEGEN_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Normal frequency"]
+    #[inline(always)]
+    pub fn nfrq(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::NFRQ)
+    }
+    #[doc = "Match frequency"]
+    #[inline(always)]
+    pub fn mfrq(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::MFRQ)
+    }
+    #[doc = "Normal PWM"]
+    #[inline(always)]
+    pub fn npwm(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::NPWM)
+    }
+    #[doc = "Dual-slope critical"]
+    #[inline(always)]
+    pub fn dscritical(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::DSCRITICAL)
+    }
+    #[doc = "Dual-slope with interrupt/event condition when COUNT reaches ZERO"]
+    #[inline(always)]
+    pub fn dsbottom(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::DSBOTTOM)
+    }
+    #[doc = "Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP"]
+    #[inline(always)]
+    pub fn dsboth(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::DSBOTH)
+    }
+    #[doc = "Dual-slope with interrupt/event condition when COUNT reaches TOP"]
+    #[inline(always)]
+    pub fn dstop(self) -> &'a mut W {
+        self.variant(WAVEGEN_A::DSTOP)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u32) & 0x07);
+        self.w
+    }
+}
+#[doc = "Ramp Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum RAMP_A {
+    #[doc = "0: RAMP1 operation"]
+    RAMP1,
+    #[doc = "1: Alternative RAMP2 operation"]
+    RAMP2A,
+    #[doc = "2: RAMP2 operation"]
+    RAMP2,
+    #[doc = "3: Critical RAMP2 operation"]
+    RAMP2C,
+}
+impl From<RAMP_A> for u8 {
+    #[inline(always)]
+    fn from(variant: RAMP_A) -> Self {
+        match variant {
+            RAMP_A::RAMP1 => 0,
+            RAMP_A::RAMP2A => 1,
+            RAMP_A::RAMP2 => 2,
+            RAMP_A::RAMP2C => 3,
+        }
+    }
+}
+#[doc = "Reader of field `RAMP`"]
+pub type RAMP_R = crate::R<u8, RAMP_A>;
+impl RAMP_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> RAMP_A {
+        match self.bits {
+            0 => RAMP_A::RAMP1,
+            1 => RAMP_A::RAMP2A,
+            2 => RAMP_A::RAMP2,
+            3 => RAMP_A::RAMP2C,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `RAMP1`"]
+    #[inline(always)]
+    pub fn is_ramp1(&self) -> bool {
+        *self == RAMP_A::RAMP1
+    }
+    #[doc = "Checks if the value of the field is `RAMP2A`"]
+    #[inline(always)]
+    pub fn is_ramp2a(&self) -> bool {
+        *self == RAMP_A::RAMP2A
+    }
+    #[doc = "Checks if the value of the field is `RAMP2`"]
+    #[inline(always)]
+    pub fn is_ramp2(&self) -> bool {
+        *self == RAMP_A::RAMP2
+    }
+    #[doc = "Checks if the value of the field is `RAMP2C`"]
+    #[inline(always)]
+    pub fn is_ramp2c(&self) -> bool {
+        *self == RAMP_A::RAMP2C
+    }
+}
+#[doc = "Write proxy for field `RAMP`"]
+pub struct RAMP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RAMP_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: RAMP_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "RAMP1 operation"]
+    #[inline(always)]
+    pub fn ramp1(self) -> &'a mut W {
+        self.variant(RAMP_A::RAMP1)
+    }
+    #[doc = "Alternative RAMP2 operation"]
+    #[inline(always)]
+    pub fn ramp2a(self) -> &'a mut W {
+        self.variant(RAMP_A::RAMP2A)
+    }
+    #[doc = "RAMP2 operation"]
+    #[inline(always)]
+    pub fn ramp2(self) -> &'a mut W {
+        self.variant(RAMP_A::RAMP2)
+    }
+    #[doc = "Critical RAMP2 operation"]
+    #[inline(always)]
+    pub fn ramp2c(self) -> &'a mut W {
+        self.variant(RAMP_A::RAMP2C)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 4)) | (((value as u32) & 0x03) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `CIPEREN`"]
+pub type CIPEREN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CIPEREN`"]
+pub struct CIPEREN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CIPEREN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `CICCEN0`"]
+pub type CICCEN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CICCEN0`"]
+pub struct CICCEN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CICCEN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `CICCEN1`"]
+pub type CICCEN1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CICCEN1`"]
+pub struct CICCEN1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CICCEN1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `CICCEN2`"]
+pub type CICCEN2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CICCEN2`"]
+pub struct CICCEN2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CICCEN2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u32) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `CICCEN3`"]
+pub type CICCEN3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CICCEN3`"]
+pub struct CICCEN3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CICCEN3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `POL0`"]
+pub type POL0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `POL0`"]
+pub struct POL0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> POL0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `POL1`"]
+pub type POL1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `POL1`"]
+pub struct POL1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> POL1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
+#[doc = "Reader of field `POL2`"]
+pub type POL2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `POL2`"]
+pub struct POL2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> POL2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 18)) | (((value as u32) & 0x01) << 18);
+        self.w
+    }
+}
+#[doc = "Reader of field `POL3`"]
+pub type POL3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `POL3`"]
+pub struct POL3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> POL3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 19)) | (((value as u32) & 0x01) << 19);
+        self.w
+    }
+}
+#[doc = "Reader of field `SWAP0`"]
+pub type SWAP0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWAP0`"]
+pub struct SWAP0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWAP0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 24)) | (((value as u32) & 0x01) << 24);
+        self.w
+    }
+}
+#[doc = "Reader of field `SWAP1`"]
+pub type SWAP1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWAP1`"]
+pub struct SWAP1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWAP1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 25)) | (((value as u32) & 0x01) << 25);
+        self.w
+    }
+}
+#[doc = "Reader of field `SWAP2`"]
+pub type SWAP2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWAP2`"]
+pub struct SWAP2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWAP2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 26)) | (((value as u32) & 0x01) << 26);
+        self.w
+    }
+}
+#[doc = "Reader of field `SWAP3`"]
+pub type SWAP3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWAP3`"]
+pub struct SWAP3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWAP3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 27)) | (((value as u32) & 0x01) << 27);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Waveform Generation"]
+    #[inline(always)]
+    pub fn wavegen(&self) -> WAVEGEN_R {
+        WAVEGEN_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bits 4:5 - Ramp Mode"]
+    #[inline(always)]
+    pub fn ramp(&self) -> RAMP_R {
+        RAMP_R::new(((self.bits >> 4) & 0x03) as u8)
+    }
+    #[doc = "Bit 7 - Circular period Enable"]
+    #[inline(always)]
+    pub fn ciperen(&self) -> CIPEREN_R {
+        CIPEREN_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Circular Channel 0 Enable"]
+    #[inline(always)]
+    pub fn ciccen0(&self) -> CICCEN0_R {
+        CICCEN0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Circular Channel 1 Enable"]
+    #[inline(always)]
+    pub fn ciccen1(&self) -> CICCEN1_R {
+        CICCEN1_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Circular Channel 2 Enable"]
+    #[inline(always)]
+    pub fn ciccen2(&self) -> CICCEN2_R {
+        CICCEN2_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Circular Channel 3 Enable"]
+    #[inline(always)]
+    pub fn ciccen3(&self) -> CICCEN3_R {
+        CICCEN3_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - Channel 0 Polarity"]
+    #[inline(always)]
+    pub fn pol0(&self) -> POL0_R {
+        POL0_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bit 17 - Channel 1 Polarity"]
+    #[inline(always)]
+    pub fn pol1(&self) -> POL1_R {
+        POL1_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+    #[doc = "Bit 18 - Channel 2 Polarity"]
+    #[inline(always)]
+    pub fn pol2(&self) -> POL2_R {
+        POL2_R::new(((self.bits >> 18) & 0x01) != 0)
+    }
+    #[doc = "Bit 19 - Channel 3 Polarity"]
+    #[inline(always)]
+    pub fn pol3(&self) -> POL3_R {
+        POL3_R::new(((self.bits >> 19) & 0x01) != 0)
+    }
+    #[doc = "Bit 24 - Swap DTI Output Pair 0"]
+    #[inline(always)]
+    pub fn swap0(&self) -> SWAP0_R {
+        SWAP0_R::new(((self.bits >> 24) & 0x01) != 0)
+    }
+    #[doc = "Bit 25 - Swap DTI Output Pair 1"]
+    #[inline(always)]
+    pub fn swap1(&self) -> SWAP1_R {
+        SWAP1_R::new(((self.bits >> 25) & 0x01) != 0)
+    }
+    #[doc = "Bit 26 - Swap DTI Output Pair 2"]
+    #[inline(always)]
+    pub fn swap2(&self) -> SWAP2_R {
+        SWAP2_R::new(((self.bits >> 26) & 0x01) != 0)
+    }
+    #[doc = "Bit 27 - Swap DTI Output Pair 3"]
+    #[inline(always)]
+    pub fn swap3(&self) -> SWAP3_R {
+        SWAP3_R::new(((self.bits >> 27) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Waveform Generation"]
+    #[inline(always)]
+    pub fn wavegen(&mut self) -> WAVEGEN_W {
+        WAVEGEN_W { w: self }
+    }
+    #[doc = "Bits 4:5 - Ramp Mode"]
+    #[inline(always)]
+    pub fn ramp(&mut self) -> RAMP_W {
+        RAMP_W { w: self }
+    }
+    #[doc = "Bit 7 - Circular period Enable"]
+    #[inline(always)]
+    pub fn ciperen(&mut self) -> CIPEREN_W {
+        CIPEREN_W { w: self }
+    }
+    #[doc = "Bit 8 - Circular Channel 0 Enable"]
+    #[inline(always)]
+    pub fn ciccen0(&mut self) -> CICCEN0_W {
+        CICCEN0_W { w: self }
+    }
+    #[doc = "Bit 9 - Circular Channel 1 Enable"]
+    #[inline(always)]
+    pub fn ciccen1(&mut self) -> CICCEN1_W {
+        CICCEN1_W { w: self }
+    }
+    #[doc = "Bit 10 - Circular Channel 2 Enable"]
+    #[inline(always)]
+    pub fn ciccen2(&mut self) -> CICCEN2_W {
+        CICCEN2_W { w: self }
+    }
+    #[doc = "Bit 11 - Circular Channel 3 Enable"]
+    #[inline(always)]
+    pub fn ciccen3(&mut self) -> CICCEN3_W {
+        CICCEN3_W { w: self }
+    }
+    #[doc = "Bit 16 - Channel 0 Polarity"]
+    #[inline(always)]
+    pub fn pol0(&mut self) -> POL0_W {
+        POL0_W { w: self }
+    }
+    #[doc = "Bit 17 - Channel 1 Polarity"]
+    #[inline(always)]
+    pub fn pol1(&mut self) -> POL1_W {
+        POL1_W { w: self }
+    }
+    #[doc = "Bit 18 - Channel 2 Polarity"]
+    #[inline(always)]
+    pub fn pol2(&mut self) -> POL2_W {
+        POL2_W { w: self }
+    }
+    #[doc = "Bit 19 - Channel 3 Polarity"]
+    #[inline(always)]
+    pub fn pol3(&mut self) -> POL3_W {
+        POL3_W { w: self }
+    }
+    #[doc = "Bit 24 - Swap DTI Output Pair 0"]
+    #[inline(always)]
+    pub fn swap0(&mut self) -> SWAP0_W {
+        SWAP0_W { w: self }
+    }
+    #[doc = "Bit 25 - Swap DTI Output Pair 1"]
+    #[inline(always)]
+    pub fn swap1(&mut self) -> SWAP1_W {
+        SWAP1_W { w: self }
+    }
+    #[doc = "Bit 26 - Swap DTI Output Pair 2"]
+    #[inline(always)]
+    pub fn swap2(&mut self) -> SWAP2_W {
+        SWAP2_W { w: self }
+    }
+    #[doc = "Bit 27 - Swap DTI Output Pair 3"]
+    #[inline(always)]
+    pub fn swap3(&mut self) -> SWAP3_W {
+        SWAP3_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/waveb.rs
+++ b/pac/atsamd11c14a/src/tcc0/waveb.rs
@@ -1,0 +1,698 @@
+#[doc = "Reader of register WAVEB"]
+pub type R = crate::R<u32, super::WAVEB>;
+#[doc = "Writer for register WAVEB"]
+pub type W = crate::W<u32, super::WAVEB>;
+#[doc = "Register WAVEB `reset()`'s with value 0"]
+impl crate::ResetValue for super::WAVEB {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Waveform Generation Buffer\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum WAVEGENB_A {
+    #[doc = "0: Normal frequency"]
+    NFRQ,
+    #[doc = "1: Match frequency"]
+    MFRQ,
+    #[doc = "2: Normal PWM"]
+    NPWM,
+    #[doc = "4: Dual-slope critical"]
+    DSCRITICAL,
+    #[doc = "5: Dual-slope with interrupt/event condition when COUNT reaches ZERO"]
+    DSBOTTOM,
+    #[doc = "6: Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP"]
+    DSBOTH,
+    #[doc = "7: Dual-slope with interrupt/event condition when COUNT reaches TOP"]
+    DSTOP,
+}
+impl From<WAVEGENB_A> for u8 {
+    #[inline(always)]
+    fn from(variant: WAVEGENB_A) -> Self {
+        match variant {
+            WAVEGENB_A::NFRQ => 0,
+            WAVEGENB_A::MFRQ => 1,
+            WAVEGENB_A::NPWM => 2,
+            WAVEGENB_A::DSCRITICAL => 4,
+            WAVEGENB_A::DSBOTTOM => 5,
+            WAVEGENB_A::DSBOTH => 6,
+            WAVEGENB_A::DSTOP => 7,
+        }
+    }
+}
+#[doc = "Reader of field `WAVEGENB`"]
+pub type WAVEGENB_R = crate::R<u8, WAVEGENB_A>;
+impl WAVEGENB_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, WAVEGENB_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(WAVEGENB_A::NFRQ),
+            1 => Val(WAVEGENB_A::MFRQ),
+            2 => Val(WAVEGENB_A::NPWM),
+            4 => Val(WAVEGENB_A::DSCRITICAL),
+            5 => Val(WAVEGENB_A::DSBOTTOM),
+            6 => Val(WAVEGENB_A::DSBOTH),
+            7 => Val(WAVEGENB_A::DSTOP),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NFRQ`"]
+    #[inline(always)]
+    pub fn is_nfrq(&self) -> bool {
+        *self == WAVEGENB_A::NFRQ
+    }
+    #[doc = "Checks if the value of the field is `MFRQ`"]
+    #[inline(always)]
+    pub fn is_mfrq(&self) -> bool {
+        *self == WAVEGENB_A::MFRQ
+    }
+    #[doc = "Checks if the value of the field is `NPWM`"]
+    #[inline(always)]
+    pub fn is_npwm(&self) -> bool {
+        *self == WAVEGENB_A::NPWM
+    }
+    #[doc = "Checks if the value of the field is `DSCRITICAL`"]
+    #[inline(always)]
+    pub fn is_dscritical(&self) -> bool {
+        *self == WAVEGENB_A::DSCRITICAL
+    }
+    #[doc = "Checks if the value of the field is `DSBOTTOM`"]
+    #[inline(always)]
+    pub fn is_dsbottom(&self) -> bool {
+        *self == WAVEGENB_A::DSBOTTOM
+    }
+    #[doc = "Checks if the value of the field is `DSBOTH`"]
+    #[inline(always)]
+    pub fn is_dsboth(&self) -> bool {
+        *self == WAVEGENB_A::DSBOTH
+    }
+    #[doc = "Checks if the value of the field is `DSTOP`"]
+    #[inline(always)]
+    pub fn is_dstop(&self) -> bool {
+        *self == WAVEGENB_A::DSTOP
+    }
+}
+#[doc = "Write proxy for field `WAVEGENB`"]
+pub struct WAVEGENB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAVEGENB_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: WAVEGENB_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Normal frequency"]
+    #[inline(always)]
+    pub fn nfrq(self) -> &'a mut W {
+        self.variant(WAVEGENB_A::NFRQ)
+    }
+    #[doc = "Match frequency"]
+    #[inline(always)]
+    pub fn mfrq(self) -> &'a mut W {
+        self.variant(WAVEGENB_A::MFRQ)
+    }
+    #[doc = "Normal PWM"]
+    #[inline(always)]
+    pub fn npwm(self) -> &'a mut W {
+        self.variant(WAVEGENB_A::NPWM)
+    }
+    #[doc = "Dual-slope critical"]
+    #[inline(always)]
+    pub fn dscritical(self) -> &'a mut W {
+        self.variant(WAVEGENB_A::DSCRITICAL)
+    }
+    #[doc = "Dual-slope with interrupt/event condition when COUNT reaches ZERO"]
+    #[inline(always)]
+    pub fn dsbottom(self) -> &'a mut W {
+        self.variant(WAVEGENB_A::DSBOTTOM)
+    }
+    #[doc = "Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP"]
+    #[inline(always)]
+    pub fn dsboth(self) -> &'a mut W {
+        self.variant(WAVEGENB_A::DSBOTH)
+    }
+    #[doc = "Dual-slope with interrupt/event condition when COUNT reaches TOP"]
+    #[inline(always)]
+    pub fn dstop(self) -> &'a mut W {
+        self.variant(WAVEGENB_A::DSTOP)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u32) & 0x07);
+        self.w
+    }
+}
+#[doc = "Ramp Mode Buffer\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum RAMPB_A {
+    #[doc = "0: RAMP1 operation"]
+    RAMP1,
+    #[doc = "1: Alternative RAMP2 operation"]
+    RAMP2A,
+    #[doc = "2: RAMP2 operation"]
+    RAMP2,
+}
+impl From<RAMPB_A> for u8 {
+    #[inline(always)]
+    fn from(variant: RAMPB_A) -> Self {
+        match variant {
+            RAMPB_A::RAMP1 => 0,
+            RAMPB_A::RAMP2A => 1,
+            RAMPB_A::RAMP2 => 2,
+        }
+    }
+}
+#[doc = "Reader of field `RAMPB`"]
+pub type RAMPB_R = crate::R<u8, RAMPB_A>;
+impl RAMPB_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, RAMPB_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(RAMPB_A::RAMP1),
+            1 => Val(RAMPB_A::RAMP2A),
+            2 => Val(RAMPB_A::RAMP2),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `RAMP1`"]
+    #[inline(always)]
+    pub fn is_ramp1(&self) -> bool {
+        *self == RAMPB_A::RAMP1
+    }
+    #[doc = "Checks if the value of the field is `RAMP2A`"]
+    #[inline(always)]
+    pub fn is_ramp2a(&self) -> bool {
+        *self == RAMPB_A::RAMP2A
+    }
+    #[doc = "Checks if the value of the field is `RAMP2`"]
+    #[inline(always)]
+    pub fn is_ramp2(&self) -> bool {
+        *self == RAMPB_A::RAMP2
+    }
+}
+#[doc = "Write proxy for field `RAMPB`"]
+pub struct RAMPB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RAMPB_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: RAMPB_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "RAMP1 operation"]
+    #[inline(always)]
+    pub fn ramp1(self) -> &'a mut W {
+        self.variant(RAMPB_A::RAMP1)
+    }
+    #[doc = "Alternative RAMP2 operation"]
+    #[inline(always)]
+    pub fn ramp2a(self) -> &'a mut W {
+        self.variant(RAMPB_A::RAMP2A)
+    }
+    #[doc = "RAMP2 operation"]
+    #[inline(always)]
+    pub fn ramp2(self) -> &'a mut W {
+        self.variant(RAMPB_A::RAMP2)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 4)) | (((value as u32) & 0x03) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `CIPERENB`"]
+pub type CIPERENB_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CIPERENB`"]
+pub struct CIPERENB_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CIPERENB_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u32) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `CICCENB0`"]
+pub type CICCENB0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CICCENB0`"]
+pub struct CICCENB0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CICCENB0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `CICCENB1`"]
+pub type CICCENB1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CICCENB1`"]
+pub struct CICCENB1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CICCENB1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `CICCENB2`"]
+pub type CICCENB2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CICCENB2`"]
+pub struct CICCENB2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CICCENB2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u32) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `CICCENB3`"]
+pub type CICCENB3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CICCENB3`"]
+pub struct CICCENB3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CICCENB3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `POLB0`"]
+pub type POLB0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `POLB0`"]
+pub struct POLB0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> POLB0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 16)) | (((value as u32) & 0x01) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `POLB1`"]
+pub type POLB1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `POLB1`"]
+pub struct POLB1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> POLB1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 17)) | (((value as u32) & 0x01) << 17);
+        self.w
+    }
+}
+#[doc = "Reader of field `POLB2`"]
+pub type POLB2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `POLB2`"]
+pub struct POLB2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> POLB2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 18)) | (((value as u32) & 0x01) << 18);
+        self.w
+    }
+}
+#[doc = "Reader of field `POLB3`"]
+pub type POLB3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `POLB3`"]
+pub struct POLB3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> POLB3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 19)) | (((value as u32) & 0x01) << 19);
+        self.w
+    }
+}
+#[doc = "Reader of field `SWAPB0`"]
+pub type SWAPB0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWAPB0`"]
+pub struct SWAPB0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWAPB0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 24)) | (((value as u32) & 0x01) << 24);
+        self.w
+    }
+}
+#[doc = "Reader of field `SWAPB1`"]
+pub type SWAPB1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWAPB1`"]
+pub struct SWAPB1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWAPB1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 25)) | (((value as u32) & 0x01) << 25);
+        self.w
+    }
+}
+#[doc = "Reader of field `SWAPB2`"]
+pub type SWAPB2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWAPB2`"]
+pub struct SWAPB2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWAPB2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 26)) | (((value as u32) & 0x01) << 26);
+        self.w
+    }
+}
+#[doc = "Reader of field `SWAPB3`"]
+pub type SWAPB3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWAPB3`"]
+pub struct SWAPB3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWAPB3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 27)) | (((value as u32) & 0x01) << 27);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Waveform Generation Buffer"]
+    #[inline(always)]
+    pub fn wavegenb(&self) -> WAVEGENB_R {
+        WAVEGENB_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bits 4:5 - Ramp Mode Buffer"]
+    #[inline(always)]
+    pub fn rampb(&self) -> RAMPB_R {
+        RAMPB_R::new(((self.bits >> 4) & 0x03) as u8)
+    }
+    #[doc = "Bit 7 - Circular Period Enable Buffer"]
+    #[inline(always)]
+    pub fn ciperenb(&self) -> CIPERENB_R {
+        CIPERENB_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Circular Channel 0 Enable Buffer"]
+    #[inline(always)]
+    pub fn ciccenb0(&self) -> CICCENB0_R {
+        CICCENB0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Circular Channel 1 Enable Buffer"]
+    #[inline(always)]
+    pub fn ciccenb1(&self) -> CICCENB1_R {
+        CICCENB1_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Circular Channel 2 Enable Buffer"]
+    #[inline(always)]
+    pub fn ciccenb2(&self) -> CICCENB2_R {
+        CICCENB2_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Circular Channel 3 Enable Buffer"]
+    #[inline(always)]
+    pub fn ciccenb3(&self) -> CICCENB3_R {
+        CICCENB3_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 16 - Channel 0 Polarity Buffer"]
+    #[inline(always)]
+    pub fn polb0(&self) -> POLB0_R {
+        POLB0_R::new(((self.bits >> 16) & 0x01) != 0)
+    }
+    #[doc = "Bit 17 - Channel 1 Polarity Buffer"]
+    #[inline(always)]
+    pub fn polb1(&self) -> POLB1_R {
+        POLB1_R::new(((self.bits >> 17) & 0x01) != 0)
+    }
+    #[doc = "Bit 18 - Channel 2 Polarity Buffer"]
+    #[inline(always)]
+    pub fn polb2(&self) -> POLB2_R {
+        POLB2_R::new(((self.bits >> 18) & 0x01) != 0)
+    }
+    #[doc = "Bit 19 - Channel 3 Polarity Buffer"]
+    #[inline(always)]
+    pub fn polb3(&self) -> POLB3_R {
+        POLB3_R::new(((self.bits >> 19) & 0x01) != 0)
+    }
+    #[doc = "Bit 24 - Swap DTI Output Pair 0 Buffer"]
+    #[inline(always)]
+    pub fn swapb0(&self) -> SWAPB0_R {
+        SWAPB0_R::new(((self.bits >> 24) & 0x01) != 0)
+    }
+    #[doc = "Bit 25 - Swap DTI Output Pair 1 Buffer"]
+    #[inline(always)]
+    pub fn swapb1(&self) -> SWAPB1_R {
+        SWAPB1_R::new(((self.bits >> 25) & 0x01) != 0)
+    }
+    #[doc = "Bit 26 - Swap DTI Output Pair 2 Buffer"]
+    #[inline(always)]
+    pub fn swapb2(&self) -> SWAPB2_R {
+        SWAPB2_R::new(((self.bits >> 26) & 0x01) != 0)
+    }
+    #[doc = "Bit 27 - Swap DTI Output Pair 3 Buffer"]
+    #[inline(always)]
+    pub fn swapb3(&self) -> SWAPB3_R {
+        SWAPB3_R::new(((self.bits >> 27) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Waveform Generation Buffer"]
+    #[inline(always)]
+    pub fn wavegenb(&mut self) -> WAVEGENB_W {
+        WAVEGENB_W { w: self }
+    }
+    #[doc = "Bits 4:5 - Ramp Mode Buffer"]
+    #[inline(always)]
+    pub fn rampb(&mut self) -> RAMPB_W {
+        RAMPB_W { w: self }
+    }
+    #[doc = "Bit 7 - Circular Period Enable Buffer"]
+    #[inline(always)]
+    pub fn ciperenb(&mut self) -> CIPERENB_W {
+        CIPERENB_W { w: self }
+    }
+    #[doc = "Bit 8 - Circular Channel 0 Enable Buffer"]
+    #[inline(always)]
+    pub fn ciccenb0(&mut self) -> CICCENB0_W {
+        CICCENB0_W { w: self }
+    }
+    #[doc = "Bit 9 - Circular Channel 1 Enable Buffer"]
+    #[inline(always)]
+    pub fn ciccenb1(&mut self) -> CICCENB1_W {
+        CICCENB1_W { w: self }
+    }
+    #[doc = "Bit 10 - Circular Channel 2 Enable Buffer"]
+    #[inline(always)]
+    pub fn ciccenb2(&mut self) -> CICCENB2_W {
+        CICCENB2_W { w: self }
+    }
+    #[doc = "Bit 11 - Circular Channel 3 Enable Buffer"]
+    #[inline(always)]
+    pub fn ciccenb3(&mut self) -> CICCENB3_W {
+        CICCENB3_W { w: self }
+    }
+    #[doc = "Bit 16 - Channel 0 Polarity Buffer"]
+    #[inline(always)]
+    pub fn polb0(&mut self) -> POLB0_W {
+        POLB0_W { w: self }
+    }
+    #[doc = "Bit 17 - Channel 1 Polarity Buffer"]
+    #[inline(always)]
+    pub fn polb1(&mut self) -> POLB1_W {
+        POLB1_W { w: self }
+    }
+    #[doc = "Bit 18 - Channel 2 Polarity Buffer"]
+    #[inline(always)]
+    pub fn polb2(&mut self) -> POLB2_W {
+        POLB2_W { w: self }
+    }
+    #[doc = "Bit 19 - Channel 3 Polarity Buffer"]
+    #[inline(always)]
+    pub fn polb3(&mut self) -> POLB3_W {
+        POLB3_W { w: self }
+    }
+    #[doc = "Bit 24 - Swap DTI Output Pair 0 Buffer"]
+    #[inline(always)]
+    pub fn swapb0(&mut self) -> SWAPB0_W {
+        SWAPB0_W { w: self }
+    }
+    #[doc = "Bit 25 - Swap DTI Output Pair 1 Buffer"]
+    #[inline(always)]
+    pub fn swapb1(&mut self) -> SWAPB1_W {
+        SWAPB1_W { w: self }
+    }
+    #[doc = "Bit 26 - Swap DTI Output Pair 2 Buffer"]
+    #[inline(always)]
+    pub fn swapb2(&mut self) -> SWAPB2_W {
+        SWAPB2_W { w: self }
+    }
+    #[doc = "Bit 27 - Swap DTI Output Pair 3 Buffer"]
+    #[inline(always)]
+    pub fn swapb3(&mut self) -> SWAPB3_W {
+        SWAPB3_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/tcc0/wexctrl.rs
+++ b/pac/atsamd11c14a/src/tcc0/wexctrl.rs
@@ -1,0 +1,224 @@
+#[doc = "Reader of register WEXCTRL"]
+pub type R = crate::R<u32, super::WEXCTRL>;
+#[doc = "Writer for register WEXCTRL"]
+pub type W = crate::W<u32, super::WEXCTRL>;
+#[doc = "Register WEXCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::WEXCTRL {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `OTMX`"]
+pub type OTMX_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `OTMX`"]
+pub struct OTMX_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OTMX_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x03) | ((value as u32) & 0x03);
+        self.w
+    }
+}
+#[doc = "Reader of field `DTIEN0`"]
+pub type DTIEN0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DTIEN0`"]
+pub struct DTIEN0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DTIEN0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u32) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `DTIEN1`"]
+pub type DTIEN1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DTIEN1`"]
+pub struct DTIEN1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DTIEN1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u32) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `DTIEN2`"]
+pub type DTIEN2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DTIEN2`"]
+pub struct DTIEN2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DTIEN2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u32) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `DTIEN3`"]
+pub type DTIEN3_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DTIEN3`"]
+pub struct DTIEN3_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DTIEN3_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u32) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `DTLS`"]
+pub type DTLS_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DTLS`"]
+pub struct DTLS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DTLS_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0xff << 16)) | (((value as u32) & 0xff) << 16);
+        self.w
+    }
+}
+#[doc = "Reader of field `DTHS`"]
+pub type DTHS_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DTHS`"]
+pub struct DTHS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DTHS_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0xff << 24)) | (((value as u32) & 0xff) << 24);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:1 - Output Matrix"]
+    #[inline(always)]
+    pub fn otmx(&self) -> OTMX_R {
+        OTMX_R::new((self.bits & 0x03) as u8)
+    }
+    #[doc = "Bit 8 - Dead-time Insertion Generator 0 Enable"]
+    #[inline(always)]
+    pub fn dtien0(&self) -> DTIEN0_R {
+        DTIEN0_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Dead-time Insertion Generator 1 Enable"]
+    #[inline(always)]
+    pub fn dtien1(&self) -> DTIEN1_R {
+        DTIEN1_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - Dead-time Insertion Generator 2 Enable"]
+    #[inline(always)]
+    pub fn dtien2(&self) -> DTIEN2_R {
+        DTIEN2_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - Dead-time Insertion Generator 3 Enable"]
+    #[inline(always)]
+    pub fn dtien3(&self) -> DTIEN3_R {
+        DTIEN3_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bits 16:23 - Dead-time Low Side Outputs Value"]
+    #[inline(always)]
+    pub fn dtls(&self) -> DTLS_R {
+        DTLS_R::new(((self.bits >> 16) & 0xff) as u8)
+    }
+    #[doc = "Bits 24:31 - Dead-time High Side Outputs Value"]
+    #[inline(always)]
+    pub fn dths(&self) -> DTHS_R {
+        DTHS_R::new(((self.bits >> 24) & 0xff) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:1 - Output Matrix"]
+    #[inline(always)]
+    pub fn otmx(&mut self) -> OTMX_W {
+        OTMX_W { w: self }
+    }
+    #[doc = "Bit 8 - Dead-time Insertion Generator 0 Enable"]
+    #[inline(always)]
+    pub fn dtien0(&mut self) -> DTIEN0_W {
+        DTIEN0_W { w: self }
+    }
+    #[doc = "Bit 9 - Dead-time Insertion Generator 1 Enable"]
+    #[inline(always)]
+    pub fn dtien1(&mut self) -> DTIEN1_W {
+        DTIEN1_W { w: self }
+    }
+    #[doc = "Bit 10 - Dead-time Insertion Generator 2 Enable"]
+    #[inline(always)]
+    pub fn dtien2(&mut self) -> DTIEN2_W {
+        DTIEN2_W { w: self }
+    }
+    #[doc = "Bit 11 - Dead-time Insertion Generator 3 Enable"]
+    #[inline(always)]
+    pub fn dtien3(&mut self) -> DTIEN3_W {
+        DTIEN3_W { w: self }
+    }
+    #[doc = "Bits 16:23 - Dead-time Low Side Outputs Value"]
+    #[inline(always)]
+    pub fn dtls(&mut self) -> DTLS_W {
+        DTLS_W { w: self }
+    }
+    #[doc = "Bits 24:31 - Dead-time High Side Outputs Value"]
+    #[inline(always)]
+    pub fn dths(&mut self) -> DTHS_W {
+        DTHS_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb.rs
+++ b/pac/atsamd11c14a/src/usb.rs
@@ -1,0 +1,178 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - USB is Device"]
+    pub device: DEVICE,
+}
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct DEVICE {
+    #[doc = "0x00 - Control A"]
+    pub ctrla: self::device::CTRLA,
+    _reserved1: [u8; 1usize],
+    #[doc = "0x02 - Synchronization Busy"]
+    pub syncbusy: self::device::SYNCBUSY,
+    #[doc = "0x03 - USB Quality Of Service"]
+    pub qosctrl: self::device::QOSCTRL,
+    _reserved3: [u8; 4usize],
+    #[doc = "0x08 - DEVICE Control B"]
+    pub ctrlb: self::device::CTRLB,
+    #[doc = "0x0a - DEVICE Device Address"]
+    pub dadd: self::device::DADD,
+    _reserved5: [u8; 1usize],
+    #[doc = "0x0c - DEVICE Status"]
+    pub status: self::device::STATUS,
+    #[doc = "0x0d - Finite State Machine Status"]
+    pub fsmstatus: self::device::FSMSTATUS,
+    _reserved7: [u8; 2usize],
+    #[doc = "0x10 - DEVICE Device Frame Number"]
+    pub fnum: self::device::FNUM,
+    _reserved8: [u8; 2usize],
+    #[doc = "0x14 - DEVICE Device Interrupt Enable Clear"]
+    pub intenclr: self::device::INTENCLR,
+    _reserved9: [u8; 2usize],
+    #[doc = "0x18 - DEVICE Device Interrupt Enable Set"]
+    pub intenset: self::device::INTENSET,
+    _reserved10: [u8; 2usize],
+    #[doc = "0x1c - DEVICE Device Interrupt Flag"]
+    pub intflag: self::device::INTFLAG,
+    _reserved11: [u8; 2usize],
+    #[doc = "0x20 - DEVICE End Point Interrupt Summary"]
+    pub epintsmry: self::device::EPINTSMRY,
+    _reserved12: [u8; 2usize],
+    #[doc = "0x24 - Descriptor Address"]
+    pub descadd: self::device::DESCADD,
+    #[doc = "0x28 - USB PAD Calibration"]
+    pub padcal: self::device::PADCAL,
+    _reserved14: [u8; 214usize],
+    #[doc = "0x100 - DEVICE End Point Configuration"]
+    pub epcfg0: self::device::EPCFG,
+    _reserved15: [u8; 3usize],
+    #[doc = "0x104 - DEVICE End Point Pipe Status Clear"]
+    pub epstatusclr0: self::device::EPSTATUSCLR,
+    #[doc = "0x105 - DEVICE End Point Pipe Status Set"]
+    pub epstatusset0: self::device::EPSTATUSSET,
+    #[doc = "0x106 - DEVICE End Point Pipe Status"]
+    pub epstatus0: self::device::EPSTATUS,
+    #[doc = "0x107 - DEVICE End Point Interrupt Flag"]
+    pub epintflag0: self::device::EPINTFLAG,
+    #[doc = "0x108 - DEVICE End Point Interrupt Clear Flag"]
+    pub epintenclr0: self::device::EPINTENCLR,
+    #[doc = "0x109 - DEVICE End Point Interrupt Set Flag"]
+    pub epintenset0: self::device::EPINTENSET,
+    _reserved21: [u8; 22usize],
+    #[doc = "0x120 - DEVICE End Point Configuration"]
+    pub epcfg1: self::device::EPCFG,
+    _reserved22: [u8; 3usize],
+    #[doc = "0x124 - DEVICE End Point Pipe Status Clear"]
+    pub epstatusclr1: self::device::EPSTATUSCLR,
+    #[doc = "0x125 - DEVICE End Point Pipe Status Set"]
+    pub epstatusset1: self::device::EPSTATUSSET,
+    #[doc = "0x126 - DEVICE End Point Pipe Status"]
+    pub epstatus1: self::device::EPSTATUS,
+    #[doc = "0x127 - DEVICE End Point Interrupt Flag"]
+    pub epintflag1: self::device::EPINTFLAG,
+    #[doc = "0x128 - DEVICE End Point Interrupt Clear Flag"]
+    pub epintenclr1: self::device::EPINTENCLR,
+    #[doc = "0x129 - DEVICE End Point Interrupt Set Flag"]
+    pub epintenset1: self::device::EPINTENSET,
+    _reserved28: [u8; 22usize],
+    #[doc = "0x140 - DEVICE End Point Configuration"]
+    pub epcfg2: self::device::EPCFG,
+    _reserved29: [u8; 3usize],
+    #[doc = "0x144 - DEVICE End Point Pipe Status Clear"]
+    pub epstatusclr2: self::device::EPSTATUSCLR,
+    #[doc = "0x145 - DEVICE End Point Pipe Status Set"]
+    pub epstatusset2: self::device::EPSTATUSSET,
+    #[doc = "0x146 - DEVICE End Point Pipe Status"]
+    pub epstatus2: self::device::EPSTATUS,
+    #[doc = "0x147 - DEVICE End Point Interrupt Flag"]
+    pub epintflag2: self::device::EPINTFLAG,
+    #[doc = "0x148 - DEVICE End Point Interrupt Clear Flag"]
+    pub epintenclr2: self::device::EPINTENCLR,
+    #[doc = "0x149 - DEVICE End Point Interrupt Set Flag"]
+    pub epintenset2: self::device::EPINTENSET,
+    _reserved35: [u8; 22usize],
+    #[doc = "0x160 - DEVICE End Point Configuration"]
+    pub epcfg3: self::device::EPCFG,
+    _reserved36: [u8; 3usize],
+    #[doc = "0x164 - DEVICE End Point Pipe Status Clear"]
+    pub epstatusclr3: self::device::EPSTATUSCLR,
+    #[doc = "0x165 - DEVICE End Point Pipe Status Set"]
+    pub epstatusset3: self::device::EPSTATUSSET,
+    #[doc = "0x166 - DEVICE End Point Pipe Status"]
+    pub epstatus3: self::device::EPSTATUS,
+    #[doc = "0x167 - DEVICE End Point Interrupt Flag"]
+    pub epintflag3: self::device::EPINTFLAG,
+    #[doc = "0x168 - DEVICE End Point Interrupt Clear Flag"]
+    pub epintenclr3: self::device::EPINTENCLR,
+    #[doc = "0x169 - DEVICE End Point Interrupt Set Flag"]
+    pub epintenset3: self::device::EPINTENSET,
+    _reserved42: [u8; 22usize],
+    #[doc = "0x180 - DEVICE End Point Configuration"]
+    pub epcfg4: self::device::EPCFG,
+    _reserved43: [u8; 3usize],
+    #[doc = "0x184 - DEVICE End Point Pipe Status Clear"]
+    pub epstatusclr4: self::device::EPSTATUSCLR,
+    #[doc = "0x185 - DEVICE End Point Pipe Status Set"]
+    pub epstatusset4: self::device::EPSTATUSSET,
+    #[doc = "0x186 - DEVICE End Point Pipe Status"]
+    pub epstatus4: self::device::EPSTATUS,
+    #[doc = "0x187 - DEVICE End Point Interrupt Flag"]
+    pub epintflag4: self::device::EPINTFLAG,
+    #[doc = "0x188 - DEVICE End Point Interrupt Clear Flag"]
+    pub epintenclr4: self::device::EPINTENCLR,
+    #[doc = "0x189 - DEVICE End Point Interrupt Set Flag"]
+    pub epintenset4: self::device::EPINTENSET,
+    _reserved49: [u8; 22usize],
+    #[doc = "0x1a0 - DEVICE End Point Configuration"]
+    pub epcfg5: self::device::EPCFG,
+    _reserved50: [u8; 3usize],
+    #[doc = "0x1a4 - DEVICE End Point Pipe Status Clear"]
+    pub epstatusclr5: self::device::EPSTATUSCLR,
+    #[doc = "0x1a5 - DEVICE End Point Pipe Status Set"]
+    pub epstatusset5: self::device::EPSTATUSSET,
+    #[doc = "0x1a6 - DEVICE End Point Pipe Status"]
+    pub epstatus5: self::device::EPSTATUS,
+    #[doc = "0x1a7 - DEVICE End Point Interrupt Flag"]
+    pub epintflag5: self::device::EPINTFLAG,
+    #[doc = "0x1a8 - DEVICE End Point Interrupt Clear Flag"]
+    pub epintenclr5: self::device::EPINTENCLR,
+    #[doc = "0x1a9 - DEVICE End Point Interrupt Set Flag"]
+    pub epintenset5: self::device::EPINTENSET,
+    _reserved56: [u8; 22usize],
+    #[doc = "0x1c0 - DEVICE End Point Configuration"]
+    pub epcfg6: self::device::EPCFG,
+    _reserved57: [u8; 3usize],
+    #[doc = "0x1c4 - DEVICE End Point Pipe Status Clear"]
+    pub epstatusclr6: self::device::EPSTATUSCLR,
+    #[doc = "0x1c5 - DEVICE End Point Pipe Status Set"]
+    pub epstatusset6: self::device::EPSTATUSSET,
+    #[doc = "0x1c6 - DEVICE End Point Pipe Status"]
+    pub epstatus6: self::device::EPSTATUS,
+    #[doc = "0x1c7 - DEVICE End Point Interrupt Flag"]
+    pub epintflag6: self::device::EPINTFLAG,
+    #[doc = "0x1c8 - DEVICE End Point Interrupt Clear Flag"]
+    pub epintenclr6: self::device::EPINTENCLR,
+    #[doc = "0x1c9 - DEVICE End Point Interrupt Set Flag"]
+    pub epintenset6: self::device::EPINTENSET,
+    _reserved63: [u8; 22usize],
+    #[doc = "0x1e0 - DEVICE End Point Configuration"]
+    pub epcfg7: self::device::EPCFG,
+    _reserved64: [u8; 3usize],
+    #[doc = "0x1e4 - DEVICE End Point Pipe Status Clear"]
+    pub epstatusclr7: self::device::EPSTATUSCLR,
+    #[doc = "0x1e5 - DEVICE End Point Pipe Status Set"]
+    pub epstatusset7: self::device::EPSTATUSSET,
+    #[doc = "0x1e6 - DEVICE End Point Pipe Status"]
+    pub epstatus7: self::device::EPSTATUS,
+    #[doc = "0x1e7 - DEVICE End Point Interrupt Flag"]
+    pub epintflag7: self::device::EPINTFLAG,
+    #[doc = "0x1e8 - DEVICE End Point Interrupt Clear Flag"]
+    pub epintenclr7: self::device::EPINTENCLR,
+    #[doc = "0x1e9 - DEVICE End Point Interrupt Set Flag"]
+    pub epintenset7: self::device::EPINTENSET,
+}
+#[doc = r"Register block"]
+#[doc = "USB is Device"]
+pub mod device;

--- a/pac/atsamd11c14a/src/usb/device.rs
+++ b/pac/atsamd11c14a/src/usb/device.rs
@@ -1,0 +1,215 @@
+#[doc = "Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrla](ctrla) module"]
+pub type CTRLA = crate::Reg<u8, _CTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLA;
+#[doc = "`read()` method returns [ctrla::R](ctrla::R) reader structure"]
+impl crate::Readable for CTRLA {}
+#[doc = "`write(|w| ..)` method takes [ctrla::W](ctrla::W) writer structure"]
+impl crate::Writable for CTRLA {}
+#[doc = "Control A"]
+pub mod ctrla;
+#[doc = "Synchronization Busy\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [syncbusy](syncbusy) module"]
+pub type SYNCBUSY = crate::Reg<u8, _SYNCBUSY>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _SYNCBUSY;
+#[doc = "`read()` method returns [syncbusy::R](syncbusy::R) reader structure"]
+impl crate::Readable for SYNCBUSY {}
+#[doc = "Synchronization Busy"]
+pub mod syncbusy;
+#[doc = "USB Quality Of Service\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [qosctrl](qosctrl) module"]
+pub type QOSCTRL = crate::Reg<u8, _QOSCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _QOSCTRL;
+#[doc = "`read()` method returns [qosctrl::R](qosctrl::R) reader structure"]
+impl crate::Readable for QOSCTRL {}
+#[doc = "`write(|w| ..)` method takes [qosctrl::W](qosctrl::W) writer structure"]
+impl crate::Writable for QOSCTRL {}
+#[doc = "USB Quality Of Service"]
+pub mod qosctrl;
+#[doc = "DEVICE Control B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrlb](ctrlb) module"]
+pub type CTRLB = crate::Reg<u16, _CTRLB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLB;
+#[doc = "`read()` method returns [ctrlb::R](ctrlb::R) reader structure"]
+impl crate::Readable for CTRLB {}
+#[doc = "`write(|w| ..)` method takes [ctrlb::W](ctrlb::W) writer structure"]
+impl crate::Writable for CTRLB {}
+#[doc = "DEVICE Control B"]
+pub mod ctrlb;
+#[doc = "DEVICE Device Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [dadd](dadd) module"]
+pub type DADD = crate::Reg<u8, _DADD>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DADD;
+#[doc = "`read()` method returns [dadd::R](dadd::R) reader structure"]
+impl crate::Readable for DADD {}
+#[doc = "`write(|w| ..)` method takes [dadd::W](dadd::W) writer structure"]
+impl crate::Writable for DADD {}
+#[doc = "DEVICE Device Address"]
+pub mod dadd;
+#[doc = "DEVICE Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u8, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "DEVICE Status"]
+pub mod status;
+#[doc = "Finite State Machine Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fsmstatus](fsmstatus) module"]
+pub type FSMSTATUS = crate::Reg<u8, _FSMSTATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _FSMSTATUS;
+#[doc = "`read()` method returns [fsmstatus::R](fsmstatus::R) reader structure"]
+impl crate::Readable for FSMSTATUS {}
+#[doc = "Finite State Machine Status"]
+pub mod fsmstatus;
+#[doc = "DEVICE Device Frame Number\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [fnum](fnum) module"]
+pub type FNUM = crate::Reg<u16, _FNUM>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _FNUM;
+#[doc = "`read()` method returns [fnum::R](fnum::R) reader structure"]
+impl crate::Readable for FNUM {}
+#[doc = "DEVICE Device Frame Number"]
+pub mod fnum;
+#[doc = "DEVICE Device Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u16, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "DEVICE Device Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "DEVICE Device Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u16, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "DEVICE Device Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "DEVICE Device Interrupt Flag\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u16, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "DEVICE Device Interrupt Flag"]
+pub mod intflag;
+#[doc = "DEVICE End Point Interrupt Summary\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epintsmry](epintsmry) module"]
+pub type EPINTSMRY = crate::Reg<u16, _EPINTSMRY>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EPINTSMRY;
+#[doc = "`read()` method returns [epintsmry::R](epintsmry::R) reader structure"]
+impl crate::Readable for EPINTSMRY {}
+#[doc = "DEVICE End Point Interrupt Summary"]
+pub mod epintsmry;
+#[doc = "Descriptor Address\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [descadd](descadd) module"]
+pub type DESCADD = crate::Reg<u32, _DESCADD>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _DESCADD;
+#[doc = "`read()` method returns [descadd::R](descadd::R) reader structure"]
+impl crate::Readable for DESCADD {}
+#[doc = "`write(|w| ..)` method takes [descadd::W](descadd::W) writer structure"]
+impl crate::Writable for DESCADD {}
+#[doc = "Descriptor Address"]
+pub mod descadd;
+#[doc = "USB PAD Calibration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [padcal](padcal) module"]
+pub type PADCAL = crate::Reg<u16, _PADCAL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _PADCAL;
+#[doc = "`read()` method returns [padcal::R](padcal::R) reader structure"]
+impl crate::Readable for PADCAL {}
+#[doc = "`write(|w| ..)` method takes [padcal::W](padcal::W) writer structure"]
+impl crate::Writable for PADCAL {}
+#[doc = "USB PAD Calibration"]
+pub mod padcal;
+#[doc = "DEVICE End Point Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epcfg](epcfg) module"]
+pub type EPCFG = crate::Reg<u8, _EPCFG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EPCFG;
+#[doc = "`read()` method returns [epcfg::R](epcfg::R) reader structure"]
+impl crate::Readable for EPCFG {}
+#[doc = "`write(|w| ..)` method takes [epcfg::W](epcfg::W) writer structure"]
+impl crate::Writable for EPCFG {}
+#[doc = "DEVICE End Point Configuration"]
+pub mod epcfg;
+#[doc = "DEVICE End Point Pipe Status Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epstatusclr](epstatusclr) module"]
+pub type EPSTATUSCLR = crate::Reg<u8, _EPSTATUSCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EPSTATUSCLR;
+#[doc = "`write(|w| ..)` method takes [epstatusclr::W](epstatusclr::W) writer structure"]
+impl crate::Writable for EPSTATUSCLR {}
+#[doc = "DEVICE End Point Pipe Status Clear"]
+pub mod epstatusclr;
+#[doc = "DEVICE End Point Pipe Status Set\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epstatusset](epstatusset) module"]
+pub type EPSTATUSSET = crate::Reg<u8, _EPSTATUSSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EPSTATUSSET;
+#[doc = "`write(|w| ..)` method takes [epstatusset::W](epstatusset::W) writer structure"]
+impl crate::Writable for EPSTATUSSET {}
+#[doc = "DEVICE End Point Pipe Status Set"]
+pub mod epstatusset;
+#[doc = "DEVICE End Point Pipe Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epstatus](epstatus) module"]
+pub type EPSTATUS = crate::Reg<u8, _EPSTATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EPSTATUS;
+#[doc = "`read()` method returns [epstatus::R](epstatus::R) reader structure"]
+impl crate::Readable for EPSTATUS {}
+#[doc = "DEVICE End Point Pipe Status"]
+pub mod epstatus;
+#[doc = "DEVICE End Point Interrupt Flag\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epintflag](epintflag) module"]
+pub type EPINTFLAG = crate::Reg<u8, _EPINTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EPINTFLAG;
+#[doc = "`read()` method returns [epintflag::R](epintflag::R) reader structure"]
+impl crate::Readable for EPINTFLAG {}
+#[doc = "`write(|w| ..)` method takes [epintflag::W](epintflag::W) writer structure"]
+impl crate::Writable for EPINTFLAG {}
+#[doc = "DEVICE End Point Interrupt Flag"]
+pub mod epintflag;
+#[doc = "DEVICE End Point Interrupt Clear Flag\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epintenclr](epintenclr) module"]
+pub type EPINTENCLR = crate::Reg<u8, _EPINTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EPINTENCLR;
+#[doc = "`read()` method returns [epintenclr::R](epintenclr::R) reader structure"]
+impl crate::Readable for EPINTENCLR {}
+#[doc = "`write(|w| ..)` method takes [epintenclr::W](epintenclr::W) writer structure"]
+impl crate::Writable for EPINTENCLR {}
+#[doc = "DEVICE End Point Interrupt Clear Flag"]
+pub mod epintenclr;
+#[doc = "DEVICE End Point Interrupt Set Flag\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [epintenset](epintenset) module"]
+pub type EPINTENSET = crate::Reg<u8, _EPINTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EPINTENSET;
+#[doc = "`read()` method returns [epintenset::R](epintenset::R) reader structure"]
+impl crate::Readable for EPINTENSET {}
+#[doc = "`write(|w| ..)` method takes [epintenset::W](epintenset::W) writer structure"]
+impl crate::Writable for EPINTENSET {}
+#[doc = "DEVICE End Point Interrupt Set Flag"]
+pub mod epintenset;

--- a/pac/atsamd11c14a/src/usb/device/ctrla.rs
+++ b/pac/atsamd11c14a/src/usb/device/ctrla.rs
@@ -1,0 +1,194 @@
+#[doc = "Reader of register CTRLA"]
+pub type R = crate::R<u8, super::CTRLA>;
+#[doc = "Writer for register CTRLA"]
+pub type W = crate::W<u8, super::CTRLA>;
+#[doc = "Register CTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLA {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Operating Mode\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum MODE_A {
+    #[doc = "0: Device Mode"]
+    DEVICE,
+}
+impl From<MODE_A> for bool {
+    #[inline(always)]
+    fn from(variant: MODE_A) -> Self {
+        match variant {
+            MODE_A::DEVICE => false,
+        }
+    }
+}
+#[doc = "Reader of field `MODE`"]
+pub type MODE_R = crate::R<bool, MODE_A>;
+impl MODE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<bool, MODE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            false => Val(MODE_A::DEVICE),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `DEVICE`"]
+    #[inline(always)]
+    pub fn is_device(&self) -> bool {
+        *self == MODE_A::DEVICE
+    }
+}
+#[doc = "Write proxy for field `MODE`"]
+pub struct MODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MODE_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: MODE_A) -> &'a mut W {
+        {
+            self.bit(variant.into())
+        }
+    }
+    #[doc = "Device Mode"]
+    #[inline(always)]
+    pub fn device(self) -> &'a mut W {
+        self.variant(MODE_A::DEVICE)
+    }
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Run in Standby Mode"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bit 2 - Run in Standby Mode"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+    #[doc = "Bit 7 - Operating Mode"]
+    #[inline(always)]
+    pub fn mode(&mut self) -> MODE_W {
+        MODE_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/ctrlb.rs
+++ b/pac/atsamd11c14a/src/usb/device/ctrlb.rs
@@ -1,0 +1,502 @@
+#[doc = "Reader of register CTRLB"]
+pub type R = crate::R<u16, super::CTRLB>;
+#[doc = "Writer for register CTRLB"]
+pub type W = crate::W<u16, super::CTRLB>;
+#[doc = "Register CTRLB `reset()`'s with value 0x01"]
+impl crate::ResetValue for super::CTRLB {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x01
+    }
+}
+#[doc = "Reader of field `DETACH`"]
+pub type DETACH_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `DETACH`"]
+pub struct DETACH_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DETACH_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `UPRSM`"]
+pub type UPRSM_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `UPRSM`"]
+pub struct UPRSM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> UPRSM_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Speed Configuration\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SPDCONF_A {
+    #[doc = "0: FS : Full Speed"]
+    FS,
+    #[doc = "1: LS : Low Speed"]
+    LS,
+    #[doc = "2: HS : High Speed capable"]
+    HS,
+    #[doc = "3: HSTM: High Speed Test Mode (force high-speed mode for test mode)"]
+    HSTM,
+}
+impl From<SPDCONF_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SPDCONF_A) -> Self {
+        match variant {
+            SPDCONF_A::FS => 0,
+            SPDCONF_A::LS => 1,
+            SPDCONF_A::HS => 2,
+            SPDCONF_A::HSTM => 3,
+        }
+    }
+}
+#[doc = "Reader of field `SPDCONF`"]
+pub type SPDCONF_R = crate::R<u8, SPDCONF_A>;
+impl SPDCONF_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> SPDCONF_A {
+        match self.bits {
+            0 => SPDCONF_A::FS,
+            1 => SPDCONF_A::LS,
+            2 => SPDCONF_A::HS,
+            3 => SPDCONF_A::HSTM,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `FS`"]
+    #[inline(always)]
+    pub fn is_fs(&self) -> bool {
+        *self == SPDCONF_A::FS
+    }
+    #[doc = "Checks if the value of the field is `LS`"]
+    #[inline(always)]
+    pub fn is_ls(&self) -> bool {
+        *self == SPDCONF_A::LS
+    }
+    #[doc = "Checks if the value of the field is `HS`"]
+    #[inline(always)]
+    pub fn is_hs(&self) -> bool {
+        *self == SPDCONF_A::HS
+    }
+    #[doc = "Checks if the value of the field is `HSTM`"]
+    #[inline(always)]
+    pub fn is_hstm(&self) -> bool {
+        *self == SPDCONF_A::HSTM
+    }
+}
+#[doc = "Write proxy for field `SPDCONF`"]
+pub struct SPDCONF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SPDCONF_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SPDCONF_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "FS : Full Speed"]
+    #[inline(always)]
+    pub fn fs(self) -> &'a mut W {
+        self.variant(SPDCONF_A::FS)
+    }
+    #[doc = "LS : Low Speed"]
+    #[inline(always)]
+    pub fn ls(self) -> &'a mut W {
+        self.variant(SPDCONF_A::LS)
+    }
+    #[doc = "HS : High Speed capable"]
+    #[inline(always)]
+    pub fn hs(self) -> &'a mut W {
+        self.variant(SPDCONF_A::HS)
+    }
+    #[doc = "HSTM: High Speed Test Mode (force high-speed mode for test mode)"]
+    #[inline(always)]
+    pub fn hstm(self) -> &'a mut W {
+        self.variant(SPDCONF_A::HSTM)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 2)) | (((value as u16) & 0x03) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `NREPLY`"]
+pub type NREPLY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NREPLY`"]
+pub struct NREPLY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NREPLY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `TSTJ`"]
+pub type TSTJ_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TSTJ`"]
+pub struct TSTJ_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TSTJ_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `TSTK`"]
+pub type TSTK_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TSTK`"]
+pub struct TSTK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TSTK_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `TSTPCKT`"]
+pub type TSTPCKT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TSTPCKT`"]
+pub struct TSTPCKT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TSTPCKT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `OPMODE2`"]
+pub type OPMODE2_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `OPMODE2`"]
+pub struct OPMODE2_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> OPMODE2_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `GNAK`"]
+pub type GNAK_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `GNAK`"]
+pub struct GNAK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> GNAK_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u16) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Link Power Management Handshake\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LPMHDSK_A {
+    #[doc = "0: No handshake. LPM is not supported"]
+    NO,
+    #[doc = "1: ACK"]
+    ACK,
+    #[doc = "2: NYET"]
+    NYET,
+    #[doc = "3: STALL"]
+    STALL,
+}
+impl From<LPMHDSK_A> for u8 {
+    #[inline(always)]
+    fn from(variant: LPMHDSK_A) -> Self {
+        match variant {
+            LPMHDSK_A::NO => 0,
+            LPMHDSK_A::ACK => 1,
+            LPMHDSK_A::NYET => 2,
+            LPMHDSK_A::STALL => 3,
+        }
+    }
+}
+#[doc = "Reader of field `LPMHDSK`"]
+pub type LPMHDSK_R = crate::R<u8, LPMHDSK_A>;
+impl LPMHDSK_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> LPMHDSK_A {
+        match self.bits {
+            0 => LPMHDSK_A::NO,
+            1 => LPMHDSK_A::ACK,
+            2 => LPMHDSK_A::NYET,
+            3 => LPMHDSK_A::STALL,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `NO`"]
+    #[inline(always)]
+    pub fn is_no(&self) -> bool {
+        *self == LPMHDSK_A::NO
+    }
+    #[doc = "Checks if the value of the field is `ACK`"]
+    #[inline(always)]
+    pub fn is_ack(&self) -> bool {
+        *self == LPMHDSK_A::ACK
+    }
+    #[doc = "Checks if the value of the field is `NYET`"]
+    #[inline(always)]
+    pub fn is_nyet(&self) -> bool {
+        *self == LPMHDSK_A::NYET
+    }
+    #[doc = "Checks if the value of the field is `STALL`"]
+    #[inline(always)]
+    pub fn is_stall(&self) -> bool {
+        *self == LPMHDSK_A::STALL
+    }
+}
+#[doc = "Write proxy for field `LPMHDSK`"]
+pub struct LPMHDSK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LPMHDSK_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: LPMHDSK_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "No handshake. LPM is not supported"]
+    #[inline(always)]
+    pub fn no(self) -> &'a mut W {
+        self.variant(LPMHDSK_A::NO)
+    }
+    #[doc = "ACK"]
+    #[inline(always)]
+    pub fn ack(self) -> &'a mut W {
+        self.variant(LPMHDSK_A::ACK)
+    }
+    #[doc = "NYET"]
+    #[inline(always)]
+    pub fn nyet(self) -> &'a mut W {
+        self.variant(LPMHDSK_A::NYET)
+    }
+    #[doc = "STALL"]
+    #[inline(always)]
+    pub fn stall(self) -> &'a mut W {
+        self.variant(LPMHDSK_A::STALL)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 10)) | (((value as u16) & 0x03) << 10);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Detach"]
+    #[inline(always)]
+    pub fn detach(&self) -> DETACH_R {
+        DETACH_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Upstream Resume"]
+    #[inline(always)]
+    pub fn uprsm(&self) -> UPRSM_R {
+        UPRSM_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bits 2:3 - Speed Configuration"]
+    #[inline(always)]
+    pub fn spdconf(&self) -> SPDCONF_R {
+        SPDCONF_R::new(((self.bits >> 2) & 0x03) as u8)
+    }
+    #[doc = "Bit 4 - No Reply"]
+    #[inline(always)]
+    pub fn nreply(&self) -> NREPLY_R {
+        NREPLY_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Test mode J"]
+    #[inline(always)]
+    pub fn tstj(&self) -> TSTJ_R {
+        TSTJ_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Test mode K"]
+    #[inline(always)]
+    pub fn tstk(&self) -> TSTK_R {
+        TSTK_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Test packet mode"]
+    #[inline(always)]
+    pub fn tstpckt(&self) -> TSTPCKT_R {
+        TSTPCKT_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Specific Operational Mode"]
+    #[inline(always)]
+    pub fn opmode2(&self) -> OPMODE2_R {
+        OPMODE2_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Global NAK"]
+    #[inline(always)]
+    pub fn gnak(&self) -> GNAK_R {
+        GNAK_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bits 10:11 - Link Power Management Handshake"]
+    #[inline(always)]
+    pub fn lpmhdsk(&self) -> LPMHDSK_R {
+        LPMHDSK_R::new(((self.bits >> 10) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Detach"]
+    #[inline(always)]
+    pub fn detach(&mut self) -> DETACH_W {
+        DETACH_W { w: self }
+    }
+    #[doc = "Bit 1 - Upstream Resume"]
+    #[inline(always)]
+    pub fn uprsm(&mut self) -> UPRSM_W {
+        UPRSM_W { w: self }
+    }
+    #[doc = "Bits 2:3 - Speed Configuration"]
+    #[inline(always)]
+    pub fn spdconf(&mut self) -> SPDCONF_W {
+        SPDCONF_W { w: self }
+    }
+    #[doc = "Bit 4 - No Reply"]
+    #[inline(always)]
+    pub fn nreply(&mut self) -> NREPLY_W {
+        NREPLY_W { w: self }
+    }
+    #[doc = "Bit 5 - Test mode J"]
+    #[inline(always)]
+    pub fn tstj(&mut self) -> TSTJ_W {
+        TSTJ_W { w: self }
+    }
+    #[doc = "Bit 6 - Test mode K"]
+    #[inline(always)]
+    pub fn tstk(&mut self) -> TSTK_W {
+        TSTK_W { w: self }
+    }
+    #[doc = "Bit 7 - Test packet mode"]
+    #[inline(always)]
+    pub fn tstpckt(&mut self) -> TSTPCKT_W {
+        TSTPCKT_W { w: self }
+    }
+    #[doc = "Bit 8 - Specific Operational Mode"]
+    #[inline(always)]
+    pub fn opmode2(&mut self) -> OPMODE2_W {
+        OPMODE2_W { w: self }
+    }
+    #[doc = "Bit 9 - Global NAK"]
+    #[inline(always)]
+    pub fn gnak(&mut self) -> GNAK_W {
+        GNAK_W { w: self }
+    }
+    #[doc = "Bits 10:11 - Link Power Management Handshake"]
+    #[inline(always)]
+    pub fn lpmhdsk(&mut self) -> LPMHDSK_W {
+        LPMHDSK_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/dadd.rs
+++ b/pac/atsamd11c14a/src/usb/device/dadd.rs
@@ -1,0 +1,74 @@
+#[doc = "Reader of register DADD"]
+pub type R = crate::R<u8, super::DADD>;
+#[doc = "Writer for register DADD"]
+pub type W = crate::W<u8, super::DADD>;
+#[doc = "Register DADD `reset()`'s with value 0"]
+impl crate::ResetValue for super::DADD {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DADD`"]
+pub type DADD_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DADD`"]
+pub struct DADD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DADD_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x7f) | ((value as u8) & 0x7f);
+        self.w
+    }
+}
+#[doc = "Reader of field `ADDEN`"]
+pub type ADDEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ADDEN`"]
+pub struct ADDEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ADDEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:6 - Device Address"]
+    #[inline(always)]
+    pub fn dadd(&self) -> DADD_R {
+        DADD_R::new((self.bits & 0x7f) as u8)
+    }
+    #[doc = "Bit 7 - Device Address Enable"]
+    #[inline(always)]
+    pub fn adden(&self) -> ADDEN_R {
+        ADDEN_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:6 - Device Address"]
+    #[inline(always)]
+    pub fn dadd(&mut self) -> DADD_W {
+        DADD_W { w: self }
+    }
+    #[doc = "Bit 7 - Device Address Enable"]
+    #[inline(always)]
+    pub fn adden(&mut self) -> ADDEN_W {
+        ADDEN_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/descadd.rs
+++ b/pac/atsamd11c14a/src/usb/device/descadd.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register DESCADD"]
+pub type R = crate::R<u32, super::DESCADD>;
+#[doc = "Writer for register DESCADD"]
+pub type W = crate::W<u32, super::DESCADD>;
+#[doc = "Register DESCADD `reset()`'s with value 0"]
+impl crate::ResetValue for super::DESCADD {
+    type Type = u32;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `DESCADD`"]
+pub type DESCADD_R = crate::R<u32, u32>;
+#[doc = "Write proxy for field `DESCADD`"]
+pub struct DESCADD_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DESCADD_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u32) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff_ffff) | ((value as u32) & 0xffff_ffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:31 - Descriptor Address Value"]
+    #[inline(always)]
+    pub fn descadd(&self) -> DESCADD_R {
+        DESCADD_R::new((self.bits & 0xffff_ffff) as u32)
+    }
+}
+impl W {
+    #[doc = "Bits 0:31 - Descriptor Address Value"]
+    #[inline(always)]
+    pub fn descadd(&mut self) -> DESCADD_W {
+        DESCADD_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/epcfg.rs
+++ b/pac/atsamd11c14a/src/usb/device/epcfg.rs
@@ -1,0 +1,98 @@
+#[doc = "Reader of register EPCFG%s"]
+pub type R = crate::R<u8, super::EPCFG>;
+#[doc = "Writer for register EPCFG%s"]
+pub type W = crate::W<u8, super::EPCFG>;
+#[doc = "Register EPCFG%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::EPCFG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `EPTYPE0`"]
+pub type EPTYPE0_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `EPTYPE0`"]
+pub struct EPTYPE0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EPTYPE0_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u8) & 0x07);
+        self.w
+    }
+}
+#[doc = "Reader of field `EPTYPE1`"]
+pub type EPTYPE1_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `EPTYPE1`"]
+pub struct EPTYPE1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EPTYPE1_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 4)) | (((value as u8) & 0x07) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `NYETDIS`"]
+pub type NYETDIS_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `NYETDIS`"]
+pub struct NYETDIS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> NYETDIS_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - End Point Type0"]
+    #[inline(always)]
+    pub fn eptype0(&self) -> EPTYPE0_R {
+        EPTYPE0_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bits 4:6 - End Point Type1"]
+    #[inline(always)]
+    pub fn eptype1(&self) -> EPTYPE1_R {
+        EPTYPE1_R::new(((self.bits >> 4) & 0x07) as u8)
+    }
+    #[doc = "Bit 7 - NYET Token Disable"]
+    #[inline(always)]
+    pub fn nyetdis(&self) -> NYETDIS_R {
+        NYETDIS_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - End Point Type0"]
+    #[inline(always)]
+    pub fn eptype0(&mut self) -> EPTYPE0_W {
+        EPTYPE0_W { w: self }
+    }
+    #[doc = "Bits 4:6 - End Point Type1"]
+    #[inline(always)]
+    pub fn eptype1(&mut self) -> EPTYPE1_W {
+        EPTYPE1_W { w: self }
+    }
+    #[doc = "Bit 7 - NYET Token Disable"]
+    #[inline(always)]
+    pub fn nyetdis(&mut self) -> NYETDIS_W {
+        NYETDIS_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/epintenclr.rs
+++ b/pac/atsamd11c14a/src/usb/device/epintenclr.rs
@@ -1,0 +1,254 @@
+#[doc = "Reader of register EPINTENCLR%s"]
+pub type R = crate::R<u8, super::EPINTENCLR>;
+#[doc = "Writer for register EPINTENCLR%s"]
+pub type W = crate::W<u8, super::EPINTENCLR>;
+#[doc = "Register EPINTENCLR%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::EPINTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `TRCPT0`"]
+pub type TRCPT0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRCPT0`"]
+pub struct TRCPT0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRCPT0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `TRCPT1`"]
+pub type TRCPT1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRCPT1`"]
+pub struct TRCPT1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRCPT1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `TRFAIL0`"]
+pub type TRFAIL0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRFAIL0`"]
+pub struct TRFAIL0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRFAIL0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `TRFAIL1`"]
+pub type TRFAIL1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRFAIL1`"]
+pub struct TRFAIL1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRFAIL1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXSTP`"]
+pub type RXSTP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RXSTP`"]
+pub struct RXSTP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXSTP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `STALL0`"]
+pub type STALL0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `STALL0`"]
+pub struct STALL0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STALL0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `STALL1`"]
+pub type STALL1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `STALL1`"]
+pub struct STALL1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STALL1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Transfer Complete 0 Interrupt Disable"]
+    #[inline(always)]
+    pub fn trcpt0(&self) -> TRCPT0_R {
+        TRCPT0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Transfer Complete 1 Interrupt Disable"]
+    #[inline(always)]
+    pub fn trcpt1(&self) -> TRCPT1_R {
+        TRCPT1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Error Flow 0 Interrupt Disable"]
+    #[inline(always)]
+    pub fn trfail0(&self) -> TRFAIL0_R {
+        TRFAIL0_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Error Flow 1 Interrupt Disable"]
+    #[inline(always)]
+    pub fn trfail1(&self) -> TRFAIL1_R {
+        TRFAIL1_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Received Setup Interrupt Disable"]
+    #[inline(always)]
+    pub fn rxstp(&self) -> RXSTP_R {
+        RXSTP_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Stall 0 In/Out Interrupt Disable"]
+    #[inline(always)]
+    pub fn stall0(&self) -> STALL0_R {
+        STALL0_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Stall 1 In/Out Interrupt Disable"]
+    #[inline(always)]
+    pub fn stall1(&self) -> STALL1_R {
+        STALL1_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Transfer Complete 0 Interrupt Disable"]
+    #[inline(always)]
+    pub fn trcpt0(&mut self) -> TRCPT0_W {
+        TRCPT0_W { w: self }
+    }
+    #[doc = "Bit 1 - Transfer Complete 1 Interrupt Disable"]
+    #[inline(always)]
+    pub fn trcpt1(&mut self) -> TRCPT1_W {
+        TRCPT1_W { w: self }
+    }
+    #[doc = "Bit 2 - Error Flow 0 Interrupt Disable"]
+    #[inline(always)]
+    pub fn trfail0(&mut self) -> TRFAIL0_W {
+        TRFAIL0_W { w: self }
+    }
+    #[doc = "Bit 3 - Error Flow 1 Interrupt Disable"]
+    #[inline(always)]
+    pub fn trfail1(&mut self) -> TRFAIL1_W {
+        TRFAIL1_W { w: self }
+    }
+    #[doc = "Bit 4 - Received Setup Interrupt Disable"]
+    #[inline(always)]
+    pub fn rxstp(&mut self) -> RXSTP_W {
+        RXSTP_W { w: self }
+    }
+    #[doc = "Bit 5 - Stall 0 In/Out Interrupt Disable"]
+    #[inline(always)]
+    pub fn stall0(&mut self) -> STALL0_W {
+        STALL0_W { w: self }
+    }
+    #[doc = "Bit 6 - Stall 1 In/Out Interrupt Disable"]
+    #[inline(always)]
+    pub fn stall1(&mut self) -> STALL1_W {
+        STALL1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/epintenset.rs
+++ b/pac/atsamd11c14a/src/usb/device/epintenset.rs
@@ -1,0 +1,254 @@
+#[doc = "Reader of register EPINTENSET%s"]
+pub type R = crate::R<u8, super::EPINTENSET>;
+#[doc = "Writer for register EPINTENSET%s"]
+pub type W = crate::W<u8, super::EPINTENSET>;
+#[doc = "Register EPINTENSET%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::EPINTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `TRCPT0`"]
+pub type TRCPT0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRCPT0`"]
+pub struct TRCPT0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRCPT0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `TRCPT1`"]
+pub type TRCPT1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRCPT1`"]
+pub struct TRCPT1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRCPT1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `TRFAIL0`"]
+pub type TRFAIL0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRFAIL0`"]
+pub struct TRFAIL0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRFAIL0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `TRFAIL1`"]
+pub type TRFAIL1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRFAIL1`"]
+pub struct TRFAIL1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRFAIL1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXSTP`"]
+pub type RXSTP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RXSTP`"]
+pub struct RXSTP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXSTP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `STALL0`"]
+pub type STALL0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `STALL0`"]
+pub struct STALL0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STALL0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `STALL1`"]
+pub type STALL1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `STALL1`"]
+pub struct STALL1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STALL1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Transfer Complete 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn trcpt0(&self) -> TRCPT0_R {
+        TRCPT0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Transfer Complete 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn trcpt1(&self) -> TRCPT1_R {
+        TRCPT1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Error Flow 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn trfail0(&self) -> TRFAIL0_R {
+        TRFAIL0_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Error Flow 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn trfail1(&self) -> TRFAIL1_R {
+        TRFAIL1_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Received Setup Interrupt Enable"]
+    #[inline(always)]
+    pub fn rxstp(&self) -> RXSTP_R {
+        RXSTP_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Stall 0 In/out Interrupt enable"]
+    #[inline(always)]
+    pub fn stall0(&self) -> STALL0_R {
+        STALL0_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Stall 1 In/out Interrupt enable"]
+    #[inline(always)]
+    pub fn stall1(&self) -> STALL1_R {
+        STALL1_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Transfer Complete 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn trcpt0(&mut self) -> TRCPT0_W {
+        TRCPT0_W { w: self }
+    }
+    #[doc = "Bit 1 - Transfer Complete 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn trcpt1(&mut self) -> TRCPT1_W {
+        TRCPT1_W { w: self }
+    }
+    #[doc = "Bit 2 - Error Flow 0 Interrupt Enable"]
+    #[inline(always)]
+    pub fn trfail0(&mut self) -> TRFAIL0_W {
+        TRFAIL0_W { w: self }
+    }
+    #[doc = "Bit 3 - Error Flow 1 Interrupt Enable"]
+    #[inline(always)]
+    pub fn trfail1(&mut self) -> TRFAIL1_W {
+        TRFAIL1_W { w: self }
+    }
+    #[doc = "Bit 4 - Received Setup Interrupt Enable"]
+    #[inline(always)]
+    pub fn rxstp(&mut self) -> RXSTP_W {
+        RXSTP_W { w: self }
+    }
+    #[doc = "Bit 5 - Stall 0 In/out Interrupt enable"]
+    #[inline(always)]
+    pub fn stall0(&mut self) -> STALL0_W {
+        STALL0_W { w: self }
+    }
+    #[doc = "Bit 6 - Stall 1 In/out Interrupt enable"]
+    #[inline(always)]
+    pub fn stall1(&mut self) -> STALL1_W {
+        STALL1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/epintflag.rs
+++ b/pac/atsamd11c14a/src/usb/device/epintflag.rs
@@ -1,0 +1,254 @@
+#[doc = "Reader of register EPINTFLAG%s"]
+pub type R = crate::R<u8, super::EPINTFLAG>;
+#[doc = "Writer for register EPINTFLAG%s"]
+pub type W = crate::W<u8, super::EPINTFLAG>;
+#[doc = "Register EPINTFLAG%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::EPINTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `TRCPT0`"]
+pub type TRCPT0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRCPT0`"]
+pub struct TRCPT0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRCPT0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `TRCPT1`"]
+pub type TRCPT1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRCPT1`"]
+pub struct TRCPT1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRCPT1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `TRFAIL0`"]
+pub type TRFAIL0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRFAIL0`"]
+pub struct TRFAIL0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRFAIL0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `TRFAIL1`"]
+pub type TRFAIL1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `TRFAIL1`"]
+pub struct TRFAIL1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRFAIL1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u8) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `RXSTP`"]
+pub type RXSTP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RXSTP`"]
+pub struct RXSTP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RXSTP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `STALL0`"]
+pub type STALL0_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `STALL0`"]
+pub struct STALL0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STALL0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `STALL1`"]
+pub type STALL1_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `STALL1`"]
+pub struct STALL1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STALL1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Transfer Complete 0"]
+    #[inline(always)]
+    pub fn trcpt0(&self) -> TRCPT0_R {
+        TRCPT0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Transfer Complete 1"]
+    #[inline(always)]
+    pub fn trcpt1(&self) -> TRCPT1_R {
+        TRCPT1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Error Flow 0"]
+    #[inline(always)]
+    pub fn trfail0(&self) -> TRFAIL0_R {
+        TRFAIL0_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - Error Flow 1"]
+    #[inline(always)]
+    pub fn trfail1(&self) -> TRFAIL1_R {
+        TRFAIL1_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Received Setup"]
+    #[inline(always)]
+    pub fn rxstp(&self) -> RXSTP_R {
+        RXSTP_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Stall 0 In/out"]
+    #[inline(always)]
+    pub fn stall0(&self) -> STALL0_R {
+        STALL0_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Stall 1 In/out"]
+    #[inline(always)]
+    pub fn stall1(&self) -> STALL1_R {
+        STALL1_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Transfer Complete 0"]
+    #[inline(always)]
+    pub fn trcpt0(&mut self) -> TRCPT0_W {
+        TRCPT0_W { w: self }
+    }
+    #[doc = "Bit 1 - Transfer Complete 1"]
+    #[inline(always)]
+    pub fn trcpt1(&mut self) -> TRCPT1_W {
+        TRCPT1_W { w: self }
+    }
+    #[doc = "Bit 2 - Error Flow 0"]
+    #[inline(always)]
+    pub fn trfail0(&mut self) -> TRFAIL0_W {
+        TRFAIL0_W { w: self }
+    }
+    #[doc = "Bit 3 - Error Flow 1"]
+    #[inline(always)]
+    pub fn trfail1(&mut self) -> TRFAIL1_W {
+        TRFAIL1_W { w: self }
+    }
+    #[doc = "Bit 4 - Received Setup"]
+    #[inline(always)]
+    pub fn rxstp(&mut self) -> RXSTP_W {
+        RXSTP_W { w: self }
+    }
+    #[doc = "Bit 5 - Stall 0 In/out"]
+    #[inline(always)]
+    pub fn stall0(&mut self) -> STALL0_W {
+        STALL0_W { w: self }
+    }
+    #[doc = "Bit 6 - Stall 1 In/out"]
+    #[inline(always)]
+    pub fn stall1(&mut self) -> STALL1_W {
+        STALL1_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/epintsmry.rs
+++ b/pac/atsamd11c14a/src/usb/device/epintsmry.rs
@@ -1,0 +1,60 @@
+#[doc = "Reader of register EPINTSMRY"]
+pub type R = crate::R<u16, super::EPINTSMRY>;
+#[doc = "Reader of field `EPINT0`"]
+pub type EPINT0_R = crate::R<bool, bool>;
+#[doc = "Reader of field `EPINT1`"]
+pub type EPINT1_R = crate::R<bool, bool>;
+#[doc = "Reader of field `EPINT2`"]
+pub type EPINT2_R = crate::R<bool, bool>;
+#[doc = "Reader of field `EPINT3`"]
+pub type EPINT3_R = crate::R<bool, bool>;
+#[doc = "Reader of field `EPINT4`"]
+pub type EPINT4_R = crate::R<bool, bool>;
+#[doc = "Reader of field `EPINT5`"]
+pub type EPINT5_R = crate::R<bool, bool>;
+#[doc = "Reader of field `EPINT6`"]
+pub type EPINT6_R = crate::R<bool, bool>;
+#[doc = "Reader of field `EPINT7`"]
+pub type EPINT7_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - End Point 0 Interrupt"]
+    #[inline(always)]
+    pub fn epint0(&self) -> EPINT0_R {
+        EPINT0_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - End Point 1 Interrupt"]
+    #[inline(always)]
+    pub fn epint1(&self) -> EPINT1_R {
+        EPINT1_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - End Point 2 Interrupt"]
+    #[inline(always)]
+    pub fn epint2(&self) -> EPINT2_R {
+        EPINT2_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - End Point 3 Interrupt"]
+    #[inline(always)]
+    pub fn epint3(&self) -> EPINT3_R {
+        EPINT3_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - End Point 4 Interrupt"]
+    #[inline(always)]
+    pub fn epint4(&self) -> EPINT4_R {
+        EPINT4_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - End Point 5 Interrupt"]
+    #[inline(always)]
+    pub fn epint5(&self) -> EPINT5_R {
+        EPINT5_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - End Point 6 Interrupt"]
+    #[inline(always)]
+    pub fn epint6(&self) -> EPINT6_R {
+        EPINT6_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - End Point 7 Interrupt"]
+    #[inline(always)]
+    pub fn epint7(&self) -> EPINT7_R {
+        EPINT7_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/epstatus.rs
+++ b/pac/atsamd11c14a/src/usb/device/epstatus.rs
@@ -1,0 +1,53 @@
+#[doc = "Reader of register EPSTATUS%s"]
+pub type R = crate::R<u8, super::EPSTATUS>;
+#[doc = "Reader of field `DTGLOUT`"]
+pub type DTGLOUT_R = crate::R<bool, bool>;
+#[doc = "Reader of field `DTGLIN`"]
+pub type DTGLIN_R = crate::R<bool, bool>;
+#[doc = "Reader of field `CURBK`"]
+pub type CURBK_R = crate::R<bool, bool>;
+#[doc = "Reader of field `STALLRQ0`"]
+pub type STALLRQ0_R = crate::R<bool, bool>;
+#[doc = "Reader of field `STALLRQ1`"]
+pub type STALLRQ1_R = crate::R<bool, bool>;
+#[doc = "Reader of field `BK0RDY`"]
+pub type BK0RDY_R = crate::R<bool, bool>;
+#[doc = "Reader of field `BK1RDY`"]
+pub type BK1RDY_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Data Toggle Out"]
+    #[inline(always)]
+    pub fn dtglout(&self) -> DTGLOUT_R {
+        DTGLOUT_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Data Toggle In"]
+    #[inline(always)]
+    pub fn dtglin(&self) -> DTGLIN_R {
+        DTGLIN_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Current Bank"]
+    #[inline(always)]
+    pub fn curbk(&self) -> CURBK_R {
+        CURBK_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Stall 0 Request"]
+    #[inline(always)]
+    pub fn stallrq0(&self) -> STALLRQ0_R {
+        STALLRQ0_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - Stall 1 Request"]
+    #[inline(always)]
+    pub fn stallrq1(&self) -> STALLRQ1_R {
+        STALLRQ1_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Bank 0 ready"]
+    #[inline(always)]
+    pub fn bk0rdy(&self) -> BK0RDY_R {
+        BK0RDY_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Bank 1 ready"]
+    #[inline(always)]
+    pub fn bk1rdy(&self) -> BK1RDY_R {
+        BK1RDY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/epstatusclr.rs
+++ b/pac/atsamd11c14a/src/usb/device/epstatusclr.rs
@@ -1,0 +1,201 @@
+#[doc = "Writer for register EPSTATUSCLR%s"]
+pub type W = crate::W<u8, super::EPSTATUSCLR>;
+#[doc = "Register EPSTATUSCLR%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::EPSTATUSCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Write proxy for field `DTGLOUT`"]
+pub struct DTGLOUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DTGLOUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `DTGLIN`"]
+pub struct DTGLIN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DTGLIN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `CURBK`"]
+pub struct CURBK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CURBK_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `STALLRQ0`"]
+pub struct STALLRQ0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STALLRQ0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `STALLRQ1`"]
+pub struct STALLRQ1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STALLRQ1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `BK0RDY`"]
+pub struct BK0RDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BK0RDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `BK1RDY`"]
+pub struct BK1RDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BK1RDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Data Toggle OUT Clear"]
+    #[inline(always)]
+    pub fn dtglout(&mut self) -> DTGLOUT_W {
+        DTGLOUT_W { w: self }
+    }
+    #[doc = "Bit 1 - Data Toggle IN Clear"]
+    #[inline(always)]
+    pub fn dtglin(&mut self) -> DTGLIN_W {
+        DTGLIN_W { w: self }
+    }
+    #[doc = "Bit 2 - Current Bank Clear"]
+    #[inline(always)]
+    pub fn curbk(&mut self) -> CURBK_W {
+        CURBK_W { w: self }
+    }
+    #[doc = "Bit 4 - Stall 0 Request Clear"]
+    #[inline(always)]
+    pub fn stallrq0(&mut self) -> STALLRQ0_W {
+        STALLRQ0_W { w: self }
+    }
+    #[doc = "Bit 5 - Stall 1 Request Clear"]
+    #[inline(always)]
+    pub fn stallrq1(&mut self) -> STALLRQ1_W {
+        STALLRQ1_W { w: self }
+    }
+    #[doc = "Bit 6 - Bank 0 Ready Clear"]
+    #[inline(always)]
+    pub fn bk0rdy(&mut self) -> BK0RDY_W {
+        BK0RDY_W { w: self }
+    }
+    #[doc = "Bit 7 - Bank 1 Ready Clear"]
+    #[inline(always)]
+    pub fn bk1rdy(&mut self) -> BK1RDY_W {
+        BK1RDY_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/epstatusset.rs
+++ b/pac/atsamd11c14a/src/usb/device/epstatusset.rs
@@ -1,0 +1,201 @@
+#[doc = "Writer for register EPSTATUSSET%s"]
+pub type W = crate::W<u8, super::EPSTATUSSET>;
+#[doc = "Register EPSTATUSSET%s `reset()`'s with value 0"]
+impl crate::ResetValue for super::EPSTATUSSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Write proxy for field `DTGLOUT`"]
+pub struct DTGLOUT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DTGLOUT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `DTGLIN`"]
+pub struct DTGLIN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DTGLIN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `CURBK`"]
+pub struct CURBK_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CURBK_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `STALLRQ0`"]
+pub struct STALLRQ0_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STALLRQ0_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `STALLRQ1`"]
+pub struct STALLRQ1_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> STALLRQ1_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u8) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `BK0RDY`"]
+pub struct BK0RDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BK0RDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u8) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Write proxy for field `BK1RDY`"]
+pub struct BK1RDY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BK1RDY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Data Toggle OUT Set"]
+    #[inline(always)]
+    pub fn dtglout(&mut self) -> DTGLOUT_W {
+        DTGLOUT_W { w: self }
+    }
+    #[doc = "Bit 1 - Data Toggle IN Set"]
+    #[inline(always)]
+    pub fn dtglin(&mut self) -> DTGLIN_W {
+        DTGLIN_W { w: self }
+    }
+    #[doc = "Bit 2 - Current Bank Set"]
+    #[inline(always)]
+    pub fn curbk(&mut self) -> CURBK_W {
+        CURBK_W { w: self }
+    }
+    #[doc = "Bit 4 - Stall 0 Request Set"]
+    #[inline(always)]
+    pub fn stallrq0(&mut self) -> STALLRQ0_W {
+        STALLRQ0_W { w: self }
+    }
+    #[doc = "Bit 5 - Stall 1 Request Set"]
+    #[inline(always)]
+    pub fn stallrq1(&mut self) -> STALLRQ1_W {
+        STALLRQ1_W { w: self }
+    }
+    #[doc = "Bit 6 - Bank 0 Ready Set"]
+    #[inline(always)]
+    pub fn bk0rdy(&mut self) -> BK0RDY_W {
+        BK0RDY_W { w: self }
+    }
+    #[doc = "Bit 7 - Bank 1 Ready Set"]
+    #[inline(always)]
+    pub fn bk1rdy(&mut self) -> BK1RDY_W {
+        BK1RDY_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/fnum.rs
+++ b/pac/atsamd11c14a/src/usb/device/fnum.rs
@@ -1,0 +1,25 @@
+#[doc = "Reader of register FNUM"]
+pub type R = crate::R<u16, super::FNUM>;
+#[doc = "Reader of field `MFNUM`"]
+pub type MFNUM_R = crate::R<u8, u8>;
+#[doc = "Reader of field `FNUM`"]
+pub type FNUM_R = crate::R<u16, u16>;
+#[doc = "Reader of field `FNCERR`"]
+pub type FNCERR_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bits 0:2 - Micro Frame Number"]
+    #[inline(always)]
+    pub fn mfnum(&self) -> MFNUM_R {
+        MFNUM_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bits 3:13 - Frame Number"]
+    #[inline(always)]
+    pub fn fnum(&self) -> FNUM_R {
+        FNUM_R::new(((self.bits >> 3) & 0x07ff) as u16)
+    }
+    #[doc = "Bit 15 - Frame Number CRC Error"]
+    #[inline(always)]
+    pub fn fncerr(&self) -> FNCERR_R {
+        FNCERR_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/fsmstatus.rs
+++ b/pac/atsamd11c14a/src/usb/device/fsmstatus.rs
@@ -1,0 +1,95 @@
+#[doc = "Reader of register FSMSTATUS"]
+pub type R = crate::R<u8, super::FSMSTATUS>;
+#[doc = "Fine State Machine Status\n\nValue on reset: 1"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum FSMSTATE_A {
+    #[doc = "1: OFF (L3). It corresponds to the powered-off, disconnected, and disabled state"]
+    OFF,
+    #[doc = "2: ON (L0). It corresponds to the Idle and Active states"]
+    ON,
+    #[doc = "4: SUSPEND (L2)"]
+    SUSPEND,
+    #[doc = "8: SLEEP (L1)"]
+    SLEEP,
+    #[doc = "16: DNRESUME. Down Stream Resume."]
+    DNRESUME,
+    #[doc = "32: UPRESUME. Up Stream Resume."]
+    UPRESUME,
+    #[doc = "64: RESET. USB lines Reset."]
+    RESET,
+}
+impl From<FSMSTATE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: FSMSTATE_A) -> Self {
+        match variant {
+            FSMSTATE_A::OFF => 1,
+            FSMSTATE_A::ON => 2,
+            FSMSTATE_A::SUSPEND => 4,
+            FSMSTATE_A::SLEEP => 8,
+            FSMSTATE_A::DNRESUME => 16,
+            FSMSTATE_A::UPRESUME => 32,
+            FSMSTATE_A::RESET => 64,
+        }
+    }
+}
+#[doc = "Reader of field `FSMSTATE`"]
+pub type FSMSTATE_R = crate::R<u8, FSMSTATE_A>;
+impl FSMSTATE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, FSMSTATE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            1 => Val(FSMSTATE_A::OFF),
+            2 => Val(FSMSTATE_A::ON),
+            4 => Val(FSMSTATE_A::SUSPEND),
+            8 => Val(FSMSTATE_A::SLEEP),
+            16 => Val(FSMSTATE_A::DNRESUME),
+            32 => Val(FSMSTATE_A::UPRESUME),
+            64 => Val(FSMSTATE_A::RESET),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `OFF`"]
+    #[inline(always)]
+    pub fn is_off(&self) -> bool {
+        *self == FSMSTATE_A::OFF
+    }
+    #[doc = "Checks if the value of the field is `ON`"]
+    #[inline(always)]
+    pub fn is_on(&self) -> bool {
+        *self == FSMSTATE_A::ON
+    }
+    #[doc = "Checks if the value of the field is `SUSPEND`"]
+    #[inline(always)]
+    pub fn is_suspend(&self) -> bool {
+        *self == FSMSTATE_A::SUSPEND
+    }
+    #[doc = "Checks if the value of the field is `SLEEP`"]
+    #[inline(always)]
+    pub fn is_sleep(&self) -> bool {
+        *self == FSMSTATE_A::SLEEP
+    }
+    #[doc = "Checks if the value of the field is `DNRESUME`"]
+    #[inline(always)]
+    pub fn is_dnresume(&self) -> bool {
+        *self == FSMSTATE_A::DNRESUME
+    }
+    #[doc = "Checks if the value of the field is `UPRESUME`"]
+    #[inline(always)]
+    pub fn is_upresume(&self) -> bool {
+        *self == FSMSTATE_A::UPRESUME
+    }
+    #[doc = "Checks if the value of the field is `RESET`"]
+    #[inline(always)]
+    pub fn is_reset(&self) -> bool {
+        *self == FSMSTATE_A::RESET
+    }
+}
+impl R {
+    #[doc = "Bits 0:5 - Fine State Machine Status"]
+    #[inline(always)]
+    pub fn fsmstate(&self) -> FSMSTATE_R {
+        FSMSTATE_R::new((self.bits & 0x3f) as u8)
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/intenclr.rs
+++ b/pac/atsamd11c14a/src/usb/device/intenclr.rs
@@ -1,0 +1,356 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u16, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u16, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SUSPEND`"]
+pub type SUSPEND_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SUSPEND`"]
+pub struct SUSPEND_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SUSPEND_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `MSOF`"]
+pub type MSOF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MSOF`"]
+pub struct MSOF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MSOF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SOF`"]
+pub type SOF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SOF`"]
+pub struct SOF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SOF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `EORST`"]
+pub type EORST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EORST`"]
+pub struct EORST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EORST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u16) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `WAKEUP`"]
+pub type WAKEUP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WAKEUP`"]
+pub struct WAKEUP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAKEUP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `EORSM`"]
+pub type EORSM_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EORSM`"]
+pub struct EORSM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EORSM_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `UPRSM`"]
+pub type UPRSM_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `UPRSM`"]
+pub struct UPRSM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> UPRSM_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `RAMACER`"]
+pub type RAMACER_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RAMACER`"]
+pub struct RAMACER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RAMACER_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `LPMNYET`"]
+pub type LPMNYET_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LPMNYET`"]
+pub struct LPMNYET_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LPMNYET_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `LPMSUSP`"]
+pub type LPMSUSP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LPMSUSP`"]
+pub struct LPMSUSP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LPMSUSP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u16) & 0x01) << 9);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Suspend Interrupt Enable"]
+    #[inline(always)]
+    pub fn suspend(&self) -> SUSPEND_R {
+        SUSPEND_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Micro Start of Frame Interrupt Enable in High Speed Mode"]
+    #[inline(always)]
+    pub fn msof(&self) -> MSOF_R {
+        MSOF_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Start Of Frame Interrupt Enable"]
+    #[inline(always)]
+    pub fn sof(&self) -> SOF_R {
+        SOF_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - End of Reset Interrupt Enable"]
+    #[inline(always)]
+    pub fn eorst(&self) -> EORST_R {
+        EORST_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Wake Up Interrupt Enable"]
+    #[inline(always)]
+    pub fn wakeup(&self) -> WAKEUP_R {
+        WAKEUP_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - End Of Resume Interrupt Enable"]
+    #[inline(always)]
+    pub fn eorsm(&self) -> EORSM_R {
+        EORSM_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Upstream Resume Interrupt Enable"]
+    #[inline(always)]
+    pub fn uprsm(&self) -> UPRSM_R {
+        UPRSM_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Ram Access Interrupt Enable"]
+    #[inline(always)]
+    pub fn ramacer(&self) -> RAMACER_R {
+        RAMACER_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Link Power Management Not Yet Interrupt Enable"]
+    #[inline(always)]
+    pub fn lpmnyet(&self) -> LPMNYET_R {
+        LPMNYET_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Link Power Management Suspend Interrupt Enable"]
+    #[inline(always)]
+    pub fn lpmsusp(&self) -> LPMSUSP_R {
+        LPMSUSP_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Suspend Interrupt Enable"]
+    #[inline(always)]
+    pub fn suspend(&mut self) -> SUSPEND_W {
+        SUSPEND_W { w: self }
+    }
+    #[doc = "Bit 1 - Micro Start of Frame Interrupt Enable in High Speed Mode"]
+    #[inline(always)]
+    pub fn msof(&mut self) -> MSOF_W {
+        MSOF_W { w: self }
+    }
+    #[doc = "Bit 2 - Start Of Frame Interrupt Enable"]
+    #[inline(always)]
+    pub fn sof(&mut self) -> SOF_W {
+        SOF_W { w: self }
+    }
+    #[doc = "Bit 3 - End of Reset Interrupt Enable"]
+    #[inline(always)]
+    pub fn eorst(&mut self) -> EORST_W {
+        EORST_W { w: self }
+    }
+    #[doc = "Bit 4 - Wake Up Interrupt Enable"]
+    #[inline(always)]
+    pub fn wakeup(&mut self) -> WAKEUP_W {
+        WAKEUP_W { w: self }
+    }
+    #[doc = "Bit 5 - End Of Resume Interrupt Enable"]
+    #[inline(always)]
+    pub fn eorsm(&mut self) -> EORSM_W {
+        EORSM_W { w: self }
+    }
+    #[doc = "Bit 6 - Upstream Resume Interrupt Enable"]
+    #[inline(always)]
+    pub fn uprsm(&mut self) -> UPRSM_W {
+        UPRSM_W { w: self }
+    }
+    #[doc = "Bit 7 - Ram Access Interrupt Enable"]
+    #[inline(always)]
+    pub fn ramacer(&mut self) -> RAMACER_W {
+        RAMACER_W { w: self }
+    }
+    #[doc = "Bit 8 - Link Power Management Not Yet Interrupt Enable"]
+    #[inline(always)]
+    pub fn lpmnyet(&mut self) -> LPMNYET_W {
+        LPMNYET_W { w: self }
+    }
+    #[doc = "Bit 9 - Link Power Management Suspend Interrupt Enable"]
+    #[inline(always)]
+    pub fn lpmsusp(&mut self) -> LPMSUSP_W {
+        LPMSUSP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/intenset.rs
+++ b/pac/atsamd11c14a/src/usb/device/intenset.rs
@@ -1,0 +1,356 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u16, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u16, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SUSPEND`"]
+pub type SUSPEND_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SUSPEND`"]
+pub struct SUSPEND_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SUSPEND_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `MSOF`"]
+pub type MSOF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MSOF`"]
+pub struct MSOF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MSOF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SOF`"]
+pub type SOF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SOF`"]
+pub struct SOF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SOF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `EORST`"]
+pub type EORST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EORST`"]
+pub struct EORST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EORST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u16) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `WAKEUP`"]
+pub type WAKEUP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WAKEUP`"]
+pub struct WAKEUP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAKEUP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `EORSM`"]
+pub type EORSM_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EORSM`"]
+pub struct EORSM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EORSM_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `UPRSM`"]
+pub type UPRSM_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `UPRSM`"]
+pub struct UPRSM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> UPRSM_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `RAMACER`"]
+pub type RAMACER_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RAMACER`"]
+pub struct RAMACER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RAMACER_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `LPMNYET`"]
+pub type LPMNYET_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LPMNYET`"]
+pub struct LPMNYET_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LPMNYET_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `LPMSUSP`"]
+pub type LPMSUSP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LPMSUSP`"]
+pub struct LPMSUSP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LPMSUSP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u16) & 0x01) << 9);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Suspend Interrupt Enable"]
+    #[inline(always)]
+    pub fn suspend(&self) -> SUSPEND_R {
+        SUSPEND_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Micro Start of Frame Interrupt Enable in High Speed Mode"]
+    #[inline(always)]
+    pub fn msof(&self) -> MSOF_R {
+        MSOF_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Start Of Frame Interrupt Enable"]
+    #[inline(always)]
+    pub fn sof(&self) -> SOF_R {
+        SOF_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - End of Reset Interrupt Enable"]
+    #[inline(always)]
+    pub fn eorst(&self) -> EORST_R {
+        EORST_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Wake Up Interrupt Enable"]
+    #[inline(always)]
+    pub fn wakeup(&self) -> WAKEUP_R {
+        WAKEUP_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - End Of Resume Interrupt Enable"]
+    #[inline(always)]
+    pub fn eorsm(&self) -> EORSM_R {
+        EORSM_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Upstream Resume Interrupt Enable"]
+    #[inline(always)]
+    pub fn uprsm(&self) -> UPRSM_R {
+        UPRSM_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Ram Access Interrupt Enable"]
+    #[inline(always)]
+    pub fn ramacer(&self) -> RAMACER_R {
+        RAMACER_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Link Power Management Not Yet Interrupt Enable"]
+    #[inline(always)]
+    pub fn lpmnyet(&self) -> LPMNYET_R {
+        LPMNYET_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Link Power Management Suspend Interrupt Enable"]
+    #[inline(always)]
+    pub fn lpmsusp(&self) -> LPMSUSP_R {
+        LPMSUSP_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Suspend Interrupt Enable"]
+    #[inline(always)]
+    pub fn suspend(&mut self) -> SUSPEND_W {
+        SUSPEND_W { w: self }
+    }
+    #[doc = "Bit 1 - Micro Start of Frame Interrupt Enable in High Speed Mode"]
+    #[inline(always)]
+    pub fn msof(&mut self) -> MSOF_W {
+        MSOF_W { w: self }
+    }
+    #[doc = "Bit 2 - Start Of Frame Interrupt Enable"]
+    #[inline(always)]
+    pub fn sof(&mut self) -> SOF_W {
+        SOF_W { w: self }
+    }
+    #[doc = "Bit 3 - End of Reset Interrupt Enable"]
+    #[inline(always)]
+    pub fn eorst(&mut self) -> EORST_W {
+        EORST_W { w: self }
+    }
+    #[doc = "Bit 4 - Wake Up Interrupt Enable"]
+    #[inline(always)]
+    pub fn wakeup(&mut self) -> WAKEUP_W {
+        WAKEUP_W { w: self }
+    }
+    #[doc = "Bit 5 - End Of Resume Interrupt Enable"]
+    #[inline(always)]
+    pub fn eorsm(&mut self) -> EORSM_W {
+        EORSM_W { w: self }
+    }
+    #[doc = "Bit 6 - Upstream Resume Interrupt Enable"]
+    #[inline(always)]
+    pub fn uprsm(&mut self) -> UPRSM_W {
+        UPRSM_W { w: self }
+    }
+    #[doc = "Bit 7 - Ram Access Interrupt Enable"]
+    #[inline(always)]
+    pub fn ramacer(&mut self) -> RAMACER_W {
+        RAMACER_W { w: self }
+    }
+    #[doc = "Bit 8 - Link Power Management Not Yet Interrupt Enable"]
+    #[inline(always)]
+    pub fn lpmnyet(&mut self) -> LPMNYET_W {
+        LPMNYET_W { w: self }
+    }
+    #[doc = "Bit 9 - Link Power Management Suspend Interrupt Enable"]
+    #[inline(always)]
+    pub fn lpmsusp(&mut self) -> LPMSUSP_W {
+        LPMSUSP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/intflag.rs
+++ b/pac/atsamd11c14a/src/usb/device/intflag.rs
@@ -1,0 +1,356 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u16, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u16, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SUSPEND`"]
+pub type SUSPEND_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SUSPEND`"]
+pub struct SUSPEND_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SUSPEND_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `MSOF`"]
+pub type MSOF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `MSOF`"]
+pub struct MSOF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MSOF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `SOF`"]
+pub type SOF_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SOF`"]
+pub struct SOF_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SOF_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `EORST`"]
+pub type EORST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EORST`"]
+pub struct EORST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EORST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u16) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `WAKEUP`"]
+pub type WAKEUP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WAKEUP`"]
+pub struct WAKEUP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WAKEUP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `EORSM`"]
+pub type EORSM_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EORSM`"]
+pub struct EORSM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EORSM_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `UPRSM`"]
+pub type UPRSM_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `UPRSM`"]
+pub struct UPRSM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> UPRSM_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `RAMACER`"]
+pub type RAMACER_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RAMACER`"]
+pub struct RAMACER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RAMACER_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `LPMNYET`"]
+pub type LPMNYET_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LPMNYET`"]
+pub struct LPMNYET_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LPMNYET_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `LPMSUSP`"]
+pub type LPMSUSP_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `LPMSUSP`"]
+pub struct LPMSUSP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> LPMSUSP_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u16) & 0x01) << 9);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Suspend"]
+    #[inline(always)]
+    pub fn suspend(&self) -> SUSPEND_R {
+        SUSPEND_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Micro Start of Frame in High Speed Mode"]
+    #[inline(always)]
+    pub fn msof(&self) -> MSOF_R {
+        MSOF_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Start Of Frame"]
+    #[inline(always)]
+    pub fn sof(&self) -> SOF_R {
+        SOF_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - End of Reset"]
+    #[inline(always)]
+    pub fn eorst(&self) -> EORST_R {
+        EORST_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - Wake Up"]
+    #[inline(always)]
+    pub fn wakeup(&self) -> WAKEUP_R {
+        WAKEUP_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - End Of Resume"]
+    #[inline(always)]
+    pub fn eorsm(&self) -> EORSM_R {
+        EORSM_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Upstream Resume"]
+    #[inline(always)]
+    pub fn uprsm(&self) -> UPRSM_R {
+        UPRSM_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Ram Access"]
+    #[inline(always)]
+    pub fn ramacer(&self) -> RAMACER_R {
+        RAMACER_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - Link Power Management Not Yet"]
+    #[inline(always)]
+    pub fn lpmnyet(&self) -> LPMNYET_R {
+        LPMNYET_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - Link Power Management Suspend"]
+    #[inline(always)]
+    pub fn lpmsusp(&self) -> LPMSUSP_R {
+        LPMSUSP_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Suspend"]
+    #[inline(always)]
+    pub fn suspend(&mut self) -> SUSPEND_W {
+        SUSPEND_W { w: self }
+    }
+    #[doc = "Bit 1 - Micro Start of Frame in High Speed Mode"]
+    #[inline(always)]
+    pub fn msof(&mut self) -> MSOF_W {
+        MSOF_W { w: self }
+    }
+    #[doc = "Bit 2 - Start Of Frame"]
+    #[inline(always)]
+    pub fn sof(&mut self) -> SOF_W {
+        SOF_W { w: self }
+    }
+    #[doc = "Bit 3 - End of Reset"]
+    #[inline(always)]
+    pub fn eorst(&mut self) -> EORST_W {
+        EORST_W { w: self }
+    }
+    #[doc = "Bit 4 - Wake Up"]
+    #[inline(always)]
+    pub fn wakeup(&mut self) -> WAKEUP_W {
+        WAKEUP_W { w: self }
+    }
+    #[doc = "Bit 5 - End Of Resume"]
+    #[inline(always)]
+    pub fn eorsm(&mut self) -> EORSM_W {
+        EORSM_W { w: self }
+    }
+    #[doc = "Bit 6 - Upstream Resume"]
+    #[inline(always)]
+    pub fn uprsm(&mut self) -> UPRSM_W {
+        UPRSM_W { w: self }
+    }
+    #[doc = "Bit 7 - Ram Access"]
+    #[inline(always)]
+    pub fn ramacer(&mut self) -> RAMACER_W {
+        RAMACER_W { w: self }
+    }
+    #[doc = "Bit 8 - Link Power Management Not Yet"]
+    #[inline(always)]
+    pub fn lpmnyet(&mut self) -> LPMNYET_W {
+        LPMNYET_W { w: self }
+    }
+    #[doc = "Bit 9 - Link Power Management Suspend"]
+    #[inline(always)]
+    pub fn lpmsusp(&mut self) -> LPMSUSP_W {
+        LPMSUSP_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/padcal.rs
+++ b/pac/atsamd11c14a/src/usb/device/padcal.rs
@@ -1,0 +1,88 @@
+#[doc = "Reader of register PADCAL"]
+pub type R = crate::R<u16, super::PADCAL>;
+#[doc = "Writer for register PADCAL"]
+pub type W = crate::W<u16, super::PADCAL>;
+#[doc = "Register PADCAL `reset()`'s with value 0"]
+impl crate::ResetValue for super::PADCAL {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `TRANSP`"]
+pub type TRANSP_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `TRANSP`"]
+pub struct TRANSP_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRANSP_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x1f) | ((value as u16) & 0x1f);
+        self.w
+    }
+}
+#[doc = "Reader of field `TRANSN`"]
+pub type TRANSN_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `TRANSN`"]
+pub struct TRANSN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRANSN_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x1f << 6)) | (((value as u16) & 0x1f) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `TRIM`"]
+pub type TRIM_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `TRIM`"]
+pub struct TRIM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> TRIM_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x07 << 12)) | (((value as u16) & 0x07) << 12);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:4 - USB Pad Transp calibration"]
+    #[inline(always)]
+    pub fn transp(&self) -> TRANSP_R {
+        TRANSP_R::new((self.bits & 0x1f) as u8)
+    }
+    #[doc = "Bits 6:10 - USB Pad Transn calibration"]
+    #[inline(always)]
+    pub fn transn(&self) -> TRANSN_R {
+        TRANSN_R::new(((self.bits >> 6) & 0x1f) as u8)
+    }
+    #[doc = "Bits 12:14 - USB Pad Trim calibration"]
+    #[inline(always)]
+    pub fn trim(&self) -> TRIM_R {
+        TRIM_R::new(((self.bits >> 12) & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:4 - USB Pad Transp calibration"]
+    #[inline(always)]
+    pub fn transp(&mut self) -> TRANSP_W {
+        TRANSP_W { w: self }
+    }
+    #[doc = "Bits 6:10 - USB Pad Transn calibration"]
+    #[inline(always)]
+    pub fn transn(&mut self) -> TRANSN_W {
+        TRANSN_W { w: self }
+    }
+    #[doc = "Bits 12:14 - USB Pad Trim calibration"]
+    #[inline(always)]
+    pub fn trim(&mut self) -> TRIM_W {
+        TRIM_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/qosctrl.rs
+++ b/pac/atsamd11c14a/src/usb/device/qosctrl.rs
@@ -1,0 +1,64 @@
+#[doc = "Reader of register QOSCTRL"]
+pub type R = crate::R<u8, super::QOSCTRL>;
+#[doc = "Writer for register QOSCTRL"]
+pub type W = crate::W<u8, super::QOSCTRL>;
+#[doc = "Register QOSCTRL `reset()`'s with value 0x05"]
+impl crate::ResetValue for super::QOSCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x05
+    }
+}
+#[doc = "Reader of field `CQOS`"]
+pub type CQOS_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `CQOS`"]
+pub struct CQOS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CQOS_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x03) | ((value as u8) & 0x03);
+        self.w
+    }
+}
+#[doc = "Reader of field `DQOS`"]
+pub type DQOS_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `DQOS`"]
+pub struct DQOS_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> DQOS_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x03 << 2)) | (((value as u8) & 0x03) << 2);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:1 - Configuration Quality of Service"]
+    #[inline(always)]
+    pub fn cqos(&self) -> CQOS_R {
+        CQOS_R::new((self.bits & 0x03) as u8)
+    }
+    #[doc = "Bits 2:3 - Data Quality of Service"]
+    #[inline(always)]
+    pub fn dqos(&self) -> DQOS_R {
+        DQOS_R::new(((self.bits >> 2) & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:1 - Configuration Quality of Service"]
+    #[inline(always)]
+    pub fn cqos(&mut self) -> CQOS_W {
+        CQOS_W { w: self }
+    }
+    #[doc = "Bits 2:3 - Data Quality of Service"]
+    #[inline(always)]
+    pub fn dqos(&mut self) -> DQOS_W {
+        DQOS_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/status.rs
+++ b/pac/atsamd11c14a/src/usb/device/status.rs
@@ -1,0 +1,114 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u8, super::STATUS>;
+#[doc = "Speed Status\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum SPEED_A {
+    #[doc = "0: Full-speed mode"]
+    FS,
+    #[doc = "1: High-speed mode"]
+    HS,
+    #[doc = "2: Low-speed mode"]
+    LS,
+}
+impl From<SPEED_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SPEED_A) -> Self {
+        match variant {
+            SPEED_A::FS => 0,
+            SPEED_A::HS => 1,
+            SPEED_A::LS => 2,
+        }
+    }
+}
+#[doc = "Reader of field `SPEED`"]
+pub type SPEED_R = crate::R<u8, SPEED_A>;
+impl SPEED_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, SPEED_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(SPEED_A::FS),
+            1 => Val(SPEED_A::HS),
+            2 => Val(SPEED_A::LS),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `FS`"]
+    #[inline(always)]
+    pub fn is_fs(&self) -> bool {
+        *self == SPEED_A::FS
+    }
+    #[doc = "Checks if the value of the field is `HS`"]
+    #[inline(always)]
+    pub fn is_hs(&self) -> bool {
+        *self == SPEED_A::HS
+    }
+    #[doc = "Checks if the value of the field is `LS`"]
+    #[inline(always)]
+    pub fn is_ls(&self) -> bool {
+        *self == SPEED_A::LS
+    }
+}
+#[doc = "USB Line State Status\n\nValue on reset: 1"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LINESTATE_A {
+    #[doc = "0: SE0/RESET"]
+    _0,
+    #[doc = "1: FS-J or LS-K State"]
+    _1,
+    #[doc = "2: FS-K or LS-J State"]
+    _2,
+}
+impl From<LINESTATE_A> for u8 {
+    #[inline(always)]
+    fn from(variant: LINESTATE_A) -> Self {
+        match variant {
+            LINESTATE_A::_0 => 0,
+            LINESTATE_A::_1 => 1,
+            LINESTATE_A::_2 => 2,
+        }
+    }
+}
+#[doc = "Reader of field `LINESTATE`"]
+pub type LINESTATE_R = crate::R<u8, LINESTATE_A>;
+impl LINESTATE_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, LINESTATE_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(LINESTATE_A::_0),
+            1 => Val(LINESTATE_A::_1),
+            2 => Val(LINESTATE_A::_2),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `_0`"]
+    #[inline(always)]
+    pub fn is_0(&self) -> bool {
+        *self == LINESTATE_A::_0
+    }
+    #[doc = "Checks if the value of the field is `_1`"]
+    #[inline(always)]
+    pub fn is_1(&self) -> bool {
+        *self == LINESTATE_A::_1
+    }
+    #[doc = "Checks if the value of the field is `_2`"]
+    #[inline(always)]
+    pub fn is_2(&self) -> bool {
+        *self == LINESTATE_A::_2
+    }
+}
+impl R {
+    #[doc = "Bits 2:3 - Speed Status"]
+    #[inline(always)]
+    pub fn speed(&self) -> SPEED_R {
+        SPEED_R::new(((self.bits >> 2) & 0x03) as u8)
+    }
+    #[doc = "Bits 6:7 - USB Line State Status"]
+    #[inline(always)]
+    pub fn linestate(&self) -> LINESTATE_R {
+        LINESTATE_R::new(((self.bits >> 6) & 0x03) as u8)
+    }
+}

--- a/pac/atsamd11c14a/src/usb/device/syncbusy.rs
+++ b/pac/atsamd11c14a/src/usb/device/syncbusy.rs
@@ -1,0 +1,18 @@
+#[doc = "Reader of register SYNCBUSY"]
+pub type R = crate::R<u8, super::SYNCBUSY>;
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 0 - Software Reset Synchronization Busy"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Enable Synchronization Busy"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}

--- a/pac/atsamd11c14a/src/wdt.rs
+++ b/pac/atsamd11c14a/src/wdt.rs
@@ -1,0 +1,105 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Control"]
+    pub ctrl: CTRL,
+    #[doc = "0x01 - Configuration"]
+    pub config: CONFIG,
+    #[doc = "0x02 - Early Warning Interrupt Control"]
+    pub ewctrl: EWCTRL,
+    _reserved3: [u8; 1usize],
+    #[doc = "0x04 - Interrupt Enable Clear"]
+    pub intenclr: INTENCLR,
+    #[doc = "0x05 - Interrupt Enable Set"]
+    pub intenset: INTENSET,
+    #[doc = "0x06 - Interrupt Flag Status and Clear"]
+    pub intflag: INTFLAG,
+    #[doc = "0x07 - Status"]
+    pub status: STATUS,
+    #[doc = "0x08 - Clear"]
+    pub clear: CLEAR,
+}
+#[doc = "Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ctrl](ctrl) module"]
+pub type CTRL = crate::Reg<u8, _CTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRL;
+#[doc = "`read()` method returns [ctrl::R](ctrl::R) reader structure"]
+impl crate::Readable for CTRL {}
+#[doc = "`write(|w| ..)` method takes [ctrl::W](ctrl::W) writer structure"]
+impl crate::Writable for CTRL {}
+#[doc = "Control"]
+pub mod ctrl;
+#[doc = "Configuration\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [config](config) module"]
+pub type CONFIG = crate::Reg<u8, _CONFIG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CONFIG;
+#[doc = "`read()` method returns [config::R](config::R) reader structure"]
+impl crate::Readable for CONFIG {}
+#[doc = "`write(|w| ..)` method takes [config::W](config::W) writer structure"]
+impl crate::Writable for CONFIG {}
+#[doc = "Configuration"]
+pub mod config;
+#[doc = "Early Warning Interrupt Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [ewctrl](ewctrl) module"]
+pub type EWCTRL = crate::Reg<u8, _EWCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _EWCTRL;
+#[doc = "`read()` method returns [ewctrl::R](ewctrl::R) reader structure"]
+impl crate::Readable for EWCTRL {}
+#[doc = "`write(|w| ..)` method takes [ewctrl::W](ewctrl::W) writer structure"]
+impl crate::Writable for EWCTRL {}
+#[doc = "Early Warning Interrupt Control"]
+pub mod ewctrl;
+#[doc = "Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Status\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [status](status) module"]
+pub type STATUS = crate::Reg<u8, _STATUS>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _STATUS;
+#[doc = "`read()` method returns [status::R](status::R) reader structure"]
+impl crate::Readable for STATUS {}
+#[doc = "Status"]
+pub mod status;
+#[doc = "Clear\n\nThis register you can [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about avaliable fields see [clear](clear) module"]
+pub type CLEAR = crate::Reg<u8, _CLEAR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CLEAR;
+#[doc = "`write(|w| ..)` method takes [clear::W](clear::W) writer structure"]
+impl crate::Writable for CLEAR {}
+#[doc = "Clear"]
+pub mod clear;

--- a/pac/atsamd11c14a/src/wdt/clear.rs
+++ b/pac/atsamd11c14a/src/wdt/clear.rs
@@ -1,0 +1,53 @@
+#[doc = "Writer for register CLEAR"]
+pub type W = crate::W<u8, super::CLEAR>;
+#[doc = "Register CLEAR `reset()`'s with value 0"]
+impl crate::ResetValue for super::CLEAR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Watchdog Clear\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CLEAR_AW {
+    #[doc = "165: Clear Key"]
+    KEY,
+}
+impl From<CLEAR_AW> for u8 {
+    #[inline(always)]
+    fn from(variant: CLEAR_AW) -> Self {
+        match variant {
+            CLEAR_AW::KEY => 165,
+        }
+    }
+}
+#[doc = "Write proxy for field `CLEAR`"]
+pub struct CLEAR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CLEAR_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: CLEAR_AW) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "Clear Key"]
+    #[inline(always)]
+    pub fn key(self) -> &'a mut W {
+        self.variant(CLEAR_AW::KEY)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xff) | ((value as u8) & 0xff);
+        self.w
+    }
+}
+impl W {
+    #[doc = "Bits 0:7 - Watchdog Clear"]
+    #[inline(always)]
+    pub fn clear(&mut self) -> CLEAR_W {
+        CLEAR_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/wdt/config.rs
+++ b/pac/atsamd11c14a/src/wdt/config.rs
@@ -1,0 +1,452 @@
+#[doc = "Reader of register CONFIG"]
+pub type R = crate::R<u8, super::CONFIG>;
+#[doc = "Writer for register CONFIG"]
+pub type W = crate::W<u8, super::CONFIG>;
+#[doc = "Register CONFIG `reset()`'s with value 0xbb"]
+impl crate::ResetValue for super::CONFIG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0xbb
+    }
+}
+#[doc = "Time-Out Period\n\nValue on reset: 11"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PER_A {
+    #[doc = "0: 8 clock cycles"]
+    _8,
+    #[doc = "1: 16 clock cycles"]
+    _16,
+    #[doc = "2: 32 clock cycles"]
+    _32,
+    #[doc = "3: 64 clock cycles"]
+    _64,
+    #[doc = "4: 128 clock cycles"]
+    _128,
+    #[doc = "5: 256 clock cycles"]
+    _256,
+    #[doc = "6: 512 clock cycles"]
+    _512,
+    #[doc = "7: 1024 clock cycles"]
+    _1K,
+    #[doc = "8: 2048 clock cycles"]
+    _2K,
+    #[doc = "9: 4096 clock cycles"]
+    _4K,
+    #[doc = "10: 8192 clock cycles"]
+    _8K,
+    #[doc = "11: 16384 clock cycles"]
+    _16K,
+}
+impl From<PER_A> for u8 {
+    #[inline(always)]
+    fn from(variant: PER_A) -> Self {
+        match variant {
+            PER_A::_8 => 0,
+            PER_A::_16 => 1,
+            PER_A::_32 => 2,
+            PER_A::_64 => 3,
+            PER_A::_128 => 4,
+            PER_A::_256 => 5,
+            PER_A::_512 => 6,
+            PER_A::_1K => 7,
+            PER_A::_2K => 8,
+            PER_A::_4K => 9,
+            PER_A::_8K => 10,
+            PER_A::_16K => 11,
+        }
+    }
+}
+#[doc = "Reader of field `PER`"]
+pub type PER_R = crate::R<u8, PER_A>;
+impl PER_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, PER_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(PER_A::_8),
+            1 => Val(PER_A::_16),
+            2 => Val(PER_A::_32),
+            3 => Val(PER_A::_64),
+            4 => Val(PER_A::_128),
+            5 => Val(PER_A::_256),
+            6 => Val(PER_A::_512),
+            7 => Val(PER_A::_1K),
+            8 => Val(PER_A::_2K),
+            9 => Val(PER_A::_4K),
+            10 => Val(PER_A::_8K),
+            11 => Val(PER_A::_16K),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `_8`"]
+    #[inline(always)]
+    pub fn is_8(&self) -> bool {
+        *self == PER_A::_8
+    }
+    #[doc = "Checks if the value of the field is `_16`"]
+    #[inline(always)]
+    pub fn is_16(&self) -> bool {
+        *self == PER_A::_16
+    }
+    #[doc = "Checks if the value of the field is `_32`"]
+    #[inline(always)]
+    pub fn is_32(&self) -> bool {
+        *self == PER_A::_32
+    }
+    #[doc = "Checks if the value of the field is `_64`"]
+    #[inline(always)]
+    pub fn is_64(&self) -> bool {
+        *self == PER_A::_64
+    }
+    #[doc = "Checks if the value of the field is `_128`"]
+    #[inline(always)]
+    pub fn is_128(&self) -> bool {
+        *self == PER_A::_128
+    }
+    #[doc = "Checks if the value of the field is `_256`"]
+    #[inline(always)]
+    pub fn is_256(&self) -> bool {
+        *self == PER_A::_256
+    }
+    #[doc = "Checks if the value of the field is `_512`"]
+    #[inline(always)]
+    pub fn is_512(&self) -> bool {
+        *self == PER_A::_512
+    }
+    #[doc = "Checks if the value of the field is `_1K`"]
+    #[inline(always)]
+    pub fn is_1k(&self) -> bool {
+        *self == PER_A::_1K
+    }
+    #[doc = "Checks if the value of the field is `_2K`"]
+    #[inline(always)]
+    pub fn is_2k(&self) -> bool {
+        *self == PER_A::_2K
+    }
+    #[doc = "Checks if the value of the field is `_4K`"]
+    #[inline(always)]
+    pub fn is_4k(&self) -> bool {
+        *self == PER_A::_4K
+    }
+    #[doc = "Checks if the value of the field is `_8K`"]
+    #[inline(always)]
+    pub fn is_8k(&self) -> bool {
+        *self == PER_A::_8K
+    }
+    #[doc = "Checks if the value of the field is `_16K`"]
+    #[inline(always)]
+    pub fn is_16k(&self) -> bool {
+        *self == PER_A::_16K
+    }
+}
+#[doc = "Write proxy for field `PER`"]
+pub struct PER_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> PER_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: PER_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "8 clock cycles"]
+    #[inline(always)]
+    pub fn _8(self) -> &'a mut W {
+        self.variant(PER_A::_8)
+    }
+    #[doc = "16 clock cycles"]
+    #[inline(always)]
+    pub fn _16(self) -> &'a mut W {
+        self.variant(PER_A::_16)
+    }
+    #[doc = "32 clock cycles"]
+    #[inline(always)]
+    pub fn _32(self) -> &'a mut W {
+        self.variant(PER_A::_32)
+    }
+    #[doc = "64 clock cycles"]
+    #[inline(always)]
+    pub fn _64(self) -> &'a mut W {
+        self.variant(PER_A::_64)
+    }
+    #[doc = "128 clock cycles"]
+    #[inline(always)]
+    pub fn _128(self) -> &'a mut W {
+        self.variant(PER_A::_128)
+    }
+    #[doc = "256 clock cycles"]
+    #[inline(always)]
+    pub fn _256(self) -> &'a mut W {
+        self.variant(PER_A::_256)
+    }
+    #[doc = "512 clock cycles"]
+    #[inline(always)]
+    pub fn _512(self) -> &'a mut W {
+        self.variant(PER_A::_512)
+    }
+    #[doc = "1024 clock cycles"]
+    #[inline(always)]
+    pub fn _1k(self) -> &'a mut W {
+        self.variant(PER_A::_1K)
+    }
+    #[doc = "2048 clock cycles"]
+    #[inline(always)]
+    pub fn _2k(self) -> &'a mut W {
+        self.variant(PER_A::_2K)
+    }
+    #[doc = "4096 clock cycles"]
+    #[inline(always)]
+    pub fn _4k(self) -> &'a mut W {
+        self.variant(PER_A::_4K)
+    }
+    #[doc = "8192 clock cycles"]
+    #[inline(always)]
+    pub fn _8k(self) -> &'a mut W {
+        self.variant(PER_A::_8K)
+    }
+    #[doc = "16384 clock cycles"]
+    #[inline(always)]
+    pub fn _16k(self) -> &'a mut W {
+        self.variant(PER_A::_16K)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0f) | ((value as u8) & 0x0f);
+        self.w
+    }
+}
+#[doc = "Window Mode Time-Out Period\n\nValue on reset: 11"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum WINDOW_A {
+    #[doc = "0: 8 clock cycles"]
+    _8,
+    #[doc = "1: 16 clock cycles"]
+    _16,
+    #[doc = "2: 32 clock cycles"]
+    _32,
+    #[doc = "3: 64 clock cycles"]
+    _64,
+    #[doc = "4: 128 clock cycles"]
+    _128,
+    #[doc = "5: 256 clock cycles"]
+    _256,
+    #[doc = "6: 512 clock cycles"]
+    _512,
+    #[doc = "7: 1024 clock cycles"]
+    _1K,
+    #[doc = "8: 2048 clock cycles"]
+    _2K,
+    #[doc = "9: 4096 clock cycles"]
+    _4K,
+    #[doc = "10: 8192 clock cycles"]
+    _8K,
+    #[doc = "11: 16384 clock cycles"]
+    _16K,
+}
+impl From<WINDOW_A> for u8 {
+    #[inline(always)]
+    fn from(variant: WINDOW_A) -> Self {
+        match variant {
+            WINDOW_A::_8 => 0,
+            WINDOW_A::_16 => 1,
+            WINDOW_A::_32 => 2,
+            WINDOW_A::_64 => 3,
+            WINDOW_A::_128 => 4,
+            WINDOW_A::_256 => 5,
+            WINDOW_A::_512 => 6,
+            WINDOW_A::_1K => 7,
+            WINDOW_A::_2K => 8,
+            WINDOW_A::_4K => 9,
+            WINDOW_A::_8K => 10,
+            WINDOW_A::_16K => 11,
+        }
+    }
+}
+#[doc = "Reader of field `WINDOW`"]
+pub type WINDOW_R = crate::R<u8, WINDOW_A>;
+impl WINDOW_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, WINDOW_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(WINDOW_A::_8),
+            1 => Val(WINDOW_A::_16),
+            2 => Val(WINDOW_A::_32),
+            3 => Val(WINDOW_A::_64),
+            4 => Val(WINDOW_A::_128),
+            5 => Val(WINDOW_A::_256),
+            6 => Val(WINDOW_A::_512),
+            7 => Val(WINDOW_A::_1K),
+            8 => Val(WINDOW_A::_2K),
+            9 => Val(WINDOW_A::_4K),
+            10 => Val(WINDOW_A::_8K),
+            11 => Val(WINDOW_A::_16K),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `_8`"]
+    #[inline(always)]
+    pub fn is_8(&self) -> bool {
+        *self == WINDOW_A::_8
+    }
+    #[doc = "Checks if the value of the field is `_16`"]
+    #[inline(always)]
+    pub fn is_16(&self) -> bool {
+        *self == WINDOW_A::_16
+    }
+    #[doc = "Checks if the value of the field is `_32`"]
+    #[inline(always)]
+    pub fn is_32(&self) -> bool {
+        *self == WINDOW_A::_32
+    }
+    #[doc = "Checks if the value of the field is `_64`"]
+    #[inline(always)]
+    pub fn is_64(&self) -> bool {
+        *self == WINDOW_A::_64
+    }
+    #[doc = "Checks if the value of the field is `_128`"]
+    #[inline(always)]
+    pub fn is_128(&self) -> bool {
+        *self == WINDOW_A::_128
+    }
+    #[doc = "Checks if the value of the field is `_256`"]
+    #[inline(always)]
+    pub fn is_256(&self) -> bool {
+        *self == WINDOW_A::_256
+    }
+    #[doc = "Checks if the value of the field is `_512`"]
+    #[inline(always)]
+    pub fn is_512(&self) -> bool {
+        *self == WINDOW_A::_512
+    }
+    #[doc = "Checks if the value of the field is `_1K`"]
+    #[inline(always)]
+    pub fn is_1k(&self) -> bool {
+        *self == WINDOW_A::_1K
+    }
+    #[doc = "Checks if the value of the field is `_2K`"]
+    #[inline(always)]
+    pub fn is_2k(&self) -> bool {
+        *self == WINDOW_A::_2K
+    }
+    #[doc = "Checks if the value of the field is `_4K`"]
+    #[inline(always)]
+    pub fn is_4k(&self) -> bool {
+        *self == WINDOW_A::_4K
+    }
+    #[doc = "Checks if the value of the field is `_8K`"]
+    #[inline(always)]
+    pub fn is_8k(&self) -> bool {
+        *self == WINDOW_A::_8K
+    }
+    #[doc = "Checks if the value of the field is `_16K`"]
+    #[inline(always)]
+    pub fn is_16k(&self) -> bool {
+        *self == WINDOW_A::_16K
+    }
+}
+#[doc = "Write proxy for field `WINDOW`"]
+pub struct WINDOW_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WINDOW_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: WINDOW_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "8 clock cycles"]
+    #[inline(always)]
+    pub fn _8(self) -> &'a mut W {
+        self.variant(WINDOW_A::_8)
+    }
+    #[doc = "16 clock cycles"]
+    #[inline(always)]
+    pub fn _16(self) -> &'a mut W {
+        self.variant(WINDOW_A::_16)
+    }
+    #[doc = "32 clock cycles"]
+    #[inline(always)]
+    pub fn _32(self) -> &'a mut W {
+        self.variant(WINDOW_A::_32)
+    }
+    #[doc = "64 clock cycles"]
+    #[inline(always)]
+    pub fn _64(self) -> &'a mut W {
+        self.variant(WINDOW_A::_64)
+    }
+    #[doc = "128 clock cycles"]
+    #[inline(always)]
+    pub fn _128(self) -> &'a mut W {
+        self.variant(WINDOW_A::_128)
+    }
+    #[doc = "256 clock cycles"]
+    #[inline(always)]
+    pub fn _256(self) -> &'a mut W {
+        self.variant(WINDOW_A::_256)
+    }
+    #[doc = "512 clock cycles"]
+    #[inline(always)]
+    pub fn _512(self) -> &'a mut W {
+        self.variant(WINDOW_A::_512)
+    }
+    #[doc = "1024 clock cycles"]
+    #[inline(always)]
+    pub fn _1k(self) -> &'a mut W {
+        self.variant(WINDOW_A::_1K)
+    }
+    #[doc = "2048 clock cycles"]
+    #[inline(always)]
+    pub fn _2k(self) -> &'a mut W {
+        self.variant(WINDOW_A::_2K)
+    }
+    #[doc = "4096 clock cycles"]
+    #[inline(always)]
+    pub fn _4k(self) -> &'a mut W {
+        self.variant(WINDOW_A::_4K)
+    }
+    #[doc = "8192 clock cycles"]
+    #[inline(always)]
+    pub fn _8k(self) -> &'a mut W {
+        self.variant(WINDOW_A::_8K)
+    }
+    #[doc = "16384 clock cycles"]
+    #[inline(always)]
+    pub fn _16k(self) -> &'a mut W {
+        self.variant(WINDOW_A::_16K)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 4)) | (((value as u8) & 0x0f) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:3 - Time-Out Period"]
+    #[inline(always)]
+    pub fn per(&self) -> PER_R {
+        PER_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bits 4:7 - Window Mode Time-Out Period"]
+    #[inline(always)]
+    pub fn window(&self) -> WINDOW_R {
+        WINDOW_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Time-Out Period"]
+    #[inline(always)]
+    pub fn per(&mut self) -> PER_W {
+        PER_W { w: self }
+    }
+    #[doc = "Bits 4:7 - Window Mode Time-Out Period"]
+    #[inline(always)]
+    pub fn window(&mut self) -> WINDOW_W {
+        WINDOW_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/wdt/ctrl.rs
+++ b/pac/atsamd11c14a/src/wdt/ctrl.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register CTRL"]
+pub type R = crate::R<u8, super::CTRL>;
+#[doc = "Writer for register CTRL"]
+pub type W = crate::W<u8, super::CTRL>;
+#[doc = "Register CTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `WEN`"]
+pub type WEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WEN`"]
+pub struct WEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `ALWAYSON`"]
+pub type ALWAYSON_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ALWAYSON`"]
+pub struct ALWAYSON_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ALWAYSON_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Watchdog Timer Window Mode Enable"]
+    #[inline(always)]
+    pub fn wen(&self) -> WEN_R {
+        WEN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - Always-On"]
+    #[inline(always)]
+    pub fn alwayson(&self) -> ALWAYSON_R {
+        ALWAYSON_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bit 2 - Watchdog Timer Window Mode Enable"]
+    #[inline(always)]
+    pub fn wen(&mut self) -> WEN_W {
+        WEN_W { w: self }
+    }
+    #[doc = "Bit 7 - Always-On"]
+    #[inline(always)]
+    pub fn alwayson(&mut self) -> ALWAYSON_W {
+        ALWAYSON_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/wdt/ewctrl.rs
+++ b/pac/atsamd11c14a/src/wdt/ewctrl.rs
@@ -1,0 +1,234 @@
+#[doc = "Reader of register EWCTRL"]
+pub type R = crate::R<u8, super::EWCTRL>;
+#[doc = "Writer for register EWCTRL"]
+pub type W = crate::W<u8, super::EWCTRL>;
+#[doc = "Register EWCTRL `reset()`'s with value 0x0b"]
+impl crate::ResetValue for super::EWCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0x0b
+    }
+}
+#[doc = "Early Warning Interrupt Time Offset\n\nValue on reset: 11"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum EWOFFSET_A {
+    #[doc = "0: 8 clock cycles"]
+    _8,
+    #[doc = "1: 16 clock cycles"]
+    _16,
+    #[doc = "2: 32 clock cycles"]
+    _32,
+    #[doc = "3: 64 clock cycles"]
+    _64,
+    #[doc = "4: 128 clock cycles"]
+    _128,
+    #[doc = "5: 256 clock cycles"]
+    _256,
+    #[doc = "6: 512 clock cycles"]
+    _512,
+    #[doc = "7: 1024 clock cycles"]
+    _1K,
+    #[doc = "8: 2048 clock cycles"]
+    _2K,
+    #[doc = "9: 4096 clock cycles"]
+    _4K,
+    #[doc = "10: 8192 clock cycles"]
+    _8K,
+    #[doc = "11: 16384 clock cycles"]
+    _16K,
+}
+impl From<EWOFFSET_A> for u8 {
+    #[inline(always)]
+    fn from(variant: EWOFFSET_A) -> Self {
+        match variant {
+            EWOFFSET_A::_8 => 0,
+            EWOFFSET_A::_16 => 1,
+            EWOFFSET_A::_32 => 2,
+            EWOFFSET_A::_64 => 3,
+            EWOFFSET_A::_128 => 4,
+            EWOFFSET_A::_256 => 5,
+            EWOFFSET_A::_512 => 6,
+            EWOFFSET_A::_1K => 7,
+            EWOFFSET_A::_2K => 8,
+            EWOFFSET_A::_4K => 9,
+            EWOFFSET_A::_8K => 10,
+            EWOFFSET_A::_16K => 11,
+        }
+    }
+}
+#[doc = "Reader of field `EWOFFSET`"]
+pub type EWOFFSET_R = crate::R<u8, EWOFFSET_A>;
+impl EWOFFSET_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, EWOFFSET_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(EWOFFSET_A::_8),
+            1 => Val(EWOFFSET_A::_16),
+            2 => Val(EWOFFSET_A::_32),
+            3 => Val(EWOFFSET_A::_64),
+            4 => Val(EWOFFSET_A::_128),
+            5 => Val(EWOFFSET_A::_256),
+            6 => Val(EWOFFSET_A::_512),
+            7 => Val(EWOFFSET_A::_1K),
+            8 => Val(EWOFFSET_A::_2K),
+            9 => Val(EWOFFSET_A::_4K),
+            10 => Val(EWOFFSET_A::_8K),
+            11 => Val(EWOFFSET_A::_16K),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `_8`"]
+    #[inline(always)]
+    pub fn is_8(&self) -> bool {
+        *self == EWOFFSET_A::_8
+    }
+    #[doc = "Checks if the value of the field is `_16`"]
+    #[inline(always)]
+    pub fn is_16(&self) -> bool {
+        *self == EWOFFSET_A::_16
+    }
+    #[doc = "Checks if the value of the field is `_32`"]
+    #[inline(always)]
+    pub fn is_32(&self) -> bool {
+        *self == EWOFFSET_A::_32
+    }
+    #[doc = "Checks if the value of the field is `_64`"]
+    #[inline(always)]
+    pub fn is_64(&self) -> bool {
+        *self == EWOFFSET_A::_64
+    }
+    #[doc = "Checks if the value of the field is `_128`"]
+    #[inline(always)]
+    pub fn is_128(&self) -> bool {
+        *self == EWOFFSET_A::_128
+    }
+    #[doc = "Checks if the value of the field is `_256`"]
+    #[inline(always)]
+    pub fn is_256(&self) -> bool {
+        *self == EWOFFSET_A::_256
+    }
+    #[doc = "Checks if the value of the field is `_512`"]
+    #[inline(always)]
+    pub fn is_512(&self) -> bool {
+        *self == EWOFFSET_A::_512
+    }
+    #[doc = "Checks if the value of the field is `_1K`"]
+    #[inline(always)]
+    pub fn is_1k(&self) -> bool {
+        *self == EWOFFSET_A::_1K
+    }
+    #[doc = "Checks if the value of the field is `_2K`"]
+    #[inline(always)]
+    pub fn is_2k(&self) -> bool {
+        *self == EWOFFSET_A::_2K
+    }
+    #[doc = "Checks if the value of the field is `_4K`"]
+    #[inline(always)]
+    pub fn is_4k(&self) -> bool {
+        *self == EWOFFSET_A::_4K
+    }
+    #[doc = "Checks if the value of the field is `_8K`"]
+    #[inline(always)]
+    pub fn is_8k(&self) -> bool {
+        *self == EWOFFSET_A::_8K
+    }
+    #[doc = "Checks if the value of the field is `_16K`"]
+    #[inline(always)]
+    pub fn is_16k(&self) -> bool {
+        *self == EWOFFSET_A::_16K
+    }
+}
+#[doc = "Write proxy for field `EWOFFSET`"]
+pub struct EWOFFSET_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EWOFFSET_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: EWOFFSET_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "8 clock cycles"]
+    #[inline(always)]
+    pub fn _8(self) -> &'a mut W {
+        self.variant(EWOFFSET_A::_8)
+    }
+    #[doc = "16 clock cycles"]
+    #[inline(always)]
+    pub fn _16(self) -> &'a mut W {
+        self.variant(EWOFFSET_A::_16)
+    }
+    #[doc = "32 clock cycles"]
+    #[inline(always)]
+    pub fn _32(self) -> &'a mut W {
+        self.variant(EWOFFSET_A::_32)
+    }
+    #[doc = "64 clock cycles"]
+    #[inline(always)]
+    pub fn _64(self) -> &'a mut W {
+        self.variant(EWOFFSET_A::_64)
+    }
+    #[doc = "128 clock cycles"]
+    #[inline(always)]
+    pub fn _128(self) -> &'a mut W {
+        self.variant(EWOFFSET_A::_128)
+    }
+    #[doc = "256 clock cycles"]
+    #[inline(always)]
+    pub fn _256(self) -> &'a mut W {
+        self.variant(EWOFFSET_A::_256)
+    }
+    #[doc = "512 clock cycles"]
+    #[inline(always)]
+    pub fn _512(self) -> &'a mut W {
+        self.variant(EWOFFSET_A::_512)
+    }
+    #[doc = "1024 clock cycles"]
+    #[inline(always)]
+    pub fn _1k(self) -> &'a mut W {
+        self.variant(EWOFFSET_A::_1K)
+    }
+    #[doc = "2048 clock cycles"]
+    #[inline(always)]
+    pub fn _2k(self) -> &'a mut W {
+        self.variant(EWOFFSET_A::_2K)
+    }
+    #[doc = "4096 clock cycles"]
+    #[inline(always)]
+    pub fn _4k(self) -> &'a mut W {
+        self.variant(EWOFFSET_A::_4K)
+    }
+    #[doc = "8192 clock cycles"]
+    #[inline(always)]
+    pub fn _8k(self) -> &'a mut W {
+        self.variant(EWOFFSET_A::_8K)
+    }
+    #[doc = "16384 clock cycles"]
+    #[inline(always)]
+    pub fn _16k(self) -> &'a mut W {
+        self.variant(EWOFFSET_A::_16K)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0f) | ((value as u8) & 0x0f);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:3 - Early Warning Interrupt Time Offset"]
+    #[inline(always)]
+    pub fn ewoffset(&self) -> EWOFFSET_R {
+        EWOFFSET_R::new((self.bits & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Early Warning Interrupt Time Offset"]
+    #[inline(always)]
+    pub fn ewoffset(&mut self) -> EWOFFSET_W {
+        EWOFFSET_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/wdt/intenclr.rs
+++ b/pac/atsamd11c14a/src/wdt/intenclr.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `EW`"]
+pub type EW_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EW`"]
+pub struct EW_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EW_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Early Warning Interrupt Enable"]
+    #[inline(always)]
+    pub fn ew(&self) -> EW_R {
+        EW_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Early Warning Interrupt Enable"]
+    #[inline(always)]
+    pub fn ew(&mut self) -> EW_W {
+        EW_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/wdt/intenset.rs
+++ b/pac/atsamd11c14a/src/wdt/intenset.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `EW`"]
+pub type EW_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EW`"]
+pub struct EW_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EW_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Early Warning Interrupt Enable"]
+    #[inline(always)]
+    pub fn ew(&self) -> EW_R {
+        EW_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Early Warning Interrupt Enable"]
+    #[inline(always)]
+    pub fn ew(&mut self) -> EW_W {
+        EW_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/wdt/intflag.rs
+++ b/pac/atsamd11c14a/src/wdt/intflag.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `EW`"]
+pub type EW_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EW`"]
+pub struct EW_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EW_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Early Warning"]
+    #[inline(always)]
+    pub fn ew(&self) -> EW_R {
+        EW_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Early Warning"]
+    #[inline(always)]
+    pub fn ew(&mut self) -> EW_W {
+        EW_W { w: self }
+    }
+}

--- a/pac/atsamd11c14a/src/wdt/status.rs
+++ b/pac/atsamd11c14a/src/wdt/status.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register STATUS"]
+pub type R = crate::R<u8, super::STATUS>;
+#[doc = "Reader of field `SYNCBUSY`"]
+pub type SYNCBUSY_R = crate::R<bool, bool>;
+impl R {
+    #[doc = "Bit 7 - Synchronization Busy"]
+    #[inline(always)]
+    pub fn syncbusy(&self) -> SYNCBUSY_R {
+        SYNCBUSY_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}

--- a/svd/ATSAMD11C14A.svd
+++ b/svd/ATSAMD11C14A.svd
@@ -1,0 +1,16999 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device schemaVersion="1.2" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+  <vendor>Microchip Technology Inc.</vendor>
+  <vendorID>MICROCHIP</vendorID>
+  <name>ATSAMD11C14A</name>
+  <series>SAMD11</series>
+  <version>B</version>
+  <description>Microchip ATSAMD11C14A device: Cortex-M0+ Microcontroller with 16KB Flash, 4KB SRAM, SOIC14_capless-pin package</description>
+  <licenseText>
+  Copyright (c) 2018 Microchip Technology Inc.\n
+\n
+  SPDX-License-Identifier: Apache-2.0\n
+\n
+  Licensed under the Apache License, Version 2.0 (the "License");\n
+  you may not use this file except in compliance with the License.\n
+  You may obtain a copy of the License at\n
+\n
+  http://www.apache.org/licenses/LICENSE-2.0\n
+\n
+  Unless required by applicable law or agreed to in writing, software\n
+  distributed under the License is distributed on an "AS IS" BASIS,\n
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n
+  See the License for the specific language governing permissions and\n
+  limitations under the License.
+  </licenseText>
+  <cpu>
+    <name>CM0+</name>
+    <revision>r0p1</revision>
+    <endian>little</endian>
+    <mpuPresent>false</mpuPresent>
+    <fpuPresent>false</fpuPresent>
+    <vtorPresent>true</vtorPresent>
+    <nvicPrioBits>2</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+    <deviceNumInterrupts>19</deviceNumInterrupts>
+  </cpu>
+  <headerSystemFilename>system_samd11</headerSystemFilename>
+  <addressUnitBits>8</addressUnitBits>
+  <width>32</width>
+  <size>32</size>
+  <access>read-write</access>
+  <resetValue>0x00000000</resetValue>
+  <resetMask>0xFFFFFFFF</resetMask>
+  <peripherals>
+    <peripheral>
+      <name>AC</name>
+      <version>1.1.1</version>
+      <description>Analog Comparators</description>
+      <groupName>AC</groupName>
+      <prependToName>AC_</prependToName>
+      <baseAddress>0x42002400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>AC</name>
+        <value>16</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMUX</name>
+              <description>Low-Power Mux</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>START0</name>
+              <description>Comparator 0 Start Comparison</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>START1</name>
+              <description>Comparator 1 Start Comparison</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COMPEO0</name>
+              <description>Comparator 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMPEO1</name>
+              <description>Comparator 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINEO0</name>
+              <description>Window 0 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMPEI0</name>
+              <description>Comparator 0 Event Input</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMPEI1</name>
+              <description>Comparator 1 Event Input</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COMP0</name>
+              <description>Comparator 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1</name>
+              <description>Comparator 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WIN0</name>
+              <description>Window 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COMP0</name>
+              <description>Comparator 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1</name>
+              <description>Comparator 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WIN0</name>
+              <description>Window 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COMP0</name>
+              <description>Comparator 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1</name>
+              <description>Comparator 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WIN0</name>
+              <description>Window 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSA</name>
+          <description>Status A</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>STATE0</name>
+              <description>Comparator 0 Current State</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STATE1</name>
+              <description>Comparator 1 Current State</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WSTATE0</name>
+              <description>Window 0 Current State</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WSTATE0Select</name>
+                <enumeratedValue>
+                  <name>ABOVE</name>
+                  <description>Signal is above window</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INSIDE</name>
+                  <description>Signal is inside window</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BELOW</name>
+                  <description>Signal is below window</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSB</name>
+          <description>Status B</description>
+          <addressOffset>0x09</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>READY0</name>
+              <description>Comparator 0 Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>READY1</name>
+              <description>Comparator 1 Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSC</name>
+          <description>Status C</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>STATE0</name>
+              <description>Comparator 0 Current State</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STATE1</name>
+              <description>Comparator 1 Current State</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WSTATE0</name>
+              <description>Window 0 Current State</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WSTATE0Select</name>
+                <enumeratedValue>
+                  <name>ABOVE</name>
+                  <description>Signal is above window</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INSIDE</name>
+                  <description>Signal is inside window</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BELOW</name>
+                  <description>Signal is below window</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINCTRL</name>
+          <description>Window Control</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>WEN0</name>
+              <description>Window 0 Mode Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINTSEL0</name>
+              <description>Window 0 Interrupt Selection</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WINTSEL0Select</name>
+                <enumeratedValue>
+                  <name>ABOVE</name>
+                  <description>Interrupt on signal above window</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INSIDE</name>
+                  <description>Interrupt on signal inside window</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BELOW</name>
+                  <description>Interrupt on signal below window</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OUTSIDE</name>
+                  <description>Interrupt on signal outside window</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>COMPCTRL%s</name>
+          <description>Comparator Control n</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SINGLE</name>
+              <description>Single-Shot Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPEED</name>
+              <description>Speed Selection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SPEEDSelect</name>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low speed</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High speed</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>INTSEL</name>
+              <description>Interrupt Selection</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>INTSELSelect</name>
+                <enumeratedValue>
+                  <name>TOGGLE</name>
+                  <description>Interrupt on comparator output toggle</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISING</name>
+                  <description>Interrupt on comparator output rising</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALLING</name>
+                  <description>Interrupt on comparator output falling</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EOC</name>
+                  <description>Interrupt on end of comparison (single-shot mode only)</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MUXNEG</name>
+              <description>Negative Input Mux Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MUXNEGSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>I/O pin 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>I/O pin 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>I/O pin 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>I/O pin 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GND</name>
+                  <description>Ground</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>VSCALE</name>
+                  <description>VDD scaler</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BANDGAP</name>
+                  <description>Internal bandgap voltage</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DAC</name>
+                  <description>DAC output</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MUXPOS</name>
+              <description>Positive Input Mux Selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MUXPOSSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>I/O pin 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>I/O pin 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>I/O pin 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>I/O pin 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SWAP</name>
+              <description>Swap Inputs and Invert</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OUT</name>
+              <description>Output</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>OUTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>The output of COMPn is not routed to the COMPn I/O port</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ASYNC</name>
+                  <description>The asynchronous output of COMPn is routed to the COMPn I/O port</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYNC</name>
+                  <description>The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>HYST</name>
+              <description>Hysteresis Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FLEN</name>
+              <description>Filter Length</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>FLENSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>No filtering</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MAJ3</name>
+                  <description>3-bit majority function (2 of 3)</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MAJ5</name>
+                  <description>5-bit majority function (3 of 5)</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>SCALER%s</name>
+          <description>Scaler n</description>
+          <addressOffset>0x20</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Scaler Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>ADC</name>
+      <version>1.2.0</version>
+      <description>Analog Digital Converter</description>
+      <groupName>ADC</groupName>
+      <prependToName>ADC_</prependToName>
+      <baseAddress>0x42002000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>ADC</name>
+        <value>15</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>REFCTRL</name>
+          <description>Reference Control</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>REFSEL</name>
+              <description>Reference Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>REFSELSelect</name>
+                <enumeratedValue>
+                  <name>INT1V</name>
+                  <description>1.0V voltage reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INTVCC0</name>
+                  <description>1/1.48 VDDANA</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INTVCC1</name>
+                  <description>1/2 VDDANA (only for VDDANA &gt; 2.0V)</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AREFA</name>
+                  <description>External reference</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AREFB</name>
+                  <description>External reference</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>REFCOMP</name>
+              <description>Reference Buffer Offset Compensation Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AVGCTRL</name>
+          <description>Average Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SAMPLENUM</name>
+              <description>Number of Samples to be Collected</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>SAMPLENUMSelect</name>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>1 sample</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>2 samples</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4</name>
+                  <description>4 samples</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 samples</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 samples</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 samples</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 samples</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 samples</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 samples</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 samples</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1024</name>
+                  <description>1024 samples</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADJRES</name>
+              <description>Adjusting Result / Division Coefficient</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SAMPCTRL</name>
+          <description>Sampling Time Control</description>
+          <addressOffset>0x03</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SAMPLEN</name>
+              <description>Sampling Time Length</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DIFFMODE</name>
+              <description>Differential Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LEFTADJ</name>
+              <description>Left-Adjusted Result</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FREERUN</name>
+              <description>Free Running Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CORREN</name>
+              <description>Digital Correction Logic Enabled</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESSEL</name>
+              <description>Conversion Result Resolution</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RESSELSelect</name>
+                <enumeratedValue>
+                  <name>12BIT</name>
+                  <description>12-bit result</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16BIT</name>
+                  <description>For averaging mode output</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>10BIT</name>
+                  <description>10-bit result</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8BIT</name>
+                  <description>8-bit result</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler Configuration</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Peripheral clock divided by 4</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Peripheral clock divided by 8</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Peripheral clock divided by 16</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Peripheral clock divided by 32</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Peripheral clock divided by 64</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Peripheral clock divided by 128</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Peripheral clock divided by 256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>Peripheral clock divided by 512</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINCTRL</name>
+          <description>Window Monitor Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>WINMODE</name>
+              <description>Window Monitor Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>WINMODESelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>No window mode (default)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE1</name>
+                  <description>Mode 1: RESULT &gt; WINLT</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE2</name>
+                  <description>Mode 2: RESULT &lt; WINUT</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE3</name>
+                  <description>Mode 3: WINLT &lt; RESULT &lt; WINUT</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE4</name>
+                  <description>Mode 4: !(WINLT &lt; RESULT &lt; WINUT)</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWTRIG</name>
+          <description>Software Trigger</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>FLUSH</name>
+              <description>ADC Conversion Flush</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>START</name>
+              <description>ADC Start Conversion</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INPUTCTRL</name>
+          <description>Input Control</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>MUXPOS</name>
+              <description>Positive Mux Input Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>MUXPOSSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>ADC AIN0 Pin</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>ADC AIN1 Pin</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>ADC AIN2 Pin</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>ADC AIN3 Pin</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN4</name>
+                  <description>ADC AIN4 Pin</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN5</name>
+                  <description>ADC AIN5 Pin</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN6</name>
+                  <description>ADC AIN6 Pin</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN7</name>
+                  <description>ADC AIN7 Pin</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN8</name>
+                  <description>ADC AIN8 Pin</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN9</name>
+                  <description>ADC AIN9 Pin</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN10</name>
+                  <description>ADC AIN10 Pin</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN11</name>
+                  <description>ADC AIN11 Pin</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN12</name>
+                  <description>ADC AIN12 Pin</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN13</name>
+                  <description>ADC AIN13 Pin</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN14</name>
+                  <description>ADC AIN14 Pin</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN15</name>
+                  <description>ADC AIN15 Pin</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN16</name>
+                  <description>ADC AIN16 Pin</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN17</name>
+                  <description>ADC AIN17 Pin</description>
+                  <value>0x11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN18</name>
+                  <description>ADC AIN18 Pin</description>
+                  <value>0x12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN19</name>
+                  <description>ADC AIN19 Pin</description>
+                  <value>0x13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TEMP</name>
+                  <description>Temperature Reference</description>
+                  <value>0x18</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BANDGAP</name>
+                  <description>Bandgap Voltage</description>
+                  <value>0x19</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SCALEDCOREVCC</name>
+                  <description>1/4  Scaled Core Supply</description>
+                  <value>0x1a</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SCALEDIOVCC</name>
+                  <description>1/4  Scaled I/O Supply</description>
+                  <value>0x1b</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DAC</name>
+                  <description>DAC Output</description>
+                  <value>0x1c</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MUXNEG</name>
+              <description>Negative Mux Input Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>MUXNEGSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>ADC AIN0 Pin</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>ADC AIN1 Pin</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>ADC AIN2 Pin</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>ADC AIN3 Pin</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN4</name>
+                  <description>ADC AIN4 Pin</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN5</name>
+                  <description>ADC AIN5 Pin</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN6</name>
+                  <description>ADC AIN6 Pin</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN7</name>
+                  <description>ADC AIN7 Pin</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GND</name>
+                  <description>Internal Ground</description>
+                  <value>0x18</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>IOGND</name>
+                  <description>I/O Ground</description>
+                  <value>0x19</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>INPUTSCAN</name>
+              <description>Number of Input Channels Included in Scan</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>INPUTOFFSET</name>
+              <description>Positive Mux Setting Offset</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>GAIN</name>
+              <description>Gain Factor Selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>GAINSelect</name>
+                <enumeratedValue>
+                  <name>1X</name>
+                  <description>1x</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2X</name>
+                  <description>2x</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4X</name>
+                  <description>4x</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8X</name>
+                  <description>8x</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16X</name>
+                  <description>16x</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>1/2x</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>STARTEI</name>
+              <description>Start Conversion Event In</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCEI</name>
+              <description>Synchronization Event In</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESRDYEO</name>
+              <description>Result Ready Event Out</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMONEO</name>
+              <description>Window Monitor Event Out</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESRDY</name>
+              <description>Result Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVERRUN</name>
+              <description>Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMON</name>
+              <description>Window Monitor Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x17</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESRDY</name>
+              <description>Result Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVERRUN</name>
+              <description>Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMON</name>
+              <description>Window Monitor Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESRDY</name>
+              <description>Result Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVERRUN</name>
+              <description>Overrun</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMON</name>
+              <description>Window Monitor</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x19</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RESULT</name>
+          <description>Result</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>RESULT</name>
+              <description>Result Conversion Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINLT</name>
+          <description>Window Monitor Lower Threshold</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>WINLT</name>
+              <description>Window Lower Threshold</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINUT</name>
+          <description>Window Monitor Upper Threshold</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>WINUT</name>
+              <description>Window Upper Threshold</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GAINCORR</name>
+          <description>Gain Correction</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>GAINCORR</name>
+              <description>Gain Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OFFSETCORR</name>
+          <description>Offset Correction</description>
+          <addressOffset>0x26</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>OFFSETCORR</name>
+              <description>Offset Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CALIB</name>
+          <description>Calibration</description>
+          <addressOffset>0x28</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>LINEARITY_CAL</name>
+              <description>Linearity Calibration Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>BIAS_CAL</name>
+              <description>Bias Calibration Value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x2A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DAC</name>
+      <version>1.1.0</version>
+      <description>Digital Analog Converter</description>
+      <groupName>DAC</groupName>
+      <prependToName>DAC_</prependToName>
+      <baseAddress>0x42002800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>DAC</name>
+        <value>17</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x1</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EOEN</name>
+              <description>External Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IOEN</name>
+              <description>Internal Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LEFTADJ</name>
+              <description>Left Adjusted Data</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VPD</name>
+              <description>Voltage Pump Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BDWP</name>
+              <description>Bypass DATABUF Write Protection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>REFSEL</name>
+              <description>Reference Selection</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>REFSELSelect</name>
+                <enumeratedValue>
+                  <name>INT1V</name>
+                  <description>Internal 1.0V reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AVCC</name>
+                  <description>AVCC</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>VREFP</name>
+                  <description>External reference</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x2</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>STARTEI</name>
+              <description>Start Conversion Event Input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTYEO</name>
+              <description>Data Buffer Empty Event Output</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x4</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>UNDERRUN</name>
+              <description>Underrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTY</name>
+              <description>Data Buffer Empty Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x5</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>UNDERRUN</name>
+              <description>Underrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTY</name>
+              <description>Data Buffer Empty Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x6</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>UNDERRUN</name>
+              <description>Underrun</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTY</name>
+              <description>Data Buffer Empty</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x7</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy Status</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>Data</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data value to be converted</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATABUF</name>
+          <description>Data Buffer</description>
+          <addressOffset>0xC</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DATABUF</name>
+              <description>Data Buffer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DMAC</name>
+      <version>1.0.0</version>
+      <description>Direct Memory Access Controller</description>
+      <groupName>DMAC</groupName>
+      <prependToName>DMAC_</prependToName>
+      <baseAddress>0x41004800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>DMAC</name>
+        <value>6</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAENABLE</name>
+              <description>DMA Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRCENABLE</name>
+              <description>CRC Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN0</name>
+              <description>Priority Level 0 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN1</name>
+              <description>Priority Level 1 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN2</name>
+              <description>Priority Level 2 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN3</name>
+              <description>Priority Level 3 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCCTRL</name>
+          <description>CRC Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>CRCBEATSIZE</name>
+              <description>CRC Beat Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CRCBEATSIZESelect</name>
+                <enumeratedValue>
+                  <name>BYTE</name>
+                  <description>8-bit bus transfer</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HWORD</name>
+                  <description>16-bit bus transfer</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WORD</name>
+                  <description>32-bit bus transfer</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CRCPOLY</name>
+              <description>CRC Polynomial Type</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CRCPOLYSelect</name>
+                <enumeratedValue>
+                  <name>CRC16</name>
+                  <description>CRC-16 (CRC-CCITT)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CRC32</name>
+                  <description>CRC32 (IEEE 802.3)</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CRCSRC</name>
+              <description>CRC Input Source</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>6</bitWidth>
+              <enumeratedValues>
+                <name>CRCSRCSelect</name>
+                <enumeratedValue>
+                  <name>NOACT</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>IO</name>
+                  <description>I/O interface</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCDATAIN</name>
+          <description>CRC Data Input</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CRCDATAIN</name>
+              <description>CRC Data Input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCCHKSUM</name>
+          <description>CRC Checksum</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CRCCHKSUM</name>
+              <description>CRC Checksum</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCSTATUS</name>
+          <description>CRC Status</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CRCBUSY</name>
+              <description>CRC Module Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRCZERO</name>
+              <description>CRC Zero</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>QOSCTRL</name>
+          <description>QOS Control</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <resetValue>0x15</resetValue>
+          <fields>
+            <field>
+              <name>WRBQOS</name>
+              <description>Write-Back Quality of Service</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WRBQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FQOS</name>
+              <description>Fetch Quality of Service</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DQOS</name>
+              <description>Data Transfer Quality of Service</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>DQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWTRIGCTRL</name>
+          <description>Software Trigger Control</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWTRIG0</name>
+              <description>Channel 0 Software Trigger</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG1</name>
+              <description>Channel 1 Software Trigger</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG2</name>
+              <description>Channel 2 Software Trigger</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG3</name>
+              <description>Channel 3 Software Trigger</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG4</name>
+              <description>Channel 4 Software Trigger</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG5</name>
+              <description>Channel 5 Software Trigger</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRICTRL0</name>
+          <description>Priority Control 0</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>LVLPRI0</name>
+              <description>Level 0 Channel Priority Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN0</name>
+              <description>Level 0 Round-Robin Scheduling Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLPRI1</name>
+              <description>Level 1 Channel Priority Number</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN1</name>
+              <description>Level 1 Round-Robin Scheduling Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLPRI2</name>
+              <description>Level 2 Channel Priority Number</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN2</name>
+              <description>Level 2 Round-Robin Scheduling Enable</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLPRI3</name>
+              <description>Level 3 Channel Priority Number</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN3</name>
+              <description>Level 3 Round-Robin Scheduling Enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTPEND</name>
+          <description>Interrupt Pending</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Channel ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>TERR</name>
+              <description>Transfer Error</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Transfer Complete</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FERR</name>
+              <description>Fetch Error</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSY</name>
+              <description>Busy</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PEND</name>
+              <description>Pending</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTSTATUS</name>
+          <description>Interrupt Status</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>CHINT0</name>
+              <description>Channel 0 Pending Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT1</name>
+              <description>Channel 1 Pending Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT2</name>
+              <description>Channel 2 Pending Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT3</name>
+              <description>Channel 3 Pending Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT4</name>
+              <description>Channel 4 Pending Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT5</name>
+              <description>Channel 5 Pending Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BUSYCH</name>
+          <description>Busy Channels</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>BUSYCH0</name>
+              <description>Busy Channel 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH1</name>
+              <description>Busy Channel 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH2</name>
+              <description>Busy Channel 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH3</name>
+              <description>Busy Channel 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH4</name>
+              <description>Busy Channel 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH5</name>
+              <description>Busy Channel 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PENDCH</name>
+          <description>Pending Channels</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PENDCH0</name>
+              <description>Pending Channel 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH1</name>
+              <description>Pending Channel 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH2</name>
+              <description>Pending Channel 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH3</name>
+              <description>Pending Channel 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH4</name>
+              <description>Pending Channel 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH5</name>
+              <description>Pending Channel 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ACTIVE</name>
+          <description>Active Channel and Levels</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>LVLEX0</name>
+              <description>Level 0 Channel Trigger Request Executing</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LVLEX1</name>
+              <description>Level 1 Channel Trigger Request Executing</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LVLEX2</name>
+              <description>Level 2 Channel Trigger Request Executing</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LVLEX3</name>
+              <description>Level 3 Channel Trigger Request Executing</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ID</name>
+              <description>Active Channel ID</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ABUSY</name>
+              <description>Active Channel Busy</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BTCNT</name>
+              <description>Active Channel Block Transfer Count</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BASEADDR</name>
+          <description>Descriptor Memory Section Base Address</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>BASEADDR</name>
+              <description>Descriptor Memory Base Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WRBADDR</name>
+          <description>Write-Back Memory Section Base Address</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WRBADDR</name>
+              <description>Write-Back Memory Base Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHID</name>
+          <description>Channel ID</description>
+          <addressOffset>0x3F</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Channel ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHCTRLA</name>
+          <description>Channel Control A</description>
+          <addressOffset>0x40</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Channel Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Channel Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHCTRLB</name>
+          <description>Channel Control B</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Input Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>NOACT</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TRIG</name>
+                  <description>Transfer and periodic transfer trigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CTRIG</name>
+                  <description>Conditional transfer trigger</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CBLOCK</name>
+                  <description>Conditional block transfer</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>Channel suspend operation</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESUME</name>
+                  <description>Channel resume operation</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSKIP</name>
+                  <description>Skip next block suspend action</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EVIE</name>
+              <description>Channel Event Input Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVOE</name>
+              <description>Channel Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVL</name>
+              <description>Channel Arbitration Level</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>LVLSelect</name>
+                <enumeratedValue>
+                  <name>LVL0</name>
+                  <description>Channel Priority Level 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LVL1</name>
+                  <description>Channel Priority Level 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LVL2</name>
+                  <description>Channel Priority Level 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LVL3</name>
+                  <description>Channel Priority Level 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TRIGSRC</name>
+              <description>Trigger Source</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>TRIGSRCSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Only software/event triggers</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TRIGACT</name>
+              <description>Trigger Action</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>TRIGACTSelect</name>
+                <enumeratedValue>
+                  <name>BLOCK</name>
+                  <description>One trigger required for each block transfer</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BEAT</name>
+                  <description>One trigger required for each beat transfer</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TRANSACTION</name>
+                  <description>One trigger required for each transaction</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Software Command</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NOACT</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>Channel suspend operation</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESUME</name>
+                  <description>Channel resume operation</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHINTENCLR</name>
+          <description>Channel Interrupt Enable Clear</description>
+          <addressOffset>0x4C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TERR</name>
+              <description>Channel Transfer Error Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Channel Transfer Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHINTENSET</name>
+          <description>Channel Interrupt Enable Set</description>
+          <addressOffset>0x4D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TERR</name>
+              <description>Channel Transfer Error Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Channel Transfer Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHINTFLAG</name>
+          <description>Channel Interrupt Flag Status and Clear</description>
+          <addressOffset>0x4E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TERR</name>
+              <description>Channel Transfer Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Channel Transfer Complete</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHSTATUS</name>
+          <description>Channel Status</description>
+          <addressOffset>0x4F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PEND</name>
+              <description>Channel Pending</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSY</name>
+              <description>Channel Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FERR</name>
+              <description>Channel Fetch Error</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DSU</name>
+      <version>2.1.1</version>
+      <description>Device Service Unit</description>
+      <groupName>DSU</groupName>
+      <prependToName>DSU_</prependToName>
+      <baseAddress>0x41002000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x2000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x0000</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CRC</name>
+              <description>32-bit Cyclic Redundancy Code</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>MBIST</name>
+              <description>Memory built-in self-test</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CE</name>
+              <description>Chip-Erase</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ARR</name>
+              <description>Auxiliary Row Read</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>SMSA</name>
+              <description>Start Memory Stream Access</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSA</name>
+          <description>Status A</description>
+          <addressOffset>0x0001</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DONE</name>
+              <description>Done</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRSTEXT</name>
+              <description>CPU Reset Phase Extension</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BERR</name>
+              <description>Bus Error</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAIL</name>
+              <description>Failure</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERR</name>
+              <description>Protection Error</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSB</name>
+          <description>Status B</description>
+          <addressOffset>0x0002</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PROT</name>
+              <description>Protected</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DBGPRES</name>
+              <description>Debugger Present</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DCCD0</name>
+              <description>Debug Communication Channel 0 Dirty</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DCCD1</name>
+              <description>Debug Communication Channel 1 Dirty</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HPE</name>
+              <description>Hot-Plugging Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>Address</description>
+          <addressOffset>0x0004</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>AMOD</name>
+              <description>Access Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>30</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LENGTH</name>
+          <description>Length</description>
+          <addressOffset>0x0008</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>LENGTH</name>
+              <description>Length</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>30</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>Data</description>
+          <addressOffset>0x000C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>DCC%s</name>
+          <description>Debug Communication Channel n</description>
+          <addressOffset>0x0010</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DID</name>
+          <description>Device Identification</description>
+          <addressOffset>0x0018</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x10030106</resetValue>
+          <fields>
+            <field>
+              <name>DEVSEL</name>
+              <description>Device Select</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>REVISION</name>
+              <description>Revision Number</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DIE</name>
+              <description>Die Number</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SERIES</name>
+              <description>Series</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>SERIESSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>Cortex-M0+ processor, basic feature set</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>Cortex-M0+ processor, USB</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FAMILY</name>
+              <description>Family</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>5</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>FAMILYSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>General purpose microcontroller</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>PicoPower</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PROCESSOR</name>
+              <description>Processor</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>PROCESSORSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>Cortex-M0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>Cortex-M0+</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>Cortex-M3</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>Cortex-M4</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>DCFG%s</name>
+          <description>Device Configuration</description>
+          <addressOffset>0x00F0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DCFG</name>
+              <description>Device Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ENTRY0</name>
+          <description>CoreSight ROM Table Entry 0</description>
+          <addressOffset>0x1000</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x9F0FC002</resetValue>
+          <fields>
+            <field>
+              <name>EPRES</name>
+              <description>Entry Present</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FMT</name>
+              <description>Format</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ADDOFF</name>
+              <description>Address Offset</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>20</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ENTRY1</name>
+          <description>CoreSight ROM Table Entry 1</description>
+          <addressOffset>0x1004</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00003002</resetValue>
+        </register>
+        <register>
+          <name>END</name>
+          <description>CoreSight ROM Table End</description>
+          <addressOffset>0x1008</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>END</name>
+              <description>End Marker</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MEMTYPE</name>
+          <description>CoreSight ROM Table Memory Type</description>
+          <addressOffset>0x1FCC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SMEMP</name>
+              <description>System Memory Present</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID4</name>
+          <description>Peripheral Identification 4</description>
+          <addressOffset>0x1FD0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>JEPCC</name>
+              <description>JEP-106 Continuation Code</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>FKBC</name>
+              <description>4KB count</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID5</name>
+          <description>Peripheral Identification 5</description>
+          <addressOffset>0x1FD4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID6</name>
+          <description>Peripheral Identification 6</description>
+          <addressOffset>0x1FD8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID7</name>
+          <description>Peripheral Identification 7</description>
+          <addressOffset>0x1FDC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID0</name>
+          <description>Peripheral Identification 0</description>
+          <addressOffset>0x1FE0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000000D0</resetValue>
+          <fields>
+            <field>
+              <name>PARTNBL</name>
+              <description>Part Number Low</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID1</name>
+          <description>Peripheral Identification 1</description>
+          <addressOffset>0x1FE4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000000FC</resetValue>
+          <fields>
+            <field>
+              <name>PARTNBH</name>
+              <description>Part Number High</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>JEPIDCL</name>
+              <description>Low part of the JEP-106 Identity Code</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID2</name>
+          <description>Peripheral Identification 2</description>
+          <addressOffset>0x1FE8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00000009</resetValue>
+          <fields>
+            <field>
+              <name>JEPIDCH</name>
+              <description>JEP-106 Identity Code High</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>JEPU</name>
+              <description>JEP-106 Identity Code is used</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>REVISION</name>
+              <description>Revision Number</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID3</name>
+          <description>Peripheral Identification 3</description>
+          <addressOffset>0x1FEC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>CUSMOD</name>
+              <description>ARM CUSMOD</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>REVAND</name>
+              <description>Revision Number</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID0</name>
+          <description>Component Identification 0</description>
+          <addressOffset>0x1FF0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x0000000D</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLEB0</name>
+              <description>Preamble Byte 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID1</name>
+          <description>Component Identification 1</description>
+          <addressOffset>0x1FF4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00000010</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLE</name>
+              <description>Preamble</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CCLASS</name>
+              <description>Component Class</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID2</name>
+          <description>Component Identification 2</description>
+          <addressOffset>0x1FF8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00000005</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLEB2</name>
+              <description>Preamble Byte 2</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID3</name>
+          <description>Component Identification 3</description>
+          <addressOffset>0x1FFC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000000B1</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLEB3</name>
+              <description>Preamble Byte 3</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EIC</name>
+      <version>1.0.1</version>
+      <description>External Interrupt Controller</description>
+      <groupName>EIC</groupName>
+      <prependToName>EIC_</prependToName>
+      <baseAddress>0x40001800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>EIC</name>
+        <value>4</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>NMICTRL</name>
+          <description>Non-Maskable Interrupt Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>NMISENSE</name>
+              <description>Non-Maskable Interrupt Sense</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>NMISENSESelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising-edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling-edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both-edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High-level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low-level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>NMIFILTEN</name>
+              <description>Non-Maskable Interrupt Filter Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>NMIFLAG</name>
+          <description>Non-Maskable Interrupt Flag Status and Clear</description>
+          <addressOffset>0x03</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>NMI</name>
+              <description>Non-Maskable Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINTEO0</name>
+              <description>External Interrupt 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO1</name>
+              <description>External Interrupt 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO2</name>
+              <description>External Interrupt 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO3</name>
+              <description>External Interrupt 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO4</name>
+              <description>External Interrupt 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO5</name>
+              <description>External Interrupt 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO6</name>
+              <description>External Interrupt 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO7</name>
+              <description>External Interrupt 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINT0</name>
+              <description>External Interrupt 0 Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT1</name>
+              <description>External Interrupt 1 Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT2</name>
+              <description>External Interrupt 2 Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT3</name>
+              <description>External Interrupt 3 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT4</name>
+              <description>External Interrupt 4 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT5</name>
+              <description>External Interrupt 5 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT6</name>
+              <description>External Interrupt 6 Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT7</name>
+              <description>External Interrupt 7 Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINT0</name>
+              <description>External Interrupt 0 Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT1</name>
+              <description>External Interrupt 1 Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT2</name>
+              <description>External Interrupt 2 Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT3</name>
+              <description>External Interrupt 3 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT4</name>
+              <description>External Interrupt 4 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT5</name>
+              <description>External Interrupt 5 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT6</name>
+              <description>External Interrupt 6 Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT7</name>
+              <description>External Interrupt 7 Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINT0</name>
+              <description>External Interrupt 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT1</name>
+              <description>External Interrupt 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT2</name>
+              <description>External Interrupt 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT3</name>
+              <description>External Interrupt 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT4</name>
+              <description>External Interrupt 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT5</name>
+              <description>External Interrupt 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT6</name>
+              <description>External Interrupt 6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT7</name>
+              <description>External Interrupt 7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAKEUP</name>
+          <description>Wake-Up Enable</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WAKEUPEN0</name>
+              <description>External Interrupt 0 Wake-up Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN1</name>
+              <description>External Interrupt 1 Wake-up Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN2</name>
+              <description>External Interrupt 2 Wake-up Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN3</name>
+              <description>External Interrupt 3 Wake-up Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN4</name>
+              <description>External Interrupt 4 Wake-up Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN5</name>
+              <description>External Interrupt 5 Wake-up Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN6</name>
+              <description>External Interrupt 6 Wake-up Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN7</name>
+              <description>External Interrupt 7 Wake-up Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CONFIG%s</name>
+          <description>Configuration n</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SENSE0</name>
+              <description>Input Sense 0 Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE0Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising-edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling-edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both-edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High-level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low-level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN0</name>
+              <description>Filter 0 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE1</name>
+              <description>Input Sense 1 Configuration</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE1Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN1</name>
+              <description>Filter 1 Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE2</name>
+              <description>Input Sense 2 Configuration</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE2Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN2</name>
+              <description>Filter 2 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE3</name>
+              <description>Input Sense 3 Configuration</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE3Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN3</name>
+              <description>Filter 3 Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE4</name>
+              <description>Input Sense 4 Configuration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE4Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN4</name>
+              <description>Filter 4 Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE5</name>
+              <description>Input Sense 5 Configuration</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE5Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN5</name>
+              <description>Filter 5 Enable</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE6</name>
+              <description>Input Sense 6 Configuration</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE6Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN6</name>
+              <description>Filter 6 Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE7</name>
+              <description>Input Sense 7 Configuration</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE7Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN7</name>
+              <description>Filter 7 Enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EVSYS</name>
+      <version>1.0.1</version>
+      <description>Event System Interface</description>
+      <groupName>EVSYS</groupName>
+      <prependToName>EVSYS_</prependToName>
+      <baseAddress>0x42000400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>EVSYS</name>
+        <value>8</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>GCLKREQ</name>
+              <description>Generic Clock Requests</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHANNEL</name>
+          <description>Channel</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CHANNEL</name>
+              <description>Channel Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SWEVT</name>
+              <description>Software Event</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVGEN</name>
+              <description>Event Generator Selection</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>PATH</name>
+              <description>Path Selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PATHSelect</name>
+                <enumeratedValue>
+                  <name>SYNCHRONOUS</name>
+                  <description>Synchronous path</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNCHRONIZED</name>
+                  <description>Resynchronized path</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ASYNCHRONOUS</name>
+                  <description>Asynchronous path</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EDGSEL</name>
+              <description>Edge Detection Selection</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>EDGSELSelect</name>
+                <enumeratedValue>
+                  <name>NO_EVT_OUTPUT</name>
+                  <description>No event output when using the resynchronized or synchronous path</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISING_EDGE</name>
+                  <description>Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALLING_EDGE</name>
+                  <description>Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH_EDGES</name>
+                  <description>Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>USER</name>
+          <description>User Multiplexer</description>
+          <addressOffset>0x08</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USER</name>
+              <description>User Multiplexer Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>CHANNEL</name>
+              <description>Channel Event Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>CHANNELSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>No Channel Output Selected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHSTATUS</name>
+          <description>Channel Status</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x0000003F</resetValue>
+          <fields>
+            <field>
+              <name>USRRDY0</name>
+              <description>Channel 0 User Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY1</name>
+              <description>Channel 1 User Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY2</name>
+              <description>Channel 2 User Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY3</name>
+              <description>Channel 3 User Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY4</name>
+              <description>Channel 4 User Ready</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY5</name>
+              <description>Channel 5 User Ready</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY0</name>
+              <description>Channel 0 Busy</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY1</name>
+              <description>Channel 1 Busy</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY2</name>
+              <description>Channel 2 Busy</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY3</name>
+              <description>Channel 3 Busy</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY4</name>
+              <description>Channel 4 Busy</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY5</name>
+              <description>Channel 5 Busy</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVR0</name>
+              <description>Channel 0 Overrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR1</name>
+              <description>Channel 1 Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR2</name>
+              <description>Channel 2 Overrun Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR3</name>
+              <description>Channel 3 Overrun Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR4</name>
+              <description>Channel 4 Overrun Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR5</name>
+              <description>Channel 5 Overrun Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD0</name>
+              <description>Channel 0 Event Detection Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD1</name>
+              <description>Channel 1 Event Detection Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD2</name>
+              <description>Channel 2 Event Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD3</name>
+              <description>Channel 3 Event Detection Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD4</name>
+              <description>Channel 4 Event Detection Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD5</name>
+              <description>Channel 5 Event Detection Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVR0</name>
+              <description>Channel 0 Overrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR1</name>
+              <description>Channel 1 Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR2</name>
+              <description>Channel 2 Overrun Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR3</name>
+              <description>Channel 3 Overrun Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR4</name>
+              <description>Channel 4 Overrun Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR5</name>
+              <description>Channel 5 Overrun Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD0</name>
+              <description>Channel 0 Event Detection Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD1</name>
+              <description>Channel 1 Event Detection Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD2</name>
+              <description>Channel 2 Event Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD3</name>
+              <description>Channel 3 Event Detection Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD4</name>
+              <description>Channel 4 Event Detection Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD5</name>
+              <description>Channel 5 Event Detection Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVR0</name>
+              <description>Channel 0 Overrun</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR1</name>
+              <description>Channel 1 Overrun</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR2</name>
+              <description>Channel 2 Overrun</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR3</name>
+              <description>Channel 3 Overrun</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR4</name>
+              <description>Channel 4 Overrun</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR5</name>
+              <description>Channel 5 Overrun</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD0</name>
+              <description>Channel 0 Event Detection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD1</name>
+              <description>Channel 1 Event Detection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD2</name>
+              <description>Channel 2 Event Detection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD3</name>
+              <description>Channel 3 Event Detection</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD4</name>
+              <description>Channel 4 Event Detection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD5</name>
+              <description>Channel 5 Event Detection</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>GCLK</name>
+      <version>2.1.0</version>
+      <description>Generic Clock Generator</description>
+      <groupName>GCLK</groupName>
+      <prependToName>GCLK_</prependToName>
+      <baseAddress>0x40000C00</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x1</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy Status</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CLKCTRL</name>
+          <description>Generic Clock Control</description>
+          <addressOffset>0x2</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Generic Clock Selection ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <enumeratedValues>
+                <name>IDSelect</name>
+                <enumeratedValue>
+                  <name>DFLL48</name>
+                  <description>DFLL48</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FDPLL</name>
+                  <description>FDPLL</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FDPLL32K</name>
+                  <description>FDPLL32K</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WDT</name>
+                  <description>WDT</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RTC</name>
+                  <description>RTC</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EIC</name>
+                  <description>EIC</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB</name>
+                  <description>USB</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_0</name>
+                  <description>EVSYS_0</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_1</name>
+                  <description>EVSYS_1</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_2</name>
+                  <description>EVSYS_2</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_3</name>
+                  <description>EVSYS_3</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_4</name>
+                  <description>EVSYS_4</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_5</name>
+                  <description>EVSYS_5</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOMX_SLOW</name>
+                  <description>SERCOMX_SLOW</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM0_CORE</name>
+                  <description>SERCOM0_CORE</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM1_CORE</name>
+                  <description>SERCOM1_CORE</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM2_CORE</name>
+                  <description>SERCOM2_CORE</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TCC0</name>
+                  <description>TCC0</description>
+                  <value>0x11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TC1_TC2</name>
+                  <description>TC1_TC2</description>
+                  <value>0x12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC</name>
+                  <description>ADC</description>
+                  <value>0x13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AC_DIG</name>
+                  <description>AC_DIG</description>
+                  <value>0x14</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AC_ANA</name>
+                  <description>AC_ANA</description>
+                  <value>0x15</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DAC</name>
+                  <description>DAC</description>
+                  <value>0x16</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>GEN</name>
+              <description>Generic Clock Generator</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>GENSelect</name>
+                <enumeratedValue>
+                  <name>GCLK0</name>
+                  <description>Generic clock generator 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK1</name>
+                  <description>Generic clock generator 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK2</name>
+                  <description>Generic clock generator 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK3</name>
+                  <description>Generic clock generator 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK4</name>
+                  <description>Generic clock generator 4</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK5</name>
+                  <description>Generic clock generator 5</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CLKEN</name>
+              <description>Clock Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GENCTRL</name>
+          <description>Generic Clock Generator Control</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Generic Clock Generator Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>SRC</name>
+              <description>Source Select</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>SRCSelect</name>
+                <enumeratedValue>
+                  <name>XOSC</name>
+                  <description>XOSC oscillator output</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLKIN</name>
+                  <description>Generator input pad</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLKGEN1</name>
+                  <description>Generic clock generator 1 output</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OSCULP32K</name>
+                  <description>OSCULP32K oscillator output</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OSC32K</name>
+                  <description>OSC32K oscillator output</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>XOSC32K</name>
+                  <description>XOSC32K oscillator output</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OSC8M</name>
+                  <description>OSC8M oscillator output</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DFLL48M</name>
+                  <description>DFLL48M output</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DPLL96M</name>
+                  <description>DPLL96M output</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>GENEN</name>
+              <description>Generic Clock Generator Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDC</name>
+              <description>Improve Duty Cycle</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OOV</name>
+              <description>Output Off Value</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OE</name>
+              <description>Output Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DIVSEL</name>
+              <description>Divide Selection</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GENDIV</name>
+          <description>Generic Clock Generator Division</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Generic Clock Generator Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>DIV</name>
+              <description>Division Factor</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>HMATRIX</name>
+      <version>2.1.2</version>
+      <description>HSB Matrix</description>
+      <groupName>HMATRIXB</groupName>
+      <prependToName>HMATRIXB_</prependToName>
+      <baseAddress>0x41007000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>PRAS%s</name>
+          <description>Priority A for Slave</description>
+          <addressOffset>0x080</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>M0PR</name>
+              <description>Master 0 Priority</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M1PR</name>
+              <description>Master 1 Priority</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M2PR</name>
+              <description>Master 2 Priority</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M3PR</name>
+              <description>Master 3 Priority</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M4PR</name>
+              <description>Master 4 Priority</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M5PR</name>
+              <description>Master 5 Priority</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M6PR</name>
+              <description>Master 6 Priority</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M7PR</name>
+              <description>Master 7 Priority</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>PRBS%s</name>
+          <description>Priority B for Slave</description>
+          <addressOffset>0x084</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>M8PR</name>
+              <description>Master 8 Priority</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M9PR</name>
+              <description>Master 9 Priority</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M10PR</name>
+              <description>Master 10 Priority</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M11PR</name>
+              <description>Master 11 Priority</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M12PR</name>
+              <description>Master 12 Priority</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M13PR</name>
+              <description>Master 13 Priority</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M14PR</name>
+              <description>Master 14 Priority</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M15PR</name>
+              <description>Master 15 Priority</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>SFR%s</name>
+          <description>Special Function</description>
+          <addressOffset>0x110</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SFR</name>
+              <description>Special Function Register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>MTB</name>
+      <version>1.0.0</version>
+      <description>Cortex-M0+ Micro-Trace Buffer</description>
+      <groupName>MTB</groupName>
+      <prependToName>MTB_</prependToName>
+      <baseAddress>0x41006000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>POSITION</name>
+          <description>MTB Position</description>
+          <addressOffset>0x000</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WRAP</name>
+              <description>Pointer Value Wraps</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POINTER</name>
+              <description>Trace Packet Location Pointer</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>29</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MASTER</name>
+          <description>MTB Master</description>
+          <addressOffset>0x004</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>MASK</name>
+              <description>Maximum Value of the Trace Buffer in SRAM</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TSTARTEN</name>
+              <description>Trace Start Input Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTOPEN</name>
+              <description>Trace Stop Input Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SFRWPRIV</name>
+              <description>Special Function Register Write Privilege</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMPRIV</name>
+              <description>SRAM Privilege</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HALTREQ</name>
+              <description>Halt Request</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN</name>
+              <description>Main Trace Enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FLOW</name>
+          <description>MTB Flow</description>
+          <addressOffset>0x008</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>AUTOSTOP</name>
+              <description>Auto Stop Tracing</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AUTOHALT</name>
+              <description>Auto Halt Request</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WATERMARK</name>
+              <description>Watermark value</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>29</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BASE</name>
+          <description>MTB Base</description>
+          <addressOffset>0x00C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>ITCTRL</name>
+          <description>MTB Integration Mode Control</description>
+          <addressOffset>0xF00</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>CLAIMSET</name>
+          <description>MTB Claim Set</description>
+          <addressOffset>0xFA0</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>CLAIMCLR</name>
+          <description>MTB Claim Clear</description>
+          <addressOffset>0xFA4</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>LOCKACCESS</name>
+          <description>MTB Lock Access</description>
+          <addressOffset>0xFB0</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>LOCKSTATUS</name>
+          <description>MTB Lock Status</description>
+          <addressOffset>0xFB4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>AUTHSTATUS</name>
+          <description>MTB Authentication Status</description>
+          <addressOffset>0xFB8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>DEVARCH</name>
+          <description>MTB Device Architecture</description>
+          <addressOffset>0xFBC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>DEVID</name>
+          <description>MTB Device Configuration</description>
+          <addressOffset>0xFC8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>DEVTYPE</name>
+          <description>MTB Device Type</description>
+          <addressOffset>0xFCC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID4</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFD0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID5</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFD4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID6</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFD8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID7</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFDC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID0</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFE0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID1</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFE4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID2</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFE8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID3</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFEC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID0</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFF0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID1</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFF4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID2</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFF8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID3</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFFC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>NVMCTRL</name>
+      <version>1.0.7</version>
+      <description>Non-Volatile Memory Controller</description>
+      <groupName>NVMCTRL</groupName>
+      <prependToName>NVMCTRL_</prependToName>
+      <baseAddress>0x41004000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>NVMCTRL</name>
+        <value>5</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>ER</name>
+                  <description>Erase Row - Erases the row addressed by the ADDR register.</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WP</name>
+                  <description>Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register.</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EAR</name>
+                  <description>Erase Auxiliary Row - Erases the auxiliary row addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row.</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WAP</name>
+                  <description>Write Auxiliary Page - Writes the contents of the page buffer to the page addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row.</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SF</name>
+                  <description>Security Flow Command</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WL</name>
+                  <description>Write lockbits</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LR</name>
+                  <description>Lock Region - Locks the region containing the address location in the ADDR register.</description>
+                  <value>0x40</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UR</name>
+                  <description>Unlock Region - Unlocks the region containing the address location in the ADDR register.</description>
+                  <value>0x41</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPRM</name>
+                  <description>Sets the power reduction mode.</description>
+                  <value>0x42</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CPRM</name>
+                  <description>Clears the power reduction mode.</description>
+                  <value>0x43</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PBC</name>
+                  <description>Page Buffer Clear - Clears the page buffer.</description>
+                  <value>0x44</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSB</name>
+                  <description>Set Security Bit - Sets the security bit by writing 0x00 to the first byte in the lockbit row.</description>
+                  <value>0x45</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INVALL</name>
+                  <description>Invalidates all cache lines.</description>
+                  <value>0x46</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMDEX</name>
+              <description>Command Execution</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+              <enumeratedValues>
+                <name>CMDEXSelect</name>
+                <enumeratedValue>
+                  <name>KEY</name>
+                  <description>Execution Key</description>
+                  <value>0xa5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>RWS</name>
+              <description>NVM Read Wait States</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>RWSSelect</name>
+                <enumeratedValue>
+                  <name>SINGLE</name>
+                  <description>Single Auto Wait State</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HALF</name>
+                  <description>Half Auto Wait State</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DUAL</name>
+                  <description>Dual Auto Wait State</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MANW</name>
+              <description>Manual Write</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLEEPPRM</name>
+              <description>Power Reduction Mode during Sleep</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SLEEPPRMSelect</name>
+                <enumeratedValue>
+                  <name>WAKEONACCESS</name>
+                  <description>NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access.</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WAKEUPINSTANT</name>
+                  <description>NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep.</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DISABLED</name>
+                  <description>Auto power reduction disabled.</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>READMODE</name>
+              <description>NVMCTRL Read Mode</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>READMODESelect</name>
+                <enumeratedValue>
+                  <name>NO_MISS_PENALTY</name>
+                  <description>The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance.</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW_POWER</name>
+                  <description>Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time.</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DETERMINISTIC</name>
+                  <description>The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings.</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CACHEDIS</name>
+              <description>Cache Disable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PARAM</name>
+          <description>NVM Parameter</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>NVMP</name>
+              <description>NVM Pages</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PSZ</name>
+              <description>Page Size</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>PSZSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 bytes</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 bytes</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 bytes</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 bytes</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 bytes</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 bytes</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 bytes</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1024</name>
+                  <description>1024 bytes</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READY</name>
+              <description>NVM Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x10</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READY</name>
+              <description>NVM Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READY</name>
+              <description>NVM Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PRM</name>
+              <description>Power Reduction Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LOAD</name>
+              <description>NVM Page Buffer Active Loading</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PROGE</name>
+              <description>Programming Error Status</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LOCKE</name>
+              <description>Lock Error Status</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NVME</name>
+              <description>NVM Error</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Security Bit Status</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>Address</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>NVM Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>22</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LOCK</name>
+          <description>Lock Section</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>LOCK</name>
+              <description>Region Lock Bits</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PAC0</name>
+      <version>1.0.1</version>
+      <description>Peripheral Access Controller 0</description>
+      <groupName>PAC</groupName>
+      <prependToName>PAC_</prependToName>
+      <baseAddress>0x40000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x08</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>WPCLR</name>
+          <description>Write Protection Clear</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WP</name>
+              <description>Write Protection Clear</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>31</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WPSET</name>
+          <description>Write Protection Set</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WP</name>
+              <description>Write Protection Set</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>31</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="PAC0">
+      <name>PAC1</name>
+      <description>Peripheral Access Controller 1</description>
+      <baseAddress>0x41000000</baseAddress>
+    </peripheral>
+    <peripheral derivedFrom="PAC0">
+      <name>PAC2</name>
+      <description>Peripheral Access Controller 2</description>
+      <baseAddress>0x42000000</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>PM</name>
+      <version>2.1.1</version>
+      <description>Power Manager</description>
+      <groupName>PM</groupName>
+      <prependToName>PM_</prependToName>
+      <baseAddress>0x40000400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>PM</name>
+        <value>0</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CFDEN</name>
+              <description>Clock Failure Detector Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BKUPCLK</name>
+              <description>Backup Clock Select</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SLEEP</name>
+          <description>Sleep Mode</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>IDLE</name>
+              <description>Idle Mode Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>IDLESelect</name>
+                <enumeratedValue>
+                  <name>CPU</name>
+                  <description>The CPU clock domain is stopped</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AHB</name>
+                  <description>The CPU and AHB clock domains are stopped</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>APB</name>
+                  <description>The CPU, AHB and APB clock domains are stopped</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTCTRL</name>
+          <description>External Reset Controller</description>
+          <addressOffset>0x02</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SETDIS</name>
+              <description>External Reset Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CPUSEL</name>
+          <description>CPU Clock Select</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CPUDIV</name>
+              <description>CPU Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CPUDIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBASEL</name>
+          <description>APBA Clock Select</description>
+          <addressOffset>0x09</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>APBADIV</name>
+              <description>APBA Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>APBADIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBBSEL</name>
+          <description>APBB Clock Select</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>APBBDIV</name>
+              <description>APBB Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>APBBDIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBCSEL</name>
+          <description>APBC Clock Select</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>APBCDIV</name>
+              <description>APBC Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>APBCDIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBMASK</name>
+          <description>AHB Mask</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <resetValue>0x0000007F</resetValue>
+          <fields>
+            <field>
+              <name>HPB0_</name>
+              <description>HPB0 AHB Clock Mask</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HPB1_</name>
+              <description>HPB1 AHB Clock Mask</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HPB2_</name>
+              <description>HPB2 AHB Clock Mask</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DSU_</name>
+              <description>DSU AHB Clock Mask</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NVMCTRL_</name>
+              <description>NVMCTRL AHB Clock Mask</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAC_</name>
+              <description>DMAC AHB Clock Mask</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USB_</name>
+              <description>USB AHB Clock Mask</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBAMASK</name>
+          <description>APBA Mask</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <resetValue>0x0000007F</resetValue>
+          <fields>
+            <field>
+              <name>PAC0_</name>
+              <description>PAC0 APB Clock Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PM_</name>
+              <description>PM APB Clock Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYSCTRL_</name>
+              <description>SYSCTRL APB Clock Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GCLK_</name>
+              <description>GCLK APB Clock Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WDT_</name>
+              <description>WDT APB Clock Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RTC_</name>
+              <description>RTC APB Clock Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EIC_</name>
+              <description>EIC APB Clock Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBBMASK</name>
+          <description>APBB Mask</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <resetValue>0x0000007F</resetValue>
+          <fields>
+            <field>
+              <name>PAC1_</name>
+              <description>PAC1 APB Clock Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DSU_</name>
+              <description>DSU APB Clock Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NVMCTRL_</name>
+              <description>NVMCTRL APB Clock Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PORT_</name>
+              <description>PORT APB Clock Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAC_</name>
+              <description>DMAC APB Clock Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USB_</name>
+              <description>USB APB Clock Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HMATRIX_</name>
+              <description>HMATRIX APB Clock Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBCMASK</name>
+          <description>APBC Mask</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <resetValue>0x00000100</resetValue>
+          <fields>
+            <field>
+              <name>PAC2_</name>
+              <description>PAC2 APB Clock Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVSYS_</name>
+              <description>EVSYS APB Clock Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM0_</name>
+              <description>SERCOM0 APB Clock Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM1_</name>
+              <description>SERCOM1 APB Clock Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCC0_</name>
+              <description>TCC0 APB Clock Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TC1_</name>
+              <description>TC1 APB Clock Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TC2_</name>
+              <description>TC2 APB Clock Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADC_</name>
+              <description>ADC APB Clock Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AC_</name>
+              <description>AC APB Clock Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DAC_</name>
+              <description>DAC APB Clock Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PTC_</name>
+              <description>PTC APB Clock Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x34</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CKRDY</name>
+              <description>Clock Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CFD</name>
+              <description>Clock Failure Detector Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x35</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CKRDY</name>
+              <description>Clock Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CFD</name>
+              <description>Clock Failure Detector Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x36</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CKRDY</name>
+              <description>Clock Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CFD</name>
+              <description>Clock Failure Detector</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCAUSE</name>
+          <description>Reset Cause</description>
+          <addressOffset>0x38</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x01</resetValue>
+          <fields>
+            <field>
+              <name>POR</name>
+              <description>Power On Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD12</name>
+              <description>Brown Out 12 Detector Reset</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33</name>
+              <description>Brown Out 33 Detector Reset</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXT</name>
+              <description>External Reset</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WDT</name>
+              <description>Watchdog Reset</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYST</name>
+              <description>System Reset Request</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PORT</name>
+      <version>1.0.0</version>
+      <description>Port Module</description>
+      <groupName>PORT</groupName>
+      <prependToName>PORT_</prependToName>
+      <baseAddress>0x41004400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x200</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIR%s</name>
+          <description>Data Direction</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Port Data Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIRCLR%s</name>
+          <description>Data Direction Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIRCLR</name>
+              <description>Port Data Direction Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIRSET%s</name>
+          <description>Data Direction Set</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIRSET</name>
+              <description>Port Data Direction Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIRTGL%s</name>
+          <description>Data Direction Toggle</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIRTGL</name>
+              <description>Port Data Direction Toggle</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUT%s</name>
+          <description>Data Output Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUT</name>
+              <description>Port Data Output Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUTCLR%s</name>
+          <description>Data Output Value Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUTCLR</name>
+              <description>Port Data Output Value Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUTSET%s</name>
+          <description>Data Output Value Set</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUTSET</name>
+              <description>Port Data Output Value Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUTTGL%s</name>
+          <description>Data Output Value Toggle</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUTTGL</name>
+              <description>Port Data Output Value Toggle</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>IN%s</name>
+          <description>Data Input Value</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>IN</name>
+              <description>Port Data Input Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>CTRL%s</name>
+          <description>Control</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SAMPLING</name>
+              <description>Input Sampling Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>WRCONFIG%s</name>
+          <description>Write Configuration</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>PINMASK</name>
+              <description>Pin Mask for Multiple Pin Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+            <field>
+              <name>PMUXEN</name>
+              <description>Peripheral Multiplexer Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INEN</name>
+              <description>Input Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PULLEN</name>
+              <description>Pull Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRVSTR</name>
+              <description>Output Driver Strength Selection</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PMUX</name>
+              <description>Peripheral Multiplexing</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>WRPMUX</name>
+              <description>Write PMUX</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WRPINCFG</name>
+              <description>Write PINCFG</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HWSEL</name>
+              <description>Half-Word Select</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>PMUX0_%s</name>
+          <description>Peripheral Multiplexing n - Group 0</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PMUXE</name>
+              <description>Peripheral Multiplexing Even</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PMUXESelect</name>
+                <enumeratedValue>
+                  <name>A</name>
+                  <description>Peripheral function A selected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>B</name>
+                  <description>Peripheral function B selected</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>C</name>
+                  <description>Peripheral function C selected</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>D</name>
+                  <description>Peripheral function D selected</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>E</name>
+                  <description>Peripheral function E selected</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>F</name>
+                  <description>Peripheral function F selected</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>G</name>
+                  <description>Peripheral function G selected</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>H</name>
+                  <description>Peripheral function H selected</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PMUXO</name>
+              <description>Peripheral Multiplexing Odd</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PMUXOSelect</name>
+                <enumeratedValue>
+                  <name>A</name>
+                  <description>Peripheral function A selected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>B</name>
+                  <description>Peripheral function B selected</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>C</name>
+                  <description>Peripheral function C selected</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>D</name>
+                  <description>Peripheral function D selected</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>E</name>
+                  <description>Peripheral function E selected</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>F</name>
+                  <description>Peripheral function F selected</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>G</name>
+                  <description>Peripheral function G selected</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>H</name>
+                  <description>Peripheral function H selected</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>32</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>PINCFG0_%s</name>
+          <description>Pin Configuration n - Group 0</description>
+          <addressOffset>0x40</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PMUXEN</name>
+              <description>Peripheral Multiplexer Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INEN</name>
+              <description>Input Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PULLEN</name>
+              <description>Pull Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRVSTR</name>
+              <description>Output Driver Strength Selection</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="PORT">
+      <name>PORT_IOBUS</name>
+      <description>Port Module (IOBUS)</description>
+      <groupName>PORT_IOBUS</groupName>
+      <prependToName>PORT_IOBUS_</prependToName>
+      <baseAddress>0x60000000</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>RTC</name>
+      <version>1.0.1</version>
+      <description>Real-Time Counter</description>
+      <groupName>RTC</groupName>
+      <prependToName>RTC_</prependToName>
+      <baseAddress>0x40001400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>RTC</name>
+        <value>3</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>MODE0</name>
+        <description>32-bit Counter with Single 32-bit Compare</description>
+        <headerStructName>RtcMode0</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRL</name>
+          <description>MODE0 Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Mode 0: 32-bit Counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Mode 1: 16-bit Counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLOCK</name>
+                  <description>Mode 2: Clock/Calendar</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MATCHCLR</name>
+              <description>Clear on Match</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/256</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/512</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1024</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <resetValue>0x0010</resetValue>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>MODE0 Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PEREO0</name>
+              <description>Periodic Interval 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO1</name>
+              <description>Periodic Interval 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO2</name>
+              <description>Periodic Interval 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO3</name>
+              <description>Periodic Interval 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO4</name>
+              <description>Periodic Interval 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO5</name>
+              <description>Periodic Interval 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO6</name>
+              <description>Periodic Interval 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO7</name>
+              <description>Periodic Interval 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMPEO0</name>
+              <description>Compare 0 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>MODE0 Interrupt Enable Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>MODE0 Interrupt Enable Set</description>
+          <addressOffset>0x07</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>MODE0 Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Run During Debug</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCORR</name>
+          <description>Frequency Correction</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>SIGN</name>
+              <description>Correction Sign</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>MODE0 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>COMP%s</name>
+          <description>MODE0 Compare n Value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COMP</name>
+              <description>Compare Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- RtcMode0 -->
+       <cluster>
+        <name>MODE1</name>
+        <description>16-bit Counter with Two 16-bit Compares</description>
+        <alternateCluster>MODE0</alternateCluster>
+        <headerStructName>RtcMode1</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRL</name>
+          <description>MODE1 Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Mode 0: 32-bit Counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Mode 1: 16-bit Counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLOCK</name>
+                  <description>Mode 2: Clock/Calendar</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/256</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/512</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1024</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <resetValue>0x0010</resetValue>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>MODE1 Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PEREO0</name>
+              <description>Periodic Interval 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO1</name>
+              <description>Periodic Interval 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO2</name>
+              <description>Periodic Interval 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO3</name>
+              <description>Periodic Interval 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO4</name>
+              <description>Periodic Interval 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO5</name>
+              <description>Periodic Interval 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO6</name>
+              <description>Periodic Interval 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO7</name>
+              <description>Periodic Interval 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMPEO0</name>
+              <description>Compare 0 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMPEO1</name>
+              <description>Compare 1 Event Output Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>MODE1 Interrupt Enable Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>MODE1 Interrupt Enable Set</description>
+          <addressOffset>0x07</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>MODE1 Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Run During Debug</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCORR</name>
+          <description>Frequency Correction</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>SIGN</name>
+              <description>Correction Sign</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>MODE1 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER</name>
+          <description>MODE1 Counter Period</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Counter Period</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x2</dimIncrement>
+          <name>COMP%s</name>
+          <description>MODE1 Compare n Value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COMP</name>
+              <description>Compare Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- RtcMode1 -->
+       <cluster>
+        <name>MODE2</name>
+        <description>Clock/Calendar with Alarm</description>
+        <alternateCluster>MODE0</alternateCluster>
+        <headerStructName>RtcMode2</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRL</name>
+          <description>MODE2 Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Mode 0: 32-bit Counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Mode 1: 16-bit Counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLOCK</name>
+                  <description>Mode 2: Clock/Calendar</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CLKREP</name>
+              <description>Clock Representation</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MATCHCLR</name>
+              <description>Clear on Match</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/256</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/512</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1024</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <resetValue>0x0010</resetValue>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>MODE2 Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PEREO0</name>
+              <description>Periodic Interval 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO1</name>
+              <description>Periodic Interval 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO2</name>
+              <description>Periodic Interval 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO3</name>
+              <description>Periodic Interval 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO4</name>
+              <description>Periodic Interval 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO5</name>
+              <description>Periodic Interval 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO6</name>
+              <description>Periodic Interval 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO7</name>
+              <description>Periodic Interval 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ALARMEO0</name>
+              <description>Alarm 0 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>MODE2 Interrupt Enable Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ALARM0</name>
+              <description>Alarm 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>MODE2 Interrupt Enable Set</description>
+          <addressOffset>0x07</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ALARM0</name>
+              <description>Alarm 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>MODE2 Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ALARM0</name>
+              <description>Alarm 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Run During Debug</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCORR</name>
+          <description>Frequency Correction</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>SIGN</name>
+              <description>Correction Sign</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CLOCK</name>
+          <description>MODE2 Clock Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SECOND</name>
+              <description>Second</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>MINUTE</name>
+              <description>Minute</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>HOUR</name>
+              <description>Hour</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>HOURSelect</name>
+                <enumeratedValue>
+                  <name>AM</name>
+                  <description>AM when CLKREP in 12-hour</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PM</name>
+                  <description>PM when CLKREP in 12-hour</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DAY</name>
+              <description>Day</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>MONTH</name>
+              <description>Month</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>YEAR</name>
+              <description>Year</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>ALARM%s</name>
+          <description>MODE2 Alarm n Value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SECOND</name>
+              <description>Second</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>MINUTE</name>
+              <description>Minute</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>HOUR</name>
+              <description>Hour</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>HOURSelect</name>
+                <enumeratedValue>
+                  <name>AM</name>
+                  <description>Morning hour</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PM</name>
+                  <description>Afternoon hour</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DAY</name>
+              <description>Day</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>MONTH</name>
+              <description>Month</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>YEAR</name>
+              <description>Year</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>MASK%s</name>
+          <description>MODE2 Alarm n Mask</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SEL</name>
+              <description>Alarm Mask Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SELSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Alarm Disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SS</name>
+                  <description>Match seconds only</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MMSS</name>
+                  <description>Match seconds and minutes only</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HHMMSS</name>
+                  <description>Match seconds, minutes, and hours only</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DDHHMMSS</name>
+                  <description>Match seconds, minutes, hours, and days only</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MMDDHHMMSS</name>
+                  <description>Match seconds, minutes, hours, days, and months only</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>YYMMDDHHMMSS</name>
+                  <description>Match seconds, minutes, hours, days, months, and years</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- RtcMode2 -->
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>SERCOM0</name>
+      <version>2.0.0</version>
+      <description>Serial Communication Interface 0</description>
+      <groupName>SERCOM</groupName>
+      <prependToName>SERCOM_</prependToName>
+      <baseAddress>0x42000800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>SERCOM0</name>
+        <value>9</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>I2CM</name>
+        <description>I2C Master Mode</description>
+        <headerStructName>SercomI2cm</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>I2CM Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINOUT</name>
+              <description>Pin Usage</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SDAHOLD</name>
+              <description>SDA Hold Time</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MEXTTOEN</name>
+              <description>Master SCL Low Extend Timeout</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SEXTTOEN</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPEED</name>
+              <description>Transfer Speed</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SCLSM</name>
+              <description>SCL Clock Stretch Mode</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INACTOUT</name>
+              <description>Inactive Time-Out</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>LOWTOUTEN</name>
+              <description>SCL Low Timeout Enable</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>I2CM Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SMEN</name>
+              <description>Smart Mode Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QCEN</name>
+              <description>Quick Command Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ACKACT</name>
+              <description>Acknowledge Action</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD</name>
+          <description>I2CM Baud Rate</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>BAUDLOW</name>
+              <description>Baud Rate Value Low</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>HSBAUD</name>
+              <description>High Speed Baud Rate Value</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>HSBAUDLOW</name>
+              <description>High Speed Baud Rate Value Low</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>I2CM Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MB</name>
+              <description>Master On Bus Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Slave On Bus Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>I2CM Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MB</name>
+              <description>Master On Bus Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Slave On Bus Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>I2CM Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MB</name>
+              <description>Master On Bus Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Slave On Bus Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>I2CM Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BUSERR</name>
+              <description>Bus Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ARBLOST</name>
+              <description>Arbitration Lost</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXNACK</name>
+              <description>Received Not Acknowledge</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSSTATE</name>
+              <description>Bus State</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>LOWTOUT</name>
+              <description>SCL Low Timeout</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CLKHOLD</name>
+              <description>Clock Hold</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>MEXTTOUT</name>
+              <description>Master SCL Low Extend Timeout</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SEXTTOUT</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LENERR</name>
+              <description>Length Error</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>I2CM Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYSOP</name>
+              <description>System Operation Synchronization Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>I2CM Address</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+            <field>
+              <name>LENEN</name>
+              <description>Length Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HS</name>
+              <description>High Speed Mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TENBITEN</name>
+              <description>Ten Bit Addressing Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LEN</name>
+              <description>Length</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>I2CM Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>I2CM Debug Control</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGSTOP</name>
+              <description>Debug Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomI2cm -->
+       <cluster>
+        <name>I2CS</name>
+        <description>I2C Slave Mode</description>
+        <alternateCluster>I2CM</alternateCluster>
+        <headerStructName>SercomI2cs</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>I2CS Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run during Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINOUT</name>
+              <description>Pin Usage</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SDAHOLD</name>
+              <description>SDA Hold Time</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SEXTTOEN</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPEED</name>
+              <description>Transfer Speed</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SCLSM</name>
+              <description>SCL Clock Stretch Mode</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LOWTOUTEN</name>
+              <description>SCL Low Timeout Enable</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>I2CS Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SMEN</name>
+              <description>Smart Mode Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GCMD</name>
+              <description>PMBus Group Command</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AACKEN</name>
+              <description>Automatic Address Acknowledge</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMODE</name>
+              <description>Address Mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ACKACT</name>
+              <description>Acknowledge Action</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>I2CS Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PREC</name>
+              <description>Stop Received Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMATCH</name>
+              <description>Address Match Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRDY</name>
+              <description>Data Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>I2CS Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PREC</name>
+              <description>Stop Received Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMATCH</name>
+              <description>Address Match Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRDY</name>
+              <description>Data Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>I2CS Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PREC</name>
+              <description>Stop Received Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMATCH</name>
+              <description>Address Match Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRDY</name>
+              <description>Data Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>I2CS Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BUSERR</name>
+              <description>Bus Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COLL</name>
+              <description>Transmit Collision</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXNACK</name>
+              <description>Received Not Acknowledge</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>Read/Write Direction</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SR</name>
+              <description>Repeated Start</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LOWTOUT</name>
+              <description>SCL Low Timeout</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CLKHOLD</name>
+              <description>Clock Hold</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SEXTTOUT</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HS</name>
+              <description>High Speed</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>I2CS Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>I2CS Address</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>GENCEN</name>
+              <description>General Call Address Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADDR</name>
+              <description>Address Value</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+            <field>
+              <name>TENBITEN</name>
+              <description>Ten Bit Addressing Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADDRMASK</name>
+              <description>Address Mask</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>I2CS Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomI2cs -->
+       <cluster>
+        <name>SPI</name>
+        <description>SPI Mode</description>
+        <alternateCluster>I2CM</alternateCluster>
+        <headerStructName>SercomSpi</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>SPI Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run during Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IBON</name>
+              <description>Immediate Buffer Overflow Notification</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DOPO</name>
+              <description>Data Out Pinout</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>DIPO</name>
+              <description>Data In Pinout</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>FORM</name>
+              <description>Frame Format</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CPHA</name>
+              <description>Clock Phase</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>Clock Polarity</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DORD</name>
+              <description>Data Order</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>SPI Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CHSIZE</name>
+              <description>Character Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>PLOADEN</name>
+              <description>Data Preload Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSDE</name>
+              <description>Slave Select Low Detect Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSSEN</name>
+              <description>Master Slave Select Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMODE</name>
+              <description>Address Mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>RXEN</name>
+              <description>Receiver Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD</name>
+          <description>SPI Baud Rate</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>SPI Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSL</name>
+              <description>Slave Select Low Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>SPI Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSL</name>
+              <description>Slave Select Low Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>SPI Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SSL</name>
+              <description>Slave Select Low Interrupt Flag</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>SPI Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BUFOVF</name>
+              <description>Buffer Overflow</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>SPI Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CTRLB</name>
+              <description>CTRLB Synchronization Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>SPI Address</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>ADDRMASK</name>
+              <description>Address Mask</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>SPI Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>SPI Debug Control</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGSTOP</name>
+              <description>Debug Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomSpi -->
+       <cluster>
+        <name>USART</name>
+        <description>USART Mode</description>
+        <alternateCluster>I2CM</alternateCluster>
+        <headerStructName>SercomUsart</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>USART Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run during Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IBON</name>
+              <description>Immediate Buffer Overflow Notification</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SAMPR</name>
+              <description>Sample</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>TXPO</name>
+              <description>Transmit Data Pinout</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>RXPO</name>
+              <description>Receive Data Pinout</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SAMPA</name>
+              <description>Sample Adjustment</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>FORM</name>
+              <description>Frame Format</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CMODE</name>
+              <description>Communication Mode</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>Clock Polarity</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DORD</name>
+              <description>Data Order</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>USART Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CHSIZE</name>
+              <description>Character Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SBMODE</name>
+              <description>Stop Bit Mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COLDEN</name>
+              <description>Collision Detection Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SFDE</name>
+              <description>Start of Frame Detection Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENC</name>
+              <description>Encoding Format</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PMODE</name>
+              <description>Parity Mode</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXEN</name>
+              <description>Transmitter Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXEN</name>
+              <description>Receiver Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD</name>
+          <description>USART Baud Rate</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD_FRAC_MODE</name>
+          <description>USART Baud Rate</description>
+          <alternateRegister>BAUD</alternateRegister>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>13</bitWidth>
+            </field>
+            <field>
+              <name>FP</name>
+              <description>Fractional Part</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD_FRACFP_MODE</name>
+          <description>USART Baud Rate</description>
+          <alternateRegister>BAUD</alternateRegister>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>13</bitWidth>
+            </field>
+            <field>
+              <name>FP</name>
+              <description>Fractional Part</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD_USARTFP_MODE</name>
+          <description>USART Baud Rate</description>
+          <alternateRegister>BAUD</alternateRegister>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXPL</name>
+          <description>USART Receive Pulse Length</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RXPL</name>
+              <description>Receive Pulse Length</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>USART Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXS</name>
+              <description>Receive Start Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTSIC</name>
+              <description>Clear To Send Input Change Interrupt Disable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXBRK</name>
+              <description>Break Received Interrupt Disable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>USART Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXS</name>
+              <description>Receive Start Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTSIC</name>
+              <description>Clear To Send Input Change Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXBRK</name>
+              <description>Break Received Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>USART Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RXS</name>
+              <description>Receive Start Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CTSIC</name>
+              <description>Clear To Send Input Change Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXBRK</name>
+              <description>Break Received Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>USART Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PERR</name>
+              <description>Parity Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FERR</name>
+              <description>Frame Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BUFOVF</name>
+              <description>Buffer Overflow</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTS</name>
+              <description>Clear To Send</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ISF</name>
+              <description>Inconsistent Sync Field</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COLL</name>
+              <description>Collision Detected</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>USART Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CTRLB</name>
+              <description>CTRLB Synchronization Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>USART Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>USART Debug Control</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGSTOP</name>
+              <description>Debug Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomUsart -->
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="SERCOM0">
+      <name>SERCOM1</name>
+      <description>Serial Communication Interface 1</description>
+      <baseAddress>0x42000C00</baseAddress>
+      <interrupt>
+        <name>SERCOM1</name>
+        <value>10</value>
+      </interrupt>
+    </peripheral>
+    <peripheral>
+      <name>SYSCTRL</name>
+      <version>2.0.2</version>
+      <description>System Control</description>
+      <groupName>SYSCTRL</groupName>
+      <prependToName>SYSCTRL_</prependToName>
+      <baseAddress>0x40000800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>SYSCTRL</name>
+        <value>1</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PCLKSR</name>
+          <description>Power and Clocks Status</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>XOSC</name>
+          <description>External Multipurpose Crystal Oscillator (XOSC) Control</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <resetValue>0x0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XTALEN</name>
+              <description>Crystal Oscillator Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GAIN</name>
+              <description>Oscillator Gain</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>GAINSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>2MHz</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>4MHz</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>8MHz</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>16MHz</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4</name>
+                  <description>30MHz</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>AMPGC</name>
+              <description>Automatic Amplitude Gain Control</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STARTUP</name>
+              <description>Start-Up Time</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>XOSC32K</name>
+          <description>32kHz External Crystal Oscillator (XOSC32K) Control</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <resetValue>0x0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XTALEN</name>
+              <description>Crystal Oscillator Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN32K</name>
+              <description>32kHz Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN1K</name>
+              <description>1kHz Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AAMPEN</name>
+              <description>Automatic Amplitude Control Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STARTUP</name>
+              <description>Oscillator Start-Up Time</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSC32K</name>
+          <description>32kHz Internal Oscillator (OSC32K) Control</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <resetValue>0x003F0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN32K</name>
+              <description>32kHz Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN1K</name>
+              <description>1kHz Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STARTUP</name>
+              <description>Oscillator Start-Up Time</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALIB</name>
+              <description>Oscillator Calibration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSCULP32K</name>
+          <description>32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>8</size>
+          <resetValue>0x1F</resetValue>
+          <fields>
+            <field>
+              <name>CALIB</name>
+              <description>Oscillator Calibration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSC8M</name>
+          <description>8MHz Internal Oscillator (OSC8M) Control</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <resetValue>0x87070382</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESC</name>
+              <description>Oscillator Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CALIB</name>
+              <description>Oscillator Calibration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+            <field>
+              <name>FRANGE</name>
+              <description>Oscillator Frequency Range</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FRANGESelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>4 to 6MHz</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>6 to 8MHz</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>8 to 11MHz</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>11 to 15MHz</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLCTRL</name>
+          <description>DFLL48M Control</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <resetValue>0x0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>DFLL Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode Selection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STABLE</name>
+              <description>Stable DFLL Frequency</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LLAW</name>
+              <description>Lose Lock After Wake</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USBCRM</name>
+              <description>USB Clock Recovery Mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCDIS</name>
+              <description>Chill Cycle Disable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QLDIS</name>
+              <description>Quick Lock Disable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BPLCKC</name>
+              <description>Bypass Coarse Lock</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAITLOCK</name>
+              <description>Wait Lock</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLVAL</name>
+          <description>DFLL48M Value</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>FINE</name>
+              <description>Fine Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+            <field>
+              <name>COARSE</name>
+              <description>Coarse Value</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>DIFF</name>
+              <description>Multiplication Ratio Difference</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLMUL</name>
+          <description>DFLL48M Multiplier</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>MUL</name>
+              <description>DFLL Multiply Factor</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+            <field>
+              <name>FSTEP</name>
+              <description>Fine Maximum Step</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+            <field>
+              <name>CSTEP</name>
+              <description>Coarse Maximum Step</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLSYNC</name>
+          <description>DFLL48M Synchronization</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READREQ</name>
+              <description>Read Request</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BOD33</name>
+          <description>3.3V Brown-Out Detector (BOD33) Control</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HYST</name>
+              <description>Hysteresis</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ACTION</name>
+              <description>BOD33 Action</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>ACTIONSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESET</name>
+                  <description>The BOD33 generates a reset</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INTERRUPT</name>
+                  <description>The BOD33 generates an interrupt</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operation Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CEN</name>
+              <description>Clock Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PSEL</name>
+              <description>Prescaler Select</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PSELSelect</name>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide clock by 2</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide clock by 4</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide clock by 8</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide clock by 16</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide clock by 32</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide clock by 64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide clock by 128</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Divide clock by 256</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>Divide clock by 512</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1K</name>
+                  <description>Divide clock by 1024</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2K</name>
+                  <description>Divide clock by 2048</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4K</name>
+                  <description>Divide clock by 4096</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8K</name>
+                  <description>Divide clock by 8192</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16K</name>
+                  <description>Divide clock by 16384</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32K</name>
+                  <description>Divide clock by 32768</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64K</name>
+                  <description>Divide clock by 65536</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LEVEL</name>
+              <description>BOD33 Threshold Level</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VREF</name>
+          <description>Voltage References System (VREF) Control</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>TSEN</name>
+              <description>Temperature Sensor Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BGOUTEN</name>
+              <description>Bandgap Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALIB</name>
+              <description>Bandgap Voltage Generator Calibration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLCTRLA</name>
+          <description>DPLL Control A</description>
+          <addressOffset>0x44</addressOffset>
+          <size>8</size>
+          <resetValue>0x80</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>DPLL Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Clock Activation</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLRATIO</name>
+          <description>DPLL Ratio Control</description>
+          <addressOffset>0x48</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>LDR</name>
+              <description>Loop Divider Ratio</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+            <field>
+              <name>LDRFRAC</name>
+              <description>Loop Divider Ratio Fractional Part</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLCTRLB</name>
+          <description>DPLL Control B</description>
+          <addressOffset>0x4C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>FILTER</name>
+              <description>Proportional Integral Filter Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FILTERSelect</name>
+                <enumeratedValue>
+                  <name>DEFAULT</name>
+                  <description>Default filter mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LBFILT</name>
+                  <description>Low bandwidth filter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HBFILT</name>
+                  <description>High bandwidth filter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HDFILT</name>
+                  <description>High damping filter</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LPEN</name>
+              <description>Low-Power Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WUF</name>
+              <description>Wake Up Fast</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>REFCLK</name>
+              <description>Reference Clock Selection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>REFCLKSelect</name>
+                <enumeratedValue>
+                  <name>REF0</name>
+                  <description>CLK_DPLL_REF0 clock reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>REF1</name>
+                  <description>CLK_DPLL_REF1 clock reference</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>GCLK_DPLL clock reference</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LTIME</name>
+              <description>Lock Time</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>LTIMESelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>Default	No time-out</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8MS</name>
+                  <description>8MS	Time-out if no lock within 8 ms</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>9MS</name>
+                  <description>9MS	Time-out if no lock within 9 ms</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>10MS</name>
+                  <description>10MS	Time-out if no lock within 10 ms</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>11MS</name>
+                  <description>11MS	Time-out if no lock within 11 ms</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LBYPASS</name>
+              <description>Lock Bypass</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DIV</name>
+              <description>Clock Divider</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLSTATUS</name>
+          <description>DPLL Status</description>
+          <addressOffset>0x50</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>LOCK</name>
+              <description>DPLL Lock Status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CLKRDY</name>
+              <description>Output Clock Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>DPLL Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DIV</name>
+              <description>Divider Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TC1</name>
+      <version>1.4.0</version>
+      <description>Basic Timer Counter 1</description>
+      <groupName>TC</groupName>
+      <prependToName>TC_</prependToName>
+      <baseAddress>0x42001800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x040</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TC1</name>
+        <value>13</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>COUNT8</name>
+        <description>8-bit Counter Mode</description>
+        <headerStructName>TcCount8</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>TC Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Counter in 16-bit mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT8</name>
+                  <description>Counter in 8-bit mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Counter in 32-bit mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation Operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MPWM</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Prescaler: GCLK_TC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Prescaler: GCLK_TC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Prescaler: GCLK_TC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Prescaler: GCLK_TC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Prescaler: GCLK_TC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Prescaler: GCLK_TC/64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Prescaler: GCLK_TC/256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Prescaler: GCLK_TC/1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset the counter on next generic clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset the counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset the counter on next generic clock. Reset the prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <resetValue>0x02</resetValue>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Invert Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Invert Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or retrigger TC on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start TC on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period captured in CC0, pulse width in CC1</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period captured in CC1, pulse width in CC0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TCINV</name>
+              <description>TC Inverted Event Input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI</name>
+              <description>TC Event Input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x08</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>COUNT8 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER</name>
+          <description>COUNT8 Period Value</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <resetValue>0xFF</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>CC%s</name>
+          <description>COUNT8 Compare/Capture</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- TcCount8 -->
+       <cluster>
+        <name>COUNT16</name>
+        <description>16-bit Counter Mode</description>
+        <alternateCluster>COUNT8</alternateCluster>
+        <headerStructName>TcCount16</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>TC Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Counter in 16-bit mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT8</name>
+                  <description>Counter in 8-bit mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Counter in 32-bit mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation Operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MPWM</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Prescaler: GCLK_TC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Prescaler: GCLK_TC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Prescaler: GCLK_TC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Prescaler: GCLK_TC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Prescaler: GCLK_TC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Prescaler: GCLK_TC/64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Prescaler: GCLK_TC/256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Prescaler: GCLK_TC/1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset the counter on next generic clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset the counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset the counter on next generic clock. Reset the prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <resetValue>0x02</resetValue>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Invert Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Invert Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or retrigger TC on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start TC on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period captured in CC0, pulse width in CC1</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period captured in CC1, pulse width in CC0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TCINV</name>
+              <description>TC Inverted Event Input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI</name>
+              <description>TC Event Input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x08</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>COUNT16 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Count Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x2</dimIncrement>
+          <name>CC%s</name>
+          <description>COUNT16 Compare/Capture</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- TcCount16 -->
+       <cluster>
+        <name>COUNT32</name>
+        <description>32-bit Counter Mode</description>
+        <alternateCluster>COUNT8</alternateCluster>
+        <headerStructName>TcCount32</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>TC Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Counter in 16-bit mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT8</name>
+                  <description>Counter in 8-bit mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Counter in 32-bit mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation Operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MPWM</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Prescaler: GCLK_TC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Prescaler: GCLK_TC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Prescaler: GCLK_TC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Prescaler: GCLK_TC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Prescaler: GCLK_TC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Prescaler: GCLK_TC/64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Prescaler: GCLK_TC/256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Prescaler: GCLK_TC/1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset the counter on next generic clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset the counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset the counter on next generic clock. Reset the prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <resetValue>0x02</resetValue>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Invert Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Invert Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or retrigger TC on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start TC on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period captured in CC0, pulse width in CC1</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period captured in CC1, pulse width in CC0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TCINV</name>
+              <description>TC Inverted Event Input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI</name>
+              <description>TC Event Input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x08</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>COUNT32 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Count Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s</name>
+          <description>COUNT32 Compare/Capture</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- TcCount32 -->
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="TC1">
+      <name>TC2</name>
+      <description>Basic Timer Counter 2</description>
+      <baseAddress>0x42001C00</baseAddress>
+      <interrupt>
+        <name>TC2</name>
+        <value>14</value>
+      </interrupt>
+    </peripheral>
+    <peripheral>
+      <name>TCC0</name>
+      <version>1.1.1</version>
+      <description>Timer Counter Control</description>
+      <groupName>TCC</groupName>
+      <prependToName>TCC_</prependToName>
+      <baseAddress>0x42001400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x090</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TCC0</name>
+        <value>12</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESOLUTION</name>
+              <description>Enhanced Resolution</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RESOLUTIONSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>Dithering is disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DITH4</name>
+                  <description>Dithering is done every 16 PWM frames</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DITH5</name>
+                  <description>Dithering is done every 32 PWM frames</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DITH6</name>
+                  <description>Dithering is done every 64 PWM frames</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>No division</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Divide by 256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Divide by 1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization Selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset counter on next GCLK</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset counter on next GCLK and reset prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ALOCK</name>
+              <description>Auto Lock</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN2</name>
+              <description>Capture Channel 2 Enable</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN3</name>
+              <description>Capture Channel 3 Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LUPD</name>
+              <description>Lock Update</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDXCMD</name>
+              <description>Ramp Index Command</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>IDXCMDSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Command disabled: Index toggles between cycles A and B</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Set index: cycle B will be forced in the next cycle</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLEAR</name>
+                  <description>Clear index: cycle A will be forced in the next cycle</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HOLD</name>
+                  <description>Hold index: the next cycle will be the same as the current cycle</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>TCC Command</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Clear start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPDATE</name>
+                  <description>Force update or double buffered registers</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>READSYNC</name>
+                  <description>Force COUNT read synchronization</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LUPD</name>
+              <description>Lock Update</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDXCMD</name>
+              <description>Ramp Index Command</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>IDXCMDSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Command disabled: Index toggles between cycles A and B</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Set index: cycle B will be forced in the next cycle</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLEAR</name>
+                  <description>Clear index: cycle A will be forced in the next cycle</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HOLD</name>
+                  <description>Hold index: the next cycle will be the same as the current cycle</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>TCC Command</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Clear start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPDATE</name>
+                  <description>Force update or double buffered registers</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>READSYNC</name>
+                  <description>Force COUNT read synchronization</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>Synchronization Busy</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Swrst Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTRLB</name>
+              <description>Ctrlb Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STATUS</name>
+              <description>Status Busy</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COUNT</name>
+              <description>Count Busy</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PATT</name>
+              <description>Pattern Busy</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAVE</name>
+              <description>Wave Busy</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC0</name>
+              <description>Compare Channel 0 Busy</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC1</name>
+              <description>Compare Channel 1 Busy</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC2</name>
+              <description>Compare Channel 2 Busy</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC3</name>
+              <description>Compare Channel 3 Busy</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PATTB</name>
+              <description>Pattern Buffer Busy</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAVEB</name>
+              <description>Wave Buffer Busy</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Busy</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB0</name>
+              <description>Compare Channel Buffer 0 Busy</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB1</name>
+              <description>Compare Channel Buffer 1 Busy</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB2</name>
+              <description>Compare Channel Buffer 2 Busy</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB3</name>
+              <description>Compare Channel Buffer 3 Busy</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FCTRLA</name>
+          <description>Recoverable Fault A Configuration</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SRC</name>
+              <description>Fault A Source</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SRCSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Fault input disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>MCEx (x=0,1) event input</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INVERT</name>
+                  <description>Inverted MCEx (x=0,1) event input</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ALTFAULT</name>
+                  <description>Alternate fault (A or B) state at the end of the previous period</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>KEEP</name>
+              <description>Fault A Keeper</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QUAL</name>
+              <description>Fault A Qualification</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANK</name>
+              <description>Fault A Blanking Mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>BLANKSelect</name>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Blanking applied from start of ramp</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Blanking applied from rising edge of the output waveform</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Blanking applied from falling edge of the output waveform</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Blanking applied from each toggle of the output waveform</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RESTART</name>
+              <description>Fault A Restart</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HALT</name>
+              <description>Fault A Halt Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>HALTSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Halt action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HW</name>
+                  <description>Hardware halt action</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SW</name>
+                  <description>Software halt action</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NR</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CHSEL</name>
+              <description>Fault A Capture Channel</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CHSELSelect</name>
+                <enumeratedValue>
+                  <name>CC0</name>
+                  <description>Capture value stored in channel 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC1</name>
+                  <description>Capture value stored in channel 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC2</name>
+                  <description>Capture value stored in channel 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC3</name>
+                  <description>Capture value stored in channel 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CAPTURE</name>
+              <description>Fault A Capture Action</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CAPTURESelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>No capture</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPT</name>
+                  <description>Capture on fault</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMIN</name>
+                  <description>Minimum capture</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMAX</name>
+                  <description>Maximum capture</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMIN</name>
+                  <description>Minimum local detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMAX</name>
+                  <description>Maximum local detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DERIV0</name>
+                  <description>Minimum and maximum local detection</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMARK</name>
+                  <description>Capture with ramp index as MSB value</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>BLANKPRESC</name>
+              <description>Fault A Blanking Prescaler</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANKVAL</name>
+              <description>Fault A Blanking Time</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL</name>
+              <description>Fault A Filter Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FCTRLB</name>
+          <description>Recoverable Fault B Configuration</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SRC</name>
+              <description>Fault B Source</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SRCSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Fault input disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>MCEx (x=0,1) event input</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INVERT</name>
+                  <description>Inverted MCEx (x=0,1) event input</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ALTFAULT</name>
+                  <description>Alternate fault (A or B) state at the end of the previous period</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>KEEP</name>
+              <description>Fault B Keeper</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QUAL</name>
+              <description>Fault B Qualification</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANK</name>
+              <description>Fault B Blanking Mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>BLANKSelect</name>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Blanking applied from start of ramp</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Blanking applied from rising edge of the output waveform</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Blanking applied from falling edge of the output waveform</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Blanking applied from each toggle of the output waveform</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RESTART</name>
+              <description>Fault B Restart</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HALT</name>
+              <description>Fault B Halt Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>HALTSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Halt action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HW</name>
+                  <description>Hardware halt action</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SW</name>
+                  <description>Software halt action</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NR</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CHSEL</name>
+              <description>Fault B Capture Channel</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CHSELSelect</name>
+                <enumeratedValue>
+                  <name>CC0</name>
+                  <description>Capture value stored in channel 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC1</name>
+                  <description>Capture value stored in channel 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC2</name>
+                  <description>Capture value stored in channel 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC3</name>
+                  <description>Capture value stored in channel 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CAPTURE</name>
+              <description>Fault B Capture Action</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CAPTURESelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>No capture</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPT</name>
+                  <description>Capture on fault</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMIN</name>
+                  <description>Minimum capture</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMAX</name>
+                  <description>Maximum capture</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMIN</name>
+                  <description>Minimum local detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMAX</name>
+                  <description>Maximum local detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DERIV0</name>
+                  <description>Minimum and maximum local detection</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMARK</name>
+                  <description>Capture with ramp index as MSB value</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>BLANKPRESC</name>
+              <description>Fault B Blanking Prescaler</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANKVAL</name>
+              <description>Fault B Blanking Time</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL</name>
+              <description>Fault B Filter Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WEXCTRL</name>
+          <description>Waveform Extension Configuration</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OTMX</name>
+              <description>Output Matrix</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN0</name>
+              <description>Dead-time Insertion Generator 0 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN1</name>
+              <description>Dead-time Insertion Generator 1 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN2</name>
+              <description>Dead-time Insertion Generator 2 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN3</name>
+              <description>Dead-time Insertion Generator 3 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTLS</name>
+              <description>Dead-time Low Side Outputs Value</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>DTHS</name>
+              <description>Dead-time High Side Outputs Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DRVCTRL</name>
+          <description>Driver Control</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>NRE0</name>
+              <description>Non-Recoverable State 0 Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE1</name>
+              <description>Non-Recoverable State 1 Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE2</name>
+              <description>Non-Recoverable State 2 Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE3</name>
+              <description>Non-Recoverable State 3 Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE4</name>
+              <description>Non-Recoverable State 4 Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE5</name>
+              <description>Non-Recoverable State 5 Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE6</name>
+              <description>Non-Recoverable State 6 Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE7</name>
+              <description>Non-Recoverable State 7 Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV0</name>
+              <description>Non-Recoverable State 0 Output Value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV1</name>
+              <description>Non-Recoverable State 1 Output Value</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV2</name>
+              <description>Non-Recoverable State 2 Output Value</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV3</name>
+              <description>Non-Recoverable State 3 Output Value</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV4</name>
+              <description>Non-Recoverable State 4 Output Value</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV5</name>
+              <description>Non-Recoverable State 5 Output Value</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV6</name>
+              <description>Non-Recoverable State 6 Output Value</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV7</name>
+              <description>Non-Recoverable State 7 Output Value</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Inversion</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Inversion</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN2</name>
+              <description>Output Waveform 2 Inversion</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN3</name>
+              <description>Output Waveform 3 Inversion</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN4</name>
+              <description>Output Waveform 4 Inversion</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN5</name>
+              <description>Output Waveform 5 Inversion</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN6</name>
+              <description>Output Waveform 6 Inversion</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN7</name>
+              <description>Output Waveform 7 Inversion</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL0</name>
+              <description>Non-Recoverable Fault Input 0 Filter Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL1</name>
+              <description>Non-Recoverable Fault Input 1 Filter Value</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x1E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Running Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FDDBD</name>
+              <description>Fault Detection on Debug Break Detection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EVACT0</name>
+              <description>Timer/counter Input Event0 Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACT0Select</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or re-trigger counter on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNTEV</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start counter on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INC</name>
+                  <description>Increment counter on event</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on active state of asynchronous event</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FAULT</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EVACT1</name>
+              <description>Timer/counter Input Event1 Action</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACT1Select</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Re-trigger counter on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIR</name>
+                  <description>Direction control</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Stop counter on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DEC</name>
+                  <description>Decrement counter on event</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period capture value in CC0 register, pulse width capture value in CC1 register</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period capture value in CC1 register, pulse width capture value in CC0 register</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FAULT</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CNTSEL</name>
+              <description>Timer/counter Output Event Mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CNTSELSelect</name>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>An interrupt/event is generated when a new counter cycle starts</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>END</name>
+                  <description>An interrupt/event is generated when a counter cycle ends</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BETWEEN</name>
+                  <description>An interrupt/event is generated when a counter cycle ends, except for the first and last cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOUNDARY</name>
+                  <description>An interrupt/event is generated when a new counter cycle starts or a counter cycle ends</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Output Event Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRGEO</name>
+              <description>Retrigger Output Event Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNTEO</name>
+              <description>Timer/counter Output Event Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCINV0</name>
+              <description>Inverted Event 0 Input Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCINV1</name>
+              <description>Inverted Event 1 Input Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI0</name>
+              <description>Timer/counter Event 0 Input Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI1</name>
+              <description>Timer/counter Event 1 Input Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI0</name>
+              <description>Match or Capture Channel 0 Event Input Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI1</name>
+              <description>Match or Capture Channel 1 Event Input Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI2</name>
+              <description>Match or Capture Channel 2 Event Input Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI3</name>
+              <description>Match or Capture Channel 3 Event Input Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO2</name>
+              <description>Match or Capture Channel 2 Event Output Enable</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO3</name>
+              <description>Match or Capture Channel 3 Event Output Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRG</name>
+              <description>Retrigger Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNT</name>
+              <description>Counter Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0 Interrupt Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1 Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC2</name>
+              <description>Match or Capture Channel 2 Interrupt Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC3</name>
+              <description>Match or Capture Channel 3 Interrupt Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRG</name>
+              <description>Retrigger Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNT</name>
+              <description>Counter Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0 Interrupt Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1 Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC2</name>
+              <description>Match or Capture Channel 2 Interrupt Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC3</name>
+              <description>Match or Capture Channel 3 Interrupt Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRG</name>
+              <description>Retrigger</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNT</name>
+              <description>Counter</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture 0</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture 1</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC2</name>
+              <description>Match or Capture 2</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC3</name>
+              <description>Match or Capture 3</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <resetValue>0x00000001</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>IDX</name>
+              <description>Ramp</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault State</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PATTBV</name>
+              <description>Pattern Buffer Valid</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAVEBV</name>
+              <description>Wave Buffer Valid</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERBV</name>
+              <description>Period Buffer Valid</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTAIN</name>
+              <description>Recoverable Fault A Input</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULTBIN</name>
+              <description>Recoverable Fault B Input</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULT0IN</name>
+              <description>Non-Recoverable Fault0 Input</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULT1IN</name>
+              <description>Non-Recoverable Fault1 Input</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A State</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B State</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0 State</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1 State</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV0</name>
+              <description>Compare Channel 0 Buffer Valid</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV1</name>
+              <description>Compare Channel 1 Buffer Valid</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV2</name>
+              <description>Compare Channel 2 Buffer Valid</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV3</name>
+              <description>Compare Channel 3 Buffer Valid</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP0</name>
+              <description>Compare Channel 0 Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare Channel 1 Value</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CMP2</name>
+              <description>Compare Channel 2 Value</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CMP3</name>
+              <description>Compare Channel 3 Value</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>Count</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT_DITH4</name>
+          <description>Count</description>
+          <alternateRegister>COUNT</alternateRegister>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT_DITH5</name>
+          <description>Count</description>
+          <alternateRegister>COUNT</alternateRegister>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT_DITH6</name>
+          <description>Count</description>
+          <alternateRegister>COUNT</alternateRegister>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PATT</name>
+          <description>Pattern</description>
+          <addressOffset>0x38</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PGE0</name>
+              <description>Pattern Generator 0 Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE1</name>
+              <description>Pattern Generator 1 Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE2</name>
+              <description>Pattern Generator 2 Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE3</name>
+              <description>Pattern Generator 3 Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE4</name>
+              <description>Pattern Generator 4 Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE5</name>
+              <description>Pattern Generator 5 Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE6</name>
+              <description>Pattern Generator 6 Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE7</name>
+              <description>Pattern Generator 7 Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV0</name>
+              <description>Pattern Generator 0 Output Value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV1</name>
+              <description>Pattern Generator 1 Output Value</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV2</name>
+              <description>Pattern Generator 2 Output Value</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV3</name>
+              <description>Pattern Generator 3 Output Value</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV4</name>
+              <description>Pattern Generator 4 Output Value</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV5</name>
+              <description>Pattern Generator 5 Output Value</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV6</name>
+              <description>Pattern Generator 6 Output Value</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV7</name>
+              <description>Pattern Generator 7 Output Value</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAVE</name>
+          <description>Waveform Control</description>
+          <addressOffset>0x3C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <description>Normal frequency</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <description>Match frequency</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <description>Normal PWM</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSCRITICAL</name>
+                  <description>Dual-slope critical</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTTOM</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTH</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSTOP</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches TOP</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RAMP</name>
+              <description>Ramp Mode</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RAMPSelect</name>
+                <enumeratedValue>
+                  <name>RAMP1</name>
+                  <description>RAMP1 operation</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2A</name>
+                  <description>Alternative RAMP2 operation</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2</name>
+                  <description>RAMP2 operation</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2C</name>
+                  <description>Critical RAMP2 operation</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CIPEREN</name>
+              <description>Circular period Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN0</name>
+              <description>Circular Channel 0 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN1</name>
+              <description>Circular Channel 1 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN2</name>
+              <description>Circular Channel 2 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN3</name>
+              <description>Circular Channel 3 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL0</name>
+              <description>Channel 0 Polarity</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL1</name>
+              <description>Channel 1 Polarity</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL2</name>
+              <description>Channel 2 Polarity</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL3</name>
+              <description>Channel 3 Polarity</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP0</name>
+              <description>Swap DTI Output Pair 0</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP1</name>
+              <description>Swap DTI Output Pair 1</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP2</name>
+              <description>Swap DTI Output Pair 2</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP3</name>
+              <description>Swap DTI Output Pair 3</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER</name>
+          <description>Period</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER_DITH4</name>
+          <description>Period</description>
+          <alternateRegister>PER</alternateRegister>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER_DITH5</name>
+          <description>Period</description>
+          <alternateRegister>PER</alternateRegister>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER_DITH6</name>
+          <description>Period</description>
+          <alternateRegister>PER</alternateRegister>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s</name>
+          <description>Compare and Capture</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s_DITH4</name>
+          <description>Compare and Capture</description>
+          <alternateRegister>CC%s</alternateRegister>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s_DITH5</name>
+          <description>Compare and Capture</description>
+          <alternateRegister>CC%s</alternateRegister>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s_DITH6</name>
+          <description>Compare and Capture</description>
+          <alternateRegister>CC%s</alternateRegister>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PATTB</name>
+          <description>Pattern Buffer</description>
+          <addressOffset>0x64</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PGEB0</name>
+              <description>Pattern Generator 0 Output Enable Buffer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB1</name>
+              <description>Pattern Generator 1 Output Enable Buffer</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB2</name>
+              <description>Pattern Generator 2 Output Enable Buffer</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB3</name>
+              <description>Pattern Generator 3 Output Enable Buffer</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB4</name>
+              <description>Pattern Generator 4 Output Enable Buffer</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB5</name>
+              <description>Pattern Generator 5 Output Enable Buffer</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB6</name>
+              <description>Pattern Generator 6 Output Enable Buffer</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB7</name>
+              <description>Pattern Generator 7 Output Enable Buffer</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB0</name>
+              <description>Pattern Generator 0 Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB1</name>
+              <description>Pattern Generator 1 Output Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB2</name>
+              <description>Pattern Generator 2 Output Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB3</name>
+              <description>Pattern Generator 3 Output Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB4</name>
+              <description>Pattern Generator 4 Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB5</name>
+              <description>Pattern Generator 5 Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB6</name>
+              <description>Pattern Generator 6 Output Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB7</name>
+              <description>Pattern Generator 7 Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAVEB</name>
+          <description>Waveform Control Buffer</description>
+          <addressOffset>0x68</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WAVEGENB</name>
+              <description>Waveform Generation Buffer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENBSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <description>Normal frequency</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <description>Match frequency</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <description>Normal PWM</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSCRITICAL</name>
+                  <description>Dual-slope critical</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTTOM</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTH</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSTOP</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches TOP</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RAMPB</name>
+              <description>Ramp Mode Buffer</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RAMPBSelect</name>
+                <enumeratedValue>
+                  <name>RAMP1</name>
+                  <description>RAMP1 operation</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2A</name>
+                  <description>Alternative RAMP2 operation</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2</name>
+                  <description>RAMP2 operation</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CIPERENB</name>
+              <description>Circular Period Enable Buffer</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB0</name>
+              <description>Circular Channel 0 Enable Buffer</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB1</name>
+              <description>Circular Channel 1 Enable Buffer</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB2</name>
+              <description>Circular Channel 2 Enable Buffer</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB3</name>
+              <description>Circular Channel 3 Enable Buffer</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB0</name>
+              <description>Channel 0 Polarity Buffer</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB1</name>
+              <description>Channel 1 Polarity Buffer</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB2</name>
+              <description>Channel 2 Polarity Buffer</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB3</name>
+              <description>Channel 3 Polarity Buffer</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB0</name>
+              <description>Swap DTI Output Pair 0 Buffer</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB1</name>
+              <description>Swap DTI Output Pair 1 Buffer</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB2</name>
+              <description>Swap DTI Output Pair 2 Buffer</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB3</name>
+              <description>Swap DTI Output Pair 3 Buffer</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB</name>
+          <description>Period Buffer</description>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB_DITH4</name>
+          <description>Period Buffer</description>
+          <alternateRegister>PERB</alternateRegister>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB_DITH5</name>
+          <description>Period Buffer</description>
+          <alternateRegister>PERB</alternateRegister>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB_DITH6</name>
+          <description>Period Buffer</description>
+          <alternateRegister>PERB</alternateRegister>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s</name>
+          <description>Compare and Capture Buffer</description>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s_DITH4</name>
+          <description>Compare and Capture Buffer</description>
+          <alternateRegister>CCB%s</alternateRegister>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s_DITH5</name>
+          <description>Compare and Capture Buffer</description>
+          <alternateRegister>CCB%s</alternateRegister>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s_DITH6</name>
+          <description>Compare and Capture Buffer</description>
+          <alternateRegister>CCB%s</alternateRegister>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>USB</name>
+      <version>1.0.2</version>
+      <description>Universal Serial Bus</description>
+      <groupName>USB</groupName>
+      <prependToName>USB_</prependToName>
+      <baseAddress>0x41005000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>USB</name>
+        <value>7</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>DEVICE</name>
+        <description>USB is Device</description>
+        <headerStructName>UsbDevice</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x000</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>DEVICE</name>
+                  <description>Device Mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>Synchronization Busy</description>
+          <addressOffset>0x002</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>QOSCTRL</name>
+          <description>USB Quality Of Service</description>
+          <addressOffset>0x003</addressOffset>
+          <size>8</size>
+          <resetValue>0x05</resetValue>
+          <fields>
+            <field>
+              <name>CQOS</name>
+              <description>Configuration Quality of Service</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>DQOS</name>
+              <description>Data Quality of Service</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>DEVICE Control B</description>
+          <addressOffset>0x008</addressOffset>
+          <size>16</size>
+          <resetValue>0x0001</resetValue>
+          <fields>
+            <field>
+              <name>DETACH</name>
+              <description>Detach</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPDCONF</name>
+              <description>Speed Configuration</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SPDCONFSelect</name>
+                <enumeratedValue>
+                  <name>FS</name>
+                  <description>FS : Full Speed</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LS</name>
+                  <description>LS : Low Speed</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HS</name>
+                  <description>HS : High Speed capable</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HSTM</name>
+                  <description>HSTM: High Speed Test Mode (force high-speed mode for test mode)</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>NREPLY</name>
+              <description>No Reply</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTJ</name>
+              <description>Test mode J</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTK</name>
+              <description>Test mode K</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTPCKT</name>
+              <description>Test packet mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OPMODE2</name>
+              <description>Specific Operational Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GNAK</name>
+              <description>Global NAK</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMHDSK</name>
+              <description>Link Power Management Handshake</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>LPMHDSKSelect</name>
+                <enumeratedValue>
+                  <name>NO</name>
+                  <description>No handshake. LPM is not supported</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ACK</name>
+                  <description>ACK</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NYET</name>
+                  <description>NYET</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STALL</name>
+                  <description>STALL</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DADD</name>
+          <description>DEVICE Device Address</description>
+          <addressOffset>0x00A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DADD</name>
+              <description>Device Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>ADDEN</name>
+              <description>Device Address Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>DEVICE Status</description>
+          <addressOffset>0x00C</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x40</resetValue>
+          <fields>
+            <field>
+              <name>SPEED</name>
+              <description>Speed Status</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>SPEEDSelect</name>
+                <enumeratedValue>
+                  <name>FS</name>
+                  <description>Full-speed mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HS</name>
+                  <description>High-speed mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LS</name>
+                  <description>Low-speed mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LINESTATE</name>
+              <description>USB Line State Status</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>LINESTATESelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>SE0/RESET</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>FS-J or LS-K State</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>FS-K or LS-J State</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FSMSTATUS</name>
+          <description>Finite State Machine Status</description>
+          <addressOffset>0x00D</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x01</resetValue>
+          <fields>
+            <field>
+              <name>FSMSTATE</name>
+              <description>Fine State Machine Status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>FSMSTATESelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>OFF (L3). It corresponds to the powered-off, disconnected, and disabled state</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ON</name>
+                  <description>ON (L0). It corresponds to the Idle and Active states</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>SUSPEND (L2)</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SLEEP</name>
+                  <description>SLEEP (L1)</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DNRESUME</name>
+                  <description>DNRESUME. Down Stream Resume.</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPRESUME</name>
+                  <description>UPRESUME. Up Stream Resume.</description>
+                  <value>0x20</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESET</name>
+                  <description>RESET. USB lines Reset.</description>
+                  <value>0x40</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FNUM</name>
+          <description>DEVICE Device Frame Number</description>
+          <addressOffset>0x010</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>MFNUM</name>
+              <description>Micro Frame Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FNUM</name>
+              <description>Frame Number</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>11</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FNCERR</name>
+              <description>Frame Number CRC Error</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>DEVICE Device Interrupt Enable Clear</description>
+          <addressOffset>0x014</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SUSPEND</name>
+              <description>Suspend Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSOF</name>
+              <description>Micro Start of Frame Interrupt Enable in High Speed Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOF</name>
+              <description>Start Of Frame Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORST</name>
+              <description>End of Reset Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORSM</name>
+              <description>End Of Resume Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMNYET</name>
+              <description>Link Power Management Not Yet Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMSUSP</name>
+              <description>Link Power Management Suspend Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>DEVICE Device Interrupt Enable Set</description>
+          <addressOffset>0x018</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SUSPEND</name>
+              <description>Suspend Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSOF</name>
+              <description>Micro Start of Frame Interrupt Enable in High Speed Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOF</name>
+              <description>Start Of Frame Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORST</name>
+              <description>End of Reset Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORSM</name>
+              <description>End Of Resume Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMNYET</name>
+              <description>Link Power Management Not Yet Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMSUSP</name>
+              <description>Link Power Management Suspend Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>DEVICE Device Interrupt Flag</description>
+          <addressOffset>0x01C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SUSPEND</name>
+              <description>Suspend</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSOF</name>
+              <description>Micro Start of Frame in High Speed Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOF</name>
+              <description>Start Of Frame</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORST</name>
+              <description>End of Reset</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORSM</name>
+              <description>End Of Resume</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMNYET</name>
+              <description>Link Power Management Not Yet</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMSUSP</name>
+              <description>Link Power Management Suspend</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EPINTSMRY</name>
+          <description>DEVICE End Point Interrupt Summary</description>
+          <addressOffset>0x020</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>EPINT0</name>
+              <description>End Point 0 Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT1</name>
+              <description>End Point 1 Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT2</name>
+              <description>End Point 2 Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT3</name>
+              <description>End Point 3 Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT4</name>
+              <description>End Point 4 Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT5</name>
+              <description>End Point 5 Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT6</name>
+              <description>End Point 6 Interrupt</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT7</name>
+              <description>End Point 7 Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DESCADD</name>
+          <description>Descriptor Address</description>
+          <addressOffset>0x024</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DESCADD</name>
+              <description>Descriptor Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PADCAL</name>
+          <description>USB PAD Calibration</description>
+          <addressOffset>0x028</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>TRANSP</name>
+              <description>USB Pad Transp calibration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TRANSN</name>
+              <description>USB Pad Transn calibration</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TRIM</name>
+              <description>USB Pad Trim calibration</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPCFG%s</name>
+          <description>DEVICE End Point Configuration</description>
+          <addressOffset>0x100</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EPTYPE0</name>
+              <description>End Point Type0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>EPTYPE1</name>
+              <description>End Point Type1</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>NYETDIS</name>
+              <description>NYET Token Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPSTATUSCLR%s</name>
+          <description>DEVICE End Point Pipe Status Clear</description>
+          <addressOffset>0x104</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>DTGLOUT</name>
+              <description>Data Toggle OUT Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>DTGLIN</name>
+              <description>Data Toggle IN Clear</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank Clear</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ0</name>
+              <description>Stall 0 Request Clear</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ1</name>
+              <description>Stall 1 Request Clear</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 Ready Clear</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 Ready Clear</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPSTATUSSET%s</name>
+          <description>DEVICE End Point Pipe Status Set</description>
+          <addressOffset>0x105</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>DTGLOUT</name>
+              <description>Data Toggle OUT Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>DTGLIN</name>
+              <description>Data Toggle IN Set</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank Set</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ0</name>
+              <description>Stall 0 Request Set</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ1</name>
+              <description>Stall 1 Request Set</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 Ready Set</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 Ready Set</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPSTATUS%s</name>
+          <description>DEVICE End Point Pipe Status</description>
+          <addressOffset>0x106</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>DTGLOUT</name>
+              <description>Data Toggle Out</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DTGLIN</name>
+              <description>Data Toggle In</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>STALLRQ0</name>
+              <description>Stall 0 Request</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>STALLRQ1</name>
+              <description>Stall 1 Request</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 ready</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPINTFLAG%s</name>
+          <description>DEVICE End Point Interrupt Flag</description>
+          <addressOffset>0x107</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL0</name>
+              <description>Error Flow 0</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL1</name>
+              <description>Error Flow 1</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXSTP</name>
+              <description>Received Setup</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL0</name>
+              <description>Stall 0 In/out</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL1</name>
+              <description>Stall 1 In/out</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPINTENCLR%s</name>
+          <description>DEVICE End Point Interrupt Clear Flag</description>
+          <addressOffset>0x108</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0 Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1 Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL0</name>
+              <description>Error Flow 0 Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL1</name>
+              <description>Error Flow 1 Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXSTP</name>
+              <description>Received Setup Interrupt Disable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL0</name>
+              <description>Stall 0 In/Out Interrupt Disable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL1</name>
+              <description>Stall 1 In/Out Interrupt Disable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPINTENSET%s</name>
+          <description>DEVICE End Point Interrupt Set Flag</description>
+          <addressOffset>0x109</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL0</name>
+              <description>Error Flow 0 Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL1</name>
+              <description>Error Flow 1 Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXSTP</name>
+              <description>Received Setup Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL0</name>
+              <description>Stall 0 In/out Interrupt enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL1</name>
+              <description>Stall 1 In/out Interrupt enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- UsbDevice -->
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>WDT</name>
+      <version>2.0.0</version>
+      <description>Watchdog Timer</description>
+      <groupName>WDT</groupName>
+      <prependToName>WDT_</prependToName>
+      <baseAddress>0x40001000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>WDT</name>
+        <value>2</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WEN</name>
+              <description>Watchdog Timer Window Mode Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ALWAYSON</name>
+              <description>Always-On</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CONFIG</name>
+          <description>Configuration</description>
+          <addressOffset>0x1</addressOffset>
+          <size>8</size>
+          <resetValue>0xBB</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Time-Out Period</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PERSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 clock cycles</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 clock cycles</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 clock cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 clock cycles</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 clock cycles</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 clock cycles</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 clock cycles</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1K</name>
+                  <description>1024 clock cycles</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2K</name>
+                  <description>2048 clock cycles</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4K</name>
+                  <description>4096 clock cycles</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8K</name>
+                  <description>8192 clock cycles</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16K</name>
+                  <description>16384 clock cycles</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WINDOW</name>
+              <description>Window Mode Time-Out Period</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>WINDOWSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 clock cycles</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 clock cycles</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 clock cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 clock cycles</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 clock cycles</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 clock cycles</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 clock cycles</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1K</name>
+                  <description>1024 clock cycles</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2K</name>
+                  <description>2048 clock cycles</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4K</name>
+                  <description>4096 clock cycles</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8K</name>
+                  <description>8192 clock cycles</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16K</name>
+                  <description>16384 clock cycles</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EWCTRL</name>
+          <description>Early Warning Interrupt Control</description>
+          <addressOffset>0x2</addressOffset>
+          <size>8</size>
+          <resetValue>0x0B</resetValue>
+          <fields>
+            <field>
+              <name>EWOFFSET</name>
+              <description>Early Warning Interrupt Time Offset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>EWOFFSETSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 clock cycles</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 clock cycles</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 clock cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 clock cycles</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 clock cycles</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 clock cycles</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 clock cycles</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1K</name>
+                  <description>1024 clock cycles</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2K</name>
+                  <description>2048 clock cycles</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4K</name>
+                  <description>4096 clock cycles</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8K</name>
+                  <description>8192 clock cycles</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16K</name>
+                  <description>16384 clock cycles</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x4</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EW</name>
+              <description>Early Warning Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x5</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EW</name>
+              <description>Early Warning Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x6</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EW</name>
+              <description>Early Warning</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x7</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CLEAR</name>
+          <description>Clear</description>
+          <addressOffset>0x8</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>CLEAR</name>
+              <description>Watchdog Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>write-only</access>
+              <enumeratedValues>
+                <name>CLEARSelect</name>
+                <enumeratedValue>
+                  <name>KEY</name>
+                  <description>Clear Key</description>
+                  <value>0xa5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+  </peripherals>
+</device>

--- a/svd/ATSAMD11D14AM.svd
+++ b/svd/ATSAMD11D14AM.svd
@@ -1,0 +1,17014 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device schemaVersion="1.2" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+  <vendor>Microchip Technology Inc.</vendor>
+  <vendorID>MICROCHIP</vendorID>
+  <name>ATSAMD11D14AM</name>
+  <series>SAMD11</series>
+  <version>B</version>
+  <description>Microchip ATSAMD11D14AM device: Cortex-M0+ Microcontroller with 16KB Flash, 4KB SRAM, QFN24_capless-pin package</description>
+  <licenseText>
+  Copyright (c) 2018 Microchip Technology Inc.\n
+\n
+  SPDX-License-Identifier: Apache-2.0\n
+\n
+  Licensed under the Apache License, Version 2.0 (the "License");\n
+  you may not use this file except in compliance with the License.\n
+  You may obtain a copy of the License at\n
+\n
+  http://www.apache.org/licenses/LICENSE-2.0\n
+\n
+  Unless required by applicable law or agreed to in writing, software\n
+  distributed under the License is distributed on an "AS IS" BASIS,\n
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n
+  See the License for the specific language governing permissions and\n
+  limitations under the License.
+  </licenseText>
+  <cpu>
+    <name>CM0+</name>
+    <revision>r0p1</revision>
+    <endian>little</endian>
+    <mpuPresent>false</mpuPresent>
+    <fpuPresent>false</fpuPresent>
+    <vtorPresent>true</vtorPresent>
+    <nvicPrioBits>2</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+    <deviceNumInterrupts>19</deviceNumInterrupts>
+  </cpu>
+  <headerSystemFilename>system_samd11</headerSystemFilename>
+  <addressUnitBits>8</addressUnitBits>
+  <width>32</width>
+  <size>32</size>
+  <access>read-write</access>
+  <resetValue>0x00000000</resetValue>
+  <resetMask>0xFFFFFFFF</resetMask>
+  <peripherals>
+    <peripheral>
+      <name>AC</name>
+      <version>1.1.1</version>
+      <description>Analog Comparators</description>
+      <groupName>AC</groupName>
+      <prependToName>AC_</prependToName>
+      <baseAddress>0x42002400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>AC</name>
+        <value>16</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMUX</name>
+              <description>Low-Power Mux</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>START0</name>
+              <description>Comparator 0 Start Comparison</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>START1</name>
+              <description>Comparator 1 Start Comparison</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COMPEO0</name>
+              <description>Comparator 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMPEO1</name>
+              <description>Comparator 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINEO0</name>
+              <description>Window 0 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMPEI0</name>
+              <description>Comparator 0 Event Input</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMPEI1</name>
+              <description>Comparator 1 Event Input</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COMP0</name>
+              <description>Comparator 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1</name>
+              <description>Comparator 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WIN0</name>
+              <description>Window 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COMP0</name>
+              <description>Comparator 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1</name>
+              <description>Comparator 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WIN0</name>
+              <description>Window 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COMP0</name>
+              <description>Comparator 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1</name>
+              <description>Comparator 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WIN0</name>
+              <description>Window 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSA</name>
+          <description>Status A</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>STATE0</name>
+              <description>Comparator 0 Current State</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STATE1</name>
+              <description>Comparator 1 Current State</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WSTATE0</name>
+              <description>Window 0 Current State</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WSTATE0Select</name>
+                <enumeratedValue>
+                  <name>ABOVE</name>
+                  <description>Signal is above window</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INSIDE</name>
+                  <description>Signal is inside window</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BELOW</name>
+                  <description>Signal is below window</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSB</name>
+          <description>Status B</description>
+          <addressOffset>0x09</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>READY0</name>
+              <description>Comparator 0 Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>READY1</name>
+              <description>Comparator 1 Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSC</name>
+          <description>Status C</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>STATE0</name>
+              <description>Comparator 0 Current State</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STATE1</name>
+              <description>Comparator 1 Current State</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WSTATE0</name>
+              <description>Window 0 Current State</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WSTATE0Select</name>
+                <enumeratedValue>
+                  <name>ABOVE</name>
+                  <description>Signal is above window</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INSIDE</name>
+                  <description>Signal is inside window</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BELOW</name>
+                  <description>Signal is below window</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINCTRL</name>
+          <description>Window Control</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>WEN0</name>
+              <description>Window 0 Mode Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINTSEL0</name>
+              <description>Window 0 Interrupt Selection</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WINTSEL0Select</name>
+                <enumeratedValue>
+                  <name>ABOVE</name>
+                  <description>Interrupt on signal above window</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INSIDE</name>
+                  <description>Interrupt on signal inside window</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BELOW</name>
+                  <description>Interrupt on signal below window</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OUTSIDE</name>
+                  <description>Interrupt on signal outside window</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>COMPCTRL%s</name>
+          <description>Comparator Control n</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SINGLE</name>
+              <description>Single-Shot Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPEED</name>
+              <description>Speed Selection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SPEEDSelect</name>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low speed</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High speed</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>INTSEL</name>
+              <description>Interrupt Selection</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>INTSELSelect</name>
+                <enumeratedValue>
+                  <name>TOGGLE</name>
+                  <description>Interrupt on comparator output toggle</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISING</name>
+                  <description>Interrupt on comparator output rising</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALLING</name>
+                  <description>Interrupt on comparator output falling</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EOC</name>
+                  <description>Interrupt on end of comparison (single-shot mode only)</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MUXNEG</name>
+              <description>Negative Input Mux Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MUXNEGSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>I/O pin 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>I/O pin 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>I/O pin 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>I/O pin 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GND</name>
+                  <description>Ground</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>VSCALE</name>
+                  <description>VDD scaler</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BANDGAP</name>
+                  <description>Internal bandgap voltage</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DAC</name>
+                  <description>DAC output</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MUXPOS</name>
+              <description>Positive Input Mux Selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MUXPOSSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>I/O pin 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>I/O pin 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>I/O pin 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>I/O pin 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SWAP</name>
+              <description>Swap Inputs and Invert</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OUT</name>
+              <description>Output</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>OUTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>The output of COMPn is not routed to the COMPn I/O port</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ASYNC</name>
+                  <description>The asynchronous output of COMPn is routed to the COMPn I/O port</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYNC</name>
+                  <description>The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>HYST</name>
+              <description>Hysteresis Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FLEN</name>
+              <description>Filter Length</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>FLENSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>No filtering</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MAJ3</name>
+                  <description>3-bit majority function (2 of 3)</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MAJ5</name>
+                  <description>5-bit majority function (3 of 5)</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>SCALER%s</name>
+          <description>Scaler n</description>
+          <addressOffset>0x20</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Scaler Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>ADC</name>
+      <version>1.2.0</version>
+      <description>Analog Digital Converter</description>
+      <groupName>ADC</groupName>
+      <prependToName>ADC_</prependToName>
+      <baseAddress>0x42002000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>ADC</name>
+        <value>15</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>REFCTRL</name>
+          <description>Reference Control</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>REFSEL</name>
+              <description>Reference Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>REFSELSelect</name>
+                <enumeratedValue>
+                  <name>INT1V</name>
+                  <description>1.0V voltage reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INTVCC0</name>
+                  <description>1/1.48 VDDANA</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INTVCC1</name>
+                  <description>1/2 VDDANA (only for VDDANA &gt; 2.0V)</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AREFA</name>
+                  <description>External reference</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AREFB</name>
+                  <description>External reference</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>REFCOMP</name>
+              <description>Reference Buffer Offset Compensation Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AVGCTRL</name>
+          <description>Average Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SAMPLENUM</name>
+              <description>Number of Samples to be Collected</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>SAMPLENUMSelect</name>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>1 sample</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>2 samples</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4</name>
+                  <description>4 samples</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 samples</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 samples</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 samples</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 samples</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 samples</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 samples</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 samples</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1024</name>
+                  <description>1024 samples</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADJRES</name>
+              <description>Adjusting Result / Division Coefficient</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SAMPCTRL</name>
+          <description>Sampling Time Control</description>
+          <addressOffset>0x03</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SAMPLEN</name>
+              <description>Sampling Time Length</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DIFFMODE</name>
+              <description>Differential Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LEFTADJ</name>
+              <description>Left-Adjusted Result</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FREERUN</name>
+              <description>Free Running Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CORREN</name>
+              <description>Digital Correction Logic Enabled</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESSEL</name>
+              <description>Conversion Result Resolution</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RESSELSelect</name>
+                <enumeratedValue>
+                  <name>12BIT</name>
+                  <description>12-bit result</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16BIT</name>
+                  <description>For averaging mode output</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>10BIT</name>
+                  <description>10-bit result</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8BIT</name>
+                  <description>8-bit result</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler Configuration</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Peripheral clock divided by 4</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Peripheral clock divided by 8</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Peripheral clock divided by 16</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Peripheral clock divided by 32</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Peripheral clock divided by 64</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Peripheral clock divided by 128</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Peripheral clock divided by 256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>Peripheral clock divided by 512</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINCTRL</name>
+          <description>Window Monitor Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>WINMODE</name>
+              <description>Window Monitor Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>WINMODESelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>No window mode (default)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE1</name>
+                  <description>Mode 1: RESULT &gt; WINLT</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE2</name>
+                  <description>Mode 2: RESULT &lt; WINUT</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE3</name>
+                  <description>Mode 3: WINLT &lt; RESULT &lt; WINUT</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE4</name>
+                  <description>Mode 4: !(WINLT &lt; RESULT &lt; WINUT)</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWTRIG</name>
+          <description>Software Trigger</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>FLUSH</name>
+              <description>ADC Conversion Flush</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>START</name>
+              <description>ADC Start Conversion</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INPUTCTRL</name>
+          <description>Input Control</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>MUXPOS</name>
+              <description>Positive Mux Input Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>MUXPOSSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>ADC AIN0 Pin</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>ADC AIN1 Pin</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>ADC AIN2 Pin</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>ADC AIN3 Pin</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN4</name>
+                  <description>ADC AIN4 Pin</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN5</name>
+                  <description>ADC AIN5 Pin</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN6</name>
+                  <description>ADC AIN6 Pin</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN7</name>
+                  <description>ADC AIN7 Pin</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN8</name>
+                  <description>ADC AIN8 Pin</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN9</name>
+                  <description>ADC AIN9 Pin</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN10</name>
+                  <description>ADC AIN10 Pin</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN11</name>
+                  <description>ADC AIN11 Pin</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN12</name>
+                  <description>ADC AIN12 Pin</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN13</name>
+                  <description>ADC AIN13 Pin</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN14</name>
+                  <description>ADC AIN14 Pin</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN15</name>
+                  <description>ADC AIN15 Pin</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN16</name>
+                  <description>ADC AIN16 Pin</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN17</name>
+                  <description>ADC AIN17 Pin</description>
+                  <value>0x11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN18</name>
+                  <description>ADC AIN18 Pin</description>
+                  <value>0x12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN19</name>
+                  <description>ADC AIN19 Pin</description>
+                  <value>0x13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TEMP</name>
+                  <description>Temperature Reference</description>
+                  <value>0x18</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BANDGAP</name>
+                  <description>Bandgap Voltage</description>
+                  <value>0x19</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SCALEDCOREVCC</name>
+                  <description>1/4  Scaled Core Supply</description>
+                  <value>0x1a</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SCALEDIOVCC</name>
+                  <description>1/4  Scaled I/O Supply</description>
+                  <value>0x1b</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DAC</name>
+                  <description>DAC Output</description>
+                  <value>0x1c</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MUXNEG</name>
+              <description>Negative Mux Input Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>MUXNEGSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>ADC AIN0 Pin</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>ADC AIN1 Pin</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>ADC AIN2 Pin</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>ADC AIN3 Pin</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN4</name>
+                  <description>ADC AIN4 Pin</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN5</name>
+                  <description>ADC AIN5 Pin</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN6</name>
+                  <description>ADC AIN6 Pin</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN7</name>
+                  <description>ADC AIN7 Pin</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GND</name>
+                  <description>Internal Ground</description>
+                  <value>0x18</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>IOGND</name>
+                  <description>I/O Ground</description>
+                  <value>0x19</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>INPUTSCAN</name>
+              <description>Number of Input Channels Included in Scan</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>INPUTOFFSET</name>
+              <description>Positive Mux Setting Offset</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>GAIN</name>
+              <description>Gain Factor Selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>GAINSelect</name>
+                <enumeratedValue>
+                  <name>1X</name>
+                  <description>1x</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2X</name>
+                  <description>2x</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4X</name>
+                  <description>4x</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8X</name>
+                  <description>8x</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16X</name>
+                  <description>16x</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>1/2x</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>STARTEI</name>
+              <description>Start Conversion Event In</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCEI</name>
+              <description>Synchronization Event In</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESRDYEO</name>
+              <description>Result Ready Event Out</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMONEO</name>
+              <description>Window Monitor Event Out</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESRDY</name>
+              <description>Result Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVERRUN</name>
+              <description>Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMON</name>
+              <description>Window Monitor Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x17</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESRDY</name>
+              <description>Result Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVERRUN</name>
+              <description>Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMON</name>
+              <description>Window Monitor Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESRDY</name>
+              <description>Result Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVERRUN</name>
+              <description>Overrun</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMON</name>
+              <description>Window Monitor</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x19</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RESULT</name>
+          <description>Result</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>RESULT</name>
+              <description>Result Conversion Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINLT</name>
+          <description>Window Monitor Lower Threshold</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>WINLT</name>
+              <description>Window Lower Threshold</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINUT</name>
+          <description>Window Monitor Upper Threshold</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>WINUT</name>
+              <description>Window Upper Threshold</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GAINCORR</name>
+          <description>Gain Correction</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>GAINCORR</name>
+              <description>Gain Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OFFSETCORR</name>
+          <description>Offset Correction</description>
+          <addressOffset>0x26</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>OFFSETCORR</name>
+              <description>Offset Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CALIB</name>
+          <description>Calibration</description>
+          <addressOffset>0x28</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>LINEARITY_CAL</name>
+              <description>Linearity Calibration Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>BIAS_CAL</name>
+              <description>Bias Calibration Value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x2A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DAC</name>
+      <version>1.1.0</version>
+      <description>Digital Analog Converter</description>
+      <groupName>DAC</groupName>
+      <prependToName>DAC_</prependToName>
+      <baseAddress>0x42002800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>DAC</name>
+        <value>17</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x1</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EOEN</name>
+              <description>External Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IOEN</name>
+              <description>Internal Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LEFTADJ</name>
+              <description>Left Adjusted Data</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VPD</name>
+              <description>Voltage Pump Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BDWP</name>
+              <description>Bypass DATABUF Write Protection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>REFSEL</name>
+              <description>Reference Selection</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>REFSELSelect</name>
+                <enumeratedValue>
+                  <name>INT1V</name>
+                  <description>Internal 1.0V reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AVCC</name>
+                  <description>AVCC</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>VREFP</name>
+                  <description>External reference</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x2</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>STARTEI</name>
+              <description>Start Conversion Event Input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTYEO</name>
+              <description>Data Buffer Empty Event Output</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x4</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>UNDERRUN</name>
+              <description>Underrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTY</name>
+              <description>Data Buffer Empty Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x5</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>UNDERRUN</name>
+              <description>Underrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTY</name>
+              <description>Data Buffer Empty Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x6</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>UNDERRUN</name>
+              <description>Underrun</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTY</name>
+              <description>Data Buffer Empty</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x7</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy Status</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>Data</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data value to be converted</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATABUF</name>
+          <description>Data Buffer</description>
+          <addressOffset>0xC</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DATABUF</name>
+              <description>Data Buffer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DMAC</name>
+      <version>1.0.0</version>
+      <description>Direct Memory Access Controller</description>
+      <groupName>DMAC</groupName>
+      <prependToName>DMAC_</prependToName>
+      <baseAddress>0x41004800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>DMAC</name>
+        <value>6</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAENABLE</name>
+              <description>DMA Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRCENABLE</name>
+              <description>CRC Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN0</name>
+              <description>Priority Level 0 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN1</name>
+              <description>Priority Level 1 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN2</name>
+              <description>Priority Level 2 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN3</name>
+              <description>Priority Level 3 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCCTRL</name>
+          <description>CRC Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>CRCBEATSIZE</name>
+              <description>CRC Beat Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CRCBEATSIZESelect</name>
+                <enumeratedValue>
+                  <name>BYTE</name>
+                  <description>8-bit bus transfer</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HWORD</name>
+                  <description>16-bit bus transfer</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WORD</name>
+                  <description>32-bit bus transfer</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CRCPOLY</name>
+              <description>CRC Polynomial Type</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CRCPOLYSelect</name>
+                <enumeratedValue>
+                  <name>CRC16</name>
+                  <description>CRC-16 (CRC-CCITT)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CRC32</name>
+                  <description>CRC32 (IEEE 802.3)</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CRCSRC</name>
+              <description>CRC Input Source</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>6</bitWidth>
+              <enumeratedValues>
+                <name>CRCSRCSelect</name>
+                <enumeratedValue>
+                  <name>NOACT</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>IO</name>
+                  <description>I/O interface</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCDATAIN</name>
+          <description>CRC Data Input</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CRCDATAIN</name>
+              <description>CRC Data Input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCCHKSUM</name>
+          <description>CRC Checksum</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CRCCHKSUM</name>
+              <description>CRC Checksum</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCSTATUS</name>
+          <description>CRC Status</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CRCBUSY</name>
+              <description>CRC Module Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRCZERO</name>
+              <description>CRC Zero</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>QOSCTRL</name>
+          <description>QOS Control</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <resetValue>0x15</resetValue>
+          <fields>
+            <field>
+              <name>WRBQOS</name>
+              <description>Write-Back Quality of Service</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WRBQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FQOS</name>
+              <description>Fetch Quality of Service</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DQOS</name>
+              <description>Data Transfer Quality of Service</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>DQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWTRIGCTRL</name>
+          <description>Software Trigger Control</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWTRIG0</name>
+              <description>Channel 0 Software Trigger</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG1</name>
+              <description>Channel 1 Software Trigger</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG2</name>
+              <description>Channel 2 Software Trigger</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG3</name>
+              <description>Channel 3 Software Trigger</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG4</name>
+              <description>Channel 4 Software Trigger</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG5</name>
+              <description>Channel 5 Software Trigger</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRICTRL0</name>
+          <description>Priority Control 0</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>LVLPRI0</name>
+              <description>Level 0 Channel Priority Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN0</name>
+              <description>Level 0 Round-Robin Scheduling Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLPRI1</name>
+              <description>Level 1 Channel Priority Number</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN1</name>
+              <description>Level 1 Round-Robin Scheduling Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLPRI2</name>
+              <description>Level 2 Channel Priority Number</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN2</name>
+              <description>Level 2 Round-Robin Scheduling Enable</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLPRI3</name>
+              <description>Level 3 Channel Priority Number</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN3</name>
+              <description>Level 3 Round-Robin Scheduling Enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTPEND</name>
+          <description>Interrupt Pending</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Channel ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>TERR</name>
+              <description>Transfer Error</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Transfer Complete</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FERR</name>
+              <description>Fetch Error</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSY</name>
+              <description>Busy</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PEND</name>
+              <description>Pending</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTSTATUS</name>
+          <description>Interrupt Status</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>CHINT0</name>
+              <description>Channel 0 Pending Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT1</name>
+              <description>Channel 1 Pending Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT2</name>
+              <description>Channel 2 Pending Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT3</name>
+              <description>Channel 3 Pending Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT4</name>
+              <description>Channel 4 Pending Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT5</name>
+              <description>Channel 5 Pending Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BUSYCH</name>
+          <description>Busy Channels</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>BUSYCH0</name>
+              <description>Busy Channel 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH1</name>
+              <description>Busy Channel 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH2</name>
+              <description>Busy Channel 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH3</name>
+              <description>Busy Channel 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH4</name>
+              <description>Busy Channel 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH5</name>
+              <description>Busy Channel 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PENDCH</name>
+          <description>Pending Channels</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PENDCH0</name>
+              <description>Pending Channel 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH1</name>
+              <description>Pending Channel 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH2</name>
+              <description>Pending Channel 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH3</name>
+              <description>Pending Channel 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH4</name>
+              <description>Pending Channel 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH5</name>
+              <description>Pending Channel 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ACTIVE</name>
+          <description>Active Channel and Levels</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>LVLEX0</name>
+              <description>Level 0 Channel Trigger Request Executing</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LVLEX1</name>
+              <description>Level 1 Channel Trigger Request Executing</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LVLEX2</name>
+              <description>Level 2 Channel Trigger Request Executing</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LVLEX3</name>
+              <description>Level 3 Channel Trigger Request Executing</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ID</name>
+              <description>Active Channel ID</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ABUSY</name>
+              <description>Active Channel Busy</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BTCNT</name>
+              <description>Active Channel Block Transfer Count</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BASEADDR</name>
+          <description>Descriptor Memory Section Base Address</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>BASEADDR</name>
+              <description>Descriptor Memory Base Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WRBADDR</name>
+          <description>Write-Back Memory Section Base Address</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WRBADDR</name>
+              <description>Write-Back Memory Base Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHID</name>
+          <description>Channel ID</description>
+          <addressOffset>0x3F</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Channel ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHCTRLA</name>
+          <description>Channel Control A</description>
+          <addressOffset>0x40</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Channel Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Channel Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHCTRLB</name>
+          <description>Channel Control B</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Input Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>NOACT</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TRIG</name>
+                  <description>Transfer and periodic transfer trigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CTRIG</name>
+                  <description>Conditional transfer trigger</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CBLOCK</name>
+                  <description>Conditional block transfer</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>Channel suspend operation</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESUME</name>
+                  <description>Channel resume operation</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSKIP</name>
+                  <description>Skip next block suspend action</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EVIE</name>
+              <description>Channel Event Input Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVOE</name>
+              <description>Channel Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVL</name>
+              <description>Channel Arbitration Level</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>LVLSelect</name>
+                <enumeratedValue>
+                  <name>LVL0</name>
+                  <description>Channel Priority Level 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LVL1</name>
+                  <description>Channel Priority Level 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LVL2</name>
+                  <description>Channel Priority Level 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LVL3</name>
+                  <description>Channel Priority Level 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TRIGSRC</name>
+              <description>Trigger Source</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>TRIGSRCSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Only software/event triggers</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TRIGACT</name>
+              <description>Trigger Action</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>TRIGACTSelect</name>
+                <enumeratedValue>
+                  <name>BLOCK</name>
+                  <description>One trigger required for each block transfer</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BEAT</name>
+                  <description>One trigger required for each beat transfer</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TRANSACTION</name>
+                  <description>One trigger required for each transaction</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Software Command</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NOACT</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>Channel suspend operation</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESUME</name>
+                  <description>Channel resume operation</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHINTENCLR</name>
+          <description>Channel Interrupt Enable Clear</description>
+          <addressOffset>0x4C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TERR</name>
+              <description>Channel Transfer Error Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Channel Transfer Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHINTENSET</name>
+          <description>Channel Interrupt Enable Set</description>
+          <addressOffset>0x4D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TERR</name>
+              <description>Channel Transfer Error Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Channel Transfer Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHINTFLAG</name>
+          <description>Channel Interrupt Flag Status and Clear</description>
+          <addressOffset>0x4E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TERR</name>
+              <description>Channel Transfer Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Channel Transfer Complete</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHSTATUS</name>
+          <description>Channel Status</description>
+          <addressOffset>0x4F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PEND</name>
+              <description>Channel Pending</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSY</name>
+              <description>Channel Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FERR</name>
+              <description>Channel Fetch Error</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DSU</name>
+      <version>2.1.1</version>
+      <description>Device Service Unit</description>
+      <groupName>DSU</groupName>
+      <prependToName>DSU_</prependToName>
+      <baseAddress>0x41002000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x2000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x0000</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CRC</name>
+              <description>32-bit Cyclic Redundancy Code</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>MBIST</name>
+              <description>Memory built-in self-test</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CE</name>
+              <description>Chip-Erase</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ARR</name>
+              <description>Auxiliary Row Read</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>SMSA</name>
+              <description>Start Memory Stream Access</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSA</name>
+          <description>Status A</description>
+          <addressOffset>0x0001</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DONE</name>
+              <description>Done</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRSTEXT</name>
+              <description>CPU Reset Phase Extension</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BERR</name>
+              <description>Bus Error</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAIL</name>
+              <description>Failure</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERR</name>
+              <description>Protection Error</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSB</name>
+          <description>Status B</description>
+          <addressOffset>0x0002</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PROT</name>
+              <description>Protected</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DBGPRES</name>
+              <description>Debugger Present</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DCCD0</name>
+              <description>Debug Communication Channel 0 Dirty</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DCCD1</name>
+              <description>Debug Communication Channel 1 Dirty</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HPE</name>
+              <description>Hot-Plugging Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>Address</description>
+          <addressOffset>0x0004</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>AMOD</name>
+              <description>Access Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>30</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LENGTH</name>
+          <description>Length</description>
+          <addressOffset>0x0008</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>LENGTH</name>
+              <description>Length</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>30</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>Data</description>
+          <addressOffset>0x000C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>DCC%s</name>
+          <description>Debug Communication Channel n</description>
+          <addressOffset>0x0010</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DID</name>
+          <description>Device Identification</description>
+          <addressOffset>0x0018</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x10030100</resetValue>
+          <fields>
+            <field>
+              <name>DEVSEL</name>
+              <description>Device Select</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>REVISION</name>
+              <description>Revision Number</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DIE</name>
+              <description>Die Number</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SERIES</name>
+              <description>Series</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>SERIESSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>Cortex-M0+ processor, basic feature set</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>Cortex-M0+ processor, USB</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FAMILY</name>
+              <description>Family</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>5</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>FAMILYSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>General purpose microcontroller</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>PicoPower</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PROCESSOR</name>
+              <description>Processor</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>PROCESSORSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>Cortex-M0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>Cortex-M0+</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>Cortex-M3</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>Cortex-M4</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>DCFG%s</name>
+          <description>Device Configuration</description>
+          <addressOffset>0x00F0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DCFG</name>
+              <description>Device Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ENTRY0</name>
+          <description>CoreSight ROM Table Entry 0</description>
+          <addressOffset>0x1000</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x9F0FC002</resetValue>
+          <fields>
+            <field>
+              <name>EPRES</name>
+              <description>Entry Present</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FMT</name>
+              <description>Format</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ADDOFF</name>
+              <description>Address Offset</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>20</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ENTRY1</name>
+          <description>CoreSight ROM Table Entry 1</description>
+          <addressOffset>0x1004</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00003002</resetValue>
+        </register>
+        <register>
+          <name>END</name>
+          <description>CoreSight ROM Table End</description>
+          <addressOffset>0x1008</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>END</name>
+              <description>End Marker</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MEMTYPE</name>
+          <description>CoreSight ROM Table Memory Type</description>
+          <addressOffset>0x1FCC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SMEMP</name>
+              <description>System Memory Present</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID4</name>
+          <description>Peripheral Identification 4</description>
+          <addressOffset>0x1FD0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>JEPCC</name>
+              <description>JEP-106 Continuation Code</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>FKBC</name>
+              <description>4KB count</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID5</name>
+          <description>Peripheral Identification 5</description>
+          <addressOffset>0x1FD4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID6</name>
+          <description>Peripheral Identification 6</description>
+          <addressOffset>0x1FD8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID7</name>
+          <description>Peripheral Identification 7</description>
+          <addressOffset>0x1FDC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID0</name>
+          <description>Peripheral Identification 0</description>
+          <addressOffset>0x1FE0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000000D0</resetValue>
+          <fields>
+            <field>
+              <name>PARTNBL</name>
+              <description>Part Number Low</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID1</name>
+          <description>Peripheral Identification 1</description>
+          <addressOffset>0x1FE4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000000FC</resetValue>
+          <fields>
+            <field>
+              <name>PARTNBH</name>
+              <description>Part Number High</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>JEPIDCL</name>
+              <description>Low part of the JEP-106 Identity Code</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID2</name>
+          <description>Peripheral Identification 2</description>
+          <addressOffset>0x1FE8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00000009</resetValue>
+          <fields>
+            <field>
+              <name>JEPIDCH</name>
+              <description>JEP-106 Identity Code High</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>JEPU</name>
+              <description>JEP-106 Identity Code is used</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>REVISION</name>
+              <description>Revision Number</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID3</name>
+          <description>Peripheral Identification 3</description>
+          <addressOffset>0x1FEC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>CUSMOD</name>
+              <description>ARM CUSMOD</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>REVAND</name>
+              <description>Revision Number</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID0</name>
+          <description>Component Identification 0</description>
+          <addressOffset>0x1FF0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x0000000D</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLEB0</name>
+              <description>Preamble Byte 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID1</name>
+          <description>Component Identification 1</description>
+          <addressOffset>0x1FF4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00000010</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLE</name>
+              <description>Preamble</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CCLASS</name>
+              <description>Component Class</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID2</name>
+          <description>Component Identification 2</description>
+          <addressOffset>0x1FF8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00000005</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLEB2</name>
+              <description>Preamble Byte 2</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID3</name>
+          <description>Component Identification 3</description>
+          <addressOffset>0x1FFC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000000B1</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLEB3</name>
+              <description>Preamble Byte 3</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EIC</name>
+      <version>1.0.1</version>
+      <description>External Interrupt Controller</description>
+      <groupName>EIC</groupName>
+      <prependToName>EIC_</prependToName>
+      <baseAddress>0x40001800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>EIC</name>
+        <value>4</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>NMICTRL</name>
+          <description>Non-Maskable Interrupt Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>NMISENSE</name>
+              <description>Non-Maskable Interrupt Sense</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>NMISENSESelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising-edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling-edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both-edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High-level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low-level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>NMIFILTEN</name>
+              <description>Non-Maskable Interrupt Filter Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>NMIFLAG</name>
+          <description>Non-Maskable Interrupt Flag Status and Clear</description>
+          <addressOffset>0x03</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>NMI</name>
+              <description>Non-Maskable Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINTEO0</name>
+              <description>External Interrupt 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO1</name>
+              <description>External Interrupt 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO2</name>
+              <description>External Interrupt 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO3</name>
+              <description>External Interrupt 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO4</name>
+              <description>External Interrupt 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO5</name>
+              <description>External Interrupt 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO6</name>
+              <description>External Interrupt 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO7</name>
+              <description>External Interrupt 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINT0</name>
+              <description>External Interrupt 0 Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT1</name>
+              <description>External Interrupt 1 Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT2</name>
+              <description>External Interrupt 2 Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT3</name>
+              <description>External Interrupt 3 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT4</name>
+              <description>External Interrupt 4 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT5</name>
+              <description>External Interrupt 5 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT6</name>
+              <description>External Interrupt 6 Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT7</name>
+              <description>External Interrupt 7 Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINT0</name>
+              <description>External Interrupt 0 Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT1</name>
+              <description>External Interrupt 1 Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT2</name>
+              <description>External Interrupt 2 Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT3</name>
+              <description>External Interrupt 3 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT4</name>
+              <description>External Interrupt 4 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT5</name>
+              <description>External Interrupt 5 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT6</name>
+              <description>External Interrupt 6 Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT7</name>
+              <description>External Interrupt 7 Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINT0</name>
+              <description>External Interrupt 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT1</name>
+              <description>External Interrupt 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT2</name>
+              <description>External Interrupt 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT3</name>
+              <description>External Interrupt 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT4</name>
+              <description>External Interrupt 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT5</name>
+              <description>External Interrupt 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT6</name>
+              <description>External Interrupt 6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT7</name>
+              <description>External Interrupt 7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAKEUP</name>
+          <description>Wake-Up Enable</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WAKEUPEN0</name>
+              <description>External Interrupt 0 Wake-up Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN1</name>
+              <description>External Interrupt 1 Wake-up Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN2</name>
+              <description>External Interrupt 2 Wake-up Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN3</name>
+              <description>External Interrupt 3 Wake-up Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN4</name>
+              <description>External Interrupt 4 Wake-up Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN5</name>
+              <description>External Interrupt 5 Wake-up Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN6</name>
+              <description>External Interrupt 6 Wake-up Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN7</name>
+              <description>External Interrupt 7 Wake-up Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CONFIG%s</name>
+          <description>Configuration n</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SENSE0</name>
+              <description>Input Sense 0 Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE0Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising-edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling-edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both-edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High-level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low-level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN0</name>
+              <description>Filter 0 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE1</name>
+              <description>Input Sense 1 Configuration</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE1Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN1</name>
+              <description>Filter 1 Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE2</name>
+              <description>Input Sense 2 Configuration</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE2Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN2</name>
+              <description>Filter 2 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE3</name>
+              <description>Input Sense 3 Configuration</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE3Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN3</name>
+              <description>Filter 3 Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE4</name>
+              <description>Input Sense 4 Configuration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE4Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN4</name>
+              <description>Filter 4 Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE5</name>
+              <description>Input Sense 5 Configuration</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE5Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN5</name>
+              <description>Filter 5 Enable</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE6</name>
+              <description>Input Sense 6 Configuration</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE6Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN6</name>
+              <description>Filter 6 Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE7</name>
+              <description>Input Sense 7 Configuration</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE7Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN7</name>
+              <description>Filter 7 Enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EVSYS</name>
+      <version>1.0.1</version>
+      <description>Event System Interface</description>
+      <groupName>EVSYS</groupName>
+      <prependToName>EVSYS_</prependToName>
+      <baseAddress>0x42000400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>EVSYS</name>
+        <value>8</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>GCLKREQ</name>
+              <description>Generic Clock Requests</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHANNEL</name>
+          <description>Channel</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CHANNEL</name>
+              <description>Channel Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SWEVT</name>
+              <description>Software Event</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVGEN</name>
+              <description>Event Generator Selection</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>PATH</name>
+              <description>Path Selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PATHSelect</name>
+                <enumeratedValue>
+                  <name>SYNCHRONOUS</name>
+                  <description>Synchronous path</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNCHRONIZED</name>
+                  <description>Resynchronized path</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ASYNCHRONOUS</name>
+                  <description>Asynchronous path</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EDGSEL</name>
+              <description>Edge Detection Selection</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>EDGSELSelect</name>
+                <enumeratedValue>
+                  <name>NO_EVT_OUTPUT</name>
+                  <description>No event output when using the resynchronized or synchronous path</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISING_EDGE</name>
+                  <description>Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALLING_EDGE</name>
+                  <description>Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH_EDGES</name>
+                  <description>Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>USER</name>
+          <description>User Multiplexer</description>
+          <addressOffset>0x08</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USER</name>
+              <description>User Multiplexer Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>CHANNEL</name>
+              <description>Channel Event Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>CHANNELSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>No Channel Output Selected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHSTATUS</name>
+          <description>Channel Status</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x0000003F</resetValue>
+          <fields>
+            <field>
+              <name>USRRDY0</name>
+              <description>Channel 0 User Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY1</name>
+              <description>Channel 1 User Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY2</name>
+              <description>Channel 2 User Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY3</name>
+              <description>Channel 3 User Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY4</name>
+              <description>Channel 4 User Ready</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY5</name>
+              <description>Channel 5 User Ready</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY0</name>
+              <description>Channel 0 Busy</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY1</name>
+              <description>Channel 1 Busy</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY2</name>
+              <description>Channel 2 Busy</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY3</name>
+              <description>Channel 3 Busy</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY4</name>
+              <description>Channel 4 Busy</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY5</name>
+              <description>Channel 5 Busy</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVR0</name>
+              <description>Channel 0 Overrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR1</name>
+              <description>Channel 1 Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR2</name>
+              <description>Channel 2 Overrun Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR3</name>
+              <description>Channel 3 Overrun Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR4</name>
+              <description>Channel 4 Overrun Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR5</name>
+              <description>Channel 5 Overrun Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD0</name>
+              <description>Channel 0 Event Detection Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD1</name>
+              <description>Channel 1 Event Detection Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD2</name>
+              <description>Channel 2 Event Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD3</name>
+              <description>Channel 3 Event Detection Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD4</name>
+              <description>Channel 4 Event Detection Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD5</name>
+              <description>Channel 5 Event Detection Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVR0</name>
+              <description>Channel 0 Overrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR1</name>
+              <description>Channel 1 Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR2</name>
+              <description>Channel 2 Overrun Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR3</name>
+              <description>Channel 3 Overrun Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR4</name>
+              <description>Channel 4 Overrun Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR5</name>
+              <description>Channel 5 Overrun Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD0</name>
+              <description>Channel 0 Event Detection Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD1</name>
+              <description>Channel 1 Event Detection Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD2</name>
+              <description>Channel 2 Event Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD3</name>
+              <description>Channel 3 Event Detection Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD4</name>
+              <description>Channel 4 Event Detection Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD5</name>
+              <description>Channel 5 Event Detection Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVR0</name>
+              <description>Channel 0 Overrun</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR1</name>
+              <description>Channel 1 Overrun</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR2</name>
+              <description>Channel 2 Overrun</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR3</name>
+              <description>Channel 3 Overrun</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR4</name>
+              <description>Channel 4 Overrun</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR5</name>
+              <description>Channel 5 Overrun</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD0</name>
+              <description>Channel 0 Event Detection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD1</name>
+              <description>Channel 1 Event Detection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD2</name>
+              <description>Channel 2 Event Detection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD3</name>
+              <description>Channel 3 Event Detection</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD4</name>
+              <description>Channel 4 Event Detection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD5</name>
+              <description>Channel 5 Event Detection</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>GCLK</name>
+      <version>2.1.0</version>
+      <description>Generic Clock Generator</description>
+      <groupName>GCLK</groupName>
+      <prependToName>GCLK_</prependToName>
+      <baseAddress>0x40000C00</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x1</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy Status</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CLKCTRL</name>
+          <description>Generic Clock Control</description>
+          <addressOffset>0x2</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Generic Clock Selection ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <enumeratedValues>
+                <name>IDSelect</name>
+                <enumeratedValue>
+                  <name>DFLL48</name>
+                  <description>DFLL48</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FDPLL</name>
+                  <description>FDPLL</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FDPLL32K</name>
+                  <description>FDPLL32K</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WDT</name>
+                  <description>WDT</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RTC</name>
+                  <description>RTC</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EIC</name>
+                  <description>EIC</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB</name>
+                  <description>USB</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_0</name>
+                  <description>EVSYS_0</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_1</name>
+                  <description>EVSYS_1</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_2</name>
+                  <description>EVSYS_2</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_3</name>
+                  <description>EVSYS_3</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_4</name>
+                  <description>EVSYS_4</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_5</name>
+                  <description>EVSYS_5</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOMX_SLOW</name>
+                  <description>SERCOMX_SLOW</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM0_CORE</name>
+                  <description>SERCOM0_CORE</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM1_CORE</name>
+                  <description>SERCOM1_CORE</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM2_CORE</name>
+                  <description>SERCOM2_CORE</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TCC0</name>
+                  <description>TCC0</description>
+                  <value>0x11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TC1_TC2</name>
+                  <description>TC1_TC2</description>
+                  <value>0x12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC</name>
+                  <description>ADC</description>
+                  <value>0x13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AC_DIG</name>
+                  <description>AC_DIG</description>
+                  <value>0x14</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AC_ANA</name>
+                  <description>AC_ANA</description>
+                  <value>0x15</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DAC</name>
+                  <description>DAC</description>
+                  <value>0x16</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>GEN</name>
+              <description>Generic Clock Generator</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>GENSelect</name>
+                <enumeratedValue>
+                  <name>GCLK0</name>
+                  <description>Generic clock generator 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK1</name>
+                  <description>Generic clock generator 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK2</name>
+                  <description>Generic clock generator 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK3</name>
+                  <description>Generic clock generator 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK4</name>
+                  <description>Generic clock generator 4</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK5</name>
+                  <description>Generic clock generator 5</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CLKEN</name>
+              <description>Clock Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GENCTRL</name>
+          <description>Generic Clock Generator Control</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Generic Clock Generator Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>SRC</name>
+              <description>Source Select</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>SRCSelect</name>
+                <enumeratedValue>
+                  <name>XOSC</name>
+                  <description>XOSC oscillator output</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLKIN</name>
+                  <description>Generator input pad</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLKGEN1</name>
+                  <description>Generic clock generator 1 output</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OSCULP32K</name>
+                  <description>OSCULP32K oscillator output</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OSC32K</name>
+                  <description>OSC32K oscillator output</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>XOSC32K</name>
+                  <description>XOSC32K oscillator output</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OSC8M</name>
+                  <description>OSC8M oscillator output</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DFLL48M</name>
+                  <description>DFLL48M output</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DPLL96M</name>
+                  <description>DPLL96M output</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>GENEN</name>
+              <description>Generic Clock Generator Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDC</name>
+              <description>Improve Duty Cycle</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OOV</name>
+              <description>Output Off Value</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OE</name>
+              <description>Output Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DIVSEL</name>
+              <description>Divide Selection</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GENDIV</name>
+          <description>Generic Clock Generator Division</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Generic Clock Generator Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>DIV</name>
+              <description>Division Factor</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>HMATRIX</name>
+      <version>2.1.2</version>
+      <description>HSB Matrix</description>
+      <groupName>HMATRIXB</groupName>
+      <prependToName>HMATRIXB_</prependToName>
+      <baseAddress>0x41007000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>PRAS%s</name>
+          <description>Priority A for Slave</description>
+          <addressOffset>0x080</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>M0PR</name>
+              <description>Master 0 Priority</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M1PR</name>
+              <description>Master 1 Priority</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M2PR</name>
+              <description>Master 2 Priority</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M3PR</name>
+              <description>Master 3 Priority</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M4PR</name>
+              <description>Master 4 Priority</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M5PR</name>
+              <description>Master 5 Priority</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M6PR</name>
+              <description>Master 6 Priority</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M7PR</name>
+              <description>Master 7 Priority</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>PRBS%s</name>
+          <description>Priority B for Slave</description>
+          <addressOffset>0x084</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>M8PR</name>
+              <description>Master 8 Priority</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M9PR</name>
+              <description>Master 9 Priority</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M10PR</name>
+              <description>Master 10 Priority</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M11PR</name>
+              <description>Master 11 Priority</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M12PR</name>
+              <description>Master 12 Priority</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M13PR</name>
+              <description>Master 13 Priority</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M14PR</name>
+              <description>Master 14 Priority</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M15PR</name>
+              <description>Master 15 Priority</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>SFR%s</name>
+          <description>Special Function</description>
+          <addressOffset>0x110</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SFR</name>
+              <description>Special Function Register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>MTB</name>
+      <version>1.0.0</version>
+      <description>Cortex-M0+ Micro-Trace Buffer</description>
+      <groupName>MTB</groupName>
+      <prependToName>MTB_</prependToName>
+      <baseAddress>0x41006000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>POSITION</name>
+          <description>MTB Position</description>
+          <addressOffset>0x000</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WRAP</name>
+              <description>Pointer Value Wraps</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POINTER</name>
+              <description>Trace Packet Location Pointer</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>29</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MASTER</name>
+          <description>MTB Master</description>
+          <addressOffset>0x004</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>MASK</name>
+              <description>Maximum Value of the Trace Buffer in SRAM</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TSTARTEN</name>
+              <description>Trace Start Input Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTOPEN</name>
+              <description>Trace Stop Input Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SFRWPRIV</name>
+              <description>Special Function Register Write Privilege</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMPRIV</name>
+              <description>SRAM Privilege</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HALTREQ</name>
+              <description>Halt Request</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN</name>
+              <description>Main Trace Enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FLOW</name>
+          <description>MTB Flow</description>
+          <addressOffset>0x008</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>AUTOSTOP</name>
+              <description>Auto Stop Tracing</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AUTOHALT</name>
+              <description>Auto Halt Request</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WATERMARK</name>
+              <description>Watermark value</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>29</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BASE</name>
+          <description>MTB Base</description>
+          <addressOffset>0x00C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>ITCTRL</name>
+          <description>MTB Integration Mode Control</description>
+          <addressOffset>0xF00</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>CLAIMSET</name>
+          <description>MTB Claim Set</description>
+          <addressOffset>0xFA0</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>CLAIMCLR</name>
+          <description>MTB Claim Clear</description>
+          <addressOffset>0xFA4</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>LOCKACCESS</name>
+          <description>MTB Lock Access</description>
+          <addressOffset>0xFB0</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>LOCKSTATUS</name>
+          <description>MTB Lock Status</description>
+          <addressOffset>0xFB4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>AUTHSTATUS</name>
+          <description>MTB Authentication Status</description>
+          <addressOffset>0xFB8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>DEVARCH</name>
+          <description>MTB Device Architecture</description>
+          <addressOffset>0xFBC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>DEVID</name>
+          <description>MTB Device Configuration</description>
+          <addressOffset>0xFC8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>DEVTYPE</name>
+          <description>MTB Device Type</description>
+          <addressOffset>0xFCC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID4</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFD0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID5</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFD4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID6</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFD8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID7</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFDC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID0</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFE0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID1</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFE4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID2</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFE8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID3</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFEC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID0</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFF0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID1</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFF4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID2</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFF8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID3</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFFC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>NVMCTRL</name>
+      <version>1.0.7</version>
+      <description>Non-Volatile Memory Controller</description>
+      <groupName>NVMCTRL</groupName>
+      <prependToName>NVMCTRL_</prependToName>
+      <baseAddress>0x41004000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>NVMCTRL</name>
+        <value>5</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>ER</name>
+                  <description>Erase Row - Erases the row addressed by the ADDR register.</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WP</name>
+                  <description>Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register.</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EAR</name>
+                  <description>Erase Auxiliary Row - Erases the auxiliary row addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row.</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WAP</name>
+                  <description>Write Auxiliary Page - Writes the contents of the page buffer to the page addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row.</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SF</name>
+                  <description>Security Flow Command</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WL</name>
+                  <description>Write lockbits</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LR</name>
+                  <description>Lock Region - Locks the region containing the address location in the ADDR register.</description>
+                  <value>0x40</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UR</name>
+                  <description>Unlock Region - Unlocks the region containing the address location in the ADDR register.</description>
+                  <value>0x41</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPRM</name>
+                  <description>Sets the power reduction mode.</description>
+                  <value>0x42</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CPRM</name>
+                  <description>Clears the power reduction mode.</description>
+                  <value>0x43</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PBC</name>
+                  <description>Page Buffer Clear - Clears the page buffer.</description>
+                  <value>0x44</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSB</name>
+                  <description>Set Security Bit - Sets the security bit by writing 0x00 to the first byte in the lockbit row.</description>
+                  <value>0x45</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INVALL</name>
+                  <description>Invalidates all cache lines.</description>
+                  <value>0x46</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMDEX</name>
+              <description>Command Execution</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+              <enumeratedValues>
+                <name>CMDEXSelect</name>
+                <enumeratedValue>
+                  <name>KEY</name>
+                  <description>Execution Key</description>
+                  <value>0xa5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>RWS</name>
+              <description>NVM Read Wait States</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>RWSSelect</name>
+                <enumeratedValue>
+                  <name>SINGLE</name>
+                  <description>Single Auto Wait State</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HALF</name>
+                  <description>Half Auto Wait State</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DUAL</name>
+                  <description>Dual Auto Wait State</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MANW</name>
+              <description>Manual Write</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLEEPPRM</name>
+              <description>Power Reduction Mode during Sleep</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SLEEPPRMSelect</name>
+                <enumeratedValue>
+                  <name>WAKEONACCESS</name>
+                  <description>NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access.</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WAKEUPINSTANT</name>
+                  <description>NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep.</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DISABLED</name>
+                  <description>Auto power reduction disabled.</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>READMODE</name>
+              <description>NVMCTRL Read Mode</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>READMODESelect</name>
+                <enumeratedValue>
+                  <name>NO_MISS_PENALTY</name>
+                  <description>The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance.</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW_POWER</name>
+                  <description>Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time.</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DETERMINISTIC</name>
+                  <description>The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings.</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CACHEDIS</name>
+              <description>Cache Disable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PARAM</name>
+          <description>NVM Parameter</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>NVMP</name>
+              <description>NVM Pages</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PSZ</name>
+              <description>Page Size</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>PSZSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 bytes</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 bytes</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 bytes</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 bytes</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 bytes</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 bytes</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 bytes</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1024</name>
+                  <description>1024 bytes</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READY</name>
+              <description>NVM Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x10</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READY</name>
+              <description>NVM Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READY</name>
+              <description>NVM Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PRM</name>
+              <description>Power Reduction Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LOAD</name>
+              <description>NVM Page Buffer Active Loading</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PROGE</name>
+              <description>Programming Error Status</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LOCKE</name>
+              <description>Lock Error Status</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NVME</name>
+              <description>NVM Error</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Security Bit Status</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>Address</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>NVM Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>22</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LOCK</name>
+          <description>Lock Section</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>LOCK</name>
+              <description>Region Lock Bits</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PAC0</name>
+      <version>1.0.1</version>
+      <description>Peripheral Access Controller 0</description>
+      <groupName>PAC</groupName>
+      <prependToName>PAC_</prependToName>
+      <baseAddress>0x40000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x08</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>WPCLR</name>
+          <description>Write Protection Clear</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WP</name>
+              <description>Write Protection Clear</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>31</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WPSET</name>
+          <description>Write Protection Set</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WP</name>
+              <description>Write Protection Set</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>31</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="PAC0">
+      <name>PAC1</name>
+      <description>Peripheral Access Controller 1</description>
+      <baseAddress>0x41000000</baseAddress>
+    </peripheral>
+    <peripheral derivedFrom="PAC0">
+      <name>PAC2</name>
+      <description>Peripheral Access Controller 2</description>
+      <baseAddress>0x42000000</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>PM</name>
+      <version>2.1.1</version>
+      <description>Power Manager</description>
+      <groupName>PM</groupName>
+      <prependToName>PM_</prependToName>
+      <baseAddress>0x40000400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>PM</name>
+        <value>0</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CFDEN</name>
+              <description>Clock Failure Detector Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BKUPCLK</name>
+              <description>Backup Clock Select</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SLEEP</name>
+          <description>Sleep Mode</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>IDLE</name>
+              <description>Idle Mode Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>IDLESelect</name>
+                <enumeratedValue>
+                  <name>CPU</name>
+                  <description>The CPU clock domain is stopped</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AHB</name>
+                  <description>The CPU and AHB clock domains are stopped</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>APB</name>
+                  <description>The CPU, AHB and APB clock domains are stopped</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTCTRL</name>
+          <description>External Reset Controller</description>
+          <addressOffset>0x02</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SETDIS</name>
+              <description>External Reset Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CPUSEL</name>
+          <description>CPU Clock Select</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CPUDIV</name>
+              <description>CPU Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CPUDIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBASEL</name>
+          <description>APBA Clock Select</description>
+          <addressOffset>0x09</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>APBADIV</name>
+              <description>APBA Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>APBADIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBBSEL</name>
+          <description>APBB Clock Select</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>APBBDIV</name>
+              <description>APBB Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>APBBDIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBCSEL</name>
+          <description>APBC Clock Select</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>APBCDIV</name>
+              <description>APBC Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>APBCDIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBMASK</name>
+          <description>AHB Mask</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <resetValue>0x0000007F</resetValue>
+          <fields>
+            <field>
+              <name>HPB0_</name>
+              <description>HPB0 AHB Clock Mask</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HPB1_</name>
+              <description>HPB1 AHB Clock Mask</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HPB2_</name>
+              <description>HPB2 AHB Clock Mask</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DSU_</name>
+              <description>DSU AHB Clock Mask</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NVMCTRL_</name>
+              <description>NVMCTRL AHB Clock Mask</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAC_</name>
+              <description>DMAC AHB Clock Mask</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USB_</name>
+              <description>USB AHB Clock Mask</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBAMASK</name>
+          <description>APBA Mask</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <resetValue>0x0000007F</resetValue>
+          <fields>
+            <field>
+              <name>PAC0_</name>
+              <description>PAC0 APB Clock Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PM_</name>
+              <description>PM APB Clock Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYSCTRL_</name>
+              <description>SYSCTRL APB Clock Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GCLK_</name>
+              <description>GCLK APB Clock Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WDT_</name>
+              <description>WDT APB Clock Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RTC_</name>
+              <description>RTC APB Clock Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EIC_</name>
+              <description>EIC APB Clock Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBBMASK</name>
+          <description>APBB Mask</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <resetValue>0x0000007F</resetValue>
+          <fields>
+            <field>
+              <name>PAC1_</name>
+              <description>PAC1 APB Clock Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DSU_</name>
+              <description>DSU APB Clock Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NVMCTRL_</name>
+              <description>NVMCTRL APB Clock Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PORT_</name>
+              <description>PORT APB Clock Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAC_</name>
+              <description>DMAC APB Clock Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USB_</name>
+              <description>USB APB Clock Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HMATRIX_</name>
+              <description>HMATRIX APB Clock Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBCMASK</name>
+          <description>APBC Mask</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <resetValue>0x00000100</resetValue>
+          <fields>
+            <field>
+              <name>PAC2_</name>
+              <description>PAC2 APB Clock Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVSYS_</name>
+              <description>EVSYS APB Clock Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM0_</name>
+              <description>SERCOM0 APB Clock Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM1_</name>
+              <description>SERCOM1 APB Clock Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM2_</name>
+              <description>SERCOM2 APB Clock Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCC0_</name>
+              <description>TCC0 APB Clock Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TC1_</name>
+              <description>TC1 APB Clock Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TC2_</name>
+              <description>TC2 APB Clock Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADC_</name>
+              <description>ADC APB Clock Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AC_</name>
+              <description>AC APB Clock Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DAC_</name>
+              <description>DAC APB Clock Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PTC_</name>
+              <description>PTC APB Clock Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x34</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CKRDY</name>
+              <description>Clock Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CFD</name>
+              <description>Clock Failure Detector Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x35</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CKRDY</name>
+              <description>Clock Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CFD</name>
+              <description>Clock Failure Detector Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x36</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CKRDY</name>
+              <description>Clock Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CFD</name>
+              <description>Clock Failure Detector</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCAUSE</name>
+          <description>Reset Cause</description>
+          <addressOffset>0x38</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x01</resetValue>
+          <fields>
+            <field>
+              <name>POR</name>
+              <description>Power On Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD12</name>
+              <description>Brown Out 12 Detector Reset</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33</name>
+              <description>Brown Out 33 Detector Reset</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXT</name>
+              <description>External Reset</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WDT</name>
+              <description>Watchdog Reset</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYST</name>
+              <description>System Reset Request</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PORT</name>
+      <version>1.0.0</version>
+      <description>Port Module</description>
+      <groupName>PORT</groupName>
+      <prependToName>PORT_</prependToName>
+      <baseAddress>0x41004400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x200</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIR%s</name>
+          <description>Data Direction</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Port Data Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIRCLR%s</name>
+          <description>Data Direction Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIRCLR</name>
+              <description>Port Data Direction Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIRSET%s</name>
+          <description>Data Direction Set</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIRSET</name>
+              <description>Port Data Direction Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIRTGL%s</name>
+          <description>Data Direction Toggle</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIRTGL</name>
+              <description>Port Data Direction Toggle</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUT%s</name>
+          <description>Data Output Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUT</name>
+              <description>Port Data Output Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUTCLR%s</name>
+          <description>Data Output Value Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUTCLR</name>
+              <description>Port Data Output Value Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUTSET%s</name>
+          <description>Data Output Value Set</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUTSET</name>
+              <description>Port Data Output Value Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUTTGL%s</name>
+          <description>Data Output Value Toggle</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUTTGL</name>
+              <description>Port Data Output Value Toggle</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>IN%s</name>
+          <description>Data Input Value</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>IN</name>
+              <description>Port Data Input Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>CTRL%s</name>
+          <description>Control</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SAMPLING</name>
+              <description>Input Sampling Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>WRCONFIG%s</name>
+          <description>Write Configuration</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>PINMASK</name>
+              <description>Pin Mask for Multiple Pin Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+            <field>
+              <name>PMUXEN</name>
+              <description>Peripheral Multiplexer Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INEN</name>
+              <description>Input Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PULLEN</name>
+              <description>Pull Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRVSTR</name>
+              <description>Output Driver Strength Selection</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PMUX</name>
+              <description>Peripheral Multiplexing</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>WRPMUX</name>
+              <description>Write PMUX</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WRPINCFG</name>
+              <description>Write PINCFG</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HWSEL</name>
+              <description>Half-Word Select</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>PMUX0_%s</name>
+          <description>Peripheral Multiplexing n - Group 0</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PMUXE</name>
+              <description>Peripheral Multiplexing Even</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PMUXESelect</name>
+                <enumeratedValue>
+                  <name>A</name>
+                  <description>Peripheral function A selected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>B</name>
+                  <description>Peripheral function B selected</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>C</name>
+                  <description>Peripheral function C selected</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>D</name>
+                  <description>Peripheral function D selected</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>E</name>
+                  <description>Peripheral function E selected</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>F</name>
+                  <description>Peripheral function F selected</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>G</name>
+                  <description>Peripheral function G selected</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>H</name>
+                  <description>Peripheral function H selected</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PMUXO</name>
+              <description>Peripheral Multiplexing Odd</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PMUXOSelect</name>
+                <enumeratedValue>
+                  <name>A</name>
+                  <description>Peripheral function A selected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>B</name>
+                  <description>Peripheral function B selected</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>C</name>
+                  <description>Peripheral function C selected</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>D</name>
+                  <description>Peripheral function D selected</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>E</name>
+                  <description>Peripheral function E selected</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>F</name>
+                  <description>Peripheral function F selected</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>G</name>
+                  <description>Peripheral function G selected</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>H</name>
+                  <description>Peripheral function H selected</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>32</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>PINCFG0_%s</name>
+          <description>Pin Configuration n - Group 0</description>
+          <addressOffset>0x40</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PMUXEN</name>
+              <description>Peripheral Multiplexer Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INEN</name>
+              <description>Input Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PULLEN</name>
+              <description>Pull Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRVSTR</name>
+              <description>Output Driver Strength Selection</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="PORT">
+      <name>PORT_IOBUS</name>
+      <description>Port Module (IOBUS)</description>
+      <groupName>PORT_IOBUS</groupName>
+      <prependToName>PORT_IOBUS_</prependToName>
+      <baseAddress>0x60000000</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>RTC</name>
+      <version>1.0.1</version>
+      <description>Real-Time Counter</description>
+      <groupName>RTC</groupName>
+      <prependToName>RTC_</prependToName>
+      <baseAddress>0x40001400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>RTC</name>
+        <value>3</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>MODE0</name>
+        <description>32-bit Counter with Single 32-bit Compare</description>
+        <headerStructName>RtcMode0</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRL</name>
+          <description>MODE0 Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Mode 0: 32-bit Counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Mode 1: 16-bit Counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLOCK</name>
+                  <description>Mode 2: Clock/Calendar</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MATCHCLR</name>
+              <description>Clear on Match</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/256</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/512</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1024</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <resetValue>0x0010</resetValue>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>MODE0 Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PEREO0</name>
+              <description>Periodic Interval 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO1</name>
+              <description>Periodic Interval 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO2</name>
+              <description>Periodic Interval 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO3</name>
+              <description>Periodic Interval 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO4</name>
+              <description>Periodic Interval 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO5</name>
+              <description>Periodic Interval 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO6</name>
+              <description>Periodic Interval 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO7</name>
+              <description>Periodic Interval 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMPEO0</name>
+              <description>Compare 0 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>MODE0 Interrupt Enable Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>MODE0 Interrupt Enable Set</description>
+          <addressOffset>0x07</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>MODE0 Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Run During Debug</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCORR</name>
+          <description>Frequency Correction</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>SIGN</name>
+              <description>Correction Sign</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>MODE0 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>COMP%s</name>
+          <description>MODE0 Compare n Value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COMP</name>
+              <description>Compare Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- RtcMode0 -->
+       <cluster>
+        <name>MODE1</name>
+        <description>16-bit Counter with Two 16-bit Compares</description>
+        <alternateCluster>MODE0</alternateCluster>
+        <headerStructName>RtcMode1</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRL</name>
+          <description>MODE1 Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Mode 0: 32-bit Counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Mode 1: 16-bit Counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLOCK</name>
+                  <description>Mode 2: Clock/Calendar</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/256</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/512</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1024</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <resetValue>0x0010</resetValue>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>MODE1 Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PEREO0</name>
+              <description>Periodic Interval 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO1</name>
+              <description>Periodic Interval 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO2</name>
+              <description>Periodic Interval 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO3</name>
+              <description>Periodic Interval 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO4</name>
+              <description>Periodic Interval 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO5</name>
+              <description>Periodic Interval 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO6</name>
+              <description>Periodic Interval 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO7</name>
+              <description>Periodic Interval 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMPEO0</name>
+              <description>Compare 0 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMPEO1</name>
+              <description>Compare 1 Event Output Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>MODE1 Interrupt Enable Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>MODE1 Interrupt Enable Set</description>
+          <addressOffset>0x07</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>MODE1 Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Run During Debug</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCORR</name>
+          <description>Frequency Correction</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>SIGN</name>
+              <description>Correction Sign</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>MODE1 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER</name>
+          <description>MODE1 Counter Period</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Counter Period</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x2</dimIncrement>
+          <name>COMP%s</name>
+          <description>MODE1 Compare n Value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COMP</name>
+              <description>Compare Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- RtcMode1 -->
+       <cluster>
+        <name>MODE2</name>
+        <description>Clock/Calendar with Alarm</description>
+        <alternateCluster>MODE0</alternateCluster>
+        <headerStructName>RtcMode2</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRL</name>
+          <description>MODE2 Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Mode 0: 32-bit Counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Mode 1: 16-bit Counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLOCK</name>
+                  <description>Mode 2: Clock/Calendar</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CLKREP</name>
+              <description>Clock Representation</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MATCHCLR</name>
+              <description>Clear on Match</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/256</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/512</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1024</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <resetValue>0x0010</resetValue>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>MODE2 Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PEREO0</name>
+              <description>Periodic Interval 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO1</name>
+              <description>Periodic Interval 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO2</name>
+              <description>Periodic Interval 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO3</name>
+              <description>Periodic Interval 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO4</name>
+              <description>Periodic Interval 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO5</name>
+              <description>Periodic Interval 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO6</name>
+              <description>Periodic Interval 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO7</name>
+              <description>Periodic Interval 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ALARMEO0</name>
+              <description>Alarm 0 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>MODE2 Interrupt Enable Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ALARM0</name>
+              <description>Alarm 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>MODE2 Interrupt Enable Set</description>
+          <addressOffset>0x07</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ALARM0</name>
+              <description>Alarm 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>MODE2 Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ALARM0</name>
+              <description>Alarm 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Run During Debug</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCORR</name>
+          <description>Frequency Correction</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>SIGN</name>
+              <description>Correction Sign</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CLOCK</name>
+          <description>MODE2 Clock Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SECOND</name>
+              <description>Second</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>MINUTE</name>
+              <description>Minute</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>HOUR</name>
+              <description>Hour</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>HOURSelect</name>
+                <enumeratedValue>
+                  <name>AM</name>
+                  <description>AM when CLKREP in 12-hour</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PM</name>
+                  <description>PM when CLKREP in 12-hour</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DAY</name>
+              <description>Day</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>MONTH</name>
+              <description>Month</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>YEAR</name>
+              <description>Year</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>ALARM%s</name>
+          <description>MODE2 Alarm n Value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SECOND</name>
+              <description>Second</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>MINUTE</name>
+              <description>Minute</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>HOUR</name>
+              <description>Hour</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>HOURSelect</name>
+                <enumeratedValue>
+                  <name>AM</name>
+                  <description>Morning hour</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PM</name>
+                  <description>Afternoon hour</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DAY</name>
+              <description>Day</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>MONTH</name>
+              <description>Month</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>YEAR</name>
+              <description>Year</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>MASK%s</name>
+          <description>MODE2 Alarm n Mask</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SEL</name>
+              <description>Alarm Mask Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SELSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Alarm Disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SS</name>
+                  <description>Match seconds only</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MMSS</name>
+                  <description>Match seconds and minutes only</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HHMMSS</name>
+                  <description>Match seconds, minutes, and hours only</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DDHHMMSS</name>
+                  <description>Match seconds, minutes, hours, and days only</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MMDDHHMMSS</name>
+                  <description>Match seconds, minutes, hours, days, and months only</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>YYMMDDHHMMSS</name>
+                  <description>Match seconds, minutes, hours, days, months, and years</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- RtcMode2 -->
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>SERCOM0</name>
+      <version>2.0.0</version>
+      <description>Serial Communication Interface 0</description>
+      <groupName>SERCOM</groupName>
+      <prependToName>SERCOM_</prependToName>
+      <baseAddress>0x42000800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>SERCOM0</name>
+        <value>9</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>I2CM</name>
+        <description>I2C Master Mode</description>
+        <headerStructName>SercomI2cm</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>I2CM Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINOUT</name>
+              <description>Pin Usage</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SDAHOLD</name>
+              <description>SDA Hold Time</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MEXTTOEN</name>
+              <description>Master SCL Low Extend Timeout</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SEXTTOEN</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPEED</name>
+              <description>Transfer Speed</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SCLSM</name>
+              <description>SCL Clock Stretch Mode</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INACTOUT</name>
+              <description>Inactive Time-Out</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>LOWTOUTEN</name>
+              <description>SCL Low Timeout Enable</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>I2CM Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SMEN</name>
+              <description>Smart Mode Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QCEN</name>
+              <description>Quick Command Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ACKACT</name>
+              <description>Acknowledge Action</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD</name>
+          <description>I2CM Baud Rate</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>BAUDLOW</name>
+              <description>Baud Rate Value Low</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>HSBAUD</name>
+              <description>High Speed Baud Rate Value</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>HSBAUDLOW</name>
+              <description>High Speed Baud Rate Value Low</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>I2CM Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MB</name>
+              <description>Master On Bus Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Slave On Bus Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>I2CM Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MB</name>
+              <description>Master On Bus Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Slave On Bus Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>I2CM Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MB</name>
+              <description>Master On Bus Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Slave On Bus Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>I2CM Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BUSERR</name>
+              <description>Bus Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ARBLOST</name>
+              <description>Arbitration Lost</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXNACK</name>
+              <description>Received Not Acknowledge</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSSTATE</name>
+              <description>Bus State</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>LOWTOUT</name>
+              <description>SCL Low Timeout</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CLKHOLD</name>
+              <description>Clock Hold</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>MEXTTOUT</name>
+              <description>Master SCL Low Extend Timeout</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SEXTTOUT</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LENERR</name>
+              <description>Length Error</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>I2CM Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYSOP</name>
+              <description>System Operation Synchronization Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>I2CM Address</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+            <field>
+              <name>LENEN</name>
+              <description>Length Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HS</name>
+              <description>High Speed Mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TENBITEN</name>
+              <description>Ten Bit Addressing Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LEN</name>
+              <description>Length</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>I2CM Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>I2CM Debug Control</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGSTOP</name>
+              <description>Debug Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomI2cm -->
+       <cluster>
+        <name>I2CS</name>
+        <description>I2C Slave Mode</description>
+        <alternateCluster>I2CM</alternateCluster>
+        <headerStructName>SercomI2cs</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>I2CS Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run during Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINOUT</name>
+              <description>Pin Usage</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SDAHOLD</name>
+              <description>SDA Hold Time</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SEXTTOEN</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPEED</name>
+              <description>Transfer Speed</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SCLSM</name>
+              <description>SCL Clock Stretch Mode</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LOWTOUTEN</name>
+              <description>SCL Low Timeout Enable</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>I2CS Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SMEN</name>
+              <description>Smart Mode Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GCMD</name>
+              <description>PMBus Group Command</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AACKEN</name>
+              <description>Automatic Address Acknowledge</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMODE</name>
+              <description>Address Mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ACKACT</name>
+              <description>Acknowledge Action</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>I2CS Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PREC</name>
+              <description>Stop Received Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMATCH</name>
+              <description>Address Match Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRDY</name>
+              <description>Data Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>I2CS Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PREC</name>
+              <description>Stop Received Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMATCH</name>
+              <description>Address Match Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRDY</name>
+              <description>Data Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>I2CS Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PREC</name>
+              <description>Stop Received Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMATCH</name>
+              <description>Address Match Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRDY</name>
+              <description>Data Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>I2CS Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BUSERR</name>
+              <description>Bus Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COLL</name>
+              <description>Transmit Collision</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXNACK</name>
+              <description>Received Not Acknowledge</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>Read/Write Direction</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SR</name>
+              <description>Repeated Start</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LOWTOUT</name>
+              <description>SCL Low Timeout</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CLKHOLD</name>
+              <description>Clock Hold</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SEXTTOUT</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HS</name>
+              <description>High Speed</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>I2CS Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>I2CS Address</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>GENCEN</name>
+              <description>General Call Address Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADDR</name>
+              <description>Address Value</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+            <field>
+              <name>TENBITEN</name>
+              <description>Ten Bit Addressing Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADDRMASK</name>
+              <description>Address Mask</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>I2CS Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomI2cs -->
+       <cluster>
+        <name>SPI</name>
+        <description>SPI Mode</description>
+        <alternateCluster>I2CM</alternateCluster>
+        <headerStructName>SercomSpi</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>SPI Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run during Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IBON</name>
+              <description>Immediate Buffer Overflow Notification</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DOPO</name>
+              <description>Data Out Pinout</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>DIPO</name>
+              <description>Data In Pinout</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>FORM</name>
+              <description>Frame Format</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CPHA</name>
+              <description>Clock Phase</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>Clock Polarity</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DORD</name>
+              <description>Data Order</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>SPI Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CHSIZE</name>
+              <description>Character Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>PLOADEN</name>
+              <description>Data Preload Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSDE</name>
+              <description>Slave Select Low Detect Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSSEN</name>
+              <description>Master Slave Select Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMODE</name>
+              <description>Address Mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>RXEN</name>
+              <description>Receiver Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD</name>
+          <description>SPI Baud Rate</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>SPI Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSL</name>
+              <description>Slave Select Low Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>SPI Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSL</name>
+              <description>Slave Select Low Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>SPI Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SSL</name>
+              <description>Slave Select Low Interrupt Flag</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>SPI Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BUFOVF</name>
+              <description>Buffer Overflow</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>SPI Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CTRLB</name>
+              <description>CTRLB Synchronization Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>SPI Address</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>ADDRMASK</name>
+              <description>Address Mask</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>SPI Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>SPI Debug Control</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGSTOP</name>
+              <description>Debug Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomSpi -->
+       <cluster>
+        <name>USART</name>
+        <description>USART Mode</description>
+        <alternateCluster>I2CM</alternateCluster>
+        <headerStructName>SercomUsart</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>USART Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run during Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IBON</name>
+              <description>Immediate Buffer Overflow Notification</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SAMPR</name>
+              <description>Sample</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>TXPO</name>
+              <description>Transmit Data Pinout</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>RXPO</name>
+              <description>Receive Data Pinout</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SAMPA</name>
+              <description>Sample Adjustment</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>FORM</name>
+              <description>Frame Format</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CMODE</name>
+              <description>Communication Mode</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>Clock Polarity</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DORD</name>
+              <description>Data Order</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>USART Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CHSIZE</name>
+              <description>Character Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SBMODE</name>
+              <description>Stop Bit Mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COLDEN</name>
+              <description>Collision Detection Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SFDE</name>
+              <description>Start of Frame Detection Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENC</name>
+              <description>Encoding Format</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PMODE</name>
+              <description>Parity Mode</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXEN</name>
+              <description>Transmitter Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXEN</name>
+              <description>Receiver Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD</name>
+          <description>USART Baud Rate</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD_FRAC_MODE</name>
+          <description>USART Baud Rate</description>
+          <alternateRegister>BAUD</alternateRegister>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>13</bitWidth>
+            </field>
+            <field>
+              <name>FP</name>
+              <description>Fractional Part</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD_FRACFP_MODE</name>
+          <description>USART Baud Rate</description>
+          <alternateRegister>BAUD</alternateRegister>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>13</bitWidth>
+            </field>
+            <field>
+              <name>FP</name>
+              <description>Fractional Part</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD_USARTFP_MODE</name>
+          <description>USART Baud Rate</description>
+          <alternateRegister>BAUD</alternateRegister>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXPL</name>
+          <description>USART Receive Pulse Length</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RXPL</name>
+              <description>Receive Pulse Length</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>USART Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXS</name>
+              <description>Receive Start Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTSIC</name>
+              <description>Clear To Send Input Change Interrupt Disable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXBRK</name>
+              <description>Break Received Interrupt Disable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>USART Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXS</name>
+              <description>Receive Start Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTSIC</name>
+              <description>Clear To Send Input Change Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXBRK</name>
+              <description>Break Received Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>USART Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RXS</name>
+              <description>Receive Start Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CTSIC</name>
+              <description>Clear To Send Input Change Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXBRK</name>
+              <description>Break Received Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>USART Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PERR</name>
+              <description>Parity Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FERR</name>
+              <description>Frame Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BUFOVF</name>
+              <description>Buffer Overflow</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTS</name>
+              <description>Clear To Send</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ISF</name>
+              <description>Inconsistent Sync Field</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COLL</name>
+              <description>Collision Detected</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>USART Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CTRLB</name>
+              <description>CTRLB Synchronization Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>USART Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>USART Debug Control</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGSTOP</name>
+              <description>Debug Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomUsart -->
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="SERCOM0">
+      <name>SERCOM1</name>
+      <description>Serial Communication Interface 1</description>
+      <baseAddress>0x42000C00</baseAddress>
+      <interrupt>
+        <name>SERCOM1</name>
+        <value>10</value>
+      </interrupt>
+    </peripheral>
+    <peripheral derivedFrom="SERCOM0">
+      <name>SERCOM2</name>
+      <description>Serial Communication Interface 2</description>
+      <baseAddress>0x42001000</baseAddress>
+      <interrupt>
+        <name>SERCOM2</name>
+        <value>11</value>
+      </interrupt>
+    </peripheral>
+    <peripheral>
+      <name>SYSCTRL</name>
+      <version>2.0.2</version>
+      <description>System Control</description>
+      <groupName>SYSCTRL</groupName>
+      <prependToName>SYSCTRL_</prependToName>
+      <baseAddress>0x40000800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>SYSCTRL</name>
+        <value>1</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PCLKSR</name>
+          <description>Power and Clocks Status</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>XOSC</name>
+          <description>External Multipurpose Crystal Oscillator (XOSC) Control</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <resetValue>0x0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XTALEN</name>
+              <description>Crystal Oscillator Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GAIN</name>
+              <description>Oscillator Gain</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>GAINSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>2MHz</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>4MHz</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>8MHz</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>16MHz</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4</name>
+                  <description>30MHz</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>AMPGC</name>
+              <description>Automatic Amplitude Gain Control</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STARTUP</name>
+              <description>Start-Up Time</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>XOSC32K</name>
+          <description>32kHz External Crystal Oscillator (XOSC32K) Control</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <resetValue>0x0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XTALEN</name>
+              <description>Crystal Oscillator Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN32K</name>
+              <description>32kHz Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN1K</name>
+              <description>1kHz Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AAMPEN</name>
+              <description>Automatic Amplitude Control Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STARTUP</name>
+              <description>Oscillator Start-Up Time</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSC32K</name>
+          <description>32kHz Internal Oscillator (OSC32K) Control</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <resetValue>0x003F0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN32K</name>
+              <description>32kHz Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN1K</name>
+              <description>1kHz Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STARTUP</name>
+              <description>Oscillator Start-Up Time</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALIB</name>
+              <description>Oscillator Calibration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSCULP32K</name>
+          <description>32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>8</size>
+          <resetValue>0x1F</resetValue>
+          <fields>
+            <field>
+              <name>CALIB</name>
+              <description>Oscillator Calibration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSC8M</name>
+          <description>8MHz Internal Oscillator (OSC8M) Control</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <resetValue>0x87070382</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESC</name>
+              <description>Oscillator Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CALIB</name>
+              <description>Oscillator Calibration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+            <field>
+              <name>FRANGE</name>
+              <description>Oscillator Frequency Range</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FRANGESelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>4 to 6MHz</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>6 to 8MHz</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>8 to 11MHz</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>11 to 15MHz</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLCTRL</name>
+          <description>DFLL48M Control</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <resetValue>0x0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>DFLL Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode Selection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STABLE</name>
+              <description>Stable DFLL Frequency</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LLAW</name>
+              <description>Lose Lock After Wake</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USBCRM</name>
+              <description>USB Clock Recovery Mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCDIS</name>
+              <description>Chill Cycle Disable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QLDIS</name>
+              <description>Quick Lock Disable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BPLCKC</name>
+              <description>Bypass Coarse Lock</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAITLOCK</name>
+              <description>Wait Lock</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLVAL</name>
+          <description>DFLL48M Value</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>FINE</name>
+              <description>Fine Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+            <field>
+              <name>COARSE</name>
+              <description>Coarse Value</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>DIFF</name>
+              <description>Multiplication Ratio Difference</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLMUL</name>
+          <description>DFLL48M Multiplier</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>MUL</name>
+              <description>DFLL Multiply Factor</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+            <field>
+              <name>FSTEP</name>
+              <description>Fine Maximum Step</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+            <field>
+              <name>CSTEP</name>
+              <description>Coarse Maximum Step</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLSYNC</name>
+          <description>DFLL48M Synchronization</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READREQ</name>
+              <description>Read Request</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BOD33</name>
+          <description>3.3V Brown-Out Detector (BOD33) Control</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HYST</name>
+              <description>Hysteresis</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ACTION</name>
+              <description>BOD33 Action</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>ACTIONSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESET</name>
+                  <description>The BOD33 generates a reset</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INTERRUPT</name>
+                  <description>The BOD33 generates an interrupt</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operation Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CEN</name>
+              <description>Clock Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PSEL</name>
+              <description>Prescaler Select</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PSELSelect</name>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide clock by 2</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide clock by 4</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide clock by 8</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide clock by 16</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide clock by 32</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide clock by 64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide clock by 128</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Divide clock by 256</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>Divide clock by 512</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1K</name>
+                  <description>Divide clock by 1024</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2K</name>
+                  <description>Divide clock by 2048</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4K</name>
+                  <description>Divide clock by 4096</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8K</name>
+                  <description>Divide clock by 8192</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16K</name>
+                  <description>Divide clock by 16384</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32K</name>
+                  <description>Divide clock by 32768</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64K</name>
+                  <description>Divide clock by 65536</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LEVEL</name>
+              <description>BOD33 Threshold Level</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VREF</name>
+          <description>Voltage References System (VREF) Control</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>TSEN</name>
+              <description>Temperature Sensor Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BGOUTEN</name>
+              <description>Bandgap Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALIB</name>
+              <description>Bandgap Voltage Generator Calibration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLCTRLA</name>
+          <description>DPLL Control A</description>
+          <addressOffset>0x44</addressOffset>
+          <size>8</size>
+          <resetValue>0x80</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>DPLL Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Clock Activation</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLRATIO</name>
+          <description>DPLL Ratio Control</description>
+          <addressOffset>0x48</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>LDR</name>
+              <description>Loop Divider Ratio</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+            <field>
+              <name>LDRFRAC</name>
+              <description>Loop Divider Ratio Fractional Part</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLCTRLB</name>
+          <description>DPLL Control B</description>
+          <addressOffset>0x4C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>FILTER</name>
+              <description>Proportional Integral Filter Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FILTERSelect</name>
+                <enumeratedValue>
+                  <name>DEFAULT</name>
+                  <description>Default filter mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LBFILT</name>
+                  <description>Low bandwidth filter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HBFILT</name>
+                  <description>High bandwidth filter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HDFILT</name>
+                  <description>High damping filter</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LPEN</name>
+              <description>Low-Power Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WUF</name>
+              <description>Wake Up Fast</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>REFCLK</name>
+              <description>Reference Clock Selection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>REFCLKSelect</name>
+                <enumeratedValue>
+                  <name>REF0</name>
+                  <description>CLK_DPLL_REF0 clock reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>REF1</name>
+                  <description>CLK_DPLL_REF1 clock reference</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>GCLK_DPLL clock reference</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LTIME</name>
+              <description>Lock Time</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>LTIMESelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>Default	No time-out</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8MS</name>
+                  <description>8MS	Time-out if no lock within 8 ms</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>9MS</name>
+                  <description>9MS	Time-out if no lock within 9 ms</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>10MS</name>
+                  <description>10MS	Time-out if no lock within 10 ms</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>11MS</name>
+                  <description>11MS	Time-out if no lock within 11 ms</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LBYPASS</name>
+              <description>Lock Bypass</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DIV</name>
+              <description>Clock Divider</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLSTATUS</name>
+          <description>DPLL Status</description>
+          <addressOffset>0x50</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>LOCK</name>
+              <description>DPLL Lock Status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CLKRDY</name>
+              <description>Output Clock Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>DPLL Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DIV</name>
+              <description>Divider Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TC1</name>
+      <version>1.4.0</version>
+      <description>Basic Timer Counter 1</description>
+      <groupName>TC</groupName>
+      <prependToName>TC_</prependToName>
+      <baseAddress>0x42001800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x040</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TC1</name>
+        <value>13</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>COUNT8</name>
+        <description>8-bit Counter Mode</description>
+        <headerStructName>TcCount8</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>TC Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Counter in 16-bit mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT8</name>
+                  <description>Counter in 8-bit mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Counter in 32-bit mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation Operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MPWM</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Prescaler: GCLK_TC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Prescaler: GCLK_TC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Prescaler: GCLK_TC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Prescaler: GCLK_TC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Prescaler: GCLK_TC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Prescaler: GCLK_TC/64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Prescaler: GCLK_TC/256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Prescaler: GCLK_TC/1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset the counter on next generic clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset the counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset the counter on next generic clock. Reset the prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <resetValue>0x02</resetValue>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Invert Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Invert Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or retrigger TC on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start TC on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period captured in CC0, pulse width in CC1</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period captured in CC1, pulse width in CC0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TCINV</name>
+              <description>TC Inverted Event Input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI</name>
+              <description>TC Event Input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x08</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>COUNT8 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER</name>
+          <description>COUNT8 Period Value</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <resetValue>0xFF</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>CC%s</name>
+          <description>COUNT8 Compare/Capture</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- TcCount8 -->
+       <cluster>
+        <name>COUNT16</name>
+        <description>16-bit Counter Mode</description>
+        <alternateCluster>COUNT8</alternateCluster>
+        <headerStructName>TcCount16</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>TC Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Counter in 16-bit mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT8</name>
+                  <description>Counter in 8-bit mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Counter in 32-bit mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation Operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MPWM</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Prescaler: GCLK_TC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Prescaler: GCLK_TC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Prescaler: GCLK_TC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Prescaler: GCLK_TC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Prescaler: GCLK_TC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Prescaler: GCLK_TC/64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Prescaler: GCLK_TC/256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Prescaler: GCLK_TC/1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset the counter on next generic clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset the counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset the counter on next generic clock. Reset the prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <resetValue>0x02</resetValue>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Invert Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Invert Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or retrigger TC on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start TC on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period captured in CC0, pulse width in CC1</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period captured in CC1, pulse width in CC0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TCINV</name>
+              <description>TC Inverted Event Input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI</name>
+              <description>TC Event Input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x08</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>COUNT16 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Count Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x2</dimIncrement>
+          <name>CC%s</name>
+          <description>COUNT16 Compare/Capture</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- TcCount16 -->
+       <cluster>
+        <name>COUNT32</name>
+        <description>32-bit Counter Mode</description>
+        <alternateCluster>COUNT8</alternateCluster>
+        <headerStructName>TcCount32</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>TC Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Counter in 16-bit mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT8</name>
+                  <description>Counter in 8-bit mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Counter in 32-bit mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation Operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MPWM</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Prescaler: GCLK_TC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Prescaler: GCLK_TC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Prescaler: GCLK_TC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Prescaler: GCLK_TC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Prescaler: GCLK_TC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Prescaler: GCLK_TC/64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Prescaler: GCLK_TC/256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Prescaler: GCLK_TC/1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset the counter on next generic clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset the counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset the counter on next generic clock. Reset the prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <resetValue>0x02</resetValue>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Invert Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Invert Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or retrigger TC on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start TC on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period captured in CC0, pulse width in CC1</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period captured in CC1, pulse width in CC0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TCINV</name>
+              <description>TC Inverted Event Input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI</name>
+              <description>TC Event Input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x08</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>COUNT32 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Count Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s</name>
+          <description>COUNT32 Compare/Capture</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- TcCount32 -->
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="TC1">
+      <name>TC2</name>
+      <description>Basic Timer Counter 2</description>
+      <baseAddress>0x42001C00</baseAddress>
+      <interrupt>
+        <name>TC2</name>
+        <value>14</value>
+      </interrupt>
+    </peripheral>
+    <peripheral>
+      <name>TCC0</name>
+      <version>1.1.1</version>
+      <description>Timer Counter Control</description>
+      <groupName>TCC</groupName>
+      <prependToName>TCC_</prependToName>
+      <baseAddress>0x42001400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x090</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TCC0</name>
+        <value>12</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESOLUTION</name>
+              <description>Enhanced Resolution</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RESOLUTIONSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>Dithering is disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DITH4</name>
+                  <description>Dithering is done every 16 PWM frames</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DITH5</name>
+                  <description>Dithering is done every 32 PWM frames</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DITH6</name>
+                  <description>Dithering is done every 64 PWM frames</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>No division</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Divide by 256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Divide by 1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization Selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset counter on next GCLK</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset counter on next GCLK and reset prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ALOCK</name>
+              <description>Auto Lock</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN2</name>
+              <description>Capture Channel 2 Enable</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN3</name>
+              <description>Capture Channel 3 Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LUPD</name>
+              <description>Lock Update</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDXCMD</name>
+              <description>Ramp Index Command</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>IDXCMDSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Command disabled: Index toggles between cycles A and B</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Set index: cycle B will be forced in the next cycle</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLEAR</name>
+                  <description>Clear index: cycle A will be forced in the next cycle</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HOLD</name>
+                  <description>Hold index: the next cycle will be the same as the current cycle</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>TCC Command</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Clear start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPDATE</name>
+                  <description>Force update or double buffered registers</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>READSYNC</name>
+                  <description>Force COUNT read synchronization</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LUPD</name>
+              <description>Lock Update</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDXCMD</name>
+              <description>Ramp Index Command</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>IDXCMDSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Command disabled: Index toggles between cycles A and B</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Set index: cycle B will be forced in the next cycle</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLEAR</name>
+                  <description>Clear index: cycle A will be forced in the next cycle</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HOLD</name>
+                  <description>Hold index: the next cycle will be the same as the current cycle</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>TCC Command</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Clear start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPDATE</name>
+                  <description>Force update or double buffered registers</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>READSYNC</name>
+                  <description>Force COUNT read synchronization</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>Synchronization Busy</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Swrst Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTRLB</name>
+              <description>Ctrlb Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STATUS</name>
+              <description>Status Busy</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COUNT</name>
+              <description>Count Busy</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PATT</name>
+              <description>Pattern Busy</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAVE</name>
+              <description>Wave Busy</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC0</name>
+              <description>Compare Channel 0 Busy</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC1</name>
+              <description>Compare Channel 1 Busy</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC2</name>
+              <description>Compare Channel 2 Busy</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC3</name>
+              <description>Compare Channel 3 Busy</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PATTB</name>
+              <description>Pattern Buffer Busy</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAVEB</name>
+              <description>Wave Buffer Busy</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Busy</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB0</name>
+              <description>Compare Channel Buffer 0 Busy</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB1</name>
+              <description>Compare Channel Buffer 1 Busy</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB2</name>
+              <description>Compare Channel Buffer 2 Busy</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB3</name>
+              <description>Compare Channel Buffer 3 Busy</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FCTRLA</name>
+          <description>Recoverable Fault A Configuration</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SRC</name>
+              <description>Fault A Source</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SRCSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Fault input disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>MCEx (x=0,1) event input</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INVERT</name>
+                  <description>Inverted MCEx (x=0,1) event input</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ALTFAULT</name>
+                  <description>Alternate fault (A or B) state at the end of the previous period</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>KEEP</name>
+              <description>Fault A Keeper</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QUAL</name>
+              <description>Fault A Qualification</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANK</name>
+              <description>Fault A Blanking Mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>BLANKSelect</name>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Blanking applied from start of ramp</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Blanking applied from rising edge of the output waveform</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Blanking applied from falling edge of the output waveform</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Blanking applied from each toggle of the output waveform</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RESTART</name>
+              <description>Fault A Restart</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HALT</name>
+              <description>Fault A Halt Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>HALTSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Halt action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HW</name>
+                  <description>Hardware halt action</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SW</name>
+                  <description>Software halt action</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NR</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CHSEL</name>
+              <description>Fault A Capture Channel</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CHSELSelect</name>
+                <enumeratedValue>
+                  <name>CC0</name>
+                  <description>Capture value stored in channel 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC1</name>
+                  <description>Capture value stored in channel 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC2</name>
+                  <description>Capture value stored in channel 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC3</name>
+                  <description>Capture value stored in channel 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CAPTURE</name>
+              <description>Fault A Capture Action</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CAPTURESelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>No capture</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPT</name>
+                  <description>Capture on fault</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMIN</name>
+                  <description>Minimum capture</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMAX</name>
+                  <description>Maximum capture</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMIN</name>
+                  <description>Minimum local detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMAX</name>
+                  <description>Maximum local detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DERIV0</name>
+                  <description>Minimum and maximum local detection</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMARK</name>
+                  <description>Capture with ramp index as MSB value</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>BLANKPRESC</name>
+              <description>Fault A Blanking Prescaler</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANKVAL</name>
+              <description>Fault A Blanking Time</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL</name>
+              <description>Fault A Filter Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FCTRLB</name>
+          <description>Recoverable Fault B Configuration</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SRC</name>
+              <description>Fault B Source</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SRCSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Fault input disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>MCEx (x=0,1) event input</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INVERT</name>
+                  <description>Inverted MCEx (x=0,1) event input</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ALTFAULT</name>
+                  <description>Alternate fault (A or B) state at the end of the previous period</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>KEEP</name>
+              <description>Fault B Keeper</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QUAL</name>
+              <description>Fault B Qualification</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANK</name>
+              <description>Fault B Blanking Mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>BLANKSelect</name>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Blanking applied from start of ramp</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Blanking applied from rising edge of the output waveform</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Blanking applied from falling edge of the output waveform</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Blanking applied from each toggle of the output waveform</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RESTART</name>
+              <description>Fault B Restart</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HALT</name>
+              <description>Fault B Halt Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>HALTSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Halt action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HW</name>
+                  <description>Hardware halt action</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SW</name>
+                  <description>Software halt action</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NR</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CHSEL</name>
+              <description>Fault B Capture Channel</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CHSELSelect</name>
+                <enumeratedValue>
+                  <name>CC0</name>
+                  <description>Capture value stored in channel 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC1</name>
+                  <description>Capture value stored in channel 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC2</name>
+                  <description>Capture value stored in channel 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC3</name>
+                  <description>Capture value stored in channel 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CAPTURE</name>
+              <description>Fault B Capture Action</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CAPTURESelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>No capture</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPT</name>
+                  <description>Capture on fault</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMIN</name>
+                  <description>Minimum capture</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMAX</name>
+                  <description>Maximum capture</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMIN</name>
+                  <description>Minimum local detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMAX</name>
+                  <description>Maximum local detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DERIV0</name>
+                  <description>Minimum and maximum local detection</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMARK</name>
+                  <description>Capture with ramp index as MSB value</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>BLANKPRESC</name>
+              <description>Fault B Blanking Prescaler</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANKVAL</name>
+              <description>Fault B Blanking Time</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL</name>
+              <description>Fault B Filter Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WEXCTRL</name>
+          <description>Waveform Extension Configuration</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OTMX</name>
+              <description>Output Matrix</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN0</name>
+              <description>Dead-time Insertion Generator 0 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN1</name>
+              <description>Dead-time Insertion Generator 1 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN2</name>
+              <description>Dead-time Insertion Generator 2 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN3</name>
+              <description>Dead-time Insertion Generator 3 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTLS</name>
+              <description>Dead-time Low Side Outputs Value</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>DTHS</name>
+              <description>Dead-time High Side Outputs Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DRVCTRL</name>
+          <description>Driver Control</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>NRE0</name>
+              <description>Non-Recoverable State 0 Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE1</name>
+              <description>Non-Recoverable State 1 Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE2</name>
+              <description>Non-Recoverable State 2 Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE3</name>
+              <description>Non-Recoverable State 3 Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE4</name>
+              <description>Non-Recoverable State 4 Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE5</name>
+              <description>Non-Recoverable State 5 Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE6</name>
+              <description>Non-Recoverable State 6 Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE7</name>
+              <description>Non-Recoverable State 7 Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV0</name>
+              <description>Non-Recoverable State 0 Output Value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV1</name>
+              <description>Non-Recoverable State 1 Output Value</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV2</name>
+              <description>Non-Recoverable State 2 Output Value</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV3</name>
+              <description>Non-Recoverable State 3 Output Value</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV4</name>
+              <description>Non-Recoverable State 4 Output Value</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV5</name>
+              <description>Non-Recoverable State 5 Output Value</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV6</name>
+              <description>Non-Recoverable State 6 Output Value</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV7</name>
+              <description>Non-Recoverable State 7 Output Value</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Inversion</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Inversion</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN2</name>
+              <description>Output Waveform 2 Inversion</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN3</name>
+              <description>Output Waveform 3 Inversion</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN4</name>
+              <description>Output Waveform 4 Inversion</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN5</name>
+              <description>Output Waveform 5 Inversion</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN6</name>
+              <description>Output Waveform 6 Inversion</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN7</name>
+              <description>Output Waveform 7 Inversion</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL0</name>
+              <description>Non-Recoverable Fault Input 0 Filter Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL1</name>
+              <description>Non-Recoverable Fault Input 1 Filter Value</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x1E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Running Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FDDBD</name>
+              <description>Fault Detection on Debug Break Detection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EVACT0</name>
+              <description>Timer/counter Input Event0 Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACT0Select</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or re-trigger counter on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNTEV</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start counter on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INC</name>
+                  <description>Increment counter on event</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on active state of asynchronous event</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FAULT</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EVACT1</name>
+              <description>Timer/counter Input Event1 Action</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACT1Select</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Re-trigger counter on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIR</name>
+                  <description>Direction control</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Stop counter on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DEC</name>
+                  <description>Decrement counter on event</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period capture value in CC0 register, pulse width capture value in CC1 register</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period capture value in CC1 register, pulse width capture value in CC0 register</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FAULT</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CNTSEL</name>
+              <description>Timer/counter Output Event Mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CNTSELSelect</name>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>An interrupt/event is generated when a new counter cycle starts</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>END</name>
+                  <description>An interrupt/event is generated when a counter cycle ends</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BETWEEN</name>
+                  <description>An interrupt/event is generated when a counter cycle ends, except for the first and last cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOUNDARY</name>
+                  <description>An interrupt/event is generated when a new counter cycle starts or a counter cycle ends</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Output Event Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRGEO</name>
+              <description>Retrigger Output Event Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNTEO</name>
+              <description>Timer/counter Output Event Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCINV0</name>
+              <description>Inverted Event 0 Input Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCINV1</name>
+              <description>Inverted Event 1 Input Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI0</name>
+              <description>Timer/counter Event 0 Input Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI1</name>
+              <description>Timer/counter Event 1 Input Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI0</name>
+              <description>Match or Capture Channel 0 Event Input Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI1</name>
+              <description>Match or Capture Channel 1 Event Input Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI2</name>
+              <description>Match or Capture Channel 2 Event Input Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI3</name>
+              <description>Match or Capture Channel 3 Event Input Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO2</name>
+              <description>Match or Capture Channel 2 Event Output Enable</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO3</name>
+              <description>Match or Capture Channel 3 Event Output Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRG</name>
+              <description>Retrigger Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNT</name>
+              <description>Counter Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0 Interrupt Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1 Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC2</name>
+              <description>Match or Capture Channel 2 Interrupt Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC3</name>
+              <description>Match or Capture Channel 3 Interrupt Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRG</name>
+              <description>Retrigger Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNT</name>
+              <description>Counter Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0 Interrupt Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1 Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC2</name>
+              <description>Match or Capture Channel 2 Interrupt Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC3</name>
+              <description>Match or Capture Channel 3 Interrupt Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRG</name>
+              <description>Retrigger</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNT</name>
+              <description>Counter</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture 0</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture 1</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC2</name>
+              <description>Match or Capture 2</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC3</name>
+              <description>Match or Capture 3</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <resetValue>0x00000001</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>IDX</name>
+              <description>Ramp</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault State</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PATTBV</name>
+              <description>Pattern Buffer Valid</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAVEBV</name>
+              <description>Wave Buffer Valid</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERBV</name>
+              <description>Period Buffer Valid</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTAIN</name>
+              <description>Recoverable Fault A Input</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULTBIN</name>
+              <description>Recoverable Fault B Input</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULT0IN</name>
+              <description>Non-Recoverable Fault0 Input</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULT1IN</name>
+              <description>Non-Recoverable Fault1 Input</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A State</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B State</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0 State</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1 State</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV0</name>
+              <description>Compare Channel 0 Buffer Valid</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV1</name>
+              <description>Compare Channel 1 Buffer Valid</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV2</name>
+              <description>Compare Channel 2 Buffer Valid</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV3</name>
+              <description>Compare Channel 3 Buffer Valid</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP0</name>
+              <description>Compare Channel 0 Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare Channel 1 Value</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CMP2</name>
+              <description>Compare Channel 2 Value</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CMP3</name>
+              <description>Compare Channel 3 Value</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>Count</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT_DITH4</name>
+          <description>Count</description>
+          <alternateRegister>COUNT</alternateRegister>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT_DITH5</name>
+          <description>Count</description>
+          <alternateRegister>COUNT</alternateRegister>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT_DITH6</name>
+          <description>Count</description>
+          <alternateRegister>COUNT</alternateRegister>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PATT</name>
+          <description>Pattern</description>
+          <addressOffset>0x38</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PGE0</name>
+              <description>Pattern Generator 0 Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE1</name>
+              <description>Pattern Generator 1 Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE2</name>
+              <description>Pattern Generator 2 Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE3</name>
+              <description>Pattern Generator 3 Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE4</name>
+              <description>Pattern Generator 4 Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE5</name>
+              <description>Pattern Generator 5 Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE6</name>
+              <description>Pattern Generator 6 Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE7</name>
+              <description>Pattern Generator 7 Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV0</name>
+              <description>Pattern Generator 0 Output Value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV1</name>
+              <description>Pattern Generator 1 Output Value</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV2</name>
+              <description>Pattern Generator 2 Output Value</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV3</name>
+              <description>Pattern Generator 3 Output Value</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV4</name>
+              <description>Pattern Generator 4 Output Value</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV5</name>
+              <description>Pattern Generator 5 Output Value</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV6</name>
+              <description>Pattern Generator 6 Output Value</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV7</name>
+              <description>Pattern Generator 7 Output Value</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAVE</name>
+          <description>Waveform Control</description>
+          <addressOffset>0x3C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <description>Normal frequency</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <description>Match frequency</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <description>Normal PWM</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSCRITICAL</name>
+                  <description>Dual-slope critical</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTTOM</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTH</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSTOP</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches TOP</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RAMP</name>
+              <description>Ramp Mode</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RAMPSelect</name>
+                <enumeratedValue>
+                  <name>RAMP1</name>
+                  <description>RAMP1 operation</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2A</name>
+                  <description>Alternative RAMP2 operation</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2</name>
+                  <description>RAMP2 operation</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2C</name>
+                  <description>Critical RAMP2 operation</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CIPEREN</name>
+              <description>Circular period Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN0</name>
+              <description>Circular Channel 0 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN1</name>
+              <description>Circular Channel 1 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN2</name>
+              <description>Circular Channel 2 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN3</name>
+              <description>Circular Channel 3 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL0</name>
+              <description>Channel 0 Polarity</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL1</name>
+              <description>Channel 1 Polarity</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL2</name>
+              <description>Channel 2 Polarity</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL3</name>
+              <description>Channel 3 Polarity</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP0</name>
+              <description>Swap DTI Output Pair 0</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP1</name>
+              <description>Swap DTI Output Pair 1</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP2</name>
+              <description>Swap DTI Output Pair 2</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP3</name>
+              <description>Swap DTI Output Pair 3</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER</name>
+          <description>Period</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER_DITH4</name>
+          <description>Period</description>
+          <alternateRegister>PER</alternateRegister>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER_DITH5</name>
+          <description>Period</description>
+          <alternateRegister>PER</alternateRegister>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER_DITH6</name>
+          <description>Period</description>
+          <alternateRegister>PER</alternateRegister>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s</name>
+          <description>Compare and Capture</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s_DITH4</name>
+          <description>Compare and Capture</description>
+          <alternateRegister>CC%s</alternateRegister>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s_DITH5</name>
+          <description>Compare and Capture</description>
+          <alternateRegister>CC%s</alternateRegister>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s_DITH6</name>
+          <description>Compare and Capture</description>
+          <alternateRegister>CC%s</alternateRegister>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PATTB</name>
+          <description>Pattern Buffer</description>
+          <addressOffset>0x64</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PGEB0</name>
+              <description>Pattern Generator 0 Output Enable Buffer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB1</name>
+              <description>Pattern Generator 1 Output Enable Buffer</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB2</name>
+              <description>Pattern Generator 2 Output Enable Buffer</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB3</name>
+              <description>Pattern Generator 3 Output Enable Buffer</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB4</name>
+              <description>Pattern Generator 4 Output Enable Buffer</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB5</name>
+              <description>Pattern Generator 5 Output Enable Buffer</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB6</name>
+              <description>Pattern Generator 6 Output Enable Buffer</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB7</name>
+              <description>Pattern Generator 7 Output Enable Buffer</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB0</name>
+              <description>Pattern Generator 0 Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB1</name>
+              <description>Pattern Generator 1 Output Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB2</name>
+              <description>Pattern Generator 2 Output Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB3</name>
+              <description>Pattern Generator 3 Output Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB4</name>
+              <description>Pattern Generator 4 Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB5</name>
+              <description>Pattern Generator 5 Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB6</name>
+              <description>Pattern Generator 6 Output Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB7</name>
+              <description>Pattern Generator 7 Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAVEB</name>
+          <description>Waveform Control Buffer</description>
+          <addressOffset>0x68</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WAVEGENB</name>
+              <description>Waveform Generation Buffer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENBSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <description>Normal frequency</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <description>Match frequency</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <description>Normal PWM</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSCRITICAL</name>
+                  <description>Dual-slope critical</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTTOM</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTH</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSTOP</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches TOP</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RAMPB</name>
+              <description>Ramp Mode Buffer</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RAMPBSelect</name>
+                <enumeratedValue>
+                  <name>RAMP1</name>
+                  <description>RAMP1 operation</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2A</name>
+                  <description>Alternative RAMP2 operation</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2</name>
+                  <description>RAMP2 operation</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CIPERENB</name>
+              <description>Circular Period Enable Buffer</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB0</name>
+              <description>Circular Channel 0 Enable Buffer</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB1</name>
+              <description>Circular Channel 1 Enable Buffer</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB2</name>
+              <description>Circular Channel 2 Enable Buffer</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB3</name>
+              <description>Circular Channel 3 Enable Buffer</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB0</name>
+              <description>Channel 0 Polarity Buffer</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB1</name>
+              <description>Channel 1 Polarity Buffer</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB2</name>
+              <description>Channel 2 Polarity Buffer</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB3</name>
+              <description>Channel 3 Polarity Buffer</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB0</name>
+              <description>Swap DTI Output Pair 0 Buffer</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB1</name>
+              <description>Swap DTI Output Pair 1 Buffer</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB2</name>
+              <description>Swap DTI Output Pair 2 Buffer</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB3</name>
+              <description>Swap DTI Output Pair 3 Buffer</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB</name>
+          <description>Period Buffer</description>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB_DITH4</name>
+          <description>Period Buffer</description>
+          <alternateRegister>PERB</alternateRegister>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB_DITH5</name>
+          <description>Period Buffer</description>
+          <alternateRegister>PERB</alternateRegister>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB_DITH6</name>
+          <description>Period Buffer</description>
+          <alternateRegister>PERB</alternateRegister>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s</name>
+          <description>Compare and Capture Buffer</description>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s_DITH4</name>
+          <description>Compare and Capture Buffer</description>
+          <alternateRegister>CCB%s</alternateRegister>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s_DITH5</name>
+          <description>Compare and Capture Buffer</description>
+          <alternateRegister>CCB%s</alternateRegister>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s_DITH6</name>
+          <description>Compare and Capture Buffer</description>
+          <alternateRegister>CCB%s</alternateRegister>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>USB</name>
+      <version>1.0.2</version>
+      <description>Universal Serial Bus</description>
+      <groupName>USB</groupName>
+      <prependToName>USB_</prependToName>
+      <baseAddress>0x41005000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>USB</name>
+        <value>7</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>DEVICE</name>
+        <description>USB is Device</description>
+        <headerStructName>UsbDevice</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x000</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>DEVICE</name>
+                  <description>Device Mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>Synchronization Busy</description>
+          <addressOffset>0x002</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>QOSCTRL</name>
+          <description>USB Quality Of Service</description>
+          <addressOffset>0x003</addressOffset>
+          <size>8</size>
+          <resetValue>0x05</resetValue>
+          <fields>
+            <field>
+              <name>CQOS</name>
+              <description>Configuration Quality of Service</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>DQOS</name>
+              <description>Data Quality of Service</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>DEVICE Control B</description>
+          <addressOffset>0x008</addressOffset>
+          <size>16</size>
+          <resetValue>0x0001</resetValue>
+          <fields>
+            <field>
+              <name>DETACH</name>
+              <description>Detach</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPDCONF</name>
+              <description>Speed Configuration</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SPDCONFSelect</name>
+                <enumeratedValue>
+                  <name>FS</name>
+                  <description>FS : Full Speed</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LS</name>
+                  <description>LS : Low Speed</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HS</name>
+                  <description>HS : High Speed capable</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HSTM</name>
+                  <description>HSTM: High Speed Test Mode (force high-speed mode for test mode)</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>NREPLY</name>
+              <description>No Reply</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTJ</name>
+              <description>Test mode J</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTK</name>
+              <description>Test mode K</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTPCKT</name>
+              <description>Test packet mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OPMODE2</name>
+              <description>Specific Operational Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GNAK</name>
+              <description>Global NAK</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMHDSK</name>
+              <description>Link Power Management Handshake</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>LPMHDSKSelect</name>
+                <enumeratedValue>
+                  <name>NO</name>
+                  <description>No handshake. LPM is not supported</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ACK</name>
+                  <description>ACK</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NYET</name>
+                  <description>NYET</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STALL</name>
+                  <description>STALL</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DADD</name>
+          <description>DEVICE Device Address</description>
+          <addressOffset>0x00A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DADD</name>
+              <description>Device Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>ADDEN</name>
+              <description>Device Address Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>DEVICE Status</description>
+          <addressOffset>0x00C</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x40</resetValue>
+          <fields>
+            <field>
+              <name>SPEED</name>
+              <description>Speed Status</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>SPEEDSelect</name>
+                <enumeratedValue>
+                  <name>FS</name>
+                  <description>Full-speed mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HS</name>
+                  <description>High-speed mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LS</name>
+                  <description>Low-speed mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LINESTATE</name>
+              <description>USB Line State Status</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>LINESTATESelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>SE0/RESET</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>FS-J or LS-K State</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>FS-K or LS-J State</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FSMSTATUS</name>
+          <description>Finite State Machine Status</description>
+          <addressOffset>0x00D</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x01</resetValue>
+          <fields>
+            <field>
+              <name>FSMSTATE</name>
+              <description>Fine State Machine Status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>FSMSTATESelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>OFF (L3). It corresponds to the powered-off, disconnected, and disabled state</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ON</name>
+                  <description>ON (L0). It corresponds to the Idle and Active states</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>SUSPEND (L2)</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SLEEP</name>
+                  <description>SLEEP (L1)</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DNRESUME</name>
+                  <description>DNRESUME. Down Stream Resume.</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPRESUME</name>
+                  <description>UPRESUME. Up Stream Resume.</description>
+                  <value>0x20</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESET</name>
+                  <description>RESET. USB lines Reset.</description>
+                  <value>0x40</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FNUM</name>
+          <description>DEVICE Device Frame Number</description>
+          <addressOffset>0x010</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>MFNUM</name>
+              <description>Micro Frame Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FNUM</name>
+              <description>Frame Number</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>11</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FNCERR</name>
+              <description>Frame Number CRC Error</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>DEVICE Device Interrupt Enable Clear</description>
+          <addressOffset>0x014</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SUSPEND</name>
+              <description>Suspend Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSOF</name>
+              <description>Micro Start of Frame Interrupt Enable in High Speed Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOF</name>
+              <description>Start Of Frame Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORST</name>
+              <description>End of Reset Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORSM</name>
+              <description>End Of Resume Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMNYET</name>
+              <description>Link Power Management Not Yet Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMSUSP</name>
+              <description>Link Power Management Suspend Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>DEVICE Device Interrupt Enable Set</description>
+          <addressOffset>0x018</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SUSPEND</name>
+              <description>Suspend Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSOF</name>
+              <description>Micro Start of Frame Interrupt Enable in High Speed Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOF</name>
+              <description>Start Of Frame Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORST</name>
+              <description>End of Reset Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORSM</name>
+              <description>End Of Resume Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMNYET</name>
+              <description>Link Power Management Not Yet Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMSUSP</name>
+              <description>Link Power Management Suspend Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>DEVICE Device Interrupt Flag</description>
+          <addressOffset>0x01C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SUSPEND</name>
+              <description>Suspend</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSOF</name>
+              <description>Micro Start of Frame in High Speed Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOF</name>
+              <description>Start Of Frame</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORST</name>
+              <description>End of Reset</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORSM</name>
+              <description>End Of Resume</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMNYET</name>
+              <description>Link Power Management Not Yet</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMSUSP</name>
+              <description>Link Power Management Suspend</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EPINTSMRY</name>
+          <description>DEVICE End Point Interrupt Summary</description>
+          <addressOffset>0x020</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>EPINT0</name>
+              <description>End Point 0 Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT1</name>
+              <description>End Point 1 Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT2</name>
+              <description>End Point 2 Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT3</name>
+              <description>End Point 3 Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT4</name>
+              <description>End Point 4 Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT5</name>
+              <description>End Point 5 Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT6</name>
+              <description>End Point 6 Interrupt</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT7</name>
+              <description>End Point 7 Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DESCADD</name>
+          <description>Descriptor Address</description>
+          <addressOffset>0x024</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DESCADD</name>
+              <description>Descriptor Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PADCAL</name>
+          <description>USB PAD Calibration</description>
+          <addressOffset>0x028</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>TRANSP</name>
+              <description>USB Pad Transp calibration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TRANSN</name>
+              <description>USB Pad Transn calibration</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TRIM</name>
+              <description>USB Pad Trim calibration</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPCFG%s</name>
+          <description>DEVICE End Point Configuration</description>
+          <addressOffset>0x100</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EPTYPE0</name>
+              <description>End Point Type0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>EPTYPE1</name>
+              <description>End Point Type1</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>NYETDIS</name>
+              <description>NYET Token Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPSTATUSCLR%s</name>
+          <description>DEVICE End Point Pipe Status Clear</description>
+          <addressOffset>0x104</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>DTGLOUT</name>
+              <description>Data Toggle OUT Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>DTGLIN</name>
+              <description>Data Toggle IN Clear</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank Clear</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ0</name>
+              <description>Stall 0 Request Clear</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ1</name>
+              <description>Stall 1 Request Clear</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 Ready Clear</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 Ready Clear</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPSTATUSSET%s</name>
+          <description>DEVICE End Point Pipe Status Set</description>
+          <addressOffset>0x105</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>DTGLOUT</name>
+              <description>Data Toggle OUT Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>DTGLIN</name>
+              <description>Data Toggle IN Set</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank Set</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ0</name>
+              <description>Stall 0 Request Set</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ1</name>
+              <description>Stall 1 Request Set</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 Ready Set</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 Ready Set</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPSTATUS%s</name>
+          <description>DEVICE End Point Pipe Status</description>
+          <addressOffset>0x106</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>DTGLOUT</name>
+              <description>Data Toggle Out</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DTGLIN</name>
+              <description>Data Toggle In</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>STALLRQ0</name>
+              <description>Stall 0 Request</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>STALLRQ1</name>
+              <description>Stall 1 Request</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 ready</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPINTFLAG%s</name>
+          <description>DEVICE End Point Interrupt Flag</description>
+          <addressOffset>0x107</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL0</name>
+              <description>Error Flow 0</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL1</name>
+              <description>Error Flow 1</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXSTP</name>
+              <description>Received Setup</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL0</name>
+              <description>Stall 0 In/out</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL1</name>
+              <description>Stall 1 In/out</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPINTENCLR%s</name>
+          <description>DEVICE End Point Interrupt Clear Flag</description>
+          <addressOffset>0x108</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0 Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1 Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL0</name>
+              <description>Error Flow 0 Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL1</name>
+              <description>Error Flow 1 Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXSTP</name>
+              <description>Received Setup Interrupt Disable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL0</name>
+              <description>Stall 0 In/Out Interrupt Disable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL1</name>
+              <description>Stall 1 In/Out Interrupt Disable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPINTENSET%s</name>
+          <description>DEVICE End Point Interrupt Set Flag</description>
+          <addressOffset>0x109</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL0</name>
+              <description>Error Flow 0 Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL1</name>
+              <description>Error Flow 1 Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXSTP</name>
+              <description>Received Setup Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL0</name>
+              <description>Stall 0 In/out Interrupt enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL1</name>
+              <description>Stall 1 In/out Interrupt enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- UsbDevice -->
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>WDT</name>
+      <version>2.0.0</version>
+      <description>Watchdog Timer</description>
+      <groupName>WDT</groupName>
+      <prependToName>WDT_</prependToName>
+      <baseAddress>0x40001000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>WDT</name>
+        <value>2</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WEN</name>
+              <description>Watchdog Timer Window Mode Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ALWAYSON</name>
+              <description>Always-On</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CONFIG</name>
+          <description>Configuration</description>
+          <addressOffset>0x1</addressOffset>
+          <size>8</size>
+          <resetValue>0xBB</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Time-Out Period</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PERSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 clock cycles</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 clock cycles</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 clock cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 clock cycles</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 clock cycles</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 clock cycles</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 clock cycles</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1K</name>
+                  <description>1024 clock cycles</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2K</name>
+                  <description>2048 clock cycles</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4K</name>
+                  <description>4096 clock cycles</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8K</name>
+                  <description>8192 clock cycles</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16K</name>
+                  <description>16384 clock cycles</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WINDOW</name>
+              <description>Window Mode Time-Out Period</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>WINDOWSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 clock cycles</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 clock cycles</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 clock cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 clock cycles</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 clock cycles</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 clock cycles</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 clock cycles</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1K</name>
+                  <description>1024 clock cycles</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2K</name>
+                  <description>2048 clock cycles</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4K</name>
+                  <description>4096 clock cycles</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8K</name>
+                  <description>8192 clock cycles</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16K</name>
+                  <description>16384 clock cycles</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EWCTRL</name>
+          <description>Early Warning Interrupt Control</description>
+          <addressOffset>0x2</addressOffset>
+          <size>8</size>
+          <resetValue>0x0B</resetValue>
+          <fields>
+            <field>
+              <name>EWOFFSET</name>
+              <description>Early Warning Interrupt Time Offset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>EWOFFSETSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 clock cycles</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 clock cycles</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 clock cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 clock cycles</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 clock cycles</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 clock cycles</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 clock cycles</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1K</name>
+                  <description>1024 clock cycles</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2K</name>
+                  <description>2048 clock cycles</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4K</name>
+                  <description>4096 clock cycles</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8K</name>
+                  <description>8192 clock cycles</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16K</name>
+                  <description>16384 clock cycles</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x4</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EW</name>
+              <description>Early Warning Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x5</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EW</name>
+              <description>Early Warning Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x6</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EW</name>
+              <description>Early Warning</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x7</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CLEAR</name>
+          <description>Clear</description>
+          <addressOffset>0x8</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>CLEAR</name>
+              <description>Watchdog Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>write-only</access>
+              <enumeratedValues>
+                <name>CLEARSelect</name>
+                <enumeratedValue>
+                  <name>KEY</name>
+                  <description>Clear Key</description>
+                  <value>0xa5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+  </peripherals>
+</device>

--- a/svd/ATSAMD11D14AS.svd
+++ b/svd/ATSAMD11D14AS.svd
@@ -1,0 +1,17014 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device schemaVersion="1.2" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+  <vendor>Microchip Technology Inc.</vendor>
+  <vendorID>MICROCHIP</vendorID>
+  <name>ATSAMD11D14AS</name>
+  <series>SAMD11</series>
+  <version>B</version>
+  <description>Microchip ATSAMD11D14AS device: Cortex-M0+ Microcontroller with 16KB Flash, 4KB SRAM, SOIC20_capless-pin package</description>
+  <licenseText>
+  Copyright (c) 2018 Microchip Technology Inc.\n
+\n
+  SPDX-License-Identifier: Apache-2.0\n
+\n
+  Licensed under the Apache License, Version 2.0 (the "License");\n
+  you may not use this file except in compliance with the License.\n
+  You may obtain a copy of the License at\n
+\n
+  http://www.apache.org/licenses/LICENSE-2.0\n
+\n
+  Unless required by applicable law or agreed to in writing, software\n
+  distributed under the License is distributed on an "AS IS" BASIS,\n
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n
+  See the License for the specific language governing permissions and\n
+  limitations under the License.
+  </licenseText>
+  <cpu>
+    <name>CM0+</name>
+    <revision>r0p1</revision>
+    <endian>little</endian>
+    <mpuPresent>false</mpuPresent>
+    <fpuPresent>false</fpuPresent>
+    <vtorPresent>true</vtorPresent>
+    <nvicPrioBits>2</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+    <deviceNumInterrupts>19</deviceNumInterrupts>
+  </cpu>
+  <headerSystemFilename>system_samd11</headerSystemFilename>
+  <addressUnitBits>8</addressUnitBits>
+  <width>32</width>
+  <size>32</size>
+  <access>read-write</access>
+  <resetValue>0x00000000</resetValue>
+  <resetMask>0xFFFFFFFF</resetMask>
+  <peripherals>
+    <peripheral>
+      <name>AC</name>
+      <version>1.1.1</version>
+      <description>Analog Comparators</description>
+      <groupName>AC</groupName>
+      <prependToName>AC_</prependToName>
+      <baseAddress>0x42002400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>AC</name>
+        <value>16</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMUX</name>
+              <description>Low-Power Mux</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>START0</name>
+              <description>Comparator 0 Start Comparison</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>START1</name>
+              <description>Comparator 1 Start Comparison</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COMPEO0</name>
+              <description>Comparator 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMPEO1</name>
+              <description>Comparator 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINEO0</name>
+              <description>Window 0 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMPEI0</name>
+              <description>Comparator 0 Event Input</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMPEI1</name>
+              <description>Comparator 1 Event Input</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COMP0</name>
+              <description>Comparator 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1</name>
+              <description>Comparator 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WIN0</name>
+              <description>Window 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COMP0</name>
+              <description>Comparator 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1</name>
+              <description>Comparator 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WIN0</name>
+              <description>Window 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COMP0</name>
+              <description>Comparator 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1</name>
+              <description>Comparator 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WIN0</name>
+              <description>Window 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSA</name>
+          <description>Status A</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>STATE0</name>
+              <description>Comparator 0 Current State</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STATE1</name>
+              <description>Comparator 1 Current State</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WSTATE0</name>
+              <description>Window 0 Current State</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WSTATE0Select</name>
+                <enumeratedValue>
+                  <name>ABOVE</name>
+                  <description>Signal is above window</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INSIDE</name>
+                  <description>Signal is inside window</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BELOW</name>
+                  <description>Signal is below window</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSB</name>
+          <description>Status B</description>
+          <addressOffset>0x09</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>READY0</name>
+              <description>Comparator 0 Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>READY1</name>
+              <description>Comparator 1 Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSC</name>
+          <description>Status C</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>STATE0</name>
+              <description>Comparator 0 Current State</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STATE1</name>
+              <description>Comparator 1 Current State</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WSTATE0</name>
+              <description>Window 0 Current State</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WSTATE0Select</name>
+                <enumeratedValue>
+                  <name>ABOVE</name>
+                  <description>Signal is above window</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INSIDE</name>
+                  <description>Signal is inside window</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BELOW</name>
+                  <description>Signal is below window</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINCTRL</name>
+          <description>Window Control</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>WEN0</name>
+              <description>Window 0 Mode Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINTSEL0</name>
+              <description>Window 0 Interrupt Selection</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WINTSEL0Select</name>
+                <enumeratedValue>
+                  <name>ABOVE</name>
+                  <description>Interrupt on signal above window</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INSIDE</name>
+                  <description>Interrupt on signal inside window</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BELOW</name>
+                  <description>Interrupt on signal below window</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OUTSIDE</name>
+                  <description>Interrupt on signal outside window</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>COMPCTRL%s</name>
+          <description>Comparator Control n</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SINGLE</name>
+              <description>Single-Shot Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPEED</name>
+              <description>Speed Selection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SPEEDSelect</name>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low speed</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High speed</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>INTSEL</name>
+              <description>Interrupt Selection</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>INTSELSelect</name>
+                <enumeratedValue>
+                  <name>TOGGLE</name>
+                  <description>Interrupt on comparator output toggle</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISING</name>
+                  <description>Interrupt on comparator output rising</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALLING</name>
+                  <description>Interrupt on comparator output falling</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EOC</name>
+                  <description>Interrupt on end of comparison (single-shot mode only)</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MUXNEG</name>
+              <description>Negative Input Mux Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MUXNEGSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>I/O pin 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>I/O pin 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>I/O pin 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>I/O pin 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GND</name>
+                  <description>Ground</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>VSCALE</name>
+                  <description>VDD scaler</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BANDGAP</name>
+                  <description>Internal bandgap voltage</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DAC</name>
+                  <description>DAC output</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MUXPOS</name>
+              <description>Positive Input Mux Selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MUXPOSSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>I/O pin 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>I/O pin 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>I/O pin 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>I/O pin 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SWAP</name>
+              <description>Swap Inputs and Invert</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OUT</name>
+              <description>Output</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>OUTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>The output of COMPn is not routed to the COMPn I/O port</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ASYNC</name>
+                  <description>The asynchronous output of COMPn is routed to the COMPn I/O port</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYNC</name>
+                  <description>The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>HYST</name>
+              <description>Hysteresis Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FLEN</name>
+              <description>Filter Length</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>FLENSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>No filtering</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MAJ3</name>
+                  <description>3-bit majority function (2 of 3)</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MAJ5</name>
+                  <description>5-bit majority function (3 of 5)</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>SCALER%s</name>
+          <description>Scaler n</description>
+          <addressOffset>0x20</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Scaler Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>ADC</name>
+      <version>1.2.0</version>
+      <description>Analog Digital Converter</description>
+      <groupName>ADC</groupName>
+      <prependToName>ADC_</prependToName>
+      <baseAddress>0x42002000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>ADC</name>
+        <value>15</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>REFCTRL</name>
+          <description>Reference Control</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>REFSEL</name>
+              <description>Reference Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>REFSELSelect</name>
+                <enumeratedValue>
+                  <name>INT1V</name>
+                  <description>1.0V voltage reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INTVCC0</name>
+                  <description>1/1.48 VDDANA</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INTVCC1</name>
+                  <description>1/2 VDDANA (only for VDDANA &gt; 2.0V)</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AREFA</name>
+                  <description>External reference</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AREFB</name>
+                  <description>External reference</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>REFCOMP</name>
+              <description>Reference Buffer Offset Compensation Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AVGCTRL</name>
+          <description>Average Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SAMPLENUM</name>
+              <description>Number of Samples to be Collected</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>SAMPLENUMSelect</name>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>1 sample</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>2 samples</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4</name>
+                  <description>4 samples</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 samples</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 samples</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 samples</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 samples</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 samples</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 samples</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 samples</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1024</name>
+                  <description>1024 samples</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADJRES</name>
+              <description>Adjusting Result / Division Coefficient</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SAMPCTRL</name>
+          <description>Sampling Time Control</description>
+          <addressOffset>0x03</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SAMPLEN</name>
+              <description>Sampling Time Length</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DIFFMODE</name>
+              <description>Differential Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LEFTADJ</name>
+              <description>Left-Adjusted Result</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FREERUN</name>
+              <description>Free Running Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CORREN</name>
+              <description>Digital Correction Logic Enabled</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESSEL</name>
+              <description>Conversion Result Resolution</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RESSELSelect</name>
+                <enumeratedValue>
+                  <name>12BIT</name>
+                  <description>12-bit result</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16BIT</name>
+                  <description>For averaging mode output</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>10BIT</name>
+                  <description>10-bit result</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8BIT</name>
+                  <description>8-bit result</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler Configuration</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Peripheral clock divided by 4</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Peripheral clock divided by 8</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Peripheral clock divided by 16</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Peripheral clock divided by 32</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Peripheral clock divided by 64</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Peripheral clock divided by 128</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Peripheral clock divided by 256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>Peripheral clock divided by 512</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINCTRL</name>
+          <description>Window Monitor Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>WINMODE</name>
+              <description>Window Monitor Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>WINMODESelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>No window mode (default)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE1</name>
+                  <description>Mode 1: RESULT &gt; WINLT</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE2</name>
+                  <description>Mode 2: RESULT &lt; WINUT</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE3</name>
+                  <description>Mode 3: WINLT &lt; RESULT &lt; WINUT</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE4</name>
+                  <description>Mode 4: !(WINLT &lt; RESULT &lt; WINUT)</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWTRIG</name>
+          <description>Software Trigger</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>FLUSH</name>
+              <description>ADC Conversion Flush</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>START</name>
+              <description>ADC Start Conversion</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INPUTCTRL</name>
+          <description>Input Control</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>MUXPOS</name>
+              <description>Positive Mux Input Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>MUXPOSSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>ADC AIN0 Pin</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>ADC AIN1 Pin</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>ADC AIN2 Pin</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>ADC AIN3 Pin</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN4</name>
+                  <description>ADC AIN4 Pin</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN5</name>
+                  <description>ADC AIN5 Pin</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN6</name>
+                  <description>ADC AIN6 Pin</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN7</name>
+                  <description>ADC AIN7 Pin</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN8</name>
+                  <description>ADC AIN8 Pin</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN9</name>
+                  <description>ADC AIN9 Pin</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN10</name>
+                  <description>ADC AIN10 Pin</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN11</name>
+                  <description>ADC AIN11 Pin</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN12</name>
+                  <description>ADC AIN12 Pin</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN13</name>
+                  <description>ADC AIN13 Pin</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN14</name>
+                  <description>ADC AIN14 Pin</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN15</name>
+                  <description>ADC AIN15 Pin</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN16</name>
+                  <description>ADC AIN16 Pin</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN17</name>
+                  <description>ADC AIN17 Pin</description>
+                  <value>0x11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN18</name>
+                  <description>ADC AIN18 Pin</description>
+                  <value>0x12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN19</name>
+                  <description>ADC AIN19 Pin</description>
+                  <value>0x13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TEMP</name>
+                  <description>Temperature Reference</description>
+                  <value>0x18</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BANDGAP</name>
+                  <description>Bandgap Voltage</description>
+                  <value>0x19</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SCALEDCOREVCC</name>
+                  <description>1/4  Scaled Core Supply</description>
+                  <value>0x1a</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SCALEDIOVCC</name>
+                  <description>1/4  Scaled I/O Supply</description>
+                  <value>0x1b</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DAC</name>
+                  <description>DAC Output</description>
+                  <value>0x1c</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MUXNEG</name>
+              <description>Negative Mux Input Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>MUXNEGSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>ADC AIN0 Pin</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>ADC AIN1 Pin</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>ADC AIN2 Pin</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>ADC AIN3 Pin</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN4</name>
+                  <description>ADC AIN4 Pin</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN5</name>
+                  <description>ADC AIN5 Pin</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN6</name>
+                  <description>ADC AIN6 Pin</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN7</name>
+                  <description>ADC AIN7 Pin</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GND</name>
+                  <description>Internal Ground</description>
+                  <value>0x18</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>IOGND</name>
+                  <description>I/O Ground</description>
+                  <value>0x19</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>INPUTSCAN</name>
+              <description>Number of Input Channels Included in Scan</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>INPUTOFFSET</name>
+              <description>Positive Mux Setting Offset</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>GAIN</name>
+              <description>Gain Factor Selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>GAINSelect</name>
+                <enumeratedValue>
+                  <name>1X</name>
+                  <description>1x</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2X</name>
+                  <description>2x</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4X</name>
+                  <description>4x</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8X</name>
+                  <description>8x</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16X</name>
+                  <description>16x</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>1/2x</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>STARTEI</name>
+              <description>Start Conversion Event In</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCEI</name>
+              <description>Synchronization Event In</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESRDYEO</name>
+              <description>Result Ready Event Out</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMONEO</name>
+              <description>Window Monitor Event Out</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESRDY</name>
+              <description>Result Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVERRUN</name>
+              <description>Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMON</name>
+              <description>Window Monitor Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x17</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESRDY</name>
+              <description>Result Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVERRUN</name>
+              <description>Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMON</name>
+              <description>Window Monitor Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESRDY</name>
+              <description>Result Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVERRUN</name>
+              <description>Overrun</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMON</name>
+              <description>Window Monitor</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x19</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RESULT</name>
+          <description>Result</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>RESULT</name>
+              <description>Result Conversion Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINLT</name>
+          <description>Window Monitor Lower Threshold</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>WINLT</name>
+              <description>Window Lower Threshold</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINUT</name>
+          <description>Window Monitor Upper Threshold</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>WINUT</name>
+              <description>Window Upper Threshold</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GAINCORR</name>
+          <description>Gain Correction</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>GAINCORR</name>
+              <description>Gain Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OFFSETCORR</name>
+          <description>Offset Correction</description>
+          <addressOffset>0x26</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>OFFSETCORR</name>
+              <description>Offset Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CALIB</name>
+          <description>Calibration</description>
+          <addressOffset>0x28</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>LINEARITY_CAL</name>
+              <description>Linearity Calibration Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>BIAS_CAL</name>
+              <description>Bias Calibration Value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x2A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DAC</name>
+      <version>1.1.0</version>
+      <description>Digital Analog Converter</description>
+      <groupName>DAC</groupName>
+      <prependToName>DAC_</prependToName>
+      <baseAddress>0x42002800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>DAC</name>
+        <value>17</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x1</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EOEN</name>
+              <description>External Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IOEN</name>
+              <description>Internal Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LEFTADJ</name>
+              <description>Left Adjusted Data</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VPD</name>
+              <description>Voltage Pump Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BDWP</name>
+              <description>Bypass DATABUF Write Protection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>REFSEL</name>
+              <description>Reference Selection</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>REFSELSelect</name>
+                <enumeratedValue>
+                  <name>INT1V</name>
+                  <description>Internal 1.0V reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AVCC</name>
+                  <description>AVCC</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>VREFP</name>
+                  <description>External reference</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x2</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>STARTEI</name>
+              <description>Start Conversion Event Input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTYEO</name>
+              <description>Data Buffer Empty Event Output</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x4</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>UNDERRUN</name>
+              <description>Underrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTY</name>
+              <description>Data Buffer Empty Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x5</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>UNDERRUN</name>
+              <description>Underrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTY</name>
+              <description>Data Buffer Empty Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x6</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>UNDERRUN</name>
+              <description>Underrun</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTY</name>
+              <description>Data Buffer Empty</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x7</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy Status</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>Data</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data value to be converted</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATABUF</name>
+          <description>Data Buffer</description>
+          <addressOffset>0xC</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DATABUF</name>
+              <description>Data Buffer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DMAC</name>
+      <version>1.0.0</version>
+      <description>Direct Memory Access Controller</description>
+      <groupName>DMAC</groupName>
+      <prependToName>DMAC_</prependToName>
+      <baseAddress>0x41004800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>DMAC</name>
+        <value>6</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAENABLE</name>
+              <description>DMA Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRCENABLE</name>
+              <description>CRC Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN0</name>
+              <description>Priority Level 0 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN1</name>
+              <description>Priority Level 1 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN2</name>
+              <description>Priority Level 2 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN3</name>
+              <description>Priority Level 3 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCCTRL</name>
+          <description>CRC Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>CRCBEATSIZE</name>
+              <description>CRC Beat Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CRCBEATSIZESelect</name>
+                <enumeratedValue>
+                  <name>BYTE</name>
+                  <description>8-bit bus transfer</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HWORD</name>
+                  <description>16-bit bus transfer</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WORD</name>
+                  <description>32-bit bus transfer</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CRCPOLY</name>
+              <description>CRC Polynomial Type</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CRCPOLYSelect</name>
+                <enumeratedValue>
+                  <name>CRC16</name>
+                  <description>CRC-16 (CRC-CCITT)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CRC32</name>
+                  <description>CRC32 (IEEE 802.3)</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CRCSRC</name>
+              <description>CRC Input Source</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>6</bitWidth>
+              <enumeratedValues>
+                <name>CRCSRCSelect</name>
+                <enumeratedValue>
+                  <name>NOACT</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>IO</name>
+                  <description>I/O interface</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCDATAIN</name>
+          <description>CRC Data Input</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CRCDATAIN</name>
+              <description>CRC Data Input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCCHKSUM</name>
+          <description>CRC Checksum</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CRCCHKSUM</name>
+              <description>CRC Checksum</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCSTATUS</name>
+          <description>CRC Status</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CRCBUSY</name>
+              <description>CRC Module Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRCZERO</name>
+              <description>CRC Zero</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>QOSCTRL</name>
+          <description>QOS Control</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <resetValue>0x15</resetValue>
+          <fields>
+            <field>
+              <name>WRBQOS</name>
+              <description>Write-Back Quality of Service</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WRBQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FQOS</name>
+              <description>Fetch Quality of Service</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DQOS</name>
+              <description>Data Transfer Quality of Service</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>DQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWTRIGCTRL</name>
+          <description>Software Trigger Control</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWTRIG0</name>
+              <description>Channel 0 Software Trigger</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG1</name>
+              <description>Channel 1 Software Trigger</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG2</name>
+              <description>Channel 2 Software Trigger</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG3</name>
+              <description>Channel 3 Software Trigger</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG4</name>
+              <description>Channel 4 Software Trigger</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG5</name>
+              <description>Channel 5 Software Trigger</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRICTRL0</name>
+          <description>Priority Control 0</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>LVLPRI0</name>
+              <description>Level 0 Channel Priority Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN0</name>
+              <description>Level 0 Round-Robin Scheduling Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLPRI1</name>
+              <description>Level 1 Channel Priority Number</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN1</name>
+              <description>Level 1 Round-Robin Scheduling Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLPRI2</name>
+              <description>Level 2 Channel Priority Number</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN2</name>
+              <description>Level 2 Round-Robin Scheduling Enable</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLPRI3</name>
+              <description>Level 3 Channel Priority Number</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN3</name>
+              <description>Level 3 Round-Robin Scheduling Enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTPEND</name>
+          <description>Interrupt Pending</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Channel ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>TERR</name>
+              <description>Transfer Error</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Transfer Complete</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FERR</name>
+              <description>Fetch Error</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSY</name>
+              <description>Busy</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PEND</name>
+              <description>Pending</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTSTATUS</name>
+          <description>Interrupt Status</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>CHINT0</name>
+              <description>Channel 0 Pending Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT1</name>
+              <description>Channel 1 Pending Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT2</name>
+              <description>Channel 2 Pending Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT3</name>
+              <description>Channel 3 Pending Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT4</name>
+              <description>Channel 4 Pending Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT5</name>
+              <description>Channel 5 Pending Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BUSYCH</name>
+          <description>Busy Channels</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>BUSYCH0</name>
+              <description>Busy Channel 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH1</name>
+              <description>Busy Channel 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH2</name>
+              <description>Busy Channel 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH3</name>
+              <description>Busy Channel 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH4</name>
+              <description>Busy Channel 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH5</name>
+              <description>Busy Channel 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PENDCH</name>
+          <description>Pending Channels</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PENDCH0</name>
+              <description>Pending Channel 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH1</name>
+              <description>Pending Channel 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH2</name>
+              <description>Pending Channel 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH3</name>
+              <description>Pending Channel 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH4</name>
+              <description>Pending Channel 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH5</name>
+              <description>Pending Channel 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ACTIVE</name>
+          <description>Active Channel and Levels</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>LVLEX0</name>
+              <description>Level 0 Channel Trigger Request Executing</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LVLEX1</name>
+              <description>Level 1 Channel Trigger Request Executing</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LVLEX2</name>
+              <description>Level 2 Channel Trigger Request Executing</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LVLEX3</name>
+              <description>Level 3 Channel Trigger Request Executing</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ID</name>
+              <description>Active Channel ID</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ABUSY</name>
+              <description>Active Channel Busy</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BTCNT</name>
+              <description>Active Channel Block Transfer Count</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BASEADDR</name>
+          <description>Descriptor Memory Section Base Address</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>BASEADDR</name>
+              <description>Descriptor Memory Base Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WRBADDR</name>
+          <description>Write-Back Memory Section Base Address</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WRBADDR</name>
+              <description>Write-Back Memory Base Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHID</name>
+          <description>Channel ID</description>
+          <addressOffset>0x3F</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Channel ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHCTRLA</name>
+          <description>Channel Control A</description>
+          <addressOffset>0x40</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Channel Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Channel Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHCTRLB</name>
+          <description>Channel Control B</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Input Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>NOACT</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TRIG</name>
+                  <description>Transfer and periodic transfer trigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CTRIG</name>
+                  <description>Conditional transfer trigger</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CBLOCK</name>
+                  <description>Conditional block transfer</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>Channel suspend operation</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESUME</name>
+                  <description>Channel resume operation</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSKIP</name>
+                  <description>Skip next block suspend action</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EVIE</name>
+              <description>Channel Event Input Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVOE</name>
+              <description>Channel Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVL</name>
+              <description>Channel Arbitration Level</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>LVLSelect</name>
+                <enumeratedValue>
+                  <name>LVL0</name>
+                  <description>Channel Priority Level 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LVL1</name>
+                  <description>Channel Priority Level 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LVL2</name>
+                  <description>Channel Priority Level 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LVL3</name>
+                  <description>Channel Priority Level 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TRIGSRC</name>
+              <description>Trigger Source</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>TRIGSRCSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Only software/event triggers</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TRIGACT</name>
+              <description>Trigger Action</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>TRIGACTSelect</name>
+                <enumeratedValue>
+                  <name>BLOCK</name>
+                  <description>One trigger required for each block transfer</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BEAT</name>
+                  <description>One trigger required for each beat transfer</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TRANSACTION</name>
+                  <description>One trigger required for each transaction</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Software Command</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NOACT</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>Channel suspend operation</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESUME</name>
+                  <description>Channel resume operation</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHINTENCLR</name>
+          <description>Channel Interrupt Enable Clear</description>
+          <addressOffset>0x4C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TERR</name>
+              <description>Channel Transfer Error Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Channel Transfer Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHINTENSET</name>
+          <description>Channel Interrupt Enable Set</description>
+          <addressOffset>0x4D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TERR</name>
+              <description>Channel Transfer Error Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Channel Transfer Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHINTFLAG</name>
+          <description>Channel Interrupt Flag Status and Clear</description>
+          <addressOffset>0x4E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TERR</name>
+              <description>Channel Transfer Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Channel Transfer Complete</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHSTATUS</name>
+          <description>Channel Status</description>
+          <addressOffset>0x4F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PEND</name>
+              <description>Channel Pending</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSY</name>
+              <description>Channel Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FERR</name>
+              <description>Channel Fetch Error</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DSU</name>
+      <version>2.1.1</version>
+      <description>Device Service Unit</description>
+      <groupName>DSU</groupName>
+      <prependToName>DSU_</prependToName>
+      <baseAddress>0x41002000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x2000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x0000</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CRC</name>
+              <description>32-bit Cyclic Redundancy Code</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>MBIST</name>
+              <description>Memory built-in self-test</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CE</name>
+              <description>Chip-Erase</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ARR</name>
+              <description>Auxiliary Row Read</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>SMSA</name>
+              <description>Start Memory Stream Access</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSA</name>
+          <description>Status A</description>
+          <addressOffset>0x0001</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DONE</name>
+              <description>Done</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRSTEXT</name>
+              <description>CPU Reset Phase Extension</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BERR</name>
+              <description>Bus Error</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAIL</name>
+              <description>Failure</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERR</name>
+              <description>Protection Error</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSB</name>
+          <description>Status B</description>
+          <addressOffset>0x0002</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PROT</name>
+              <description>Protected</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DBGPRES</name>
+              <description>Debugger Present</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DCCD0</name>
+              <description>Debug Communication Channel 0 Dirty</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DCCD1</name>
+              <description>Debug Communication Channel 1 Dirty</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HPE</name>
+              <description>Hot-Plugging Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>Address</description>
+          <addressOffset>0x0004</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>AMOD</name>
+              <description>Access Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>30</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LENGTH</name>
+          <description>Length</description>
+          <addressOffset>0x0008</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>LENGTH</name>
+              <description>Length</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>30</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>Data</description>
+          <addressOffset>0x000C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>DCC%s</name>
+          <description>Debug Communication Channel n</description>
+          <addressOffset>0x0010</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DID</name>
+          <description>Device Identification</description>
+          <addressOffset>0x0018</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x10030103</resetValue>
+          <fields>
+            <field>
+              <name>DEVSEL</name>
+              <description>Device Select</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>REVISION</name>
+              <description>Revision Number</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DIE</name>
+              <description>Die Number</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SERIES</name>
+              <description>Series</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>SERIESSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>Cortex-M0+ processor, basic feature set</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>Cortex-M0+ processor, USB</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FAMILY</name>
+              <description>Family</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>5</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>FAMILYSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>General purpose microcontroller</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>PicoPower</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PROCESSOR</name>
+              <description>Processor</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>PROCESSORSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>Cortex-M0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>Cortex-M0+</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>Cortex-M3</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>Cortex-M4</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>DCFG%s</name>
+          <description>Device Configuration</description>
+          <addressOffset>0x00F0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DCFG</name>
+              <description>Device Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ENTRY0</name>
+          <description>CoreSight ROM Table Entry 0</description>
+          <addressOffset>0x1000</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x9F0FC002</resetValue>
+          <fields>
+            <field>
+              <name>EPRES</name>
+              <description>Entry Present</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FMT</name>
+              <description>Format</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ADDOFF</name>
+              <description>Address Offset</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>20</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ENTRY1</name>
+          <description>CoreSight ROM Table Entry 1</description>
+          <addressOffset>0x1004</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00003002</resetValue>
+        </register>
+        <register>
+          <name>END</name>
+          <description>CoreSight ROM Table End</description>
+          <addressOffset>0x1008</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>END</name>
+              <description>End Marker</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MEMTYPE</name>
+          <description>CoreSight ROM Table Memory Type</description>
+          <addressOffset>0x1FCC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SMEMP</name>
+              <description>System Memory Present</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID4</name>
+          <description>Peripheral Identification 4</description>
+          <addressOffset>0x1FD0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>JEPCC</name>
+              <description>JEP-106 Continuation Code</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>FKBC</name>
+              <description>4KB count</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID5</name>
+          <description>Peripheral Identification 5</description>
+          <addressOffset>0x1FD4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID6</name>
+          <description>Peripheral Identification 6</description>
+          <addressOffset>0x1FD8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID7</name>
+          <description>Peripheral Identification 7</description>
+          <addressOffset>0x1FDC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID0</name>
+          <description>Peripheral Identification 0</description>
+          <addressOffset>0x1FE0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000000D0</resetValue>
+          <fields>
+            <field>
+              <name>PARTNBL</name>
+              <description>Part Number Low</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID1</name>
+          <description>Peripheral Identification 1</description>
+          <addressOffset>0x1FE4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000000FC</resetValue>
+          <fields>
+            <field>
+              <name>PARTNBH</name>
+              <description>Part Number High</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>JEPIDCL</name>
+              <description>Low part of the JEP-106 Identity Code</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID2</name>
+          <description>Peripheral Identification 2</description>
+          <addressOffset>0x1FE8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00000009</resetValue>
+          <fields>
+            <field>
+              <name>JEPIDCH</name>
+              <description>JEP-106 Identity Code High</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>JEPU</name>
+              <description>JEP-106 Identity Code is used</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>REVISION</name>
+              <description>Revision Number</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID3</name>
+          <description>Peripheral Identification 3</description>
+          <addressOffset>0x1FEC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>CUSMOD</name>
+              <description>ARM CUSMOD</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>REVAND</name>
+              <description>Revision Number</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID0</name>
+          <description>Component Identification 0</description>
+          <addressOffset>0x1FF0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x0000000D</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLEB0</name>
+              <description>Preamble Byte 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID1</name>
+          <description>Component Identification 1</description>
+          <addressOffset>0x1FF4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00000010</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLE</name>
+              <description>Preamble</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CCLASS</name>
+              <description>Component Class</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID2</name>
+          <description>Component Identification 2</description>
+          <addressOffset>0x1FF8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00000005</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLEB2</name>
+              <description>Preamble Byte 2</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID3</name>
+          <description>Component Identification 3</description>
+          <addressOffset>0x1FFC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000000B1</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLEB3</name>
+              <description>Preamble Byte 3</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EIC</name>
+      <version>1.0.1</version>
+      <description>External Interrupt Controller</description>
+      <groupName>EIC</groupName>
+      <prependToName>EIC_</prependToName>
+      <baseAddress>0x40001800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>EIC</name>
+        <value>4</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>NMICTRL</name>
+          <description>Non-Maskable Interrupt Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>NMISENSE</name>
+              <description>Non-Maskable Interrupt Sense</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>NMISENSESelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising-edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling-edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both-edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High-level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low-level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>NMIFILTEN</name>
+              <description>Non-Maskable Interrupt Filter Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>NMIFLAG</name>
+          <description>Non-Maskable Interrupt Flag Status and Clear</description>
+          <addressOffset>0x03</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>NMI</name>
+              <description>Non-Maskable Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINTEO0</name>
+              <description>External Interrupt 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO1</name>
+              <description>External Interrupt 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO2</name>
+              <description>External Interrupt 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO3</name>
+              <description>External Interrupt 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO4</name>
+              <description>External Interrupt 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO5</name>
+              <description>External Interrupt 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO6</name>
+              <description>External Interrupt 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO7</name>
+              <description>External Interrupt 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINT0</name>
+              <description>External Interrupt 0 Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT1</name>
+              <description>External Interrupt 1 Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT2</name>
+              <description>External Interrupt 2 Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT3</name>
+              <description>External Interrupt 3 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT4</name>
+              <description>External Interrupt 4 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT5</name>
+              <description>External Interrupt 5 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT6</name>
+              <description>External Interrupt 6 Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT7</name>
+              <description>External Interrupt 7 Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINT0</name>
+              <description>External Interrupt 0 Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT1</name>
+              <description>External Interrupt 1 Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT2</name>
+              <description>External Interrupt 2 Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT3</name>
+              <description>External Interrupt 3 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT4</name>
+              <description>External Interrupt 4 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT5</name>
+              <description>External Interrupt 5 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT6</name>
+              <description>External Interrupt 6 Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT7</name>
+              <description>External Interrupt 7 Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINT0</name>
+              <description>External Interrupt 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT1</name>
+              <description>External Interrupt 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT2</name>
+              <description>External Interrupt 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT3</name>
+              <description>External Interrupt 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT4</name>
+              <description>External Interrupt 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT5</name>
+              <description>External Interrupt 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT6</name>
+              <description>External Interrupt 6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT7</name>
+              <description>External Interrupt 7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAKEUP</name>
+          <description>Wake-Up Enable</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WAKEUPEN0</name>
+              <description>External Interrupt 0 Wake-up Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN1</name>
+              <description>External Interrupt 1 Wake-up Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN2</name>
+              <description>External Interrupt 2 Wake-up Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN3</name>
+              <description>External Interrupt 3 Wake-up Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN4</name>
+              <description>External Interrupt 4 Wake-up Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN5</name>
+              <description>External Interrupt 5 Wake-up Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN6</name>
+              <description>External Interrupt 6 Wake-up Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN7</name>
+              <description>External Interrupt 7 Wake-up Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CONFIG%s</name>
+          <description>Configuration n</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SENSE0</name>
+              <description>Input Sense 0 Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE0Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising-edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling-edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both-edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High-level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low-level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN0</name>
+              <description>Filter 0 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE1</name>
+              <description>Input Sense 1 Configuration</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE1Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN1</name>
+              <description>Filter 1 Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE2</name>
+              <description>Input Sense 2 Configuration</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE2Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN2</name>
+              <description>Filter 2 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE3</name>
+              <description>Input Sense 3 Configuration</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE3Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN3</name>
+              <description>Filter 3 Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE4</name>
+              <description>Input Sense 4 Configuration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE4Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN4</name>
+              <description>Filter 4 Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE5</name>
+              <description>Input Sense 5 Configuration</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE5Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN5</name>
+              <description>Filter 5 Enable</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE6</name>
+              <description>Input Sense 6 Configuration</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE6Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN6</name>
+              <description>Filter 6 Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE7</name>
+              <description>Input Sense 7 Configuration</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE7Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN7</name>
+              <description>Filter 7 Enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EVSYS</name>
+      <version>1.0.1</version>
+      <description>Event System Interface</description>
+      <groupName>EVSYS</groupName>
+      <prependToName>EVSYS_</prependToName>
+      <baseAddress>0x42000400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>EVSYS</name>
+        <value>8</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>GCLKREQ</name>
+              <description>Generic Clock Requests</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHANNEL</name>
+          <description>Channel</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CHANNEL</name>
+              <description>Channel Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SWEVT</name>
+              <description>Software Event</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVGEN</name>
+              <description>Event Generator Selection</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>PATH</name>
+              <description>Path Selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PATHSelect</name>
+                <enumeratedValue>
+                  <name>SYNCHRONOUS</name>
+                  <description>Synchronous path</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNCHRONIZED</name>
+                  <description>Resynchronized path</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ASYNCHRONOUS</name>
+                  <description>Asynchronous path</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EDGSEL</name>
+              <description>Edge Detection Selection</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>EDGSELSelect</name>
+                <enumeratedValue>
+                  <name>NO_EVT_OUTPUT</name>
+                  <description>No event output when using the resynchronized or synchronous path</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISING_EDGE</name>
+                  <description>Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALLING_EDGE</name>
+                  <description>Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH_EDGES</name>
+                  <description>Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>USER</name>
+          <description>User Multiplexer</description>
+          <addressOffset>0x08</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USER</name>
+              <description>User Multiplexer Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>CHANNEL</name>
+              <description>Channel Event Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>CHANNELSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>No Channel Output Selected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHSTATUS</name>
+          <description>Channel Status</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x0000003F</resetValue>
+          <fields>
+            <field>
+              <name>USRRDY0</name>
+              <description>Channel 0 User Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY1</name>
+              <description>Channel 1 User Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY2</name>
+              <description>Channel 2 User Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY3</name>
+              <description>Channel 3 User Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY4</name>
+              <description>Channel 4 User Ready</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY5</name>
+              <description>Channel 5 User Ready</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY0</name>
+              <description>Channel 0 Busy</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY1</name>
+              <description>Channel 1 Busy</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY2</name>
+              <description>Channel 2 Busy</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY3</name>
+              <description>Channel 3 Busy</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY4</name>
+              <description>Channel 4 Busy</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY5</name>
+              <description>Channel 5 Busy</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVR0</name>
+              <description>Channel 0 Overrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR1</name>
+              <description>Channel 1 Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR2</name>
+              <description>Channel 2 Overrun Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR3</name>
+              <description>Channel 3 Overrun Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR4</name>
+              <description>Channel 4 Overrun Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR5</name>
+              <description>Channel 5 Overrun Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD0</name>
+              <description>Channel 0 Event Detection Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD1</name>
+              <description>Channel 1 Event Detection Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD2</name>
+              <description>Channel 2 Event Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD3</name>
+              <description>Channel 3 Event Detection Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD4</name>
+              <description>Channel 4 Event Detection Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD5</name>
+              <description>Channel 5 Event Detection Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVR0</name>
+              <description>Channel 0 Overrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR1</name>
+              <description>Channel 1 Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR2</name>
+              <description>Channel 2 Overrun Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR3</name>
+              <description>Channel 3 Overrun Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR4</name>
+              <description>Channel 4 Overrun Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR5</name>
+              <description>Channel 5 Overrun Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD0</name>
+              <description>Channel 0 Event Detection Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD1</name>
+              <description>Channel 1 Event Detection Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD2</name>
+              <description>Channel 2 Event Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD3</name>
+              <description>Channel 3 Event Detection Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD4</name>
+              <description>Channel 4 Event Detection Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD5</name>
+              <description>Channel 5 Event Detection Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVR0</name>
+              <description>Channel 0 Overrun</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR1</name>
+              <description>Channel 1 Overrun</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR2</name>
+              <description>Channel 2 Overrun</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR3</name>
+              <description>Channel 3 Overrun</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR4</name>
+              <description>Channel 4 Overrun</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR5</name>
+              <description>Channel 5 Overrun</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD0</name>
+              <description>Channel 0 Event Detection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD1</name>
+              <description>Channel 1 Event Detection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD2</name>
+              <description>Channel 2 Event Detection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD3</name>
+              <description>Channel 3 Event Detection</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD4</name>
+              <description>Channel 4 Event Detection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD5</name>
+              <description>Channel 5 Event Detection</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>GCLK</name>
+      <version>2.1.0</version>
+      <description>Generic Clock Generator</description>
+      <groupName>GCLK</groupName>
+      <prependToName>GCLK_</prependToName>
+      <baseAddress>0x40000C00</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x1</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy Status</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CLKCTRL</name>
+          <description>Generic Clock Control</description>
+          <addressOffset>0x2</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Generic Clock Selection ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <enumeratedValues>
+                <name>IDSelect</name>
+                <enumeratedValue>
+                  <name>DFLL48</name>
+                  <description>DFLL48</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FDPLL</name>
+                  <description>FDPLL</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FDPLL32K</name>
+                  <description>FDPLL32K</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WDT</name>
+                  <description>WDT</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RTC</name>
+                  <description>RTC</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EIC</name>
+                  <description>EIC</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB</name>
+                  <description>USB</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_0</name>
+                  <description>EVSYS_0</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_1</name>
+                  <description>EVSYS_1</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_2</name>
+                  <description>EVSYS_2</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_3</name>
+                  <description>EVSYS_3</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_4</name>
+                  <description>EVSYS_4</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_5</name>
+                  <description>EVSYS_5</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOMX_SLOW</name>
+                  <description>SERCOMX_SLOW</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM0_CORE</name>
+                  <description>SERCOM0_CORE</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM1_CORE</name>
+                  <description>SERCOM1_CORE</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM2_CORE</name>
+                  <description>SERCOM2_CORE</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TCC0</name>
+                  <description>TCC0</description>
+                  <value>0x11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TC1_TC2</name>
+                  <description>TC1_TC2</description>
+                  <value>0x12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC</name>
+                  <description>ADC</description>
+                  <value>0x13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AC_DIG</name>
+                  <description>AC_DIG</description>
+                  <value>0x14</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AC_ANA</name>
+                  <description>AC_ANA</description>
+                  <value>0x15</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DAC</name>
+                  <description>DAC</description>
+                  <value>0x16</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>GEN</name>
+              <description>Generic Clock Generator</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>GENSelect</name>
+                <enumeratedValue>
+                  <name>GCLK0</name>
+                  <description>Generic clock generator 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK1</name>
+                  <description>Generic clock generator 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK2</name>
+                  <description>Generic clock generator 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK3</name>
+                  <description>Generic clock generator 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK4</name>
+                  <description>Generic clock generator 4</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK5</name>
+                  <description>Generic clock generator 5</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CLKEN</name>
+              <description>Clock Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GENCTRL</name>
+          <description>Generic Clock Generator Control</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Generic Clock Generator Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>SRC</name>
+              <description>Source Select</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>SRCSelect</name>
+                <enumeratedValue>
+                  <name>XOSC</name>
+                  <description>XOSC oscillator output</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLKIN</name>
+                  <description>Generator input pad</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLKGEN1</name>
+                  <description>Generic clock generator 1 output</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OSCULP32K</name>
+                  <description>OSCULP32K oscillator output</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OSC32K</name>
+                  <description>OSC32K oscillator output</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>XOSC32K</name>
+                  <description>XOSC32K oscillator output</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OSC8M</name>
+                  <description>OSC8M oscillator output</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DFLL48M</name>
+                  <description>DFLL48M output</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DPLL96M</name>
+                  <description>DPLL96M output</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>GENEN</name>
+              <description>Generic Clock Generator Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDC</name>
+              <description>Improve Duty Cycle</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OOV</name>
+              <description>Output Off Value</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OE</name>
+              <description>Output Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DIVSEL</name>
+              <description>Divide Selection</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GENDIV</name>
+          <description>Generic Clock Generator Division</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Generic Clock Generator Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>DIV</name>
+              <description>Division Factor</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>HMATRIX</name>
+      <version>2.1.2</version>
+      <description>HSB Matrix</description>
+      <groupName>HMATRIXB</groupName>
+      <prependToName>HMATRIXB_</prependToName>
+      <baseAddress>0x41007000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>PRAS%s</name>
+          <description>Priority A for Slave</description>
+          <addressOffset>0x080</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>M0PR</name>
+              <description>Master 0 Priority</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M1PR</name>
+              <description>Master 1 Priority</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M2PR</name>
+              <description>Master 2 Priority</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M3PR</name>
+              <description>Master 3 Priority</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M4PR</name>
+              <description>Master 4 Priority</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M5PR</name>
+              <description>Master 5 Priority</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M6PR</name>
+              <description>Master 6 Priority</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M7PR</name>
+              <description>Master 7 Priority</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>PRBS%s</name>
+          <description>Priority B for Slave</description>
+          <addressOffset>0x084</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>M8PR</name>
+              <description>Master 8 Priority</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M9PR</name>
+              <description>Master 9 Priority</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M10PR</name>
+              <description>Master 10 Priority</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M11PR</name>
+              <description>Master 11 Priority</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M12PR</name>
+              <description>Master 12 Priority</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M13PR</name>
+              <description>Master 13 Priority</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M14PR</name>
+              <description>Master 14 Priority</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M15PR</name>
+              <description>Master 15 Priority</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>SFR%s</name>
+          <description>Special Function</description>
+          <addressOffset>0x110</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SFR</name>
+              <description>Special Function Register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>MTB</name>
+      <version>1.0.0</version>
+      <description>Cortex-M0+ Micro-Trace Buffer</description>
+      <groupName>MTB</groupName>
+      <prependToName>MTB_</prependToName>
+      <baseAddress>0x41006000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>POSITION</name>
+          <description>MTB Position</description>
+          <addressOffset>0x000</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WRAP</name>
+              <description>Pointer Value Wraps</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POINTER</name>
+              <description>Trace Packet Location Pointer</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>29</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MASTER</name>
+          <description>MTB Master</description>
+          <addressOffset>0x004</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>MASK</name>
+              <description>Maximum Value of the Trace Buffer in SRAM</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TSTARTEN</name>
+              <description>Trace Start Input Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTOPEN</name>
+              <description>Trace Stop Input Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SFRWPRIV</name>
+              <description>Special Function Register Write Privilege</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMPRIV</name>
+              <description>SRAM Privilege</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HALTREQ</name>
+              <description>Halt Request</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN</name>
+              <description>Main Trace Enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FLOW</name>
+          <description>MTB Flow</description>
+          <addressOffset>0x008</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>AUTOSTOP</name>
+              <description>Auto Stop Tracing</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AUTOHALT</name>
+              <description>Auto Halt Request</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WATERMARK</name>
+              <description>Watermark value</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>29</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BASE</name>
+          <description>MTB Base</description>
+          <addressOffset>0x00C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>ITCTRL</name>
+          <description>MTB Integration Mode Control</description>
+          <addressOffset>0xF00</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>CLAIMSET</name>
+          <description>MTB Claim Set</description>
+          <addressOffset>0xFA0</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>CLAIMCLR</name>
+          <description>MTB Claim Clear</description>
+          <addressOffset>0xFA4</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>LOCKACCESS</name>
+          <description>MTB Lock Access</description>
+          <addressOffset>0xFB0</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>LOCKSTATUS</name>
+          <description>MTB Lock Status</description>
+          <addressOffset>0xFB4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>AUTHSTATUS</name>
+          <description>MTB Authentication Status</description>
+          <addressOffset>0xFB8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>DEVARCH</name>
+          <description>MTB Device Architecture</description>
+          <addressOffset>0xFBC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>DEVID</name>
+          <description>MTB Device Configuration</description>
+          <addressOffset>0xFC8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>DEVTYPE</name>
+          <description>MTB Device Type</description>
+          <addressOffset>0xFCC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID4</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFD0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID5</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFD4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID6</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFD8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID7</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFDC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID0</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFE0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID1</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFE4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID2</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFE8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID3</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFEC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID0</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFF0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID1</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFF4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID2</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFF8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID3</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFFC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>NVMCTRL</name>
+      <version>1.0.7</version>
+      <description>Non-Volatile Memory Controller</description>
+      <groupName>NVMCTRL</groupName>
+      <prependToName>NVMCTRL_</prependToName>
+      <baseAddress>0x41004000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>NVMCTRL</name>
+        <value>5</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>ER</name>
+                  <description>Erase Row - Erases the row addressed by the ADDR register.</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WP</name>
+                  <description>Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register.</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EAR</name>
+                  <description>Erase Auxiliary Row - Erases the auxiliary row addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row.</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WAP</name>
+                  <description>Write Auxiliary Page - Writes the contents of the page buffer to the page addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row.</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SF</name>
+                  <description>Security Flow Command</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WL</name>
+                  <description>Write lockbits</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LR</name>
+                  <description>Lock Region - Locks the region containing the address location in the ADDR register.</description>
+                  <value>0x40</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UR</name>
+                  <description>Unlock Region - Unlocks the region containing the address location in the ADDR register.</description>
+                  <value>0x41</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPRM</name>
+                  <description>Sets the power reduction mode.</description>
+                  <value>0x42</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CPRM</name>
+                  <description>Clears the power reduction mode.</description>
+                  <value>0x43</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PBC</name>
+                  <description>Page Buffer Clear - Clears the page buffer.</description>
+                  <value>0x44</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSB</name>
+                  <description>Set Security Bit - Sets the security bit by writing 0x00 to the first byte in the lockbit row.</description>
+                  <value>0x45</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INVALL</name>
+                  <description>Invalidates all cache lines.</description>
+                  <value>0x46</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMDEX</name>
+              <description>Command Execution</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+              <enumeratedValues>
+                <name>CMDEXSelect</name>
+                <enumeratedValue>
+                  <name>KEY</name>
+                  <description>Execution Key</description>
+                  <value>0xa5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>RWS</name>
+              <description>NVM Read Wait States</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>RWSSelect</name>
+                <enumeratedValue>
+                  <name>SINGLE</name>
+                  <description>Single Auto Wait State</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HALF</name>
+                  <description>Half Auto Wait State</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DUAL</name>
+                  <description>Dual Auto Wait State</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MANW</name>
+              <description>Manual Write</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLEEPPRM</name>
+              <description>Power Reduction Mode during Sleep</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SLEEPPRMSelect</name>
+                <enumeratedValue>
+                  <name>WAKEONACCESS</name>
+                  <description>NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access.</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WAKEUPINSTANT</name>
+                  <description>NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep.</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DISABLED</name>
+                  <description>Auto power reduction disabled.</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>READMODE</name>
+              <description>NVMCTRL Read Mode</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>READMODESelect</name>
+                <enumeratedValue>
+                  <name>NO_MISS_PENALTY</name>
+                  <description>The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance.</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW_POWER</name>
+                  <description>Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time.</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DETERMINISTIC</name>
+                  <description>The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings.</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CACHEDIS</name>
+              <description>Cache Disable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PARAM</name>
+          <description>NVM Parameter</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>NVMP</name>
+              <description>NVM Pages</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PSZ</name>
+              <description>Page Size</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>PSZSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 bytes</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 bytes</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 bytes</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 bytes</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 bytes</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 bytes</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 bytes</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1024</name>
+                  <description>1024 bytes</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READY</name>
+              <description>NVM Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x10</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READY</name>
+              <description>NVM Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READY</name>
+              <description>NVM Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PRM</name>
+              <description>Power Reduction Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LOAD</name>
+              <description>NVM Page Buffer Active Loading</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PROGE</name>
+              <description>Programming Error Status</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LOCKE</name>
+              <description>Lock Error Status</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NVME</name>
+              <description>NVM Error</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Security Bit Status</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>Address</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>NVM Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>22</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LOCK</name>
+          <description>Lock Section</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>LOCK</name>
+              <description>Region Lock Bits</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PAC0</name>
+      <version>1.0.1</version>
+      <description>Peripheral Access Controller 0</description>
+      <groupName>PAC</groupName>
+      <prependToName>PAC_</prependToName>
+      <baseAddress>0x40000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x08</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>WPCLR</name>
+          <description>Write Protection Clear</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WP</name>
+              <description>Write Protection Clear</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>31</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WPSET</name>
+          <description>Write Protection Set</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WP</name>
+              <description>Write Protection Set</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>31</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="PAC0">
+      <name>PAC1</name>
+      <description>Peripheral Access Controller 1</description>
+      <baseAddress>0x41000000</baseAddress>
+    </peripheral>
+    <peripheral derivedFrom="PAC0">
+      <name>PAC2</name>
+      <description>Peripheral Access Controller 2</description>
+      <baseAddress>0x42000000</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>PM</name>
+      <version>2.1.1</version>
+      <description>Power Manager</description>
+      <groupName>PM</groupName>
+      <prependToName>PM_</prependToName>
+      <baseAddress>0x40000400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>PM</name>
+        <value>0</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CFDEN</name>
+              <description>Clock Failure Detector Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BKUPCLK</name>
+              <description>Backup Clock Select</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SLEEP</name>
+          <description>Sleep Mode</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>IDLE</name>
+              <description>Idle Mode Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>IDLESelect</name>
+                <enumeratedValue>
+                  <name>CPU</name>
+                  <description>The CPU clock domain is stopped</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AHB</name>
+                  <description>The CPU and AHB clock domains are stopped</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>APB</name>
+                  <description>The CPU, AHB and APB clock domains are stopped</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTCTRL</name>
+          <description>External Reset Controller</description>
+          <addressOffset>0x02</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SETDIS</name>
+              <description>External Reset Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CPUSEL</name>
+          <description>CPU Clock Select</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CPUDIV</name>
+              <description>CPU Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CPUDIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBASEL</name>
+          <description>APBA Clock Select</description>
+          <addressOffset>0x09</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>APBADIV</name>
+              <description>APBA Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>APBADIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBBSEL</name>
+          <description>APBB Clock Select</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>APBBDIV</name>
+              <description>APBB Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>APBBDIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBCSEL</name>
+          <description>APBC Clock Select</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>APBCDIV</name>
+              <description>APBC Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>APBCDIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBMASK</name>
+          <description>AHB Mask</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <resetValue>0x0000007F</resetValue>
+          <fields>
+            <field>
+              <name>HPB0_</name>
+              <description>HPB0 AHB Clock Mask</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HPB1_</name>
+              <description>HPB1 AHB Clock Mask</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HPB2_</name>
+              <description>HPB2 AHB Clock Mask</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DSU_</name>
+              <description>DSU AHB Clock Mask</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NVMCTRL_</name>
+              <description>NVMCTRL AHB Clock Mask</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAC_</name>
+              <description>DMAC AHB Clock Mask</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USB_</name>
+              <description>USB AHB Clock Mask</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBAMASK</name>
+          <description>APBA Mask</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <resetValue>0x0000007F</resetValue>
+          <fields>
+            <field>
+              <name>PAC0_</name>
+              <description>PAC0 APB Clock Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PM_</name>
+              <description>PM APB Clock Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYSCTRL_</name>
+              <description>SYSCTRL APB Clock Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GCLK_</name>
+              <description>GCLK APB Clock Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WDT_</name>
+              <description>WDT APB Clock Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RTC_</name>
+              <description>RTC APB Clock Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EIC_</name>
+              <description>EIC APB Clock Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBBMASK</name>
+          <description>APBB Mask</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <resetValue>0x0000007F</resetValue>
+          <fields>
+            <field>
+              <name>PAC1_</name>
+              <description>PAC1 APB Clock Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DSU_</name>
+              <description>DSU APB Clock Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NVMCTRL_</name>
+              <description>NVMCTRL APB Clock Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PORT_</name>
+              <description>PORT APB Clock Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAC_</name>
+              <description>DMAC APB Clock Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USB_</name>
+              <description>USB APB Clock Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HMATRIX_</name>
+              <description>HMATRIX APB Clock Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBCMASK</name>
+          <description>APBC Mask</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <resetValue>0x00000100</resetValue>
+          <fields>
+            <field>
+              <name>PAC2_</name>
+              <description>PAC2 APB Clock Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVSYS_</name>
+              <description>EVSYS APB Clock Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM0_</name>
+              <description>SERCOM0 APB Clock Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM1_</name>
+              <description>SERCOM1 APB Clock Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM2_</name>
+              <description>SERCOM2 APB Clock Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCC0_</name>
+              <description>TCC0 APB Clock Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TC1_</name>
+              <description>TC1 APB Clock Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TC2_</name>
+              <description>TC2 APB Clock Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADC_</name>
+              <description>ADC APB Clock Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AC_</name>
+              <description>AC APB Clock Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DAC_</name>
+              <description>DAC APB Clock Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PTC_</name>
+              <description>PTC APB Clock Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x34</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CKRDY</name>
+              <description>Clock Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CFD</name>
+              <description>Clock Failure Detector Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x35</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CKRDY</name>
+              <description>Clock Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CFD</name>
+              <description>Clock Failure Detector Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x36</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CKRDY</name>
+              <description>Clock Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CFD</name>
+              <description>Clock Failure Detector</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCAUSE</name>
+          <description>Reset Cause</description>
+          <addressOffset>0x38</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x01</resetValue>
+          <fields>
+            <field>
+              <name>POR</name>
+              <description>Power On Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD12</name>
+              <description>Brown Out 12 Detector Reset</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33</name>
+              <description>Brown Out 33 Detector Reset</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXT</name>
+              <description>External Reset</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WDT</name>
+              <description>Watchdog Reset</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYST</name>
+              <description>System Reset Request</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PORT</name>
+      <version>1.0.0</version>
+      <description>Port Module</description>
+      <groupName>PORT</groupName>
+      <prependToName>PORT_</prependToName>
+      <baseAddress>0x41004400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x200</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIR%s</name>
+          <description>Data Direction</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Port Data Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIRCLR%s</name>
+          <description>Data Direction Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIRCLR</name>
+              <description>Port Data Direction Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIRSET%s</name>
+          <description>Data Direction Set</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIRSET</name>
+              <description>Port Data Direction Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIRTGL%s</name>
+          <description>Data Direction Toggle</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIRTGL</name>
+              <description>Port Data Direction Toggle</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUT%s</name>
+          <description>Data Output Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUT</name>
+              <description>Port Data Output Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUTCLR%s</name>
+          <description>Data Output Value Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUTCLR</name>
+              <description>Port Data Output Value Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUTSET%s</name>
+          <description>Data Output Value Set</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUTSET</name>
+              <description>Port Data Output Value Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUTTGL%s</name>
+          <description>Data Output Value Toggle</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUTTGL</name>
+              <description>Port Data Output Value Toggle</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>IN%s</name>
+          <description>Data Input Value</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>IN</name>
+              <description>Port Data Input Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>CTRL%s</name>
+          <description>Control</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SAMPLING</name>
+              <description>Input Sampling Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>WRCONFIG%s</name>
+          <description>Write Configuration</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>PINMASK</name>
+              <description>Pin Mask for Multiple Pin Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+            <field>
+              <name>PMUXEN</name>
+              <description>Peripheral Multiplexer Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INEN</name>
+              <description>Input Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PULLEN</name>
+              <description>Pull Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRVSTR</name>
+              <description>Output Driver Strength Selection</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PMUX</name>
+              <description>Peripheral Multiplexing</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>WRPMUX</name>
+              <description>Write PMUX</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WRPINCFG</name>
+              <description>Write PINCFG</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HWSEL</name>
+              <description>Half-Word Select</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>PMUX0_%s</name>
+          <description>Peripheral Multiplexing n - Group 0</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PMUXE</name>
+              <description>Peripheral Multiplexing Even</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PMUXESelect</name>
+                <enumeratedValue>
+                  <name>A</name>
+                  <description>Peripheral function A selected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>B</name>
+                  <description>Peripheral function B selected</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>C</name>
+                  <description>Peripheral function C selected</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>D</name>
+                  <description>Peripheral function D selected</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>E</name>
+                  <description>Peripheral function E selected</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>F</name>
+                  <description>Peripheral function F selected</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>G</name>
+                  <description>Peripheral function G selected</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>H</name>
+                  <description>Peripheral function H selected</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PMUXO</name>
+              <description>Peripheral Multiplexing Odd</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PMUXOSelect</name>
+                <enumeratedValue>
+                  <name>A</name>
+                  <description>Peripheral function A selected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>B</name>
+                  <description>Peripheral function B selected</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>C</name>
+                  <description>Peripheral function C selected</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>D</name>
+                  <description>Peripheral function D selected</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>E</name>
+                  <description>Peripheral function E selected</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>F</name>
+                  <description>Peripheral function F selected</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>G</name>
+                  <description>Peripheral function G selected</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>H</name>
+                  <description>Peripheral function H selected</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>32</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>PINCFG0_%s</name>
+          <description>Pin Configuration n - Group 0</description>
+          <addressOffset>0x40</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PMUXEN</name>
+              <description>Peripheral Multiplexer Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INEN</name>
+              <description>Input Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PULLEN</name>
+              <description>Pull Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRVSTR</name>
+              <description>Output Driver Strength Selection</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="PORT">
+      <name>PORT_IOBUS</name>
+      <description>Port Module (IOBUS)</description>
+      <groupName>PORT_IOBUS</groupName>
+      <prependToName>PORT_IOBUS_</prependToName>
+      <baseAddress>0x60000000</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>RTC</name>
+      <version>1.0.1</version>
+      <description>Real-Time Counter</description>
+      <groupName>RTC</groupName>
+      <prependToName>RTC_</prependToName>
+      <baseAddress>0x40001400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>RTC</name>
+        <value>3</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>MODE0</name>
+        <description>32-bit Counter with Single 32-bit Compare</description>
+        <headerStructName>RtcMode0</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRL</name>
+          <description>MODE0 Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Mode 0: 32-bit Counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Mode 1: 16-bit Counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLOCK</name>
+                  <description>Mode 2: Clock/Calendar</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MATCHCLR</name>
+              <description>Clear on Match</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/256</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/512</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1024</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <resetValue>0x0010</resetValue>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>MODE0 Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PEREO0</name>
+              <description>Periodic Interval 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO1</name>
+              <description>Periodic Interval 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO2</name>
+              <description>Periodic Interval 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO3</name>
+              <description>Periodic Interval 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO4</name>
+              <description>Periodic Interval 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO5</name>
+              <description>Periodic Interval 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO6</name>
+              <description>Periodic Interval 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO7</name>
+              <description>Periodic Interval 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMPEO0</name>
+              <description>Compare 0 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>MODE0 Interrupt Enable Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>MODE0 Interrupt Enable Set</description>
+          <addressOffset>0x07</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>MODE0 Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Run During Debug</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCORR</name>
+          <description>Frequency Correction</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>SIGN</name>
+              <description>Correction Sign</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>MODE0 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>COMP%s</name>
+          <description>MODE0 Compare n Value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COMP</name>
+              <description>Compare Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- RtcMode0 -->
+       <cluster>
+        <name>MODE1</name>
+        <description>16-bit Counter with Two 16-bit Compares</description>
+        <alternateCluster>MODE0</alternateCluster>
+        <headerStructName>RtcMode1</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRL</name>
+          <description>MODE1 Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Mode 0: 32-bit Counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Mode 1: 16-bit Counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLOCK</name>
+                  <description>Mode 2: Clock/Calendar</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/256</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/512</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1024</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <resetValue>0x0010</resetValue>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>MODE1 Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PEREO0</name>
+              <description>Periodic Interval 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO1</name>
+              <description>Periodic Interval 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO2</name>
+              <description>Periodic Interval 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO3</name>
+              <description>Periodic Interval 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO4</name>
+              <description>Periodic Interval 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO5</name>
+              <description>Periodic Interval 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO6</name>
+              <description>Periodic Interval 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO7</name>
+              <description>Periodic Interval 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMPEO0</name>
+              <description>Compare 0 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMPEO1</name>
+              <description>Compare 1 Event Output Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>MODE1 Interrupt Enable Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>MODE1 Interrupt Enable Set</description>
+          <addressOffset>0x07</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>MODE1 Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Run During Debug</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCORR</name>
+          <description>Frequency Correction</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>SIGN</name>
+              <description>Correction Sign</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>MODE1 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER</name>
+          <description>MODE1 Counter Period</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Counter Period</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x2</dimIncrement>
+          <name>COMP%s</name>
+          <description>MODE1 Compare n Value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COMP</name>
+              <description>Compare Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- RtcMode1 -->
+       <cluster>
+        <name>MODE2</name>
+        <description>Clock/Calendar with Alarm</description>
+        <alternateCluster>MODE0</alternateCluster>
+        <headerStructName>RtcMode2</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRL</name>
+          <description>MODE2 Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Mode 0: 32-bit Counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Mode 1: 16-bit Counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLOCK</name>
+                  <description>Mode 2: Clock/Calendar</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CLKREP</name>
+              <description>Clock Representation</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MATCHCLR</name>
+              <description>Clear on Match</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/256</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/512</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1024</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <resetValue>0x0010</resetValue>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>MODE2 Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PEREO0</name>
+              <description>Periodic Interval 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO1</name>
+              <description>Periodic Interval 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO2</name>
+              <description>Periodic Interval 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO3</name>
+              <description>Periodic Interval 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO4</name>
+              <description>Periodic Interval 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO5</name>
+              <description>Periodic Interval 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO6</name>
+              <description>Periodic Interval 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO7</name>
+              <description>Periodic Interval 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ALARMEO0</name>
+              <description>Alarm 0 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>MODE2 Interrupt Enable Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ALARM0</name>
+              <description>Alarm 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>MODE2 Interrupt Enable Set</description>
+          <addressOffset>0x07</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ALARM0</name>
+              <description>Alarm 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>MODE2 Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ALARM0</name>
+              <description>Alarm 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Run During Debug</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCORR</name>
+          <description>Frequency Correction</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>SIGN</name>
+              <description>Correction Sign</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CLOCK</name>
+          <description>MODE2 Clock Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SECOND</name>
+              <description>Second</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>MINUTE</name>
+              <description>Minute</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>HOUR</name>
+              <description>Hour</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>HOURSelect</name>
+                <enumeratedValue>
+                  <name>AM</name>
+                  <description>AM when CLKREP in 12-hour</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PM</name>
+                  <description>PM when CLKREP in 12-hour</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DAY</name>
+              <description>Day</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>MONTH</name>
+              <description>Month</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>YEAR</name>
+              <description>Year</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>ALARM%s</name>
+          <description>MODE2 Alarm n Value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SECOND</name>
+              <description>Second</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>MINUTE</name>
+              <description>Minute</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>HOUR</name>
+              <description>Hour</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>HOURSelect</name>
+                <enumeratedValue>
+                  <name>AM</name>
+                  <description>Morning hour</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PM</name>
+                  <description>Afternoon hour</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DAY</name>
+              <description>Day</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>MONTH</name>
+              <description>Month</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>YEAR</name>
+              <description>Year</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>MASK%s</name>
+          <description>MODE2 Alarm n Mask</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SEL</name>
+              <description>Alarm Mask Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SELSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Alarm Disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SS</name>
+                  <description>Match seconds only</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MMSS</name>
+                  <description>Match seconds and minutes only</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HHMMSS</name>
+                  <description>Match seconds, minutes, and hours only</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DDHHMMSS</name>
+                  <description>Match seconds, minutes, hours, and days only</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MMDDHHMMSS</name>
+                  <description>Match seconds, minutes, hours, days, and months only</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>YYMMDDHHMMSS</name>
+                  <description>Match seconds, minutes, hours, days, months, and years</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- RtcMode2 -->
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>SERCOM0</name>
+      <version>2.0.0</version>
+      <description>Serial Communication Interface 0</description>
+      <groupName>SERCOM</groupName>
+      <prependToName>SERCOM_</prependToName>
+      <baseAddress>0x42000800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>SERCOM0</name>
+        <value>9</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>I2CM</name>
+        <description>I2C Master Mode</description>
+        <headerStructName>SercomI2cm</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>I2CM Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINOUT</name>
+              <description>Pin Usage</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SDAHOLD</name>
+              <description>SDA Hold Time</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MEXTTOEN</name>
+              <description>Master SCL Low Extend Timeout</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SEXTTOEN</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPEED</name>
+              <description>Transfer Speed</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SCLSM</name>
+              <description>SCL Clock Stretch Mode</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INACTOUT</name>
+              <description>Inactive Time-Out</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>LOWTOUTEN</name>
+              <description>SCL Low Timeout Enable</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>I2CM Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SMEN</name>
+              <description>Smart Mode Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QCEN</name>
+              <description>Quick Command Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ACKACT</name>
+              <description>Acknowledge Action</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD</name>
+          <description>I2CM Baud Rate</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>BAUDLOW</name>
+              <description>Baud Rate Value Low</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>HSBAUD</name>
+              <description>High Speed Baud Rate Value</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>HSBAUDLOW</name>
+              <description>High Speed Baud Rate Value Low</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>I2CM Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MB</name>
+              <description>Master On Bus Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Slave On Bus Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>I2CM Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MB</name>
+              <description>Master On Bus Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Slave On Bus Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>I2CM Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MB</name>
+              <description>Master On Bus Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Slave On Bus Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>I2CM Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BUSERR</name>
+              <description>Bus Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ARBLOST</name>
+              <description>Arbitration Lost</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXNACK</name>
+              <description>Received Not Acknowledge</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSSTATE</name>
+              <description>Bus State</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>LOWTOUT</name>
+              <description>SCL Low Timeout</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CLKHOLD</name>
+              <description>Clock Hold</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>MEXTTOUT</name>
+              <description>Master SCL Low Extend Timeout</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SEXTTOUT</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LENERR</name>
+              <description>Length Error</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>I2CM Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYSOP</name>
+              <description>System Operation Synchronization Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>I2CM Address</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+            <field>
+              <name>LENEN</name>
+              <description>Length Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HS</name>
+              <description>High Speed Mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TENBITEN</name>
+              <description>Ten Bit Addressing Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LEN</name>
+              <description>Length</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>I2CM Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>I2CM Debug Control</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGSTOP</name>
+              <description>Debug Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomI2cm -->
+       <cluster>
+        <name>I2CS</name>
+        <description>I2C Slave Mode</description>
+        <alternateCluster>I2CM</alternateCluster>
+        <headerStructName>SercomI2cs</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>I2CS Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run during Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINOUT</name>
+              <description>Pin Usage</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SDAHOLD</name>
+              <description>SDA Hold Time</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SEXTTOEN</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPEED</name>
+              <description>Transfer Speed</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SCLSM</name>
+              <description>SCL Clock Stretch Mode</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LOWTOUTEN</name>
+              <description>SCL Low Timeout Enable</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>I2CS Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SMEN</name>
+              <description>Smart Mode Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GCMD</name>
+              <description>PMBus Group Command</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AACKEN</name>
+              <description>Automatic Address Acknowledge</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMODE</name>
+              <description>Address Mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ACKACT</name>
+              <description>Acknowledge Action</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>I2CS Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PREC</name>
+              <description>Stop Received Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMATCH</name>
+              <description>Address Match Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRDY</name>
+              <description>Data Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>I2CS Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PREC</name>
+              <description>Stop Received Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMATCH</name>
+              <description>Address Match Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRDY</name>
+              <description>Data Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>I2CS Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PREC</name>
+              <description>Stop Received Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMATCH</name>
+              <description>Address Match Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRDY</name>
+              <description>Data Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>I2CS Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BUSERR</name>
+              <description>Bus Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COLL</name>
+              <description>Transmit Collision</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXNACK</name>
+              <description>Received Not Acknowledge</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>Read/Write Direction</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SR</name>
+              <description>Repeated Start</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LOWTOUT</name>
+              <description>SCL Low Timeout</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CLKHOLD</name>
+              <description>Clock Hold</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SEXTTOUT</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HS</name>
+              <description>High Speed</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>I2CS Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>I2CS Address</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>GENCEN</name>
+              <description>General Call Address Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADDR</name>
+              <description>Address Value</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+            <field>
+              <name>TENBITEN</name>
+              <description>Ten Bit Addressing Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADDRMASK</name>
+              <description>Address Mask</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>I2CS Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomI2cs -->
+       <cluster>
+        <name>SPI</name>
+        <description>SPI Mode</description>
+        <alternateCluster>I2CM</alternateCluster>
+        <headerStructName>SercomSpi</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>SPI Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run during Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IBON</name>
+              <description>Immediate Buffer Overflow Notification</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DOPO</name>
+              <description>Data Out Pinout</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>DIPO</name>
+              <description>Data In Pinout</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>FORM</name>
+              <description>Frame Format</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CPHA</name>
+              <description>Clock Phase</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>Clock Polarity</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DORD</name>
+              <description>Data Order</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>SPI Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CHSIZE</name>
+              <description>Character Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>PLOADEN</name>
+              <description>Data Preload Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSDE</name>
+              <description>Slave Select Low Detect Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSSEN</name>
+              <description>Master Slave Select Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMODE</name>
+              <description>Address Mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>RXEN</name>
+              <description>Receiver Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD</name>
+          <description>SPI Baud Rate</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>SPI Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSL</name>
+              <description>Slave Select Low Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>SPI Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSL</name>
+              <description>Slave Select Low Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>SPI Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SSL</name>
+              <description>Slave Select Low Interrupt Flag</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>SPI Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BUFOVF</name>
+              <description>Buffer Overflow</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>SPI Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CTRLB</name>
+              <description>CTRLB Synchronization Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>SPI Address</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>ADDRMASK</name>
+              <description>Address Mask</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>SPI Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>SPI Debug Control</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGSTOP</name>
+              <description>Debug Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomSpi -->
+       <cluster>
+        <name>USART</name>
+        <description>USART Mode</description>
+        <alternateCluster>I2CM</alternateCluster>
+        <headerStructName>SercomUsart</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>USART Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run during Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IBON</name>
+              <description>Immediate Buffer Overflow Notification</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SAMPR</name>
+              <description>Sample</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>TXPO</name>
+              <description>Transmit Data Pinout</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>RXPO</name>
+              <description>Receive Data Pinout</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SAMPA</name>
+              <description>Sample Adjustment</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>FORM</name>
+              <description>Frame Format</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CMODE</name>
+              <description>Communication Mode</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>Clock Polarity</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DORD</name>
+              <description>Data Order</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>USART Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CHSIZE</name>
+              <description>Character Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SBMODE</name>
+              <description>Stop Bit Mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COLDEN</name>
+              <description>Collision Detection Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SFDE</name>
+              <description>Start of Frame Detection Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENC</name>
+              <description>Encoding Format</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PMODE</name>
+              <description>Parity Mode</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXEN</name>
+              <description>Transmitter Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXEN</name>
+              <description>Receiver Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD</name>
+          <description>USART Baud Rate</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD_FRAC_MODE</name>
+          <description>USART Baud Rate</description>
+          <alternateRegister>BAUD</alternateRegister>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>13</bitWidth>
+            </field>
+            <field>
+              <name>FP</name>
+              <description>Fractional Part</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD_FRACFP_MODE</name>
+          <description>USART Baud Rate</description>
+          <alternateRegister>BAUD</alternateRegister>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>13</bitWidth>
+            </field>
+            <field>
+              <name>FP</name>
+              <description>Fractional Part</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD_USARTFP_MODE</name>
+          <description>USART Baud Rate</description>
+          <alternateRegister>BAUD</alternateRegister>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXPL</name>
+          <description>USART Receive Pulse Length</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RXPL</name>
+              <description>Receive Pulse Length</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>USART Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXS</name>
+              <description>Receive Start Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTSIC</name>
+              <description>Clear To Send Input Change Interrupt Disable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXBRK</name>
+              <description>Break Received Interrupt Disable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>USART Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXS</name>
+              <description>Receive Start Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTSIC</name>
+              <description>Clear To Send Input Change Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXBRK</name>
+              <description>Break Received Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>USART Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RXS</name>
+              <description>Receive Start Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CTSIC</name>
+              <description>Clear To Send Input Change Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXBRK</name>
+              <description>Break Received Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>USART Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PERR</name>
+              <description>Parity Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FERR</name>
+              <description>Frame Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BUFOVF</name>
+              <description>Buffer Overflow</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTS</name>
+              <description>Clear To Send</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ISF</name>
+              <description>Inconsistent Sync Field</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COLL</name>
+              <description>Collision Detected</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>USART Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CTRLB</name>
+              <description>CTRLB Synchronization Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>USART Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>USART Debug Control</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGSTOP</name>
+              <description>Debug Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomUsart -->
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="SERCOM0">
+      <name>SERCOM1</name>
+      <description>Serial Communication Interface 1</description>
+      <baseAddress>0x42000C00</baseAddress>
+      <interrupt>
+        <name>SERCOM1</name>
+        <value>10</value>
+      </interrupt>
+    </peripheral>
+    <peripheral derivedFrom="SERCOM0">
+      <name>SERCOM2</name>
+      <description>Serial Communication Interface 2</description>
+      <baseAddress>0x42001000</baseAddress>
+      <interrupt>
+        <name>SERCOM2</name>
+        <value>11</value>
+      </interrupt>
+    </peripheral>
+    <peripheral>
+      <name>SYSCTRL</name>
+      <version>2.0.2</version>
+      <description>System Control</description>
+      <groupName>SYSCTRL</groupName>
+      <prependToName>SYSCTRL_</prependToName>
+      <baseAddress>0x40000800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>SYSCTRL</name>
+        <value>1</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PCLKSR</name>
+          <description>Power and Clocks Status</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>XOSC</name>
+          <description>External Multipurpose Crystal Oscillator (XOSC) Control</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <resetValue>0x0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XTALEN</name>
+              <description>Crystal Oscillator Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GAIN</name>
+              <description>Oscillator Gain</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>GAINSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>2MHz</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>4MHz</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>8MHz</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>16MHz</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4</name>
+                  <description>30MHz</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>AMPGC</name>
+              <description>Automatic Amplitude Gain Control</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STARTUP</name>
+              <description>Start-Up Time</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>XOSC32K</name>
+          <description>32kHz External Crystal Oscillator (XOSC32K) Control</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <resetValue>0x0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XTALEN</name>
+              <description>Crystal Oscillator Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN32K</name>
+              <description>32kHz Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN1K</name>
+              <description>1kHz Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AAMPEN</name>
+              <description>Automatic Amplitude Control Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STARTUP</name>
+              <description>Oscillator Start-Up Time</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSC32K</name>
+          <description>32kHz Internal Oscillator (OSC32K) Control</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <resetValue>0x003F0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN32K</name>
+              <description>32kHz Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN1K</name>
+              <description>1kHz Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STARTUP</name>
+              <description>Oscillator Start-Up Time</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALIB</name>
+              <description>Oscillator Calibration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSCULP32K</name>
+          <description>32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>8</size>
+          <resetValue>0x1F</resetValue>
+          <fields>
+            <field>
+              <name>CALIB</name>
+              <description>Oscillator Calibration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSC8M</name>
+          <description>8MHz Internal Oscillator (OSC8M) Control</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <resetValue>0x87070382</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESC</name>
+              <description>Oscillator Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CALIB</name>
+              <description>Oscillator Calibration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+            <field>
+              <name>FRANGE</name>
+              <description>Oscillator Frequency Range</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FRANGESelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>4 to 6MHz</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>6 to 8MHz</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>8 to 11MHz</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>11 to 15MHz</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLCTRL</name>
+          <description>DFLL48M Control</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <resetValue>0x0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>DFLL Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode Selection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STABLE</name>
+              <description>Stable DFLL Frequency</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LLAW</name>
+              <description>Lose Lock After Wake</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USBCRM</name>
+              <description>USB Clock Recovery Mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCDIS</name>
+              <description>Chill Cycle Disable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QLDIS</name>
+              <description>Quick Lock Disable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BPLCKC</name>
+              <description>Bypass Coarse Lock</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAITLOCK</name>
+              <description>Wait Lock</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLVAL</name>
+          <description>DFLL48M Value</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>FINE</name>
+              <description>Fine Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+            <field>
+              <name>COARSE</name>
+              <description>Coarse Value</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>DIFF</name>
+              <description>Multiplication Ratio Difference</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLMUL</name>
+          <description>DFLL48M Multiplier</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>MUL</name>
+              <description>DFLL Multiply Factor</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+            <field>
+              <name>FSTEP</name>
+              <description>Fine Maximum Step</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+            <field>
+              <name>CSTEP</name>
+              <description>Coarse Maximum Step</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLSYNC</name>
+          <description>DFLL48M Synchronization</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READREQ</name>
+              <description>Read Request</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BOD33</name>
+          <description>3.3V Brown-Out Detector (BOD33) Control</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HYST</name>
+              <description>Hysteresis</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ACTION</name>
+              <description>BOD33 Action</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>ACTIONSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESET</name>
+                  <description>The BOD33 generates a reset</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INTERRUPT</name>
+                  <description>The BOD33 generates an interrupt</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operation Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CEN</name>
+              <description>Clock Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PSEL</name>
+              <description>Prescaler Select</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PSELSelect</name>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide clock by 2</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide clock by 4</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide clock by 8</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide clock by 16</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide clock by 32</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide clock by 64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide clock by 128</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Divide clock by 256</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>Divide clock by 512</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1K</name>
+                  <description>Divide clock by 1024</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2K</name>
+                  <description>Divide clock by 2048</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4K</name>
+                  <description>Divide clock by 4096</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8K</name>
+                  <description>Divide clock by 8192</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16K</name>
+                  <description>Divide clock by 16384</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32K</name>
+                  <description>Divide clock by 32768</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64K</name>
+                  <description>Divide clock by 65536</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LEVEL</name>
+              <description>BOD33 Threshold Level</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VREF</name>
+          <description>Voltage References System (VREF) Control</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>TSEN</name>
+              <description>Temperature Sensor Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BGOUTEN</name>
+              <description>Bandgap Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALIB</name>
+              <description>Bandgap Voltage Generator Calibration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLCTRLA</name>
+          <description>DPLL Control A</description>
+          <addressOffset>0x44</addressOffset>
+          <size>8</size>
+          <resetValue>0x80</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>DPLL Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Clock Activation</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLRATIO</name>
+          <description>DPLL Ratio Control</description>
+          <addressOffset>0x48</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>LDR</name>
+              <description>Loop Divider Ratio</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+            <field>
+              <name>LDRFRAC</name>
+              <description>Loop Divider Ratio Fractional Part</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLCTRLB</name>
+          <description>DPLL Control B</description>
+          <addressOffset>0x4C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>FILTER</name>
+              <description>Proportional Integral Filter Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FILTERSelect</name>
+                <enumeratedValue>
+                  <name>DEFAULT</name>
+                  <description>Default filter mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LBFILT</name>
+                  <description>Low bandwidth filter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HBFILT</name>
+                  <description>High bandwidth filter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HDFILT</name>
+                  <description>High damping filter</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LPEN</name>
+              <description>Low-Power Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WUF</name>
+              <description>Wake Up Fast</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>REFCLK</name>
+              <description>Reference Clock Selection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>REFCLKSelect</name>
+                <enumeratedValue>
+                  <name>REF0</name>
+                  <description>CLK_DPLL_REF0 clock reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>REF1</name>
+                  <description>CLK_DPLL_REF1 clock reference</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>GCLK_DPLL clock reference</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LTIME</name>
+              <description>Lock Time</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>LTIMESelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>Default	No time-out</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8MS</name>
+                  <description>8MS	Time-out if no lock within 8 ms</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>9MS</name>
+                  <description>9MS	Time-out if no lock within 9 ms</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>10MS</name>
+                  <description>10MS	Time-out if no lock within 10 ms</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>11MS</name>
+                  <description>11MS	Time-out if no lock within 11 ms</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LBYPASS</name>
+              <description>Lock Bypass</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DIV</name>
+              <description>Clock Divider</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLSTATUS</name>
+          <description>DPLL Status</description>
+          <addressOffset>0x50</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>LOCK</name>
+              <description>DPLL Lock Status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CLKRDY</name>
+              <description>Output Clock Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>DPLL Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DIV</name>
+              <description>Divider Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TC1</name>
+      <version>1.4.0</version>
+      <description>Basic Timer Counter 1</description>
+      <groupName>TC</groupName>
+      <prependToName>TC_</prependToName>
+      <baseAddress>0x42001800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x040</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TC1</name>
+        <value>13</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>COUNT8</name>
+        <description>8-bit Counter Mode</description>
+        <headerStructName>TcCount8</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>TC Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Counter in 16-bit mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT8</name>
+                  <description>Counter in 8-bit mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Counter in 32-bit mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation Operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MPWM</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Prescaler: GCLK_TC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Prescaler: GCLK_TC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Prescaler: GCLK_TC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Prescaler: GCLK_TC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Prescaler: GCLK_TC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Prescaler: GCLK_TC/64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Prescaler: GCLK_TC/256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Prescaler: GCLK_TC/1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset the counter on next generic clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset the counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset the counter on next generic clock. Reset the prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <resetValue>0x02</resetValue>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Invert Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Invert Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or retrigger TC on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start TC on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period captured in CC0, pulse width in CC1</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period captured in CC1, pulse width in CC0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TCINV</name>
+              <description>TC Inverted Event Input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI</name>
+              <description>TC Event Input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x08</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>COUNT8 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER</name>
+          <description>COUNT8 Period Value</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <resetValue>0xFF</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>CC%s</name>
+          <description>COUNT8 Compare/Capture</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- TcCount8 -->
+       <cluster>
+        <name>COUNT16</name>
+        <description>16-bit Counter Mode</description>
+        <alternateCluster>COUNT8</alternateCluster>
+        <headerStructName>TcCount16</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>TC Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Counter in 16-bit mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT8</name>
+                  <description>Counter in 8-bit mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Counter in 32-bit mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation Operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MPWM</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Prescaler: GCLK_TC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Prescaler: GCLK_TC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Prescaler: GCLK_TC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Prescaler: GCLK_TC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Prescaler: GCLK_TC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Prescaler: GCLK_TC/64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Prescaler: GCLK_TC/256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Prescaler: GCLK_TC/1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset the counter on next generic clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset the counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset the counter on next generic clock. Reset the prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <resetValue>0x02</resetValue>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Invert Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Invert Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or retrigger TC on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start TC on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period captured in CC0, pulse width in CC1</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period captured in CC1, pulse width in CC0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TCINV</name>
+              <description>TC Inverted Event Input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI</name>
+              <description>TC Event Input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x08</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>COUNT16 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Count Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x2</dimIncrement>
+          <name>CC%s</name>
+          <description>COUNT16 Compare/Capture</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- TcCount16 -->
+       <cluster>
+        <name>COUNT32</name>
+        <description>32-bit Counter Mode</description>
+        <alternateCluster>COUNT8</alternateCluster>
+        <headerStructName>TcCount32</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>TC Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Counter in 16-bit mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT8</name>
+                  <description>Counter in 8-bit mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Counter in 32-bit mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation Operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MPWM</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Prescaler: GCLK_TC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Prescaler: GCLK_TC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Prescaler: GCLK_TC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Prescaler: GCLK_TC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Prescaler: GCLK_TC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Prescaler: GCLK_TC/64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Prescaler: GCLK_TC/256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Prescaler: GCLK_TC/1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset the counter on next generic clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset the counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset the counter on next generic clock. Reset the prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <resetValue>0x02</resetValue>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Invert Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Invert Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or retrigger TC on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start TC on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period captured in CC0, pulse width in CC1</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period captured in CC1, pulse width in CC0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TCINV</name>
+              <description>TC Inverted Event Input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI</name>
+              <description>TC Event Input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x08</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>COUNT32 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Count Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s</name>
+          <description>COUNT32 Compare/Capture</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- TcCount32 -->
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="TC1">
+      <name>TC2</name>
+      <description>Basic Timer Counter 2</description>
+      <baseAddress>0x42001C00</baseAddress>
+      <interrupt>
+        <name>TC2</name>
+        <value>14</value>
+      </interrupt>
+    </peripheral>
+    <peripheral>
+      <name>TCC0</name>
+      <version>1.1.1</version>
+      <description>Timer Counter Control</description>
+      <groupName>TCC</groupName>
+      <prependToName>TCC_</prependToName>
+      <baseAddress>0x42001400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x090</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TCC0</name>
+        <value>12</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESOLUTION</name>
+              <description>Enhanced Resolution</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RESOLUTIONSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>Dithering is disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DITH4</name>
+                  <description>Dithering is done every 16 PWM frames</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DITH5</name>
+                  <description>Dithering is done every 32 PWM frames</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DITH6</name>
+                  <description>Dithering is done every 64 PWM frames</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>No division</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Divide by 256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Divide by 1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization Selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset counter on next GCLK</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset counter on next GCLK and reset prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ALOCK</name>
+              <description>Auto Lock</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN2</name>
+              <description>Capture Channel 2 Enable</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN3</name>
+              <description>Capture Channel 3 Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LUPD</name>
+              <description>Lock Update</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDXCMD</name>
+              <description>Ramp Index Command</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>IDXCMDSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Command disabled: Index toggles between cycles A and B</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Set index: cycle B will be forced in the next cycle</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLEAR</name>
+                  <description>Clear index: cycle A will be forced in the next cycle</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HOLD</name>
+                  <description>Hold index: the next cycle will be the same as the current cycle</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>TCC Command</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Clear start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPDATE</name>
+                  <description>Force update or double buffered registers</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>READSYNC</name>
+                  <description>Force COUNT read synchronization</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LUPD</name>
+              <description>Lock Update</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDXCMD</name>
+              <description>Ramp Index Command</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>IDXCMDSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Command disabled: Index toggles between cycles A and B</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Set index: cycle B will be forced in the next cycle</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLEAR</name>
+                  <description>Clear index: cycle A will be forced in the next cycle</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HOLD</name>
+                  <description>Hold index: the next cycle will be the same as the current cycle</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>TCC Command</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Clear start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPDATE</name>
+                  <description>Force update or double buffered registers</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>READSYNC</name>
+                  <description>Force COUNT read synchronization</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>Synchronization Busy</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Swrst Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTRLB</name>
+              <description>Ctrlb Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STATUS</name>
+              <description>Status Busy</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COUNT</name>
+              <description>Count Busy</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PATT</name>
+              <description>Pattern Busy</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAVE</name>
+              <description>Wave Busy</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC0</name>
+              <description>Compare Channel 0 Busy</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC1</name>
+              <description>Compare Channel 1 Busy</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC2</name>
+              <description>Compare Channel 2 Busy</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC3</name>
+              <description>Compare Channel 3 Busy</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PATTB</name>
+              <description>Pattern Buffer Busy</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAVEB</name>
+              <description>Wave Buffer Busy</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Busy</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB0</name>
+              <description>Compare Channel Buffer 0 Busy</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB1</name>
+              <description>Compare Channel Buffer 1 Busy</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB2</name>
+              <description>Compare Channel Buffer 2 Busy</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB3</name>
+              <description>Compare Channel Buffer 3 Busy</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FCTRLA</name>
+          <description>Recoverable Fault A Configuration</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SRC</name>
+              <description>Fault A Source</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SRCSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Fault input disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>MCEx (x=0,1) event input</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INVERT</name>
+                  <description>Inverted MCEx (x=0,1) event input</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ALTFAULT</name>
+                  <description>Alternate fault (A or B) state at the end of the previous period</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>KEEP</name>
+              <description>Fault A Keeper</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QUAL</name>
+              <description>Fault A Qualification</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANK</name>
+              <description>Fault A Blanking Mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>BLANKSelect</name>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Blanking applied from start of ramp</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Blanking applied from rising edge of the output waveform</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Blanking applied from falling edge of the output waveform</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Blanking applied from each toggle of the output waveform</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RESTART</name>
+              <description>Fault A Restart</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HALT</name>
+              <description>Fault A Halt Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>HALTSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Halt action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HW</name>
+                  <description>Hardware halt action</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SW</name>
+                  <description>Software halt action</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NR</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CHSEL</name>
+              <description>Fault A Capture Channel</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CHSELSelect</name>
+                <enumeratedValue>
+                  <name>CC0</name>
+                  <description>Capture value stored in channel 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC1</name>
+                  <description>Capture value stored in channel 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC2</name>
+                  <description>Capture value stored in channel 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC3</name>
+                  <description>Capture value stored in channel 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CAPTURE</name>
+              <description>Fault A Capture Action</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CAPTURESelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>No capture</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPT</name>
+                  <description>Capture on fault</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMIN</name>
+                  <description>Minimum capture</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMAX</name>
+                  <description>Maximum capture</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMIN</name>
+                  <description>Minimum local detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMAX</name>
+                  <description>Maximum local detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DERIV0</name>
+                  <description>Minimum and maximum local detection</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMARK</name>
+                  <description>Capture with ramp index as MSB value</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>BLANKPRESC</name>
+              <description>Fault A Blanking Prescaler</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANKVAL</name>
+              <description>Fault A Blanking Time</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL</name>
+              <description>Fault A Filter Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FCTRLB</name>
+          <description>Recoverable Fault B Configuration</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SRC</name>
+              <description>Fault B Source</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SRCSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Fault input disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>MCEx (x=0,1) event input</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INVERT</name>
+                  <description>Inverted MCEx (x=0,1) event input</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ALTFAULT</name>
+                  <description>Alternate fault (A or B) state at the end of the previous period</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>KEEP</name>
+              <description>Fault B Keeper</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QUAL</name>
+              <description>Fault B Qualification</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANK</name>
+              <description>Fault B Blanking Mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>BLANKSelect</name>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Blanking applied from start of ramp</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Blanking applied from rising edge of the output waveform</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Blanking applied from falling edge of the output waveform</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Blanking applied from each toggle of the output waveform</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RESTART</name>
+              <description>Fault B Restart</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HALT</name>
+              <description>Fault B Halt Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>HALTSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Halt action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HW</name>
+                  <description>Hardware halt action</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SW</name>
+                  <description>Software halt action</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NR</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CHSEL</name>
+              <description>Fault B Capture Channel</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CHSELSelect</name>
+                <enumeratedValue>
+                  <name>CC0</name>
+                  <description>Capture value stored in channel 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC1</name>
+                  <description>Capture value stored in channel 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC2</name>
+                  <description>Capture value stored in channel 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC3</name>
+                  <description>Capture value stored in channel 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CAPTURE</name>
+              <description>Fault B Capture Action</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CAPTURESelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>No capture</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPT</name>
+                  <description>Capture on fault</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMIN</name>
+                  <description>Minimum capture</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMAX</name>
+                  <description>Maximum capture</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMIN</name>
+                  <description>Minimum local detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMAX</name>
+                  <description>Maximum local detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DERIV0</name>
+                  <description>Minimum and maximum local detection</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMARK</name>
+                  <description>Capture with ramp index as MSB value</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>BLANKPRESC</name>
+              <description>Fault B Blanking Prescaler</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANKVAL</name>
+              <description>Fault B Blanking Time</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL</name>
+              <description>Fault B Filter Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WEXCTRL</name>
+          <description>Waveform Extension Configuration</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OTMX</name>
+              <description>Output Matrix</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN0</name>
+              <description>Dead-time Insertion Generator 0 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN1</name>
+              <description>Dead-time Insertion Generator 1 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN2</name>
+              <description>Dead-time Insertion Generator 2 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN3</name>
+              <description>Dead-time Insertion Generator 3 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTLS</name>
+              <description>Dead-time Low Side Outputs Value</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>DTHS</name>
+              <description>Dead-time High Side Outputs Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DRVCTRL</name>
+          <description>Driver Control</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>NRE0</name>
+              <description>Non-Recoverable State 0 Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE1</name>
+              <description>Non-Recoverable State 1 Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE2</name>
+              <description>Non-Recoverable State 2 Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE3</name>
+              <description>Non-Recoverable State 3 Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE4</name>
+              <description>Non-Recoverable State 4 Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE5</name>
+              <description>Non-Recoverable State 5 Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE6</name>
+              <description>Non-Recoverable State 6 Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE7</name>
+              <description>Non-Recoverable State 7 Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV0</name>
+              <description>Non-Recoverable State 0 Output Value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV1</name>
+              <description>Non-Recoverable State 1 Output Value</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV2</name>
+              <description>Non-Recoverable State 2 Output Value</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV3</name>
+              <description>Non-Recoverable State 3 Output Value</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV4</name>
+              <description>Non-Recoverable State 4 Output Value</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV5</name>
+              <description>Non-Recoverable State 5 Output Value</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV6</name>
+              <description>Non-Recoverable State 6 Output Value</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV7</name>
+              <description>Non-Recoverable State 7 Output Value</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Inversion</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Inversion</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN2</name>
+              <description>Output Waveform 2 Inversion</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN3</name>
+              <description>Output Waveform 3 Inversion</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN4</name>
+              <description>Output Waveform 4 Inversion</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN5</name>
+              <description>Output Waveform 5 Inversion</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN6</name>
+              <description>Output Waveform 6 Inversion</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN7</name>
+              <description>Output Waveform 7 Inversion</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL0</name>
+              <description>Non-Recoverable Fault Input 0 Filter Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL1</name>
+              <description>Non-Recoverable Fault Input 1 Filter Value</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x1E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Running Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FDDBD</name>
+              <description>Fault Detection on Debug Break Detection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EVACT0</name>
+              <description>Timer/counter Input Event0 Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACT0Select</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or re-trigger counter on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNTEV</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start counter on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INC</name>
+                  <description>Increment counter on event</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on active state of asynchronous event</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FAULT</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EVACT1</name>
+              <description>Timer/counter Input Event1 Action</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACT1Select</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Re-trigger counter on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIR</name>
+                  <description>Direction control</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Stop counter on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DEC</name>
+                  <description>Decrement counter on event</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period capture value in CC0 register, pulse width capture value in CC1 register</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period capture value in CC1 register, pulse width capture value in CC0 register</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FAULT</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CNTSEL</name>
+              <description>Timer/counter Output Event Mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CNTSELSelect</name>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>An interrupt/event is generated when a new counter cycle starts</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>END</name>
+                  <description>An interrupt/event is generated when a counter cycle ends</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BETWEEN</name>
+                  <description>An interrupt/event is generated when a counter cycle ends, except for the first and last cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOUNDARY</name>
+                  <description>An interrupt/event is generated when a new counter cycle starts or a counter cycle ends</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Output Event Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRGEO</name>
+              <description>Retrigger Output Event Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNTEO</name>
+              <description>Timer/counter Output Event Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCINV0</name>
+              <description>Inverted Event 0 Input Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCINV1</name>
+              <description>Inverted Event 1 Input Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI0</name>
+              <description>Timer/counter Event 0 Input Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI1</name>
+              <description>Timer/counter Event 1 Input Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI0</name>
+              <description>Match or Capture Channel 0 Event Input Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI1</name>
+              <description>Match or Capture Channel 1 Event Input Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI2</name>
+              <description>Match or Capture Channel 2 Event Input Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI3</name>
+              <description>Match or Capture Channel 3 Event Input Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO2</name>
+              <description>Match or Capture Channel 2 Event Output Enable</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO3</name>
+              <description>Match or Capture Channel 3 Event Output Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRG</name>
+              <description>Retrigger Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNT</name>
+              <description>Counter Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0 Interrupt Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1 Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC2</name>
+              <description>Match or Capture Channel 2 Interrupt Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC3</name>
+              <description>Match or Capture Channel 3 Interrupt Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRG</name>
+              <description>Retrigger Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNT</name>
+              <description>Counter Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0 Interrupt Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1 Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC2</name>
+              <description>Match or Capture Channel 2 Interrupt Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC3</name>
+              <description>Match or Capture Channel 3 Interrupt Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRG</name>
+              <description>Retrigger</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNT</name>
+              <description>Counter</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture 0</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture 1</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC2</name>
+              <description>Match or Capture 2</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC3</name>
+              <description>Match or Capture 3</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <resetValue>0x00000001</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>IDX</name>
+              <description>Ramp</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault State</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PATTBV</name>
+              <description>Pattern Buffer Valid</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAVEBV</name>
+              <description>Wave Buffer Valid</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERBV</name>
+              <description>Period Buffer Valid</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTAIN</name>
+              <description>Recoverable Fault A Input</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULTBIN</name>
+              <description>Recoverable Fault B Input</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULT0IN</name>
+              <description>Non-Recoverable Fault0 Input</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULT1IN</name>
+              <description>Non-Recoverable Fault1 Input</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A State</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B State</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0 State</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1 State</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV0</name>
+              <description>Compare Channel 0 Buffer Valid</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV1</name>
+              <description>Compare Channel 1 Buffer Valid</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV2</name>
+              <description>Compare Channel 2 Buffer Valid</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV3</name>
+              <description>Compare Channel 3 Buffer Valid</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP0</name>
+              <description>Compare Channel 0 Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare Channel 1 Value</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CMP2</name>
+              <description>Compare Channel 2 Value</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CMP3</name>
+              <description>Compare Channel 3 Value</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>Count</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT_DITH4</name>
+          <description>Count</description>
+          <alternateRegister>COUNT</alternateRegister>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT_DITH5</name>
+          <description>Count</description>
+          <alternateRegister>COUNT</alternateRegister>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT_DITH6</name>
+          <description>Count</description>
+          <alternateRegister>COUNT</alternateRegister>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PATT</name>
+          <description>Pattern</description>
+          <addressOffset>0x38</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PGE0</name>
+              <description>Pattern Generator 0 Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE1</name>
+              <description>Pattern Generator 1 Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE2</name>
+              <description>Pattern Generator 2 Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE3</name>
+              <description>Pattern Generator 3 Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE4</name>
+              <description>Pattern Generator 4 Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE5</name>
+              <description>Pattern Generator 5 Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE6</name>
+              <description>Pattern Generator 6 Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE7</name>
+              <description>Pattern Generator 7 Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV0</name>
+              <description>Pattern Generator 0 Output Value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV1</name>
+              <description>Pattern Generator 1 Output Value</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV2</name>
+              <description>Pattern Generator 2 Output Value</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV3</name>
+              <description>Pattern Generator 3 Output Value</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV4</name>
+              <description>Pattern Generator 4 Output Value</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV5</name>
+              <description>Pattern Generator 5 Output Value</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV6</name>
+              <description>Pattern Generator 6 Output Value</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV7</name>
+              <description>Pattern Generator 7 Output Value</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAVE</name>
+          <description>Waveform Control</description>
+          <addressOffset>0x3C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <description>Normal frequency</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <description>Match frequency</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <description>Normal PWM</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSCRITICAL</name>
+                  <description>Dual-slope critical</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTTOM</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTH</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSTOP</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches TOP</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RAMP</name>
+              <description>Ramp Mode</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RAMPSelect</name>
+                <enumeratedValue>
+                  <name>RAMP1</name>
+                  <description>RAMP1 operation</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2A</name>
+                  <description>Alternative RAMP2 operation</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2</name>
+                  <description>RAMP2 operation</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2C</name>
+                  <description>Critical RAMP2 operation</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CIPEREN</name>
+              <description>Circular period Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN0</name>
+              <description>Circular Channel 0 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN1</name>
+              <description>Circular Channel 1 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN2</name>
+              <description>Circular Channel 2 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN3</name>
+              <description>Circular Channel 3 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL0</name>
+              <description>Channel 0 Polarity</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL1</name>
+              <description>Channel 1 Polarity</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL2</name>
+              <description>Channel 2 Polarity</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL3</name>
+              <description>Channel 3 Polarity</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP0</name>
+              <description>Swap DTI Output Pair 0</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP1</name>
+              <description>Swap DTI Output Pair 1</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP2</name>
+              <description>Swap DTI Output Pair 2</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP3</name>
+              <description>Swap DTI Output Pair 3</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER</name>
+          <description>Period</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER_DITH4</name>
+          <description>Period</description>
+          <alternateRegister>PER</alternateRegister>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER_DITH5</name>
+          <description>Period</description>
+          <alternateRegister>PER</alternateRegister>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER_DITH6</name>
+          <description>Period</description>
+          <alternateRegister>PER</alternateRegister>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s</name>
+          <description>Compare and Capture</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s_DITH4</name>
+          <description>Compare and Capture</description>
+          <alternateRegister>CC%s</alternateRegister>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s_DITH5</name>
+          <description>Compare and Capture</description>
+          <alternateRegister>CC%s</alternateRegister>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s_DITH6</name>
+          <description>Compare and Capture</description>
+          <alternateRegister>CC%s</alternateRegister>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PATTB</name>
+          <description>Pattern Buffer</description>
+          <addressOffset>0x64</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PGEB0</name>
+              <description>Pattern Generator 0 Output Enable Buffer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB1</name>
+              <description>Pattern Generator 1 Output Enable Buffer</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB2</name>
+              <description>Pattern Generator 2 Output Enable Buffer</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB3</name>
+              <description>Pattern Generator 3 Output Enable Buffer</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB4</name>
+              <description>Pattern Generator 4 Output Enable Buffer</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB5</name>
+              <description>Pattern Generator 5 Output Enable Buffer</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB6</name>
+              <description>Pattern Generator 6 Output Enable Buffer</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB7</name>
+              <description>Pattern Generator 7 Output Enable Buffer</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB0</name>
+              <description>Pattern Generator 0 Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB1</name>
+              <description>Pattern Generator 1 Output Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB2</name>
+              <description>Pattern Generator 2 Output Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB3</name>
+              <description>Pattern Generator 3 Output Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB4</name>
+              <description>Pattern Generator 4 Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB5</name>
+              <description>Pattern Generator 5 Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB6</name>
+              <description>Pattern Generator 6 Output Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB7</name>
+              <description>Pattern Generator 7 Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAVEB</name>
+          <description>Waveform Control Buffer</description>
+          <addressOffset>0x68</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WAVEGENB</name>
+              <description>Waveform Generation Buffer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENBSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <description>Normal frequency</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <description>Match frequency</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <description>Normal PWM</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSCRITICAL</name>
+                  <description>Dual-slope critical</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTTOM</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTH</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSTOP</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches TOP</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RAMPB</name>
+              <description>Ramp Mode Buffer</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RAMPBSelect</name>
+                <enumeratedValue>
+                  <name>RAMP1</name>
+                  <description>RAMP1 operation</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2A</name>
+                  <description>Alternative RAMP2 operation</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2</name>
+                  <description>RAMP2 operation</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CIPERENB</name>
+              <description>Circular Period Enable Buffer</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB0</name>
+              <description>Circular Channel 0 Enable Buffer</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB1</name>
+              <description>Circular Channel 1 Enable Buffer</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB2</name>
+              <description>Circular Channel 2 Enable Buffer</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB3</name>
+              <description>Circular Channel 3 Enable Buffer</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB0</name>
+              <description>Channel 0 Polarity Buffer</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB1</name>
+              <description>Channel 1 Polarity Buffer</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB2</name>
+              <description>Channel 2 Polarity Buffer</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB3</name>
+              <description>Channel 3 Polarity Buffer</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB0</name>
+              <description>Swap DTI Output Pair 0 Buffer</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB1</name>
+              <description>Swap DTI Output Pair 1 Buffer</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB2</name>
+              <description>Swap DTI Output Pair 2 Buffer</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB3</name>
+              <description>Swap DTI Output Pair 3 Buffer</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB</name>
+          <description>Period Buffer</description>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB_DITH4</name>
+          <description>Period Buffer</description>
+          <alternateRegister>PERB</alternateRegister>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB_DITH5</name>
+          <description>Period Buffer</description>
+          <alternateRegister>PERB</alternateRegister>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB_DITH6</name>
+          <description>Period Buffer</description>
+          <alternateRegister>PERB</alternateRegister>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s</name>
+          <description>Compare and Capture Buffer</description>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s_DITH4</name>
+          <description>Compare and Capture Buffer</description>
+          <alternateRegister>CCB%s</alternateRegister>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s_DITH5</name>
+          <description>Compare and Capture Buffer</description>
+          <alternateRegister>CCB%s</alternateRegister>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s_DITH6</name>
+          <description>Compare and Capture Buffer</description>
+          <alternateRegister>CCB%s</alternateRegister>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>USB</name>
+      <version>1.0.2</version>
+      <description>Universal Serial Bus</description>
+      <groupName>USB</groupName>
+      <prependToName>USB_</prependToName>
+      <baseAddress>0x41005000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>USB</name>
+        <value>7</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>DEVICE</name>
+        <description>USB is Device</description>
+        <headerStructName>UsbDevice</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x000</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>DEVICE</name>
+                  <description>Device Mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>Synchronization Busy</description>
+          <addressOffset>0x002</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>QOSCTRL</name>
+          <description>USB Quality Of Service</description>
+          <addressOffset>0x003</addressOffset>
+          <size>8</size>
+          <resetValue>0x05</resetValue>
+          <fields>
+            <field>
+              <name>CQOS</name>
+              <description>Configuration Quality of Service</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>DQOS</name>
+              <description>Data Quality of Service</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>DEVICE Control B</description>
+          <addressOffset>0x008</addressOffset>
+          <size>16</size>
+          <resetValue>0x0001</resetValue>
+          <fields>
+            <field>
+              <name>DETACH</name>
+              <description>Detach</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPDCONF</name>
+              <description>Speed Configuration</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SPDCONFSelect</name>
+                <enumeratedValue>
+                  <name>FS</name>
+                  <description>FS : Full Speed</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LS</name>
+                  <description>LS : Low Speed</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HS</name>
+                  <description>HS : High Speed capable</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HSTM</name>
+                  <description>HSTM: High Speed Test Mode (force high-speed mode for test mode)</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>NREPLY</name>
+              <description>No Reply</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTJ</name>
+              <description>Test mode J</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTK</name>
+              <description>Test mode K</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTPCKT</name>
+              <description>Test packet mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OPMODE2</name>
+              <description>Specific Operational Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GNAK</name>
+              <description>Global NAK</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMHDSK</name>
+              <description>Link Power Management Handshake</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>LPMHDSKSelect</name>
+                <enumeratedValue>
+                  <name>NO</name>
+                  <description>No handshake. LPM is not supported</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ACK</name>
+                  <description>ACK</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NYET</name>
+                  <description>NYET</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STALL</name>
+                  <description>STALL</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DADD</name>
+          <description>DEVICE Device Address</description>
+          <addressOffset>0x00A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DADD</name>
+              <description>Device Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>ADDEN</name>
+              <description>Device Address Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>DEVICE Status</description>
+          <addressOffset>0x00C</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x40</resetValue>
+          <fields>
+            <field>
+              <name>SPEED</name>
+              <description>Speed Status</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>SPEEDSelect</name>
+                <enumeratedValue>
+                  <name>FS</name>
+                  <description>Full-speed mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HS</name>
+                  <description>High-speed mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LS</name>
+                  <description>Low-speed mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LINESTATE</name>
+              <description>USB Line State Status</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>LINESTATESelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>SE0/RESET</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>FS-J or LS-K State</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>FS-K or LS-J State</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FSMSTATUS</name>
+          <description>Finite State Machine Status</description>
+          <addressOffset>0x00D</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x01</resetValue>
+          <fields>
+            <field>
+              <name>FSMSTATE</name>
+              <description>Fine State Machine Status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>FSMSTATESelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>OFF (L3). It corresponds to the powered-off, disconnected, and disabled state</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ON</name>
+                  <description>ON (L0). It corresponds to the Idle and Active states</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>SUSPEND (L2)</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SLEEP</name>
+                  <description>SLEEP (L1)</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DNRESUME</name>
+                  <description>DNRESUME. Down Stream Resume.</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPRESUME</name>
+                  <description>UPRESUME. Up Stream Resume.</description>
+                  <value>0x20</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESET</name>
+                  <description>RESET. USB lines Reset.</description>
+                  <value>0x40</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FNUM</name>
+          <description>DEVICE Device Frame Number</description>
+          <addressOffset>0x010</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>MFNUM</name>
+              <description>Micro Frame Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FNUM</name>
+              <description>Frame Number</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>11</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FNCERR</name>
+              <description>Frame Number CRC Error</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>DEVICE Device Interrupt Enable Clear</description>
+          <addressOffset>0x014</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SUSPEND</name>
+              <description>Suspend Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSOF</name>
+              <description>Micro Start of Frame Interrupt Enable in High Speed Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOF</name>
+              <description>Start Of Frame Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORST</name>
+              <description>End of Reset Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORSM</name>
+              <description>End Of Resume Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMNYET</name>
+              <description>Link Power Management Not Yet Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMSUSP</name>
+              <description>Link Power Management Suspend Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>DEVICE Device Interrupt Enable Set</description>
+          <addressOffset>0x018</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SUSPEND</name>
+              <description>Suspend Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSOF</name>
+              <description>Micro Start of Frame Interrupt Enable in High Speed Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOF</name>
+              <description>Start Of Frame Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORST</name>
+              <description>End of Reset Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORSM</name>
+              <description>End Of Resume Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMNYET</name>
+              <description>Link Power Management Not Yet Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMSUSP</name>
+              <description>Link Power Management Suspend Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>DEVICE Device Interrupt Flag</description>
+          <addressOffset>0x01C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SUSPEND</name>
+              <description>Suspend</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSOF</name>
+              <description>Micro Start of Frame in High Speed Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOF</name>
+              <description>Start Of Frame</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORST</name>
+              <description>End of Reset</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORSM</name>
+              <description>End Of Resume</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMNYET</name>
+              <description>Link Power Management Not Yet</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMSUSP</name>
+              <description>Link Power Management Suspend</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EPINTSMRY</name>
+          <description>DEVICE End Point Interrupt Summary</description>
+          <addressOffset>0x020</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>EPINT0</name>
+              <description>End Point 0 Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT1</name>
+              <description>End Point 1 Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT2</name>
+              <description>End Point 2 Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT3</name>
+              <description>End Point 3 Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT4</name>
+              <description>End Point 4 Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT5</name>
+              <description>End Point 5 Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT6</name>
+              <description>End Point 6 Interrupt</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT7</name>
+              <description>End Point 7 Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DESCADD</name>
+          <description>Descriptor Address</description>
+          <addressOffset>0x024</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DESCADD</name>
+              <description>Descriptor Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PADCAL</name>
+          <description>USB PAD Calibration</description>
+          <addressOffset>0x028</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>TRANSP</name>
+              <description>USB Pad Transp calibration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TRANSN</name>
+              <description>USB Pad Transn calibration</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TRIM</name>
+              <description>USB Pad Trim calibration</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPCFG%s</name>
+          <description>DEVICE End Point Configuration</description>
+          <addressOffset>0x100</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EPTYPE0</name>
+              <description>End Point Type0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>EPTYPE1</name>
+              <description>End Point Type1</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>NYETDIS</name>
+              <description>NYET Token Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPSTATUSCLR%s</name>
+          <description>DEVICE End Point Pipe Status Clear</description>
+          <addressOffset>0x104</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>DTGLOUT</name>
+              <description>Data Toggle OUT Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>DTGLIN</name>
+              <description>Data Toggle IN Clear</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank Clear</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ0</name>
+              <description>Stall 0 Request Clear</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ1</name>
+              <description>Stall 1 Request Clear</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 Ready Clear</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 Ready Clear</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPSTATUSSET%s</name>
+          <description>DEVICE End Point Pipe Status Set</description>
+          <addressOffset>0x105</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>DTGLOUT</name>
+              <description>Data Toggle OUT Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>DTGLIN</name>
+              <description>Data Toggle IN Set</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank Set</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ0</name>
+              <description>Stall 0 Request Set</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ1</name>
+              <description>Stall 1 Request Set</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 Ready Set</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 Ready Set</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPSTATUS%s</name>
+          <description>DEVICE End Point Pipe Status</description>
+          <addressOffset>0x106</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>DTGLOUT</name>
+              <description>Data Toggle Out</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DTGLIN</name>
+              <description>Data Toggle In</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>STALLRQ0</name>
+              <description>Stall 0 Request</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>STALLRQ1</name>
+              <description>Stall 1 Request</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 ready</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPINTFLAG%s</name>
+          <description>DEVICE End Point Interrupt Flag</description>
+          <addressOffset>0x107</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL0</name>
+              <description>Error Flow 0</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL1</name>
+              <description>Error Flow 1</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXSTP</name>
+              <description>Received Setup</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL0</name>
+              <description>Stall 0 In/out</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL1</name>
+              <description>Stall 1 In/out</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPINTENCLR%s</name>
+          <description>DEVICE End Point Interrupt Clear Flag</description>
+          <addressOffset>0x108</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0 Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1 Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL0</name>
+              <description>Error Flow 0 Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL1</name>
+              <description>Error Flow 1 Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXSTP</name>
+              <description>Received Setup Interrupt Disable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL0</name>
+              <description>Stall 0 In/Out Interrupt Disable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL1</name>
+              <description>Stall 1 In/Out Interrupt Disable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPINTENSET%s</name>
+          <description>DEVICE End Point Interrupt Set Flag</description>
+          <addressOffset>0x109</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL0</name>
+              <description>Error Flow 0 Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL1</name>
+              <description>Error Flow 1 Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXSTP</name>
+              <description>Received Setup Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL0</name>
+              <description>Stall 0 In/out Interrupt enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL1</name>
+              <description>Stall 1 In/out Interrupt enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- UsbDevice -->
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>WDT</name>
+      <version>2.0.0</version>
+      <description>Watchdog Timer</description>
+      <groupName>WDT</groupName>
+      <prependToName>WDT_</prependToName>
+      <baseAddress>0x40001000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>WDT</name>
+        <value>2</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WEN</name>
+              <description>Watchdog Timer Window Mode Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ALWAYSON</name>
+              <description>Always-On</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CONFIG</name>
+          <description>Configuration</description>
+          <addressOffset>0x1</addressOffset>
+          <size>8</size>
+          <resetValue>0xBB</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Time-Out Period</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PERSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 clock cycles</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 clock cycles</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 clock cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 clock cycles</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 clock cycles</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 clock cycles</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 clock cycles</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1K</name>
+                  <description>1024 clock cycles</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2K</name>
+                  <description>2048 clock cycles</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4K</name>
+                  <description>4096 clock cycles</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8K</name>
+                  <description>8192 clock cycles</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16K</name>
+                  <description>16384 clock cycles</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WINDOW</name>
+              <description>Window Mode Time-Out Period</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>WINDOWSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 clock cycles</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 clock cycles</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 clock cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 clock cycles</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 clock cycles</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 clock cycles</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 clock cycles</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1K</name>
+                  <description>1024 clock cycles</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2K</name>
+                  <description>2048 clock cycles</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4K</name>
+                  <description>4096 clock cycles</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8K</name>
+                  <description>8192 clock cycles</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16K</name>
+                  <description>16384 clock cycles</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EWCTRL</name>
+          <description>Early Warning Interrupt Control</description>
+          <addressOffset>0x2</addressOffset>
+          <size>8</size>
+          <resetValue>0x0B</resetValue>
+          <fields>
+            <field>
+              <name>EWOFFSET</name>
+              <description>Early Warning Interrupt Time Offset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>EWOFFSETSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 clock cycles</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 clock cycles</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 clock cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 clock cycles</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 clock cycles</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 clock cycles</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 clock cycles</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1K</name>
+                  <description>1024 clock cycles</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2K</name>
+                  <description>2048 clock cycles</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4K</name>
+                  <description>4096 clock cycles</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8K</name>
+                  <description>8192 clock cycles</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16K</name>
+                  <description>16384 clock cycles</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x4</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EW</name>
+              <description>Early Warning Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x5</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EW</name>
+              <description>Early Warning Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x6</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EW</name>
+              <description>Early Warning</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x7</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CLEAR</name>
+          <description>Clear</description>
+          <addressOffset>0x8</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>CLEAR</name>
+              <description>Watchdog Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>write-only</access>
+              <enumeratedValues>
+                <name>CLEARSelect</name>
+                <enumeratedValue>
+                  <name>KEY</name>
+                  <description>Clear Key</description>
+                  <value>0xa5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+  </peripherals>
+</device>

--- a/svd/ATSAMD11D14AU.svd
+++ b/svd/ATSAMD11D14AU.svd
@@ -1,0 +1,17014 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device schemaVersion="1.2" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+  <vendor>Microchip Technology Inc.</vendor>
+  <vendorID>MICROCHIP</vendorID>
+  <name>ATSAMD11D14AU</name>
+  <series>SAMD11</series>
+  <version>B</version>
+  <description>Microchip ATSAMD11D14AU device: Cortex-M0+ Microcontroller with 16KB Flash, 4KB SRAM, WLCSP20_capless-pin package</description>
+  <licenseText>
+  Copyright (c) 2018 Microchip Technology Inc.\n
+\n
+  SPDX-License-Identifier: Apache-2.0\n
+\n
+  Licensed under the Apache License, Version 2.0 (the "License");\n
+  you may not use this file except in compliance with the License.\n
+  You may obtain a copy of the License at\n
+\n
+  http://www.apache.org/licenses/LICENSE-2.0\n
+\n
+  Unless required by applicable law or agreed to in writing, software\n
+  distributed under the License is distributed on an "AS IS" BASIS,\n
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n
+  See the License for the specific language governing permissions and\n
+  limitations under the License.
+  </licenseText>
+  <cpu>
+    <name>CM0+</name>
+    <revision>r0p1</revision>
+    <endian>little</endian>
+    <mpuPresent>false</mpuPresent>
+    <fpuPresent>false</fpuPresent>
+    <vtorPresent>true</vtorPresent>
+    <nvicPrioBits>2</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+    <deviceNumInterrupts>19</deviceNumInterrupts>
+  </cpu>
+  <headerSystemFilename>system_samd11</headerSystemFilename>
+  <addressUnitBits>8</addressUnitBits>
+  <width>32</width>
+  <size>32</size>
+  <access>read-write</access>
+  <resetValue>0x00000000</resetValue>
+  <resetMask>0xFFFFFFFF</resetMask>
+  <peripherals>
+    <peripheral>
+      <name>AC</name>
+      <version>1.1.1</version>
+      <description>Analog Comparators</description>
+      <groupName>AC</groupName>
+      <prependToName>AC_</prependToName>
+      <baseAddress>0x42002400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>AC</name>
+        <value>16</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMUX</name>
+              <description>Low-Power Mux</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>START0</name>
+              <description>Comparator 0 Start Comparison</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>START1</name>
+              <description>Comparator 1 Start Comparison</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COMPEO0</name>
+              <description>Comparator 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMPEO1</name>
+              <description>Comparator 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINEO0</name>
+              <description>Window 0 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMPEI0</name>
+              <description>Comparator 0 Event Input</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMPEI1</name>
+              <description>Comparator 1 Event Input</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COMP0</name>
+              <description>Comparator 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1</name>
+              <description>Comparator 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WIN0</name>
+              <description>Window 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COMP0</name>
+              <description>Comparator 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1</name>
+              <description>Comparator 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WIN0</name>
+              <description>Window 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COMP0</name>
+              <description>Comparator 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COMP1</name>
+              <description>Comparator 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WIN0</name>
+              <description>Window 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSA</name>
+          <description>Status A</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>STATE0</name>
+              <description>Comparator 0 Current State</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STATE1</name>
+              <description>Comparator 1 Current State</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WSTATE0</name>
+              <description>Window 0 Current State</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WSTATE0Select</name>
+                <enumeratedValue>
+                  <name>ABOVE</name>
+                  <description>Signal is above window</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INSIDE</name>
+                  <description>Signal is inside window</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BELOW</name>
+                  <description>Signal is below window</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSB</name>
+          <description>Status B</description>
+          <addressOffset>0x09</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>READY0</name>
+              <description>Comparator 0 Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>READY1</name>
+              <description>Comparator 1 Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSC</name>
+          <description>Status C</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>STATE0</name>
+              <description>Comparator 0 Current State</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STATE1</name>
+              <description>Comparator 1 Current State</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WSTATE0</name>
+              <description>Window 0 Current State</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WSTATE0Select</name>
+                <enumeratedValue>
+                  <name>ABOVE</name>
+                  <description>Signal is above window</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INSIDE</name>
+                  <description>Signal is inside window</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BELOW</name>
+                  <description>Signal is below window</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINCTRL</name>
+          <description>Window Control</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>WEN0</name>
+              <description>Window 0 Mode Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINTSEL0</name>
+              <description>Window 0 Interrupt Selection</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WINTSEL0Select</name>
+                <enumeratedValue>
+                  <name>ABOVE</name>
+                  <description>Interrupt on signal above window</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INSIDE</name>
+                  <description>Interrupt on signal inside window</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BELOW</name>
+                  <description>Interrupt on signal below window</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OUTSIDE</name>
+                  <description>Interrupt on signal outside window</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>COMPCTRL%s</name>
+          <description>Comparator Control n</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SINGLE</name>
+              <description>Single-Shot Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPEED</name>
+              <description>Speed Selection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SPEEDSelect</name>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low speed</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High speed</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>INTSEL</name>
+              <description>Interrupt Selection</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>INTSELSelect</name>
+                <enumeratedValue>
+                  <name>TOGGLE</name>
+                  <description>Interrupt on comparator output toggle</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISING</name>
+                  <description>Interrupt on comparator output rising</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALLING</name>
+                  <description>Interrupt on comparator output falling</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EOC</name>
+                  <description>Interrupt on end of comparison (single-shot mode only)</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MUXNEG</name>
+              <description>Negative Input Mux Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MUXNEGSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>I/O pin 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>I/O pin 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>I/O pin 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>I/O pin 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GND</name>
+                  <description>Ground</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>VSCALE</name>
+                  <description>VDD scaler</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BANDGAP</name>
+                  <description>Internal bandgap voltage</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DAC</name>
+                  <description>DAC output</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MUXPOS</name>
+              <description>Positive Input Mux Selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MUXPOSSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>I/O pin 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>I/O pin 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>I/O pin 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>I/O pin 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>SWAP</name>
+              <description>Swap Inputs and Invert</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OUT</name>
+              <description>Output</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>OUTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>The output of COMPn is not routed to the COMPn I/O port</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ASYNC</name>
+                  <description>The asynchronous output of COMPn is routed to the COMPn I/O port</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SYNC</name>
+                  <description>The synchronous output (including filtering) of COMPn is routed to the COMPn I/O port</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>HYST</name>
+              <description>Hysteresis Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FLEN</name>
+              <description>Filter Length</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>FLENSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>No filtering</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MAJ3</name>
+                  <description>3-bit majority function (2 of 3)</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MAJ5</name>
+                  <description>5-bit majority function (3 of 5)</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>SCALER%s</name>
+          <description>Scaler n</description>
+          <addressOffset>0x20</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Scaler Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>ADC</name>
+      <version>1.2.0</version>
+      <description>Analog Digital Converter</description>
+      <groupName>ADC</groupName>
+      <prependToName>ADC_</prependToName>
+      <baseAddress>0x42002000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>ADC</name>
+        <value>15</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>REFCTRL</name>
+          <description>Reference Control</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>REFSEL</name>
+              <description>Reference Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>REFSELSelect</name>
+                <enumeratedValue>
+                  <name>INT1V</name>
+                  <description>1.0V voltage reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INTVCC0</name>
+                  <description>1/1.48 VDDANA</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INTVCC1</name>
+                  <description>1/2 VDDANA (only for VDDANA &gt; 2.0V)</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AREFA</name>
+                  <description>External reference</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AREFB</name>
+                  <description>External reference</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>REFCOMP</name>
+              <description>Reference Buffer Offset Compensation Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AVGCTRL</name>
+          <description>Average Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SAMPLENUM</name>
+              <description>Number of Samples to be Collected</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>SAMPLENUMSelect</name>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>1 sample</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>2 samples</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4</name>
+                  <description>4 samples</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 samples</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 samples</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 samples</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 samples</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 samples</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 samples</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 samples</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1024</name>
+                  <description>1024 samples</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ADJRES</name>
+              <description>Adjusting Result / Division Coefficient</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SAMPCTRL</name>
+          <description>Sampling Time Control</description>
+          <addressOffset>0x03</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SAMPLEN</name>
+              <description>Sampling Time Length</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DIFFMODE</name>
+              <description>Differential Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LEFTADJ</name>
+              <description>Left-Adjusted Result</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FREERUN</name>
+              <description>Free Running Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CORREN</name>
+              <description>Digital Correction Logic Enabled</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESSEL</name>
+              <description>Conversion Result Resolution</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RESSELSelect</name>
+                <enumeratedValue>
+                  <name>12BIT</name>
+                  <description>12-bit result</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16BIT</name>
+                  <description>For averaging mode output</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>10BIT</name>
+                  <description>10-bit result</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8BIT</name>
+                  <description>8-bit result</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler Configuration</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Peripheral clock divided by 4</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Peripheral clock divided by 8</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Peripheral clock divided by 16</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Peripheral clock divided by 32</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Peripheral clock divided by 64</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Peripheral clock divided by 128</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Peripheral clock divided by 256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>Peripheral clock divided by 512</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINCTRL</name>
+          <description>Window Monitor Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>WINMODE</name>
+              <description>Window Monitor Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>WINMODESelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>No window mode (default)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE1</name>
+                  <description>Mode 1: RESULT &gt; WINLT</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE2</name>
+                  <description>Mode 2: RESULT &lt; WINUT</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE3</name>
+                  <description>Mode 3: WINLT &lt; RESULT &lt; WINUT</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MODE4</name>
+                  <description>Mode 4: !(WINLT &lt; RESULT &lt; WINUT)</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWTRIG</name>
+          <description>Software Trigger</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>FLUSH</name>
+              <description>ADC Conversion Flush</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>START</name>
+              <description>ADC Start Conversion</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INPUTCTRL</name>
+          <description>Input Control</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>MUXPOS</name>
+              <description>Positive Mux Input Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>MUXPOSSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>ADC AIN0 Pin</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>ADC AIN1 Pin</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>ADC AIN2 Pin</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>ADC AIN3 Pin</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN4</name>
+                  <description>ADC AIN4 Pin</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN5</name>
+                  <description>ADC AIN5 Pin</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN6</name>
+                  <description>ADC AIN6 Pin</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN7</name>
+                  <description>ADC AIN7 Pin</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN8</name>
+                  <description>ADC AIN8 Pin</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN9</name>
+                  <description>ADC AIN9 Pin</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN10</name>
+                  <description>ADC AIN10 Pin</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN11</name>
+                  <description>ADC AIN11 Pin</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN12</name>
+                  <description>ADC AIN12 Pin</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN13</name>
+                  <description>ADC AIN13 Pin</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN14</name>
+                  <description>ADC AIN14 Pin</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN15</name>
+                  <description>ADC AIN15 Pin</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN16</name>
+                  <description>ADC AIN16 Pin</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN17</name>
+                  <description>ADC AIN17 Pin</description>
+                  <value>0x11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN18</name>
+                  <description>ADC AIN18 Pin</description>
+                  <value>0x12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN19</name>
+                  <description>ADC AIN19 Pin</description>
+                  <value>0x13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TEMP</name>
+                  <description>Temperature Reference</description>
+                  <value>0x18</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BANDGAP</name>
+                  <description>Bandgap Voltage</description>
+                  <value>0x19</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SCALEDCOREVCC</name>
+                  <description>1/4  Scaled Core Supply</description>
+                  <value>0x1a</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SCALEDIOVCC</name>
+                  <description>1/4  Scaled I/O Supply</description>
+                  <value>0x1b</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DAC</name>
+                  <description>DAC Output</description>
+                  <value>0x1c</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MUXNEG</name>
+              <description>Negative Mux Input Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>MUXNEGSelect</name>
+                <enumeratedValue>
+                  <name>PIN0</name>
+                  <description>ADC AIN0 Pin</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN1</name>
+                  <description>ADC AIN1 Pin</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN2</name>
+                  <description>ADC AIN2 Pin</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN3</name>
+                  <description>ADC AIN3 Pin</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN4</name>
+                  <description>ADC AIN4 Pin</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN5</name>
+                  <description>ADC AIN5 Pin</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN6</name>
+                  <description>ADC AIN6 Pin</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PIN7</name>
+                  <description>ADC AIN7 Pin</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GND</name>
+                  <description>Internal Ground</description>
+                  <value>0x18</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>IOGND</name>
+                  <description>I/O Ground</description>
+                  <value>0x19</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>INPUTSCAN</name>
+              <description>Number of Input Channels Included in Scan</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>INPUTOFFSET</name>
+              <description>Positive Mux Setting Offset</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>GAIN</name>
+              <description>Gain Factor Selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>GAINSelect</name>
+                <enumeratedValue>
+                  <name>1X</name>
+                  <description>1x</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2X</name>
+                  <description>2x</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4X</name>
+                  <description>4x</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8X</name>
+                  <description>8x</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16X</name>
+                  <description>16x</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>1/2x</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>STARTEI</name>
+              <description>Start Conversion Event In</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCEI</name>
+              <description>Synchronization Event In</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESRDYEO</name>
+              <description>Result Ready Event Out</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMONEO</name>
+              <description>Window Monitor Event Out</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESRDY</name>
+              <description>Result Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVERRUN</name>
+              <description>Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMON</name>
+              <description>Window Monitor Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x17</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESRDY</name>
+              <description>Result Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVERRUN</name>
+              <description>Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMON</name>
+              <description>Window Monitor Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESRDY</name>
+              <description>Result Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVERRUN</name>
+              <description>Overrun</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WINMON</name>
+              <description>Window Monitor</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x19</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RESULT</name>
+          <description>Result</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>RESULT</name>
+              <description>Result Conversion Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINLT</name>
+          <description>Window Monitor Lower Threshold</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>WINLT</name>
+              <description>Window Lower Threshold</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WINUT</name>
+          <description>Window Monitor Upper Threshold</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>WINUT</name>
+              <description>Window Upper Threshold</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GAINCORR</name>
+          <description>Gain Correction</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>GAINCORR</name>
+              <description>Gain Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OFFSETCORR</name>
+          <description>Offset Correction</description>
+          <addressOffset>0x26</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>OFFSETCORR</name>
+              <description>Offset Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CALIB</name>
+          <description>Calibration</description>
+          <addressOffset>0x28</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>LINEARITY_CAL</name>
+              <description>Linearity Calibration Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>BIAS_CAL</name>
+              <description>Bias Calibration Value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x2A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DAC</name>
+      <version>1.1.0</version>
+      <description>Digital Analog Converter</description>
+      <groupName>DAC</groupName>
+      <prependToName>DAC_</prependToName>
+      <baseAddress>0x42002800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>DAC</name>
+        <value>17</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x1</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EOEN</name>
+              <description>External Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IOEN</name>
+              <description>Internal Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LEFTADJ</name>
+              <description>Left Adjusted Data</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>VPD</name>
+              <description>Voltage Pump Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BDWP</name>
+              <description>Bypass DATABUF Write Protection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>REFSEL</name>
+              <description>Reference Selection</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>REFSELSelect</name>
+                <enumeratedValue>
+                  <name>INT1V</name>
+                  <description>Internal 1.0V reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AVCC</name>
+                  <description>AVCC</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>VREFP</name>
+                  <description>External reference</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x2</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>STARTEI</name>
+              <description>Start Conversion Event Input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTYEO</name>
+              <description>Data Buffer Empty Event Output</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x4</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>UNDERRUN</name>
+              <description>Underrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTY</name>
+              <description>Data Buffer Empty Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x5</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>UNDERRUN</name>
+              <description>Underrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTY</name>
+              <description>Data Buffer Empty Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x6</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>UNDERRUN</name>
+              <description>Underrun</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EMPTY</name>
+              <description>Data Buffer Empty</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x7</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy Status</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>Data</description>
+          <addressOffset>0x8</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data value to be converted</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATABUF</name>
+          <description>Data Buffer</description>
+          <addressOffset>0xC</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DATABUF</name>
+              <description>Data Buffer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DMAC</name>
+      <version>1.0.0</version>
+      <description>Direct Memory Access Controller</description>
+      <groupName>DMAC</groupName>
+      <prependToName>DMAC_</prependToName>
+      <baseAddress>0x41004800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>DMAC</name>
+        <value>6</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAENABLE</name>
+              <description>DMA Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRCENABLE</name>
+              <description>CRC Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN0</name>
+              <description>Priority Level 0 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN1</name>
+              <description>Priority Level 1 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN2</name>
+              <description>Priority Level 2 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLEN3</name>
+              <description>Priority Level 3 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCCTRL</name>
+          <description>CRC Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>CRCBEATSIZE</name>
+              <description>CRC Beat Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CRCBEATSIZESelect</name>
+                <enumeratedValue>
+                  <name>BYTE</name>
+                  <description>8-bit bus transfer</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HWORD</name>
+                  <description>16-bit bus transfer</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WORD</name>
+                  <description>32-bit bus transfer</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CRCPOLY</name>
+              <description>CRC Polynomial Type</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CRCPOLYSelect</name>
+                <enumeratedValue>
+                  <name>CRC16</name>
+                  <description>CRC-16 (CRC-CCITT)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CRC32</name>
+                  <description>CRC32 (IEEE 802.3)</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CRCSRC</name>
+              <description>CRC Input Source</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>6</bitWidth>
+              <enumeratedValues>
+                <name>CRCSRCSelect</name>
+                <enumeratedValue>
+                  <name>NOACT</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>IO</name>
+                  <description>I/O interface</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCDATAIN</name>
+          <description>CRC Data Input</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CRCDATAIN</name>
+              <description>CRC Data Input</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCCHKSUM</name>
+          <description>CRC Checksum</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CRCCHKSUM</name>
+              <description>CRC Checksum</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CRCSTATUS</name>
+          <description>CRC Status</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CRCBUSY</name>
+              <description>CRC Module Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRCZERO</name>
+              <description>CRC Zero</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>QOSCTRL</name>
+          <description>QOS Control</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <resetValue>0x15</resetValue>
+          <fields>
+            <field>
+              <name>WRBQOS</name>
+              <description>Write-Back Quality of Service</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WRBQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FQOS</name>
+              <description>Fetch Quality of Service</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DQOS</name>
+              <description>Data Transfer Quality of Service</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>DQOSSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Background (no sensitive operation)</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Sensitive Bandwidth</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MEDIUM</name>
+                  <description>Sensitive Latency</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>Critical Latency</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SWTRIGCTRL</name>
+          <description>Software Trigger Control</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWTRIG0</name>
+              <description>Channel 0 Software Trigger</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG1</name>
+              <description>Channel 1 Software Trigger</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG2</name>
+              <description>Channel 2 Software Trigger</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG3</name>
+              <description>Channel 3 Software Trigger</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG4</name>
+              <description>Channel 4 Software Trigger</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWTRIG5</name>
+              <description>Channel 5 Software Trigger</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PRICTRL0</name>
+          <description>Priority Control 0</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>LVLPRI0</name>
+              <description>Level 0 Channel Priority Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN0</name>
+              <description>Level 0 Round-Robin Scheduling Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLPRI1</name>
+              <description>Level 1 Channel Priority Number</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN1</name>
+              <description>Level 1 Round-Robin Scheduling Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLPRI2</name>
+              <description>Level 2 Channel Priority Number</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN2</name>
+              <description>Level 2 Round-Robin Scheduling Enable</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVLPRI3</name>
+              <description>Level 3 Channel Priority Number</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>RRLVLEN3</name>
+              <description>Level 3 Round-Robin Scheduling Enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTPEND</name>
+          <description>Interrupt Pending</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Channel ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>TERR</name>
+              <description>Transfer Error</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Transfer Complete</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FERR</name>
+              <description>Fetch Error</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSY</name>
+              <description>Busy</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PEND</name>
+              <description>Pending</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTSTATUS</name>
+          <description>Interrupt Status</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>CHINT0</name>
+              <description>Channel 0 Pending Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT1</name>
+              <description>Channel 1 Pending Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT2</name>
+              <description>Channel 2 Pending Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT3</name>
+              <description>Channel 3 Pending Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT4</name>
+              <description>Channel 4 Pending Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHINT5</name>
+              <description>Channel 5 Pending Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BUSYCH</name>
+          <description>Busy Channels</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>BUSYCH0</name>
+              <description>Busy Channel 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH1</name>
+              <description>Busy Channel 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH2</name>
+              <description>Busy Channel 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH3</name>
+              <description>Busy Channel 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH4</name>
+              <description>Busy Channel 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSYCH5</name>
+              <description>Busy Channel 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PENDCH</name>
+          <description>Pending Channels</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PENDCH0</name>
+              <description>Pending Channel 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH1</name>
+              <description>Pending Channel 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH2</name>
+              <description>Pending Channel 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH3</name>
+              <description>Pending Channel 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH4</name>
+              <description>Pending Channel 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PENDCH5</name>
+              <description>Pending Channel 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ACTIVE</name>
+          <description>Active Channel and Levels</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>LVLEX0</name>
+              <description>Level 0 Channel Trigger Request Executing</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LVLEX1</name>
+              <description>Level 1 Channel Trigger Request Executing</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LVLEX2</name>
+              <description>Level 2 Channel Trigger Request Executing</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LVLEX3</name>
+              <description>Level 3 Channel Trigger Request Executing</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ID</name>
+              <description>Active Channel ID</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ABUSY</name>
+              <description>Active Channel Busy</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BTCNT</name>
+              <description>Active Channel Block Transfer Count</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BASEADDR</name>
+          <description>Descriptor Memory Section Base Address</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>BASEADDR</name>
+              <description>Descriptor Memory Base Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WRBADDR</name>
+          <description>Write-Back Memory Section Base Address</description>
+          <addressOffset>0x38</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WRBADDR</name>
+              <description>Write-Back Memory Base Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHID</name>
+          <description>Channel ID</description>
+          <addressOffset>0x3F</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Channel ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHCTRLA</name>
+          <description>Channel Control A</description>
+          <addressOffset>0x40</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Channel Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Channel Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHCTRLB</name>
+          <description>Channel Control B</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Input Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>NOACT</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TRIG</name>
+                  <description>Transfer and periodic transfer trigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CTRIG</name>
+                  <description>Conditional transfer trigger</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CBLOCK</name>
+                  <description>Conditional block transfer</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>Channel suspend operation</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESUME</name>
+                  <description>Channel resume operation</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSKIP</name>
+                  <description>Skip next block suspend action</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EVIE</name>
+              <description>Channel Event Input Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVOE</name>
+              <description>Channel Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LVL</name>
+              <description>Channel Arbitration Level</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>LVLSelect</name>
+                <enumeratedValue>
+                  <name>LVL0</name>
+                  <description>Channel Priority Level 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LVL1</name>
+                  <description>Channel Priority Level 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LVL2</name>
+                  <description>Channel Priority Level 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LVL3</name>
+                  <description>Channel Priority Level 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TRIGSRC</name>
+              <description>Trigger Source</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>TRIGSRCSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Only software/event triggers</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TRIGACT</name>
+              <description>Trigger Action</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>TRIGACTSelect</name>
+                <enumeratedValue>
+                  <name>BLOCK</name>
+                  <description>One trigger required for each block transfer</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BEAT</name>
+                  <description>One trigger required for each beat transfer</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TRANSACTION</name>
+                  <description>One trigger required for each transaction</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Software Command</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NOACT</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>Channel suspend operation</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESUME</name>
+                  <description>Channel resume operation</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHINTENCLR</name>
+          <description>Channel Interrupt Enable Clear</description>
+          <addressOffset>0x4C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TERR</name>
+              <description>Channel Transfer Error Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Channel Transfer Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHINTENSET</name>
+          <description>Channel Interrupt Enable Set</description>
+          <addressOffset>0x4D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TERR</name>
+              <description>Channel Transfer Error Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Channel Transfer Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHINTFLAG</name>
+          <description>Channel Interrupt Flag Status and Clear</description>
+          <addressOffset>0x4E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TERR</name>
+              <description>Channel Transfer Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCMPL</name>
+              <description>Channel Transfer Complete</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SUSP</name>
+              <description>Channel Suspend</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHSTATUS</name>
+          <description>Channel Status</description>
+          <addressOffset>0x4F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PEND</name>
+              <description>Channel Pending</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSY</name>
+              <description>Channel Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FERR</name>
+              <description>Channel Fetch Error</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>DSU</name>
+      <version>2.1.1</version>
+      <description>Device Service Unit</description>
+      <groupName>DSU</groupName>
+      <prependToName>DSU_</prependToName>
+      <baseAddress>0x41002000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x2000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x0000</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CRC</name>
+              <description>32-bit Cyclic Redundancy Code</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>MBIST</name>
+              <description>Memory built-in self-test</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CE</name>
+              <description>Chip-Erase</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ARR</name>
+              <description>Auxiliary Row Read</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>SMSA</name>
+              <description>Start Memory Stream Access</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSA</name>
+          <description>Status A</description>
+          <addressOffset>0x0001</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DONE</name>
+              <description>Done</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CRSTEXT</name>
+              <description>CPU Reset Phase Extension</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BERR</name>
+              <description>Bus Error</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAIL</name>
+              <description>Failure</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERR</name>
+              <description>Protection Error</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUSB</name>
+          <description>Status B</description>
+          <addressOffset>0x0002</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>PROT</name>
+              <description>Protected</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DBGPRES</name>
+              <description>Debugger Present</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DCCD0</name>
+              <description>Debug Communication Channel 0 Dirty</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DCCD1</name>
+              <description>Debug Communication Channel 1 Dirty</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HPE</name>
+              <description>Hot-Plugging Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>Address</description>
+          <addressOffset>0x0004</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>AMOD</name>
+              <description>Access Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>30</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LENGTH</name>
+          <description>Length</description>
+          <addressOffset>0x0008</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>LENGTH</name>
+              <description>Length</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>30</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>Data</description>
+          <addressOffset>0x000C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>DCC%s</name>
+          <description>Debug Communication Channel n</description>
+          <addressOffset>0x0010</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DID</name>
+          <description>Device Identification</description>
+          <addressOffset>0x0018</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x10030109</resetValue>
+          <fields>
+            <field>
+              <name>DEVSEL</name>
+              <description>Device Select</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>REVISION</name>
+              <description>Revision Number</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DIE</name>
+              <description>Die Number</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SERIES</name>
+              <description>Series</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>SERIESSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>Cortex-M0+ processor, basic feature set</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>Cortex-M0+ processor, USB</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FAMILY</name>
+              <description>Family</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>5</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>FAMILYSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>General purpose microcontroller</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>PicoPower</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PROCESSOR</name>
+              <description>Processor</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>PROCESSORSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>Cortex-M0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>Cortex-M0+</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>Cortex-M3</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>Cortex-M4</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>DCFG%s</name>
+          <description>Device Configuration</description>
+          <addressOffset>0x00F0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DCFG</name>
+              <description>Device Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ENTRY0</name>
+          <description>CoreSight ROM Table Entry 0</description>
+          <addressOffset>0x1000</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x9F0FC002</resetValue>
+          <fields>
+            <field>
+              <name>EPRES</name>
+              <description>Entry Present</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FMT</name>
+              <description>Format</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ADDOFF</name>
+              <description>Address Offset</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>20</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ENTRY1</name>
+          <description>CoreSight ROM Table Entry 1</description>
+          <addressOffset>0x1004</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00003002</resetValue>
+        </register>
+        <register>
+          <name>END</name>
+          <description>CoreSight ROM Table End</description>
+          <addressOffset>0x1008</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>END</name>
+              <description>End Marker</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MEMTYPE</name>
+          <description>CoreSight ROM Table Memory Type</description>
+          <addressOffset>0x1FCC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SMEMP</name>
+              <description>System Memory Present</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID4</name>
+          <description>Peripheral Identification 4</description>
+          <addressOffset>0x1FD0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>JEPCC</name>
+              <description>JEP-106 Continuation Code</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>FKBC</name>
+              <description>4KB count</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID5</name>
+          <description>Peripheral Identification 5</description>
+          <addressOffset>0x1FD4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID6</name>
+          <description>Peripheral Identification 6</description>
+          <addressOffset>0x1FD8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID7</name>
+          <description>Peripheral Identification 7</description>
+          <addressOffset>0x1FDC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID0</name>
+          <description>Peripheral Identification 0</description>
+          <addressOffset>0x1FE0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000000D0</resetValue>
+          <fields>
+            <field>
+              <name>PARTNBL</name>
+              <description>Part Number Low</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID1</name>
+          <description>Peripheral Identification 1</description>
+          <addressOffset>0x1FE4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000000FC</resetValue>
+          <fields>
+            <field>
+              <name>PARTNBH</name>
+              <description>Part Number High</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>JEPIDCL</name>
+              <description>Low part of the JEP-106 Identity Code</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID2</name>
+          <description>Peripheral Identification 2</description>
+          <addressOffset>0x1FE8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00000009</resetValue>
+          <fields>
+            <field>
+              <name>JEPIDCH</name>
+              <description>JEP-106 Identity Code High</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>JEPU</name>
+              <description>JEP-106 Identity Code is used</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>REVISION</name>
+              <description>Revision Number</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PID3</name>
+          <description>Peripheral Identification 3</description>
+          <addressOffset>0x1FEC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>CUSMOD</name>
+              <description>ARM CUSMOD</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>REVAND</name>
+              <description>Revision Number</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID0</name>
+          <description>Component Identification 0</description>
+          <addressOffset>0x1FF0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x0000000D</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLEB0</name>
+              <description>Preamble Byte 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID1</name>
+          <description>Component Identification 1</description>
+          <addressOffset>0x1FF4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00000010</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLE</name>
+              <description>Preamble</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CCLASS</name>
+              <description>Component Class</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID2</name>
+          <description>Component Identification 2</description>
+          <addressOffset>0x1FF8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x00000005</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLEB2</name>
+              <description>Preamble Byte 2</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CID3</name>
+          <description>Component Identification 3</description>
+          <addressOffset>0x1FFC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x000000B1</resetValue>
+          <fields>
+            <field>
+              <name>PREAMBLEB3</name>
+              <description>Preamble Byte 3</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EIC</name>
+      <version>1.0.1</version>
+      <description>External Interrupt Controller</description>
+      <groupName>EIC</groupName>
+      <prependToName>EIC_</prependToName>
+      <baseAddress>0x40001800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>EIC</name>
+        <value>4</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>NMICTRL</name>
+          <description>Non-Maskable Interrupt Control</description>
+          <addressOffset>0x02</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>NMISENSE</name>
+              <description>Non-Maskable Interrupt Sense</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>NMISENSESelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising-edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling-edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both-edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High-level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low-level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>NMIFILTEN</name>
+              <description>Non-Maskable Interrupt Filter Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>NMIFLAG</name>
+          <description>Non-Maskable Interrupt Flag Status and Clear</description>
+          <addressOffset>0x03</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>NMI</name>
+              <description>Non-Maskable Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINTEO0</name>
+              <description>External Interrupt 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO1</name>
+              <description>External Interrupt 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO2</name>
+              <description>External Interrupt 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO3</name>
+              <description>External Interrupt 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO4</name>
+              <description>External Interrupt 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO5</name>
+              <description>External Interrupt 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO6</name>
+              <description>External Interrupt 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINTEO7</name>
+              <description>External Interrupt 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINT0</name>
+              <description>External Interrupt 0 Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT1</name>
+              <description>External Interrupt 1 Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT2</name>
+              <description>External Interrupt 2 Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT3</name>
+              <description>External Interrupt 3 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT4</name>
+              <description>External Interrupt 4 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT5</name>
+              <description>External Interrupt 5 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT6</name>
+              <description>External Interrupt 6 Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT7</name>
+              <description>External Interrupt 7 Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINT0</name>
+              <description>External Interrupt 0 Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT1</name>
+              <description>External Interrupt 1 Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT2</name>
+              <description>External Interrupt 2 Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT3</name>
+              <description>External Interrupt 3 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT4</name>
+              <description>External Interrupt 4 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT5</name>
+              <description>External Interrupt 5 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT6</name>
+              <description>External Interrupt 6 Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT7</name>
+              <description>External Interrupt 7 Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EXTINT0</name>
+              <description>External Interrupt 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT1</name>
+              <description>External Interrupt 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT2</name>
+              <description>External Interrupt 2</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT3</name>
+              <description>External Interrupt 3</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT4</name>
+              <description>External Interrupt 4</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT5</name>
+              <description>External Interrupt 5</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT6</name>
+              <description>External Interrupt 6</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXTINT7</name>
+              <description>External Interrupt 7</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAKEUP</name>
+          <description>Wake-Up Enable</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WAKEUPEN0</name>
+              <description>External Interrupt 0 Wake-up Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN1</name>
+              <description>External Interrupt 1 Wake-up Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN2</name>
+              <description>External Interrupt 2 Wake-up Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN3</name>
+              <description>External Interrupt 3 Wake-up Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN4</name>
+              <description>External Interrupt 4 Wake-up Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN5</name>
+              <description>External Interrupt 5 Wake-up Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN6</name>
+              <description>External Interrupt 6 Wake-up Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUPEN7</name>
+              <description>External Interrupt 7 Wake-up Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CONFIG%s</name>
+          <description>Configuration n</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SENSE0</name>
+              <description>Input Sense 0 Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE0Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising-edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling-edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both-edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High-level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low-level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN0</name>
+              <description>Filter 0 Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE1</name>
+              <description>Input Sense 1 Configuration</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE1Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN1</name>
+              <description>Filter 1 Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE2</name>
+              <description>Input Sense 2 Configuration</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE2Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN2</name>
+              <description>Filter 2 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE3</name>
+              <description>Input Sense 3 Configuration</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE3Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN3</name>
+              <description>Filter 3 Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE4</name>
+              <description>Input Sense 4 Configuration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE4Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN4</name>
+              <description>Filter 4 Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE5</name>
+              <description>Input Sense 5 Configuration</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE5Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN5</name>
+              <description>Filter 5 Enable</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE6</name>
+              <description>Input Sense 6 Configuration</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE6Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN6</name>
+              <description>Filter 6 Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SENSE7</name>
+              <description>Input Sense 7 Configuration</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SENSE7Select</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No detection</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Rising edge detection</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Falling edge detection</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Both edges detection</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HIGH</name>
+                  <description>High level detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW</name>
+                  <description>Low level detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FILTEN7</name>
+              <description>Filter 7 Enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>EVSYS</name>
+      <version>1.0.1</version>
+      <description>Event System Interface</description>
+      <groupName>EVSYS</groupName>
+      <prependToName>EVSYS_</prependToName>
+      <baseAddress>0x42000400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>EVSYS</name>
+        <value>8</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>GCLKREQ</name>
+              <description>Generic Clock Requests</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHANNEL</name>
+          <description>Channel</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CHANNEL</name>
+              <description>Channel Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SWEVT</name>
+              <description>Software Event</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVGEN</name>
+              <description>Event Generator Selection</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>PATH</name>
+              <description>Path Selection</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PATHSelect</name>
+                <enumeratedValue>
+                  <name>SYNCHRONOUS</name>
+                  <description>Synchronous path</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNCHRONIZED</name>
+                  <description>Resynchronized path</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ASYNCHRONOUS</name>
+                  <description>Asynchronous path</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EDGSEL</name>
+              <description>Edge Detection Selection</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>EDGSELSelect</name>
+                <enumeratedValue>
+                  <name>NO_EVT_OUTPUT</name>
+                  <description>No event output when using the resynchronized or synchronous path</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISING_EDGE</name>
+                  <description>Event detection only on the rising edge of the signal from the event generator when using the resynchronized or synchronous path</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALLING_EDGE</name>
+                  <description>Event detection only on the falling edge of the signal from the event generator when using the resynchronized or synchronous path</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH_EDGES</name>
+                  <description>Event detection on rising and falling edges of the signal from the event generator when using the resynchronized or synchronous path</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>USER</name>
+          <description>User Multiplexer</description>
+          <addressOffset>0x08</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>USER</name>
+              <description>User Multiplexer Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>CHANNEL</name>
+              <description>Channel Event Selection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>CHANNELSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>No Channel Output Selected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CHSTATUS</name>
+          <description>Channel Status</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <resetValue>0x0000003F</resetValue>
+          <fields>
+            <field>
+              <name>USRRDY0</name>
+              <description>Channel 0 User Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY1</name>
+              <description>Channel 1 User Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY2</name>
+              <description>Channel 2 User Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY3</name>
+              <description>Channel 3 User Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY4</name>
+              <description>Channel 4 User Ready</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>USRRDY5</name>
+              <description>Channel 5 User Ready</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY0</name>
+              <description>Channel 0 Busy</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY1</name>
+              <description>Channel 1 Busy</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY2</name>
+              <description>Channel 2 Busy</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY3</name>
+              <description>Channel 3 Busy</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY4</name>
+              <description>Channel 4 Busy</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CHBUSY5</name>
+              <description>Channel 5 Busy</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVR0</name>
+              <description>Channel 0 Overrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR1</name>
+              <description>Channel 1 Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR2</name>
+              <description>Channel 2 Overrun Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR3</name>
+              <description>Channel 3 Overrun Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR4</name>
+              <description>Channel 4 Overrun Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR5</name>
+              <description>Channel 5 Overrun Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD0</name>
+              <description>Channel 0 Event Detection Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD1</name>
+              <description>Channel 1 Event Detection Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD2</name>
+              <description>Channel 2 Event Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD3</name>
+              <description>Channel 3 Event Detection Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD4</name>
+              <description>Channel 4 Event Detection Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD5</name>
+              <description>Channel 5 Event Detection Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVR0</name>
+              <description>Channel 0 Overrun Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR1</name>
+              <description>Channel 1 Overrun Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR2</name>
+              <description>Channel 2 Overrun Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR3</name>
+              <description>Channel 3 Overrun Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR4</name>
+              <description>Channel 4 Overrun Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR5</name>
+              <description>Channel 5 Overrun Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD0</name>
+              <description>Channel 0 Event Detection Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD1</name>
+              <description>Channel 1 Event Detection Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD2</name>
+              <description>Channel 2 Event Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD3</name>
+              <description>Channel 3 Event Detection Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD4</name>
+              <description>Channel 4 Event Detection Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD5</name>
+              <description>Channel 5 Event Detection Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVR0</name>
+              <description>Channel 0 Overrun</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR1</name>
+              <description>Channel 1 Overrun</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR2</name>
+              <description>Channel 2 Overrun</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR3</name>
+              <description>Channel 3 Overrun</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR4</name>
+              <description>Channel 4 Overrun</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVR5</name>
+              <description>Channel 5 Overrun</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD0</name>
+              <description>Channel 0 Event Detection</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD1</name>
+              <description>Channel 1 Event Detection</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD2</name>
+              <description>Channel 2 Event Detection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD3</name>
+              <description>Channel 3 Event Detection</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD4</name>
+              <description>Channel 4 Event Detection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVD5</name>
+              <description>Channel 5 Event Detection</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>GCLK</name>
+      <version>2.1.0</version>
+      <description>Generic Clock Generator</description>
+      <groupName>GCLK</groupName>
+      <prependToName>GCLK_</prependToName>
+      <baseAddress>0x40000C00</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x1</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy Status</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CLKCTRL</name>
+          <description>Generic Clock Control</description>
+          <addressOffset>0x2</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Generic Clock Selection ID</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <enumeratedValues>
+                <name>IDSelect</name>
+                <enumeratedValue>
+                  <name>DFLL48</name>
+                  <description>DFLL48</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FDPLL</name>
+                  <description>FDPLL</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FDPLL32K</name>
+                  <description>FDPLL32K</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WDT</name>
+                  <description>WDT</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RTC</name>
+                  <description>RTC</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EIC</name>
+                  <description>EIC</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USB</name>
+                  <description>USB</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_0</name>
+                  <description>EVSYS_0</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_1</name>
+                  <description>EVSYS_1</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_2</name>
+                  <description>EVSYS_2</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_3</name>
+                  <description>EVSYS_3</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_4</name>
+                  <description>EVSYS_4</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EVSYS_5</name>
+                  <description>EVSYS_5</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOMX_SLOW</name>
+                  <description>SERCOMX_SLOW</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM0_CORE</name>
+                  <description>SERCOM0_CORE</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM1_CORE</name>
+                  <description>SERCOM1_CORE</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SERCOM2_CORE</name>
+                  <description>SERCOM2_CORE</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TCC0</name>
+                  <description>TCC0</description>
+                  <value>0x11</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>TC1_TC2</name>
+                  <description>TC1_TC2</description>
+                  <value>0x12</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ADC</name>
+                  <description>ADC</description>
+                  <value>0x13</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AC_DIG</name>
+                  <description>AC_DIG</description>
+                  <value>0x14</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AC_ANA</name>
+                  <description>AC_ANA</description>
+                  <value>0x15</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DAC</name>
+                  <description>DAC</description>
+                  <value>0x16</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>GEN</name>
+              <description>Generic Clock Generator</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>GENSelect</name>
+                <enumeratedValue>
+                  <name>GCLK0</name>
+                  <description>Generic clock generator 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK1</name>
+                  <description>Generic clock generator 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK2</name>
+                  <description>Generic clock generator 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK3</name>
+                  <description>Generic clock generator 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK4</name>
+                  <description>Generic clock generator 4</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK5</name>
+                  <description>Generic clock generator 5</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CLKEN</name>
+              <description>Clock Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GENCTRL</name>
+          <description>Generic Clock Generator Control</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Generic Clock Generator Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>SRC</name>
+              <description>Source Select</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>SRCSelect</name>
+                <enumeratedValue>
+                  <name>XOSC</name>
+                  <description>XOSC oscillator output</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLKIN</name>
+                  <description>Generator input pad</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLKGEN1</name>
+                  <description>Generic clock generator 1 output</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OSCULP32K</name>
+                  <description>OSCULP32K oscillator output</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OSC32K</name>
+                  <description>OSC32K oscillator output</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>XOSC32K</name>
+                  <description>XOSC32K oscillator output</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OSC8M</name>
+                  <description>OSC8M oscillator output</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DFLL48M</name>
+                  <description>DFLL48M output</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DPLL96M</name>
+                  <description>DPLL96M output</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>GENEN</name>
+              <description>Generic Clock Generator Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDC</name>
+              <description>Improve Duty Cycle</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OOV</name>
+              <description>Output Off Value</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OE</name>
+              <description>Output Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DIVSEL</name>
+              <description>Divide Selection</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>GENDIV</name>
+          <description>Generic Clock Generator Division</description>
+          <addressOffset>0x8</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ID</name>
+              <description>Generic Clock Generator Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>DIV</name>
+              <description>Division Factor</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>HMATRIX</name>
+      <version>2.1.2</version>
+      <description>HSB Matrix</description>
+      <groupName>HMATRIXB</groupName>
+      <prependToName>HMATRIXB_</prependToName>
+      <baseAddress>0x41007000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x400</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>PRAS%s</name>
+          <description>Priority A for Slave</description>
+          <addressOffset>0x080</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>M0PR</name>
+              <description>Master 0 Priority</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M1PR</name>
+              <description>Master 1 Priority</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M2PR</name>
+              <description>Master 2 Priority</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M3PR</name>
+              <description>Master 3 Priority</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M4PR</name>
+              <description>Master 4 Priority</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M5PR</name>
+              <description>Master 5 Priority</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M6PR</name>
+              <description>Master 6 Priority</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M7PR</name>
+              <description>Master 7 Priority</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>PRBS%s</name>
+          <description>Priority B for Slave</description>
+          <addressOffset>0x084</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>M8PR</name>
+              <description>Master 8 Priority</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M9PR</name>
+              <description>Master 9 Priority</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M10PR</name>
+              <description>Master 10 Priority</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M11PR</name>
+              <description>Master 11 Priority</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M12PR</name>
+              <description>Master 12 Priority</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M13PR</name>
+              <description>Master 13 Priority</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M14PR</name>
+              <description>Master 14 Priority</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>M15PR</name>
+              <description>Master 15 Priority</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>SFR%s</name>
+          <description>Special Function</description>
+          <addressOffset>0x110</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SFR</name>
+              <description>Special Function Register</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>MTB</name>
+      <version>1.0.0</version>
+      <description>Cortex-M0+ Micro-Trace Buffer</description>
+      <groupName>MTB</groupName>
+      <prependToName>MTB_</prependToName>
+      <baseAddress>0x41006000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>POSITION</name>
+          <description>MTB Position</description>
+          <addressOffset>0x000</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WRAP</name>
+              <description>Pointer Value Wraps</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POINTER</name>
+              <description>Trace Packet Location Pointer</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>29</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>MASTER</name>
+          <description>MTB Master</description>
+          <addressOffset>0x004</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>MASK</name>
+              <description>Maximum Value of the Trace Buffer in SRAM</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TSTARTEN</name>
+              <description>Trace Start Input Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTOPEN</name>
+              <description>Trace Stop Input Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SFRWPRIV</name>
+              <description>Special Function Register Write Privilege</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMPRIV</name>
+              <description>SRAM Privilege</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HALTREQ</name>
+              <description>Halt Request</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN</name>
+              <description>Main Trace Enable</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FLOW</name>
+          <description>MTB Flow</description>
+          <addressOffset>0x008</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>AUTOSTOP</name>
+              <description>Auto Stop Tracing</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AUTOHALT</name>
+              <description>Auto Halt Request</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WATERMARK</name>
+              <description>Watermark value</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>29</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BASE</name>
+          <description>MTB Base</description>
+          <addressOffset>0x00C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>ITCTRL</name>
+          <description>MTB Integration Mode Control</description>
+          <addressOffset>0xF00</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>CLAIMSET</name>
+          <description>MTB Claim Set</description>
+          <addressOffset>0xFA0</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>CLAIMCLR</name>
+          <description>MTB Claim Clear</description>
+          <addressOffset>0xFA4</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>LOCKACCESS</name>
+          <description>MTB Lock Access</description>
+          <addressOffset>0xFB0</addressOffset>
+          <size>32</size>
+        </register>
+        <register>
+          <name>LOCKSTATUS</name>
+          <description>MTB Lock Status</description>
+          <addressOffset>0xFB4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>AUTHSTATUS</name>
+          <description>MTB Authentication Status</description>
+          <addressOffset>0xFB8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>DEVARCH</name>
+          <description>MTB Device Architecture</description>
+          <addressOffset>0xFBC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>DEVID</name>
+          <description>MTB Device Configuration</description>
+          <addressOffset>0xFC8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>DEVTYPE</name>
+          <description>MTB Device Type</description>
+          <addressOffset>0xFCC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID4</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFD0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID5</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFD4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID6</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFD8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID7</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFDC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID0</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFE0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID1</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFE4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID2</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFE8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>PID3</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFEC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID0</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFF0</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID1</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFF4</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID2</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFF8</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+        <register>
+          <name>CID3</name>
+          <description>CoreSight</description>
+          <addressOffset>0xFFC</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>NVMCTRL</name>
+      <version>1.0.7</version>
+      <description>Non-Volatile Memory Controller</description>
+      <groupName>NVMCTRL</groupName>
+      <prependToName>NVMCTRL_</prependToName>
+      <baseAddress>0x41004000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>NVMCTRL</name>
+        <value>5</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>ER</name>
+                  <description>Erase Row - Erases the row addressed by the ADDR register.</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WP</name>
+                  <description>Write Page - Writes the contents of the page buffer to the page addressed by the ADDR register.</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>EAR</name>
+                  <description>Erase Auxiliary Row - Erases the auxiliary row addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row.</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WAP</name>
+                  <description>Write Auxiliary Page - Writes the contents of the page buffer to the page addressed by the ADDR register. This command can be given only when the security bit is not set and only to the user configuration row.</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SF</name>
+                  <description>Security Flow Command</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WL</name>
+                  <description>Write lockbits</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LR</name>
+                  <description>Lock Region - Locks the region containing the address location in the ADDR register.</description>
+                  <value>0x40</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UR</name>
+                  <description>Unlock Region - Unlocks the region containing the address location in the ADDR register.</description>
+                  <value>0x41</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPRM</name>
+                  <description>Sets the power reduction mode.</description>
+                  <value>0x42</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CPRM</name>
+                  <description>Clears the power reduction mode.</description>
+                  <value>0x43</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PBC</name>
+                  <description>Page Buffer Clear - Clears the page buffer.</description>
+                  <value>0x44</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SSB</name>
+                  <description>Set Security Bit - Sets the security bit by writing 0x00 to the first byte in the lockbit row.</description>
+                  <value>0x45</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INVALL</name>
+                  <description>Invalidates all cache lines.</description>
+                  <value>0x46</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMDEX</name>
+              <description>Command Execution</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+              <enumeratedValues>
+                <name>CMDEXSelect</name>
+                <enumeratedValue>
+                  <name>KEY</name>
+                  <description>Execution Key</description>
+                  <value>0xa5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>RWS</name>
+              <description>NVM Read Wait States</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>RWSSelect</name>
+                <enumeratedValue>
+                  <name>SINGLE</name>
+                  <description>Single Auto Wait State</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HALF</name>
+                  <description>Half Auto Wait State</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DUAL</name>
+                  <description>Dual Auto Wait State</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MANW</name>
+              <description>Manual Write</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLEEPPRM</name>
+              <description>Power Reduction Mode during Sleep</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SLEEPPRMSelect</name>
+                <enumeratedValue>
+                  <name>WAKEONACCESS</name>
+                  <description>NVM block enters low-power mode when entering sleep.NVM block exits low-power mode upon first access.</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>WAKEUPINSTANT</name>
+                  <description>NVM block enters low-power mode when entering sleep.NVM block exits low-power mode when exiting sleep.</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DISABLED</name>
+                  <description>Auto power reduction disabled.</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>READMODE</name>
+              <description>NVMCTRL Read Mode</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>READMODESelect</name>
+                <enumeratedValue>
+                  <name>NO_MISS_PENALTY</name>
+                  <description>The NVM Controller (cache system) does not insert wait states on a cache miss. Gives the best system performance.</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOW_POWER</name>
+                  <description>Reduces power consumption of the cache system, but inserts a wait state each time there is a cache miss. This mode may not be relevant if CPU performance is required, as the application will be stalled and may lead to increase run time.</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DETERMINISTIC</name>
+                  <description>The cache system ensures that a cache hit or miss takes the same amount of time, determined by the number of programmed flash wait states. This mode can be used for real-time applications that require deterministic execution timings.</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CACHEDIS</name>
+              <description>Cache Disable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PARAM</name>
+          <description>NVM Parameter</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>NVMP</name>
+              <description>NVM Pages</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PSZ</name>
+              <description>Page Size</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>PSZSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 bytes</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 bytes</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 bytes</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 bytes</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 bytes</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 bytes</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 bytes</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1024</name>
+                  <description>1024 bytes</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READY</name>
+              <description>NVM Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x10</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READY</name>
+              <description>NVM Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READY</name>
+              <description>NVM Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PRM</name>
+              <description>Power Reduction Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LOAD</name>
+              <description>NVM Page Buffer Active Loading</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PROGE</name>
+              <description>Programming Error Status</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LOCKE</name>
+              <description>Lock Error Status</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NVME</name>
+              <description>NVM Error</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Security Bit Status</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>Address</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>NVM Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>22</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>LOCK</name>
+          <description>Lock Section</description>
+          <addressOffset>0x20</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>LOCK</name>
+              <description>Region Lock Bits</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PAC0</name>
+      <version>1.0.1</version>
+      <description>Peripheral Access Controller 0</description>
+      <groupName>PAC</groupName>
+      <prependToName>PAC_</prependToName>
+      <baseAddress>0x40000000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x08</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <name>WPCLR</name>
+          <description>Write Protection Clear</description>
+          <addressOffset>0x0</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WP</name>
+              <description>Write Protection Clear</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>31</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WPSET</name>
+          <description>Write Protection Set</description>
+          <addressOffset>0x4</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WP</name>
+              <description>Write Protection Set</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>31</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="PAC0">
+      <name>PAC1</name>
+      <description>Peripheral Access Controller 1</description>
+      <baseAddress>0x41000000</baseAddress>
+    </peripheral>
+    <peripheral derivedFrom="PAC0">
+      <name>PAC2</name>
+      <description>Peripheral Access Controller 2</description>
+      <baseAddress>0x42000000</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>PM</name>
+      <version>2.1.1</version>
+      <description>Power Manager</description>
+      <groupName>PM</groupName>
+      <prependToName>PM_</prependToName>
+      <baseAddress>0x40000400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>PM</name>
+        <value>0</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CFDEN</name>
+              <description>Clock Failure Detector Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BKUPCLK</name>
+              <description>Backup Clock Select</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SLEEP</name>
+          <description>Sleep Mode</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>IDLE</name>
+              <description>Idle Mode Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>IDLESelect</name>
+                <enumeratedValue>
+                  <name>CPU</name>
+                  <description>The CPU clock domain is stopped</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>AHB</name>
+                  <description>The CPU and AHB clock domains are stopped</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>APB</name>
+                  <description>The CPU, AHB and APB clock domains are stopped</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EXTCTRL</name>
+          <description>External Reset Controller</description>
+          <addressOffset>0x02</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SETDIS</name>
+              <description>External Reset Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CPUSEL</name>
+          <description>CPU Clock Select</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CPUDIV</name>
+              <description>CPU Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CPUDIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBASEL</name>
+          <description>APBA Clock Select</description>
+          <addressOffset>0x09</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>APBADIV</name>
+              <description>APBA Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>APBADIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBBSEL</name>
+          <description>APBB Clock Select</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>APBBDIV</name>
+              <description>APBB Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>APBBDIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBCSEL</name>
+          <description>APBC Clock Select</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>APBCDIV</name>
+              <description>APBC Prescaler Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>APBCDIVSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Divide by 1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide by 32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide by 128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>AHBMASK</name>
+          <description>AHB Mask</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <resetValue>0x0000007F</resetValue>
+          <fields>
+            <field>
+              <name>HPB0_</name>
+              <description>HPB0 AHB Clock Mask</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HPB1_</name>
+              <description>HPB1 AHB Clock Mask</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HPB2_</name>
+              <description>HPB2 AHB Clock Mask</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DSU_</name>
+              <description>DSU AHB Clock Mask</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NVMCTRL_</name>
+              <description>NVMCTRL AHB Clock Mask</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAC_</name>
+              <description>DMAC AHB Clock Mask</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USB_</name>
+              <description>USB AHB Clock Mask</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBAMASK</name>
+          <description>APBA Mask</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <resetValue>0x0000007F</resetValue>
+          <fields>
+            <field>
+              <name>PAC0_</name>
+              <description>PAC0 APB Clock Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PM_</name>
+              <description>PM APB Clock Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYSCTRL_</name>
+              <description>SYSCTRL APB Clock Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GCLK_</name>
+              <description>GCLK APB Clock Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WDT_</name>
+              <description>WDT APB Clock Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RTC_</name>
+              <description>RTC APB Clock Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EIC_</name>
+              <description>EIC APB Clock Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBBMASK</name>
+          <description>APBB Mask</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <resetValue>0x0000007F</resetValue>
+          <fields>
+            <field>
+              <name>PAC1_</name>
+              <description>PAC1 APB Clock Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DSU_</name>
+              <description>DSU APB Clock Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NVMCTRL_</name>
+              <description>NVMCTRL APB Clock Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PORT_</name>
+              <description>PORT APB Clock Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DMAC_</name>
+              <description>DMAC APB Clock Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USB_</name>
+              <description>USB APB Clock Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HMATRIX_</name>
+              <description>HMATRIX APB Clock Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>APBCMASK</name>
+          <description>APBC Mask</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <resetValue>0x00000100</resetValue>
+          <fields>
+            <field>
+              <name>PAC2_</name>
+              <description>PAC2 APB Clock Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EVSYS_</name>
+              <description>EVSYS APB Clock Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM0_</name>
+              <description>SERCOM0 APB Clock Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM1_</name>
+              <description>SERCOM1 APB Clock Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SERCOM2_</name>
+              <description>SERCOM2 APB Clock Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCC0_</name>
+              <description>TCC0 APB Clock Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TC1_</name>
+              <description>TC1 APB Clock Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TC2_</name>
+              <description>TC2 APB Clock Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADC_</name>
+              <description>ADC APB Clock Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AC_</name>
+              <description>AC APB Clock Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DAC_</name>
+              <description>DAC APB Clock Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PTC_</name>
+              <description>PTC APB Clock Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x34</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CKRDY</name>
+              <description>Clock Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CFD</name>
+              <description>Clock Failure Detector Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x35</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CKRDY</name>
+              <description>Clock Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CFD</name>
+              <description>Clock Failure Detector Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x36</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CKRDY</name>
+              <description>Clock Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CFD</name>
+              <description>Clock Failure Detector</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RCAUSE</name>
+          <description>Reset Cause</description>
+          <addressOffset>0x38</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x01</resetValue>
+          <fields>
+            <field>
+              <name>POR</name>
+              <description>Power On Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD12</name>
+              <description>Brown Out 12 Detector Reset</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33</name>
+              <description>Brown Out 33 Detector Reset</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EXT</name>
+              <description>External Reset</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WDT</name>
+              <description>Watchdog Reset</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYST</name>
+              <description>System Reset Request</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>PORT</name>
+      <version>1.0.0</version>
+      <description>Port Module</description>
+      <groupName>PORT</groupName>
+      <prependToName>PORT_</prependToName>
+      <baseAddress>0x41004400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x200</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <registers>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIR%s</name>
+          <description>Data Direction</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Port Data Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIRCLR%s</name>
+          <description>Data Direction Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIRCLR</name>
+              <description>Port Data Direction Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIRSET%s</name>
+          <description>Data Direction Set</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIRSET</name>
+              <description>Port Data Direction Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>DIRTGL%s</name>
+          <description>Data Direction Toggle</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DIRTGL</name>
+              <description>Port Data Direction Toggle</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUT%s</name>
+          <description>Data Output Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUT</name>
+              <description>Port Data Output Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUTCLR%s</name>
+          <description>Data Output Value Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUTCLR</name>
+              <description>Port Data Output Value Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUTSET%s</name>
+          <description>Data Output Value Set</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUTSET</name>
+              <description>Port Data Output Value Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>OUTTGL%s</name>
+          <description>Data Output Value Toggle</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OUTTGL</name>
+              <description>Port Data Output Value Toggle</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>IN%s</name>
+          <description>Data Input Value</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>IN</name>
+              <description>Port Data Input Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>CTRL%s</name>
+          <description>Control</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SAMPLING</name>
+              <description>Input Sampling Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x80</dimIncrement>
+          <name>WRCONFIG%s</name>
+          <description>Write Configuration</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>PINMASK</name>
+              <description>Pin Mask for Multiple Pin Configuration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+            <field>
+              <name>PMUXEN</name>
+              <description>Peripheral Multiplexer Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INEN</name>
+              <description>Input Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PULLEN</name>
+              <description>Pull Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRVSTR</name>
+              <description>Output Driver Strength Selection</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PMUX</name>
+              <description>Peripheral Multiplexing</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>WRPMUX</name>
+              <description>Write PMUX</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WRPINCFG</name>
+              <description>Write PINCFG</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HWSEL</name>
+              <description>Half-Word Select</description>
+              <bitOffset>31</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>16</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>PMUX0_%s</name>
+          <description>Peripheral Multiplexing n - Group 0</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PMUXE</name>
+              <description>Peripheral Multiplexing Even</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PMUXESelect</name>
+                <enumeratedValue>
+                  <name>A</name>
+                  <description>Peripheral function A selected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>B</name>
+                  <description>Peripheral function B selected</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>C</name>
+                  <description>Peripheral function C selected</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>D</name>
+                  <description>Peripheral function D selected</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>E</name>
+                  <description>Peripheral function E selected</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>F</name>
+                  <description>Peripheral function F selected</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>G</name>
+                  <description>Peripheral function G selected</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>H</name>
+                  <description>Peripheral function H selected</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PMUXO</name>
+              <description>Peripheral Multiplexing Odd</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PMUXOSelect</name>
+                <enumeratedValue>
+                  <name>A</name>
+                  <description>Peripheral function A selected</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>B</name>
+                  <description>Peripheral function B selected</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>C</name>
+                  <description>Peripheral function C selected</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>D</name>
+                  <description>Peripheral function D selected</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>E</name>
+                  <description>Peripheral function E selected</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>F</name>
+                  <description>Peripheral function F selected</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>G</name>
+                  <description>Peripheral function G selected</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>H</name>
+                  <description>Peripheral function H selected</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>32</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>PINCFG0_%s</name>
+          <description>Pin Configuration n - Group 0</description>
+          <addressOffset>0x40</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PMUXEN</name>
+              <description>Peripheral Multiplexer Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INEN</name>
+              <description>Input Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PULLEN</name>
+              <description>Pull Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRVSTR</name>
+              <description>Output Driver Strength Selection</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="PORT">
+      <name>PORT_IOBUS</name>
+      <description>Port Module (IOBUS)</description>
+      <groupName>PORT_IOBUS</groupName>
+      <prependToName>PORT_IOBUS_</prependToName>
+      <baseAddress>0x60000000</baseAddress>
+    </peripheral>
+    <peripheral>
+      <name>RTC</name>
+      <version>1.0.1</version>
+      <description>Real-Time Counter</description>
+      <groupName>RTC</groupName>
+      <prependToName>RTC_</prependToName>
+      <baseAddress>0x40001400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>RTC</name>
+        <value>3</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>MODE0</name>
+        <description>32-bit Counter with Single 32-bit Compare</description>
+        <headerStructName>RtcMode0</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRL</name>
+          <description>MODE0 Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Mode 0: 32-bit Counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Mode 1: 16-bit Counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLOCK</name>
+                  <description>Mode 2: Clock/Calendar</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>MATCHCLR</name>
+              <description>Clear on Match</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/256</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/512</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1024</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <resetValue>0x0010</resetValue>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>MODE0 Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PEREO0</name>
+              <description>Periodic Interval 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO1</name>
+              <description>Periodic Interval 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO2</name>
+              <description>Periodic Interval 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO3</name>
+              <description>Periodic Interval 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO4</name>
+              <description>Periodic Interval 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO5</name>
+              <description>Periodic Interval 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO6</name>
+              <description>Periodic Interval 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO7</name>
+              <description>Periodic Interval 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMPEO0</name>
+              <description>Compare 0 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>MODE0 Interrupt Enable Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>MODE0 Interrupt Enable Set</description>
+          <addressOffset>0x07</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>MODE0 Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Run During Debug</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCORR</name>
+          <description>Frequency Correction</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>SIGN</name>
+              <description>Correction Sign</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>MODE0 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>COMP%s</name>
+          <description>MODE0 Compare n Value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COMP</name>
+              <description>Compare Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- RtcMode0 -->
+       <cluster>
+        <name>MODE1</name>
+        <description>16-bit Counter with Two 16-bit Compares</description>
+        <alternateCluster>MODE0</alternateCluster>
+        <headerStructName>RtcMode1</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRL</name>
+          <description>MODE1 Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Mode 0: 32-bit Counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Mode 1: 16-bit Counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLOCK</name>
+                  <description>Mode 2: Clock/Calendar</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/256</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/512</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1024</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <resetValue>0x0010</resetValue>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>MODE1 Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PEREO0</name>
+              <description>Periodic Interval 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO1</name>
+              <description>Periodic Interval 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO2</name>
+              <description>Periodic Interval 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO3</name>
+              <description>Periodic Interval 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO4</name>
+              <description>Periodic Interval 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO5</name>
+              <description>Periodic Interval 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO6</name>
+              <description>Periodic Interval 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO7</name>
+              <description>Periodic Interval 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMPEO0</name>
+              <description>Compare 0 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMPEO1</name>
+              <description>Compare 1 Event Output Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>MODE1 Interrupt Enable Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>MODE1 Interrupt Enable Set</description>
+          <addressOffset>0x07</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>MODE1 Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CMP0</name>
+              <description>Compare 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Run During Debug</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCORR</name>
+          <description>Frequency Correction</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>SIGN</name>
+              <description>Correction Sign</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>MODE1 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER</name>
+          <description>MODE1 Counter Period</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Counter Period</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x2</dimIncrement>
+          <name>COMP%s</name>
+          <description>MODE1 Compare n Value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COMP</name>
+              <description>Compare Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- RtcMode1 -->
+       <cluster>
+        <name>MODE2</name>
+        <description>Clock/Calendar with Alarm</description>
+        <alternateCluster>MODE0</alternateCluster>
+        <headerStructName>RtcMode2</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRL</name>
+          <description>MODE2 Control</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Mode 0: 32-bit Counter</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Mode 1: 16-bit Counter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLOCK</name>
+                  <description>Mode 2: Clock/Calendar</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CLKREP</name>
+              <description>Clock Representation</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MATCHCLR</name>
+              <description>Clear on Match</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/32</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/64</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/128</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/256</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/512</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>CLK_RTC_CNT = GCLK_RTC/1024</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <resetValue>0x0010</resetValue>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>MODE2 Event Control</description>
+          <addressOffset>0x04</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PEREO0</name>
+              <description>Periodic Interval 0 Event Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO1</name>
+              <description>Periodic Interval 1 Event Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO2</name>
+              <description>Periodic Interval 2 Event Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO3</name>
+              <description>Periodic Interval 3 Event Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO4</name>
+              <description>Periodic Interval 4 Event Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO5</name>
+              <description>Periodic Interval 5 Event Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO6</name>
+              <description>Periodic Interval 6 Event Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PEREO7</name>
+              <description>Periodic Interval 7 Event Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ALARMEO0</name>
+              <description>Alarm 0 Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow Event Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>MODE2 Interrupt Enable Clear</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ALARM0</name>
+              <description>Alarm 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>MODE2 Interrupt Enable Set</description>
+          <addressOffset>0x07</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ALARM0</name>
+              <description>Alarm 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>MODE2 Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ALARM0</name>
+              <description>Alarm 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x0B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Run During Debug</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCORR</name>
+          <description>Frequency Correction</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Correction Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>SIGN</name>
+              <description>Correction Sign</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CLOCK</name>
+          <description>MODE2 Clock Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SECOND</name>
+              <description>Second</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>MINUTE</name>
+              <description>Minute</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>HOUR</name>
+              <description>Hour</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>HOURSelect</name>
+                <enumeratedValue>
+                  <name>AM</name>
+                  <description>AM when CLKREP in 12-hour</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PM</name>
+                  <description>PM when CLKREP in 12-hour</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DAY</name>
+              <description>Day</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>MONTH</name>
+              <description>Month</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>YEAR</name>
+              <description>Year</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>ALARM%s</name>
+          <description>MODE2 Alarm n Value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SECOND</name>
+              <description>Second</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>MINUTE</name>
+              <description>Minute</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>HOUR</name>
+              <description>Hour</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>5</bitWidth>
+              <enumeratedValues>
+                <name>HOURSelect</name>
+                <enumeratedValue>
+                  <name>AM</name>
+                  <description>Morning hour</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PM</name>
+                  <description>Afternoon hour</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>DAY</name>
+              <description>Day</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>MONTH</name>
+              <description>Month</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>YEAR</name>
+              <description>Year</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>1</dim>
+          <dimIncrement>0x8</dimIncrement>
+          <name>MASK%s</name>
+          <description>MODE2 Alarm n Mask</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SEL</name>
+              <description>Alarm Mask Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>SELSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Alarm Disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SS</name>
+                  <description>Match seconds only</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MMSS</name>
+                  <description>Match seconds and minutes only</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HHMMSS</name>
+                  <description>Match seconds, minutes, and hours only</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DDHHMMSS</name>
+                  <description>Match seconds, minutes, hours, and days only</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MMDDHHMMSS</name>
+                  <description>Match seconds, minutes, hours, days, and months only</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>YYMMDDHHMMSS</name>
+                  <description>Match seconds, minutes, hours, days, months, and years</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- RtcMode2 -->
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>SERCOM0</name>
+      <version>2.0.0</version>
+      <description>Serial Communication Interface 0</description>
+      <groupName>SERCOM</groupName>
+      <prependToName>SERCOM_</prependToName>
+      <baseAddress>0x42000800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x40</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>SERCOM0</name>
+        <value>9</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>I2CM</name>
+        <description>I2C Master Mode</description>
+        <headerStructName>SercomI2cm</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>I2CM Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINOUT</name>
+              <description>Pin Usage</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SDAHOLD</name>
+              <description>SDA Hold Time</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>MEXTTOEN</name>
+              <description>Master SCL Low Extend Timeout</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SEXTTOEN</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPEED</name>
+              <description>Transfer Speed</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SCLSM</name>
+              <description>SCL Clock Stretch Mode</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INACTOUT</name>
+              <description>Inactive Time-Out</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>LOWTOUTEN</name>
+              <description>SCL Low Timeout Enable</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>I2CM Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SMEN</name>
+              <description>Smart Mode Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QCEN</name>
+              <description>Quick Command Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ACKACT</name>
+              <description>Acknowledge Action</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD</name>
+          <description>I2CM Baud Rate</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>BAUDLOW</name>
+              <description>Baud Rate Value Low</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>HSBAUD</name>
+              <description>High Speed Baud Rate Value</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>HSBAUDLOW</name>
+              <description>High Speed Baud Rate Value Low</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>I2CM Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MB</name>
+              <description>Master On Bus Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Slave On Bus Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>I2CM Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MB</name>
+              <description>Master On Bus Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Slave On Bus Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>I2CM Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MB</name>
+              <description>Master On Bus Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SB</name>
+              <description>Slave On Bus Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>I2CM Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BUSERR</name>
+              <description>Bus Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ARBLOST</name>
+              <description>Arbitration Lost</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXNACK</name>
+              <description>Received Not Acknowledge</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BUSSTATE</name>
+              <description>Bus State</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>LOWTOUT</name>
+              <description>SCL Low Timeout</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CLKHOLD</name>
+              <description>Clock Hold</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>MEXTTOUT</name>
+              <description>Master SCL Low Extend Timeout</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SEXTTOUT</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LENERR</name>
+              <description>Length Error</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>I2CM Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYSOP</name>
+              <description>System Operation Synchronization Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>I2CM Address</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+            <field>
+              <name>LENEN</name>
+              <description>Length Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HS</name>
+              <description>High Speed Mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TENBITEN</name>
+              <description>Ten Bit Addressing Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LEN</name>
+              <description>Length</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>I2CM Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>I2CM Debug Control</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGSTOP</name>
+              <description>Debug Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomI2cm -->
+       <cluster>
+        <name>I2CS</name>
+        <description>I2C Slave Mode</description>
+        <alternateCluster>I2CM</alternateCluster>
+        <headerStructName>SercomI2cs</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>I2CS Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run during Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PINOUT</name>
+              <description>Pin Usage</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SDAHOLD</name>
+              <description>SDA Hold Time</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SEXTTOEN</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPEED</name>
+              <description>Transfer Speed</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SCLSM</name>
+              <description>SCL Clock Stretch Mode</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LOWTOUTEN</name>
+              <description>SCL Low Timeout Enable</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>I2CS Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SMEN</name>
+              <description>Smart Mode Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GCMD</name>
+              <description>PMBus Group Command</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AACKEN</name>
+              <description>Automatic Address Acknowledge</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMODE</name>
+              <description>Address Mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ACKACT</name>
+              <description>Acknowledge Action</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>I2CS Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PREC</name>
+              <description>Stop Received Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMATCH</name>
+              <description>Address Match Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRDY</name>
+              <description>Data Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>I2CS Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PREC</name>
+              <description>Stop Received Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMATCH</name>
+              <description>Address Match Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRDY</name>
+              <description>Data Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>I2CS Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>PREC</name>
+              <description>Stop Received Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMATCH</name>
+              <description>Address Match Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DRDY</name>
+              <description>Data Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>I2CS Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BUSERR</name>
+              <description>Bus Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COLL</name>
+              <description>Transmit Collision</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXNACK</name>
+              <description>Received Not Acknowledge</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DIR</name>
+              <description>Read/Write Direction</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SR</name>
+              <description>Repeated Start</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>LOWTOUT</name>
+              <description>SCL Low Timeout</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CLKHOLD</name>
+              <description>Clock Hold</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SEXTTOUT</name>
+              <description>Slave SCL Low Extend Timeout</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HS</name>
+              <description>High Speed</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>I2CS Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>I2CS Address</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>GENCEN</name>
+              <description>General Call Address Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADDR</name>
+              <description>Address Value</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+            <field>
+              <name>TENBITEN</name>
+              <description>Ten Bit Addressing Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ADDRMASK</name>
+              <description>Address Mask</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>I2CS Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomI2cs -->
+       <cluster>
+        <name>SPI</name>
+        <description>SPI Mode</description>
+        <alternateCluster>I2CM</alternateCluster>
+        <headerStructName>SercomSpi</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>SPI Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run during Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IBON</name>
+              <description>Immediate Buffer Overflow Notification</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DOPO</name>
+              <description>Data Out Pinout</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>DIPO</name>
+              <description>Data In Pinout</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>FORM</name>
+              <description>Frame Format</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CPHA</name>
+              <description>Clock Phase</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>Clock Polarity</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DORD</name>
+              <description>Data Order</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>SPI Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CHSIZE</name>
+              <description>Character Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>PLOADEN</name>
+              <description>Data Preload Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSDE</name>
+              <description>Slave Select Low Detect Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSSEN</name>
+              <description>Master Slave Select Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AMODE</name>
+              <description>Address Mode</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>RXEN</name>
+              <description>Receiver Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD</name>
+          <description>SPI Baud Rate</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>SPI Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSL</name>
+              <description>Slave Select Low Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>SPI Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SSL</name>
+              <description>Slave Select Low Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>SPI Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SSL</name>
+              <description>Slave Select Low Interrupt Flag</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>SPI Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BUFOVF</name>
+              <description>Buffer Overflow</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>SPI Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CTRLB</name>
+              <description>CTRLB Synchronization Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>ADDR</name>
+          <description>SPI Address</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>ADDRMASK</name>
+              <description>Address Mask</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>SPI Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>SPI Debug Control</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGSTOP</name>
+              <description>Debug Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomSpi -->
+       <cluster>
+        <name>USART</name>
+        <description>USART Mode</description>
+        <alternateCluster>I2CM</alternateCluster>
+        <headerStructName>SercomUsart</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>USART Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>USART_EXT_CLK</name>
+                  <description>USART mode with external clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>USART_INT_CLK</name>
+                  <description>USART mode with internal clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_SLAVE</name>
+                  <description>SPI mode with external clock</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SPI_MASTER</name>
+                  <description>SPI mode with internal clock</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_SLAVE</name>
+                  <description>I2C mode with external clock</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>I2C_MASTER</name>
+                  <description>I2C mode with internal clock</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run during Standby</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IBON</name>
+              <description>Immediate Buffer Overflow Notification</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SAMPR</name>
+              <description>Sample</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>TXPO</name>
+              <description>Transmit Data Pinout</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>RXPO</name>
+              <description>Receive Data Pinout</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>SAMPA</name>
+              <description>Sample Adjustment</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>FORM</name>
+              <description>Frame Format</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CMODE</name>
+              <description>Communication Mode</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPOL</name>
+              <description>Clock Polarity</description>
+              <bitOffset>29</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DORD</name>
+              <description>Data Order</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>USART Control B</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CHSIZE</name>
+              <description>Character Size</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>SBMODE</name>
+              <description>Stop Bit Mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COLDEN</name>
+              <description>Collision Detection Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SFDE</name>
+              <description>Start of Frame Detection Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENC</name>
+              <description>Encoding Format</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PMODE</name>
+              <description>Parity Mode</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXEN</name>
+              <description>Transmitter Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXEN</name>
+              <description>Receiver Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD</name>
+          <description>USART Baud Rate</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD_FRAC_MODE</name>
+          <description>USART Baud Rate</description>
+          <alternateRegister>BAUD</alternateRegister>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>13</bitWidth>
+            </field>
+            <field>
+              <name>FP</name>
+              <description>Fractional Part</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD_FRACFP_MODE</name>
+          <description>USART Baud Rate</description>
+          <alternateRegister>BAUD</alternateRegister>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>13</bitWidth>
+            </field>
+            <field>
+              <name>FP</name>
+              <description>Fractional Part</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BAUD_USARTFP_MODE</name>
+          <description>USART Baud Rate</description>
+          <alternateRegister>BAUD</alternateRegister>
+          <addressOffset>0x0C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>BAUD</name>
+              <description>Baud Rate Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RXPL</name>
+          <description>USART Receive Pulse Length</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RXPL</name>
+              <description>Receive Pulse Length</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>USART Interrupt Enable Clear</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXS</name>
+              <description>Receive Start Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTSIC</name>
+              <description>Clear To Send Input Change Interrupt Disable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXBRK</name>
+              <description>Break Received Interrupt Disable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>USART Interrupt Enable Set</description>
+          <addressOffset>0x16</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXS</name>
+              <description>Receive Start Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTSIC</name>
+              <description>Clear To Send Input Change Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXBRK</name>
+              <description>Break Received Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>USART Interrupt Flag Status and Clear</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DRE</name>
+              <description>Data Register Empty Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>TXC</name>
+              <description>Transmit Complete Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXC</name>
+              <description>Receive Complete Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>RXS</name>
+              <description>Receive Start Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CTSIC</name>
+              <description>Clear To Send Input Change Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXBRK</name>
+              <description>Break Received Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERROR</name>
+              <description>Combined Error Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>USART Status</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PERR</name>
+              <description>Parity Error</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FERR</name>
+              <description>Frame Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BUFOVF</name>
+              <description>Buffer Overflow</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTS</name>
+              <description>Clear To Send</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ISF</name>
+              <description>Inconsistent Sync Field</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COLL</name>
+              <description>Collision Detected</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>USART Syncbusy</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>SERCOM Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CTRLB</name>
+              <description>CTRLB Synchronization Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DATA</name>
+          <description>USART Data</description>
+          <addressOffset>0x28</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>DATA</name>
+              <description>Data Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>9</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>USART Debug Control</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGSTOP</name>
+              <description>Debug Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- SercomUsart -->
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="SERCOM0">
+      <name>SERCOM1</name>
+      <description>Serial Communication Interface 1</description>
+      <baseAddress>0x42000C00</baseAddress>
+      <interrupt>
+        <name>SERCOM1</name>
+        <value>10</value>
+      </interrupt>
+    </peripheral>
+    <peripheral derivedFrom="SERCOM0">
+      <name>SERCOM2</name>
+      <description>Serial Communication Interface 2</description>
+      <baseAddress>0x42001000</baseAddress>
+      <interrupt>
+        <name>SERCOM2</name>
+        <value>11</value>
+      </interrupt>
+    </peripheral>
+    <peripheral>
+      <name>SYSCTRL</name>
+      <version>2.0.2</version>
+      <description>System Control</description>
+      <groupName>SYSCTRL</groupName>
+      <prependToName>SYSCTRL_</prependToName>
+      <baseAddress>0x40000800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x80</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>SYSCTRL</name>
+        <value>1</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x04</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection Interrupt Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PCLKSR</name>
+          <description>Power and Clocks Status</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>XOSCRDY</name>
+              <description>XOSC Ready</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>XOSC32KRDY</name>
+              <description>XOSC32K Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>OSC32KRDY</name>
+              <description>OSC32K Ready</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>OSC8MRDY</name>
+              <description>OSC8M Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLRDY</name>
+              <description>DFLL Ready</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLOOB</name>
+              <description>DFLL Out Of Bounds</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLLCKF</name>
+              <description>DFLL Lock Fine</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLLCKC</name>
+              <description>DFLL Lock Coarse</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFLLRCS</name>
+              <description>DFLL Reference Clock Stopped</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BOD33RDY</name>
+              <description>BOD33 Ready</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BOD33DET</name>
+              <description>BOD33 Detection</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>B33SRDY</name>
+              <description>BOD33 Synchronization Ready</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DPLLLCKR</name>
+              <description>DPLL Lock Rise</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DPLLLCKF</name>
+              <description>DPLL Lock Fall</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DPLLLTO</name>
+              <description>DPLL Lock Timeout</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>XOSC</name>
+          <description>External Multipurpose Crystal Oscillator (XOSC) Control</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <resetValue>0x0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XTALEN</name>
+              <description>Crystal Oscillator Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GAIN</name>
+              <description>Oscillator Gain</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>GAINSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>2MHz</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>4MHz</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>8MHz</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>16MHz</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4</name>
+                  <description>30MHz</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>AMPGC</name>
+              <description>Automatic Amplitude Gain Control</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STARTUP</name>
+              <description>Start-Up Time</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>XOSC32K</name>
+          <description>32kHz External Crystal Oscillator (XOSC32K) Control</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <resetValue>0x0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>XTALEN</name>
+              <description>Crystal Oscillator Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN32K</name>
+              <description>32kHz Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN1K</name>
+              <description>1kHz Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>AAMPEN</name>
+              <description>Automatic Amplitude Control Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STARTUP</name>
+              <description>Oscillator Start-Up Time</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSC32K</name>
+          <description>32kHz Internal Oscillator (OSC32K) Control</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <resetValue>0x003F0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN32K</name>
+              <description>32kHz Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EN1K</name>
+              <description>1kHz Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STARTUP</name>
+              <description>Oscillator Start-Up Time</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALIB</name>
+              <description>Oscillator Calibration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSCULP32K</name>
+          <description>32kHz Ultra Low Power Internal Oscillator (OSCULP32K) Control</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>8</size>
+          <resetValue>0x1F</resetValue>
+          <fields>
+            <field>
+              <name>CALIB</name>
+              <description>Oscillator Calibration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>WRTLOCK</name>
+              <description>Write Lock</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>OSC8M</name>
+          <description>8MHz Internal Oscillator (OSC8M) Control</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <resetValue>0x87070382</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Oscillator Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESC</name>
+              <description>Oscillator Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>1</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CALIB</name>
+              <description>Oscillator Calibration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+            <field>
+              <name>FRANGE</name>
+              <description>Oscillator Frequency Range</description>
+              <bitOffset>30</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FRANGESelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>4 to 6MHz</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>6 to 8MHz</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>8 to 11MHz</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>3</name>
+                  <description>11 to 15MHz</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLCTRL</name>
+          <description>DFLL48M Control</description>
+          <addressOffset>0x24</addressOffset>
+          <size>16</size>
+          <resetValue>0x0080</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>DFLL Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode Selection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STABLE</name>
+              <description>Stable DFLL Frequency</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LLAW</name>
+              <description>Lose Lock After Wake</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>USBCRM</name>
+              <description>USB Clock Recovery Mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Control</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCDIS</name>
+              <description>Chill Cycle Disable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QLDIS</name>
+              <description>Quick Lock Disable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BPLCKC</name>
+              <description>Bypass Coarse Lock</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAITLOCK</name>
+              <description>Wait Lock</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLVAL</name>
+          <description>DFLL48M Value</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>FINE</name>
+              <description>Fine Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+            <field>
+              <name>COARSE</name>
+              <description>Coarse Value</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>DIFF</name>
+              <description>Multiplication Ratio Difference</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLMUL</name>
+          <description>DFLL48M Multiplier</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>MUL</name>
+              <description>DFLL Multiply Factor</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+            <field>
+              <name>FSTEP</name>
+              <description>Fine Maximum Step</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>10</bitWidth>
+            </field>
+            <field>
+              <name>CSTEP</name>
+              <description>Coarse Maximum Step</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DFLLSYNC</name>
+          <description>DFLL48M Synchronization</description>
+          <addressOffset>0x30</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>READREQ</name>
+              <description>Read Request</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BOD33</name>
+          <description>3.3V Brown-Out Detector (BOD33) Control</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HYST</name>
+              <description>Hysteresis</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ACTION</name>
+              <description>BOD33 Action</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>ACTIONSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESET</name>
+                  <description>The BOD33 generates a reset</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INTERRUPT</name>
+                  <description>The BOD33 generates an interrupt</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operation Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CEN</name>
+              <description>Clock Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PSEL</name>
+              <description>Prescaler Select</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PSELSelect</name>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide clock by 2</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide clock by 4</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide clock by 8</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide clock by 16</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32</name>
+                  <description>Divide clock by 32</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide clock by 64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV128</name>
+                  <description>Divide clock by 128</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Divide clock by 256</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV512</name>
+                  <description>Divide clock by 512</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1K</name>
+                  <description>Divide clock by 1024</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2K</name>
+                  <description>Divide clock by 2048</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4K</name>
+                  <description>Divide clock by 4096</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8K</name>
+                  <description>Divide clock by 8192</description>
+                  <value>0xc</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16K</name>
+                  <description>Divide clock by 16384</description>
+                  <value>0xd</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV32K</name>
+                  <description>Divide clock by 32768</description>
+                  <value>0xe</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64K</name>
+                  <description>Divide clock by 65536</description>
+                  <value>0xf</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LEVEL</name>
+              <description>BOD33 Threshold Level</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>VREF</name>
+          <description>Voltage References System (VREF) Control</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>TSEN</name>
+              <description>Temperature Sensor Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BGOUTEN</name>
+              <description>Bandgap Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CALIB</name>
+              <description>Bandgap Voltage Generator Calibration</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLCTRLA</name>
+          <description>DPLL Control A</description>
+          <addressOffset>0x44</addressOffset>
+          <size>8</size>
+          <resetValue>0x80</resetValue>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>DPLL Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONDEMAND</name>
+              <description>On Demand Clock Activation</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLRATIO</name>
+          <description>DPLL Ratio Control</description>
+          <addressOffset>0x48</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>LDR</name>
+              <description>Loop Divider Ratio</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>12</bitWidth>
+            </field>
+            <field>
+              <name>LDRFRAC</name>
+              <description>Loop Divider Ratio Fractional Part</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLCTRLB</name>
+          <description>DPLL Control B</description>
+          <addressOffset>0x4C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>FILTER</name>
+              <description>Proportional Integral Filter Selection</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>FILTERSelect</name>
+                <enumeratedValue>
+                  <name>DEFAULT</name>
+                  <description>Default filter mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LBFILT</name>
+                  <description>Low bandwidth filter</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HBFILT</name>
+                  <description>High bandwidth filter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HDFILT</name>
+                  <description>High damping filter</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LPEN</name>
+              <description>Low-Power Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WUF</name>
+              <description>Wake Up Fast</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>REFCLK</name>
+              <description>Reference Clock Selection</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>REFCLKSelect</name>
+                <enumeratedValue>
+                  <name>REF0</name>
+                  <description>CLK_DPLL_REF0 clock reference</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>REF1</name>
+                  <description>CLK_DPLL_REF1 clock reference</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>GCLK_DPLL clock reference</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LTIME</name>
+              <description>Lock Time</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>LTIMESelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>Default	No time-out</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8MS</name>
+                  <description>8MS	Time-out if no lock within 8 ms</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>9MS</name>
+                  <description>9MS	Time-out if no lock within 9 ms</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>10MS</name>
+                  <description>10MS	Time-out if no lock within 10 ms</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>11MS</name>
+                  <description>11MS	Time-out if no lock within 11 ms</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LBYPASS</name>
+              <description>Lock Bypass</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DIV</name>
+              <description>Clock Divider</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>11</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DPLLSTATUS</name>
+          <description>DPLL Status</description>
+          <addressOffset>0x50</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>LOCK</name>
+              <description>DPLL Lock Status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CLKRDY</name>
+              <description>Output Clock Ready</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>DPLL Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DIV</name>
+              <description>Divider Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>TC1</name>
+      <version>1.4.0</version>
+      <description>Basic Timer Counter 1</description>
+      <groupName>TC</groupName>
+      <prependToName>TC_</prependToName>
+      <baseAddress>0x42001800</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x040</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TC1</name>
+        <value>13</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>COUNT8</name>
+        <description>8-bit Counter Mode</description>
+        <headerStructName>TcCount8</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>TC Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Counter in 16-bit mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT8</name>
+                  <description>Counter in 8-bit mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Counter in 32-bit mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation Operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MPWM</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Prescaler: GCLK_TC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Prescaler: GCLK_TC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Prescaler: GCLK_TC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Prescaler: GCLK_TC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Prescaler: GCLK_TC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Prescaler: GCLK_TC/64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Prescaler: GCLK_TC/256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Prescaler: GCLK_TC/1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset the counter on next generic clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset the counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset the counter on next generic clock. Reset the prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <resetValue>0x02</resetValue>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Invert Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Invert Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or retrigger TC on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start TC on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period captured in CC0, pulse width in CC1</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period captured in CC1, pulse width in CC0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TCINV</name>
+              <description>TC Inverted Event Input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI</name>
+              <description>TC Event Input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x08</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>COUNT8 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER</name>
+          <description>COUNT8 Period Value</description>
+          <addressOffset>0x14</addressOffset>
+          <size>8</size>
+          <resetValue>0xFF</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x1</dimIncrement>
+          <name>CC%s</name>
+          <description>COUNT8 Compare/Capture</description>
+          <addressOffset>0x18</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- TcCount8 -->
+       <cluster>
+        <name>COUNT16</name>
+        <description>16-bit Counter Mode</description>
+        <alternateCluster>COUNT8</alternateCluster>
+        <headerStructName>TcCount16</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>TC Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Counter in 16-bit mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT8</name>
+                  <description>Counter in 8-bit mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Counter in 32-bit mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation Operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MPWM</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Prescaler: GCLK_TC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Prescaler: GCLK_TC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Prescaler: GCLK_TC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Prescaler: GCLK_TC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Prescaler: GCLK_TC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Prescaler: GCLK_TC/64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Prescaler: GCLK_TC/256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Prescaler: GCLK_TC/1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset the counter on next generic clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset the counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset the counter on next generic clock. Reset the prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <resetValue>0x02</resetValue>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Invert Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Invert Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or retrigger TC on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start TC on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period captured in CC0, pulse width in CC1</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period captured in CC1, pulse width in CC0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TCINV</name>
+              <description>TC Inverted Event Input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI</name>
+              <description>TC Event Input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x08</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>COUNT16 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Count Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x2</dimIncrement>
+          <name>CC%s</name>
+          <description>COUNT16 Compare/Capture</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- TcCount16 -->
+       <cluster>
+        <name>COUNT32</name>
+        <description>32-bit Counter Mode</description>
+        <alternateCluster>COUNT8</alternateCluster>
+        <headerStructName>TcCount32</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>TC Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>COUNT16</name>
+                  <description>Counter in 16-bit mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT8</name>
+                  <description>Counter in 8-bit mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT32</name>
+                  <description>Counter in 32-bit mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation Operation</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MPWM</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>Prescaler: GCLK_TC</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Prescaler: GCLK_TC/2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Prescaler: GCLK_TC/4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Prescaler: GCLK_TC/8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Prescaler: GCLK_TC/16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Prescaler: GCLK_TC/64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Prescaler: GCLK_TC/256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Prescaler: GCLK_TC/1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset the counter on next generic clock</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset the counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset the counter on next generic clock. Reset the prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>READREQ</name>
+          <description>Read Request</description>
+          <addressOffset>0x02</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>ADDR</name>
+              <description>Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>RCONT</name>
+              <description>Read Continuously</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RREQ</name>
+              <description>Read Request</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <resetValue>0x02</resetValue>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>Command</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Force a start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force a stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x06</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Invert Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Invert Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Run Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>EVACT</name>
+              <description>Event Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACTSelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or retrigger TC on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start TC on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period captured in CC0, pulse width in CC1</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period captured in CC1, pulse width in CC0</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>TCINV</name>
+              <description>TC Inverted Event Input</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI</name>
+              <description>TC Event Input</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Event Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SYNCRDY</name>
+              <description>Synchronization Ready</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x0F</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x08</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>COUNT32 Counter Value</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Count Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>2</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s</name>
+          <description>COUNT32 Compare/Capture</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- TcCount32 -->
+      </registers>
+    </peripheral>
+    <peripheral derivedFrom="TC1">
+      <name>TC2</name>
+      <description>Basic Timer Counter 2</description>
+      <baseAddress>0x42001C00</baseAddress>
+      <interrupt>
+        <name>TC2</name>
+        <value>14</value>
+      </interrupt>
+    </peripheral>
+    <peripheral>
+      <name>TCC0</name>
+      <version>1.1.1</version>
+      <description>Timer Counter Control</description>
+      <groupName>TCC</groupName>
+      <prependToName>TCC_</prependToName>
+      <baseAddress>0x42001400</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x090</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>TCC0</name>
+        <value>12</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RESOLUTION</name>
+              <description>Enhanced Resolution</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RESOLUTIONSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>Dithering is disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DITH4</name>
+                  <description>Dithering is done every 16 PWM frames</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DITH5</name>
+                  <description>Dithering is done every 32 PWM frames</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DITH6</name>
+                  <description>Dithering is done every 64 PWM frames</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>PRESCALER</name>
+              <description>Prescaler</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>PRESCALERSelect</name>
+                <enumeratedValue>
+                  <name>DIV1</name>
+                  <description>No division</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV2</name>
+                  <description>Divide by 2</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV4</name>
+                  <description>Divide by 4</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV8</name>
+                  <description>Divide by 8</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV16</name>
+                  <description>Divide by 16</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV64</name>
+                  <description>Divide by 64</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV256</name>
+                  <description>Divide by 256</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIV1024</name>
+                  <description>Divide by 1024</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PRESCSYNC</name>
+              <description>Prescaler and Counter Synchronization Selection</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>PRESCSYNCSelect</name>
+                <enumeratedValue>
+                  <name>GCLK</name>
+                  <description>Reload or reset counter on next GCLK</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PRESC</name>
+                  <description>Reload or reset counter on next prescaler clock</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESYNC</name>
+                  <description>Reload or reset counter on next GCLK and reset prescaler counter</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>ALOCK</name>
+              <description>Auto Lock</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN0</name>
+              <description>Capture Channel 0 Enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN1</name>
+              <description>Capture Channel 1 Enable</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN2</name>
+              <description>Capture Channel 2 Enable</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CPTEN3</name>
+              <description>Capture Channel 3 Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBCLR</name>
+          <description>Control B Clear</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LUPD</name>
+              <description>Lock Update</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDXCMD</name>
+              <description>Ramp Index Command</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>IDXCMDSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Command disabled: Index toggles between cycles A and B</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Set index: cycle B will be forced in the next cycle</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLEAR</name>
+                  <description>Clear index: cycle A will be forced in the next cycle</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HOLD</name>
+                  <description>Hold index: the next cycle will be the same as the current cycle</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>TCC Command</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Clear start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPDATE</name>
+                  <description>Force update or double buffered registers</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>READSYNC</name>
+                  <description>Force COUNT read synchronization</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLBSET</name>
+          <description>Control B Set</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DIR</name>
+              <description>Counter Direction</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LUPD</name>
+              <description>Lock Update</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ONESHOT</name>
+              <description>One-Shot</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>IDXCMD</name>
+              <description>Ramp Index Command</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>IDXCMDSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Command disabled: Index toggles between cycles A and B</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SET</name>
+                  <description>Set index: cycle B will be forced in the next cycle</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CLEAR</name>
+                  <description>Clear index: cycle A will be forced in the next cycle</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HOLD</name>
+                  <description>Hold index: the next cycle will be the same as the current cycle</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CMD</name>
+              <description>TCC Command</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CMDSelect</name>
+                <enumeratedValue>
+                  <name>NONE</name>
+                  <description>No action</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Clear start, restart or retrigger</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Force stop</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPDATE</name>
+                  <description>Force update or double buffered registers</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>READSYNC</name>
+                  <description>Force COUNT read synchronization</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>Synchronization Busy</description>
+          <addressOffset>0x08</addressOffset>
+          <size>32</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Swrst Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CTRLB</name>
+              <description>Ctrlb Busy</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STATUS</name>
+              <description>Status Busy</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>COUNT</name>
+              <description>Count Busy</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PATT</name>
+              <description>Pattern Busy</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAVE</name>
+              <description>Wave Busy</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC0</name>
+              <description>Compare Channel 0 Busy</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC1</name>
+              <description>Compare Channel 1 Busy</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC2</name>
+              <description>Compare Channel 2 Busy</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CC3</name>
+              <description>Compare Channel 3 Busy</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PATTB</name>
+              <description>Pattern Buffer Busy</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAVEB</name>
+              <description>Wave Buffer Busy</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Busy</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB0</name>
+              <description>Compare Channel Buffer 0 Busy</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB1</name>
+              <description>Compare Channel Buffer 1 Busy</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB2</name>
+              <description>Compare Channel Buffer 2 Busy</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCB3</name>
+              <description>Compare Channel Buffer 3 Busy</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FCTRLA</name>
+          <description>Recoverable Fault A Configuration</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SRC</name>
+              <description>Fault A Source</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SRCSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Fault input disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>MCEx (x=0,1) event input</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INVERT</name>
+                  <description>Inverted MCEx (x=0,1) event input</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ALTFAULT</name>
+                  <description>Alternate fault (A or B) state at the end of the previous period</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>KEEP</name>
+              <description>Fault A Keeper</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QUAL</name>
+              <description>Fault A Qualification</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANK</name>
+              <description>Fault A Blanking Mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>BLANKSelect</name>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Blanking applied from start of ramp</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Blanking applied from rising edge of the output waveform</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Blanking applied from falling edge of the output waveform</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Blanking applied from each toggle of the output waveform</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RESTART</name>
+              <description>Fault A Restart</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HALT</name>
+              <description>Fault A Halt Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>HALTSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Halt action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HW</name>
+                  <description>Hardware halt action</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SW</name>
+                  <description>Software halt action</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NR</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CHSEL</name>
+              <description>Fault A Capture Channel</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CHSELSelect</name>
+                <enumeratedValue>
+                  <name>CC0</name>
+                  <description>Capture value stored in channel 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC1</name>
+                  <description>Capture value stored in channel 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC2</name>
+                  <description>Capture value stored in channel 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC3</name>
+                  <description>Capture value stored in channel 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CAPTURE</name>
+              <description>Fault A Capture Action</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CAPTURESelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>No capture</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPT</name>
+                  <description>Capture on fault</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMIN</name>
+                  <description>Minimum capture</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMAX</name>
+                  <description>Maximum capture</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMIN</name>
+                  <description>Minimum local detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMAX</name>
+                  <description>Maximum local detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DERIV0</name>
+                  <description>Minimum and maximum local detection</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMARK</name>
+                  <description>Capture with ramp index as MSB value</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>BLANKPRESC</name>
+              <description>Fault A Blanking Prescaler</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANKVAL</name>
+              <description>Fault A Blanking Time</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL</name>
+              <description>Fault A Filter Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FCTRLB</name>
+          <description>Recoverable Fault B Configuration</description>
+          <addressOffset>0x10</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>SRC</name>
+              <description>Fault B Source</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SRCSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Fault input disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ENABLE</name>
+                  <description>MCEx (x=0,1) event input</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INVERT</name>
+                  <description>Inverted MCEx (x=0,1) event input</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ALTFAULT</name>
+                  <description>Alternate fault (A or B) state at the end of the previous period</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>KEEP</name>
+              <description>Fault B Keeper</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>QUAL</name>
+              <description>Fault B Qualification</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANK</name>
+              <description>Fault B Blanking Mode</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>BLANKSelect</name>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Blanking applied from start of ramp</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RISE</name>
+                  <description>Blanking applied from rising edge of the output waveform</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FALL</name>
+                  <description>Blanking applied from falling edge of the output waveform</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOTH</name>
+                  <description>Blanking applied from each toggle of the output waveform</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RESTART</name>
+              <description>Fault B Restart</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>HALT</name>
+              <description>Fault B Halt Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>HALTSelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>Halt action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HW</name>
+                  <description>Hardware halt action</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SW</name>
+                  <description>Software halt action</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NR</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CHSEL</name>
+              <description>Fault B Capture Channel</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CHSELSelect</name>
+                <enumeratedValue>
+                  <name>CC0</name>
+                  <description>Capture value stored in channel 0</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC1</name>
+                  <description>Capture value stored in channel 1</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC2</name>
+                  <description>Capture value stored in channel 2</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CC3</name>
+                  <description>Capture value stored in channel 3</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CAPTURE</name>
+              <description>Fault B Capture Action</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>CAPTURESelect</name>
+                <enumeratedValue>
+                  <name>DISABLE</name>
+                  <description>No capture</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPT</name>
+                  <description>Capture on fault</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMIN</name>
+                  <description>Minimum capture</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMAX</name>
+                  <description>Maximum capture</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMIN</name>
+                  <description>Minimum local detection</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LOCMAX</name>
+                  <description>Maximum local detection</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DERIV0</name>
+                  <description>Minimum and maximum local detection</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>CAPTMARK</name>
+                  <description>Capture with ramp index as MSB value</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>BLANKPRESC</name>
+              <description>Fault B Blanking Prescaler</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BLANKVAL</name>
+              <description>Fault B Blanking Time</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL</name>
+              <description>Fault B Filter Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WEXCTRL</name>
+          <description>Waveform Extension Configuration</description>
+          <addressOffset>0x14</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OTMX</name>
+              <description>Output Matrix</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN0</name>
+              <description>Dead-time Insertion Generator 0 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN1</name>
+              <description>Dead-time Insertion Generator 1 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN2</name>
+              <description>Dead-time Insertion Generator 2 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTIEN3</name>
+              <description>Dead-time Insertion Generator 3 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DTLS</name>
+              <description>Dead-time Low Side Outputs Value</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+            <field>
+              <name>DTHS</name>
+              <description>Dead-time High Side Outputs Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>8</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DRVCTRL</name>
+          <description>Driver Control</description>
+          <addressOffset>0x18</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>NRE0</name>
+              <description>Non-Recoverable State 0 Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE1</name>
+              <description>Non-Recoverable State 1 Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE2</name>
+              <description>Non-Recoverable State 2 Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE3</name>
+              <description>Non-Recoverable State 3 Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE4</name>
+              <description>Non-Recoverable State 4 Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE5</name>
+              <description>Non-Recoverable State 5 Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE6</name>
+              <description>Non-Recoverable State 6 Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRE7</name>
+              <description>Non-Recoverable State 7 Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV0</name>
+              <description>Non-Recoverable State 0 Output Value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV1</name>
+              <description>Non-Recoverable State 1 Output Value</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV2</name>
+              <description>Non-Recoverable State 2 Output Value</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV3</name>
+              <description>Non-Recoverable State 3 Output Value</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV4</name>
+              <description>Non-Recoverable State 4 Output Value</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV5</name>
+              <description>Non-Recoverable State 5 Output Value</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV6</name>
+              <description>Non-Recoverable State 6 Output Value</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>NRV7</name>
+              <description>Non-Recoverable State 7 Output Value</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN0</name>
+              <description>Output Waveform 0 Inversion</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN1</name>
+              <description>Output Waveform 1 Inversion</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN2</name>
+              <description>Output Waveform 2 Inversion</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN3</name>
+              <description>Output Waveform 3 Inversion</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN4</name>
+              <description>Output Waveform 4 Inversion</description>
+              <bitOffset>20</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN5</name>
+              <description>Output Waveform 5 Inversion</description>
+              <bitOffset>21</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN6</name>
+              <description>Output Waveform 6 Inversion</description>
+              <bitOffset>22</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>INVEN7</name>
+              <description>Output Waveform 7 Inversion</description>
+              <bitOffset>23</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL0</name>
+              <description>Non-Recoverable Fault Input 0 Filter Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>FILTERVAL1</name>
+              <description>Non-Recoverable Fault Input 1 Filter Value</description>
+              <bitOffset>28</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DBGCTRL</name>
+          <description>Debug Control</description>
+          <addressOffset>0x1E</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DBGRUN</name>
+              <description>Debug Running Mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FDDBD</name>
+              <description>Fault Detection on Debug Break Detection</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EVCTRL</name>
+          <description>Event Control</description>
+          <addressOffset>0x20</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>EVACT0</name>
+              <description>Timer/counter Input Event0 Action</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACT0Select</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Start, restart or re-trigger counter on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNTEV</name>
+                  <description>Count on event</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>Start counter on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>INC</name>
+                  <description>Increment counter on event</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>COUNT</name>
+                  <description>Count on active state of asynchronous event</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FAULT</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>EVACT1</name>
+              <description>Timer/counter Input Event1 Action</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>EVACT1Select</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>Event action disabled</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RETRIGGER</name>
+                  <description>Re-trigger counter on event</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DIR</name>
+                  <description>Direction control</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STOP</name>
+                  <description>Stop counter on event</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DEC</name>
+                  <description>Decrement counter on event</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PPW</name>
+                  <description>Period capture value in CC0 register, pulse width capture value in CC1 register</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>PWP</name>
+                  <description>Period capture value in CC1 register, pulse width capture value in CC0 register</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FAULT</name>
+                  <description>Non-recoverable fault</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CNTSEL</name>
+              <description>Timer/counter Output Event Mode</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>CNTSELSelect</name>
+                <enumeratedValue>
+                  <name>START</name>
+                  <description>An interrupt/event is generated when a new counter cycle starts</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>END</name>
+                  <description>An interrupt/event is generated when a counter cycle ends</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BETWEEN</name>
+                  <description>An interrupt/event is generated when a counter cycle ends, except for the first and last cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>BOUNDARY</name>
+                  <description>An interrupt/event is generated when a new counter cycle starts or a counter cycle ends</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>OVFEO</name>
+              <description>Overflow/Underflow Output Event Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRGEO</name>
+              <description>Retrigger Output Event Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNTEO</name>
+              <description>Timer/counter Output Event Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCINV0</name>
+              <description>Inverted Event 0 Input Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCINV1</name>
+              <description>Inverted Event 1 Input Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI0</name>
+              <description>Timer/counter Event 0 Input Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TCEI1</name>
+              <description>Timer/counter Event 1 Input Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI0</name>
+              <description>Match or Capture Channel 0 Event Input Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI1</name>
+              <description>Match or Capture Channel 1 Event Input Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI2</name>
+              <description>Match or Capture Channel 2 Event Input Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEI3</name>
+              <description>Match or Capture Channel 3 Event Input Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO0</name>
+              <description>Match or Capture Channel 0 Event Output Enable</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO1</name>
+              <description>Match or Capture Channel 1 Event Output Enable</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO2</name>
+              <description>Match or Capture Channel 2 Event Output Enable</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MCEO3</name>
+              <description>Match or Capture Channel 3 Event Output Enable</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x24</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRG</name>
+              <description>Retrigger Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNT</name>
+              <description>Counter Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0 Interrupt Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1 Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC2</name>
+              <description>Match or Capture Channel 2 Interrupt Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC3</name>
+              <description>Match or Capture Channel 3 Interrupt Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x28</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRG</name>
+              <description>Retrigger Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNT</name>
+              <description>Counter Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault Interrupt Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A Interrupt Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B Interrupt Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0 Interrupt Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1 Interrupt Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture Channel 0 Interrupt Enable</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture Channel 1 Interrupt Enable</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC2</name>
+              <description>Match or Capture Channel 2 Interrupt Enable</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC3</name>
+              <description>Match or Capture Channel 3 Interrupt Enable</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x2C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>OVF</name>
+              <description>Overflow</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRG</name>
+              <description>Retrigger</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CNT</name>
+              <description>Counter</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ERR</name>
+              <description>Error</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC0</name>
+              <description>Match or Capture 0</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC1</name>
+              <description>Match or Capture 1</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC2</name>
+              <description>Match or Capture 2</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MC3</name>
+              <description>Match or Capture 3</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x30</addressOffset>
+          <size>32</size>
+          <resetValue>0x00000001</resetValue>
+          <fields>
+            <field>
+              <name>STOP</name>
+              <description>Stop</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>IDX</name>
+              <description>Ramp</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DFS</name>
+              <description>Non-Recoverable Debug Fault State</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SLAVE</name>
+              <description>Slave</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>PATTBV</name>
+              <description>Pattern Buffer Valid</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAVEBV</name>
+              <description>Wave Buffer Valid</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PERBV</name>
+              <description>Period Buffer Valid</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTAIN</name>
+              <description>Recoverable Fault A Input</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULTBIN</name>
+              <description>Recoverable Fault B Input</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULT0IN</name>
+              <description>Non-Recoverable Fault0 Input</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULT1IN</name>
+              <description>Non-Recoverable Fault1 Input</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FAULTA</name>
+              <description>Recoverable Fault A State</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULTB</name>
+              <description>Recoverable Fault B State</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT0</name>
+              <description>Non-Recoverable Fault 0 State</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>FAULT1</name>
+              <description>Non-Recoverable Fault 1 State</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV0</name>
+              <description>Compare Channel 0 Buffer Valid</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV1</name>
+              <description>Compare Channel 1 Buffer Valid</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV2</name>
+              <description>Compare Channel 2 Buffer Valid</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CCBV3</name>
+              <description>Compare Channel 3 Buffer Valid</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CMP0</name>
+              <description>Compare Channel 0 Value</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CMP1</name>
+              <description>Compare Channel 1 Value</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CMP2</name>
+              <description>Compare Channel 2 Value</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CMP3</name>
+              <description>Compare Channel 3 Value</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT</name>
+          <description>Count</description>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT_DITH4</name>
+          <description>Count</description>
+          <alternateRegister>COUNT</alternateRegister>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT_DITH5</name>
+          <description>Count</description>
+          <alternateRegister>COUNT</alternateRegister>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COUNT_DITH6</name>
+          <description>Count</description>
+          <alternateRegister>COUNT</alternateRegister>
+          <addressOffset>0x34</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>COUNT</name>
+              <description>Counter Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PATT</name>
+          <description>Pattern</description>
+          <addressOffset>0x38</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PGE0</name>
+              <description>Pattern Generator 0 Output Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE1</name>
+              <description>Pattern Generator 1 Output Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE2</name>
+              <description>Pattern Generator 2 Output Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE3</name>
+              <description>Pattern Generator 3 Output Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE4</name>
+              <description>Pattern Generator 4 Output Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE5</name>
+              <description>Pattern Generator 5 Output Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE6</name>
+              <description>Pattern Generator 6 Output Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGE7</name>
+              <description>Pattern Generator 7 Output Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV0</name>
+              <description>Pattern Generator 0 Output Value</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV1</name>
+              <description>Pattern Generator 1 Output Value</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV2</name>
+              <description>Pattern Generator 2 Output Value</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV3</name>
+              <description>Pattern Generator 3 Output Value</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV4</name>
+              <description>Pattern Generator 4 Output Value</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV5</name>
+              <description>Pattern Generator 5 Output Value</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV6</name>
+              <description>Pattern Generator 6 Output Value</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGV7</name>
+              <description>Pattern Generator 7 Output Value</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAVE</name>
+          <description>Waveform Control</description>
+          <addressOffset>0x3C</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WAVEGEN</name>
+              <description>Waveform Generation</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <description>Normal frequency</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <description>Match frequency</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <description>Normal PWM</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSCRITICAL</name>
+                  <description>Dual-slope critical</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTTOM</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTH</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSTOP</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches TOP</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RAMP</name>
+              <description>Ramp Mode</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RAMPSelect</name>
+                <enumeratedValue>
+                  <name>RAMP1</name>
+                  <description>RAMP1 operation</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2A</name>
+                  <description>Alternative RAMP2 operation</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2</name>
+                  <description>RAMP2 operation</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2C</name>
+                  <description>Critical RAMP2 operation</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CIPEREN</name>
+              <description>Circular period Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN0</name>
+              <description>Circular Channel 0 Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN1</name>
+              <description>Circular Channel 1 Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN2</name>
+              <description>Circular Channel 2 Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCEN3</name>
+              <description>Circular Channel 3 Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL0</name>
+              <description>Channel 0 Polarity</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL1</name>
+              <description>Channel 1 Polarity</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL2</name>
+              <description>Channel 2 Polarity</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POL3</name>
+              <description>Channel 3 Polarity</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP0</name>
+              <description>Swap DTI Output Pair 0</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP1</name>
+              <description>Swap DTI Output Pair 1</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP2</name>
+              <description>Swap DTI Output Pair 2</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAP3</name>
+              <description>Swap DTI Output Pair 3</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER</name>
+          <description>Period</description>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER_DITH4</name>
+          <description>Period</description>
+          <alternateRegister>PER</alternateRegister>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER_DITH5</name>
+          <description>Period</description>
+          <alternateRegister>PER</alternateRegister>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PER_DITH6</name>
+          <description>Period</description>
+          <alternateRegister>PER</alternateRegister>
+          <addressOffset>0x40</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>PER</name>
+              <description>Period Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s</name>
+          <description>Compare and Capture</description>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s_DITH4</name>
+          <description>Compare and Capture</description>
+          <alternateRegister>CC%s</alternateRegister>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s_DITH5</name>
+          <description>Compare and Capture</description>
+          <alternateRegister>CC%s</alternateRegister>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CC%s_DITH6</name>
+          <description>Compare and Capture</description>
+          <alternateRegister>CC%s</alternateRegister>
+          <addressOffset>0x44</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCY</name>
+              <description>Dithering Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>CC</name>
+              <description>Channel Compare/Capture Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PATTB</name>
+          <description>Pattern Buffer</description>
+          <addressOffset>0x64</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>PGEB0</name>
+              <description>Pattern Generator 0 Output Enable Buffer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB1</name>
+              <description>Pattern Generator 1 Output Enable Buffer</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB2</name>
+              <description>Pattern Generator 2 Output Enable Buffer</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB3</name>
+              <description>Pattern Generator 3 Output Enable Buffer</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB4</name>
+              <description>Pattern Generator 4 Output Enable Buffer</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB5</name>
+              <description>Pattern Generator 5 Output Enable Buffer</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB6</name>
+              <description>Pattern Generator 6 Output Enable Buffer</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGEB7</name>
+              <description>Pattern Generator 7 Output Enable Buffer</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB0</name>
+              <description>Pattern Generator 0 Output Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB1</name>
+              <description>Pattern Generator 1 Output Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB2</name>
+              <description>Pattern Generator 2 Output Enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB3</name>
+              <description>Pattern Generator 3 Output Enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB4</name>
+              <description>Pattern Generator 4 Output Enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB5</name>
+              <description>Pattern Generator 5 Output Enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB6</name>
+              <description>Pattern Generator 6 Output Enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>PGVB7</name>
+              <description>Pattern Generator 7 Output Enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WAVEB</name>
+          <description>Waveform Control Buffer</description>
+          <addressOffset>0x68</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>WAVEGENB</name>
+              <description>Waveform Generation Buffer</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>WAVEGENBSelect</name>
+                <enumeratedValue>
+                  <name>NFRQ</name>
+                  <description>Normal frequency</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>MFRQ</name>
+                  <description>Match frequency</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NPWM</name>
+                  <description>Normal PWM</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSCRITICAL</name>
+                  <description>Dual-slope critical</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTTOM</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSBOTH</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches ZERO or TOP</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DSTOP</name>
+                  <description>Dual-slope with interrupt/event condition when COUNT reaches TOP</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>RAMPB</name>
+              <description>Ramp Mode Buffer</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RAMPBSelect</name>
+                <enumeratedValue>
+                  <name>RAMP1</name>
+                  <description>RAMP1 operation</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2A</name>
+                  <description>Alternative RAMP2 operation</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RAMP2</name>
+                  <description>RAMP2 operation</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CIPERENB</name>
+              <description>Circular Period Enable Buffer</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB0</name>
+              <description>Circular Channel 0 Enable Buffer</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB1</name>
+              <description>Circular Channel 1 Enable Buffer</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB2</name>
+              <description>Circular Channel 2 Enable Buffer</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>CICCENB3</name>
+              <description>Circular Channel 3 Enable Buffer</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB0</name>
+              <description>Channel 0 Polarity Buffer</description>
+              <bitOffset>16</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB1</name>
+              <description>Channel 1 Polarity Buffer</description>
+              <bitOffset>17</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB2</name>
+              <description>Channel 2 Polarity Buffer</description>
+              <bitOffset>18</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>POLB3</name>
+              <description>Channel 3 Polarity Buffer</description>
+              <bitOffset>19</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB0</name>
+              <description>Swap DTI Output Pair 0 Buffer</description>
+              <bitOffset>24</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB1</name>
+              <description>Swap DTI Output Pair 1 Buffer</description>
+              <bitOffset>25</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB2</name>
+              <description>Swap DTI Output Pair 2 Buffer</description>
+              <bitOffset>26</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SWAPB3</name>
+              <description>Swap DTI Output Pair 3 Buffer</description>
+              <bitOffset>27</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB</name>
+          <description>Period Buffer</description>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB_DITH4</name>
+          <description>Period Buffer</description>
+          <alternateRegister>PERB</alternateRegister>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB_DITH5</name>
+          <description>Period Buffer</description>
+          <alternateRegister>PERB</alternateRegister>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PERB_DITH6</name>
+          <description>Period Buffer</description>
+          <alternateRegister>PERB</alternateRegister>
+          <addressOffset>0x6C</addressOffset>
+          <size>32</size>
+          <resetValue>0xFFFFFFFF</resetValue>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>PERB</name>
+              <description>Period Buffer Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s</name>
+          <description>Compare and Capture Buffer</description>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>24</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s_DITH4</name>
+          <description>Compare and Capture Buffer</description>
+          <alternateRegister>CCB%s</alternateRegister>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>20</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s_DITH5</name>
+          <description>Compare and Capture Buffer</description>
+          <alternateRegister>CCB%s</alternateRegister>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>19</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>4</dim>
+          <dimIncrement>0x4</dimIncrement>
+          <name>CCB%s_DITH6</name>
+          <description>Compare and Capture Buffer</description>
+          <alternateRegister>CCB%s</alternateRegister>
+          <addressOffset>0x70</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DITHERCYB</name>
+              <description>Dithering Buffer Cycle Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+            <field>
+              <name>CCB</name>
+              <description>Channel Compare/Capture Buffer Value</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>18</bitWidth>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>USB</name>
+      <version>1.0.2</version>
+      <description>Universal Serial Bus</description>
+      <groupName>USB</groupName>
+      <prependToName>USB_</prependToName>
+      <baseAddress>0x41005000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x1000</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>USB</name>
+        <value>7</value>
+      </interrupt>
+      <registers>
+       <cluster>
+        <name>DEVICE</name>
+        <description>USB is Device</description>
+        <headerStructName>UsbDevice</headerStructName>
+        <addressOffset>0x0</addressOffset>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x000</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby Mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MODE</name>
+              <description>Operating Mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <enumeratedValues>
+                <name>MODESelect</name>
+                <enumeratedValue>
+                  <name>DEVICE</name>
+                  <description>Device Mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SYNCBUSY</name>
+          <description>Synchronization Busy</description>
+          <addressOffset>0x002</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset Synchronization Busy</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable Synchronization Busy</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>QOSCTRL</name>
+          <description>USB Quality Of Service</description>
+          <addressOffset>0x003</addressOffset>
+          <size>8</size>
+          <resetValue>0x05</resetValue>
+          <fields>
+            <field>
+              <name>CQOS</name>
+              <description>Configuration Quality of Service</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+            <field>
+              <name>DQOS</name>
+              <description>Data Quality of Service</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>DEVICE Control B</description>
+          <addressOffset>0x008</addressOffset>
+          <size>16</size>
+          <resetValue>0x0001</resetValue>
+          <fields>
+            <field>
+              <name>DETACH</name>
+              <description>Detach</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SPDCONF</name>
+              <description>Speed Configuration</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>SPDCONFSelect</name>
+                <enumeratedValue>
+                  <name>FS</name>
+                  <description>FS : Full Speed</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LS</name>
+                  <description>LS : Low Speed</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HS</name>
+                  <description>HS : High Speed capable</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HSTM</name>
+                  <description>HSTM: High Speed Test Mode (force high-speed mode for test mode)</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>NREPLY</name>
+              <description>No Reply</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTJ</name>
+              <description>Test mode J</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTK</name>
+              <description>Test mode K</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TSTPCKT</name>
+              <description>Test packet mode</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>OPMODE2</name>
+              <description>Specific Operational Mode</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>GNAK</name>
+              <description>Global NAK</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMHDSK</name>
+              <description>Link Power Management Handshake</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>LPMHDSKSelect</name>
+                <enumeratedValue>
+                  <name>NO</name>
+                  <description>No handshake. LPM is not supported</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ACK</name>
+                  <description>ACK</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>NYET</name>
+                  <description>NYET</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>STALL</name>
+                  <description>STALL</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DADD</name>
+          <description>DEVICE Device Address</description>
+          <addressOffset>0x00A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>DADD</name>
+              <description>Device Address</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>7</bitWidth>
+            </field>
+            <field>
+              <name>ADDEN</name>
+              <description>Device Address Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>DEVICE Status</description>
+          <addressOffset>0x00C</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x40</resetValue>
+          <fields>
+            <field>
+              <name>SPEED</name>
+              <description>Speed Status</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>SPEEDSelect</name>
+                <enumeratedValue>
+                  <name>FS</name>
+                  <description>Full-speed mode</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>HS</name>
+                  <description>High-speed mode</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>LS</name>
+                  <description>Low-speed mode</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>LINESTATE</name>
+              <description>USB Line State Status</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>2</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>LINESTATESelect</name>
+                <enumeratedValue>
+                  <name>0</name>
+                  <description>SE0/RESET</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1</name>
+                  <description>FS-J or LS-K State</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2</name>
+                  <description>FS-K or LS-J State</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FSMSTATUS</name>
+          <description>Finite State Machine Status</description>
+          <addressOffset>0x00D</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <resetValue>0x01</resetValue>
+          <fields>
+            <field>
+              <name>FSMSTATE</name>
+              <description>Fine State Machine Status</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+              <access>read-only</access>
+              <enumeratedValues>
+                <name>FSMSTATESelect</name>
+                <enumeratedValue>
+                  <name>OFF</name>
+                  <description>OFF (L3). It corresponds to the powered-off, disconnected, and disabled state</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>ON</name>
+                  <description>ON (L0). It corresponds to the Idle and Active states</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SUSPEND</name>
+                  <description>SUSPEND (L2)</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>SLEEP</name>
+                  <description>SLEEP (L1)</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>DNRESUME</name>
+                  <description>DNRESUME. Down Stream Resume.</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>UPRESUME</name>
+                  <description>UPRESUME. Up Stream Resume.</description>
+                  <value>0x20</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RESET</name>
+                  <description>RESET. USB lines Reset.</description>
+                  <value>0x40</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FNUM</name>
+          <description>DEVICE Device Frame Number</description>
+          <addressOffset>0x010</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>MFNUM</name>
+              <description>Micro Frame Number</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FNUM</name>
+              <description>Frame Number</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>11</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>FNCERR</name>
+              <description>Frame Number CRC Error</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>DEVICE Device Interrupt Enable Clear</description>
+          <addressOffset>0x014</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SUSPEND</name>
+              <description>Suspend Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSOF</name>
+              <description>Micro Start of Frame Interrupt Enable in High Speed Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOF</name>
+              <description>Start Of Frame Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORST</name>
+              <description>End of Reset Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORSM</name>
+              <description>End Of Resume Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMNYET</name>
+              <description>Link Power Management Not Yet Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMSUSP</name>
+              <description>Link Power Management Suspend Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>DEVICE Device Interrupt Enable Set</description>
+          <addressOffset>0x018</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SUSPEND</name>
+              <description>Suspend Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSOF</name>
+              <description>Micro Start of Frame Interrupt Enable in High Speed Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOF</name>
+              <description>Start Of Frame Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORST</name>
+              <description>End of Reset Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORSM</name>
+              <description>End Of Resume Interrupt Enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume Interrupt Enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access Interrupt Enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMNYET</name>
+              <description>Link Power Management Not Yet Interrupt Enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMSUSP</name>
+              <description>Link Power Management Suspend Interrupt Enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>DEVICE Device Interrupt Flag</description>
+          <addressOffset>0x01C</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>SUSPEND</name>
+              <description>Suspend</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>MSOF</name>
+              <description>Micro Start of Frame in High Speed Mode</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>SOF</name>
+              <description>Start Of Frame</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORST</name>
+              <description>End of Reset</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WAKEUP</name>
+              <description>Wake Up</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>EORSM</name>
+              <description>End Of Resume</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>UPRSM</name>
+              <description>Upstream Resume</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RAMACER</name>
+              <description>Ram Access</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMNYET</name>
+              <description>Link Power Management Not Yet</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>LPMSUSP</name>
+              <description>Link Power Management Suspend</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EPINTSMRY</name>
+          <description>DEVICE End Point Interrupt Summary</description>
+          <addressOffset>0x020</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>EPINT0</name>
+              <description>End Point 0 Interrupt</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT1</name>
+              <description>End Point 1 Interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT2</name>
+              <description>End Point 2 Interrupt</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT3</name>
+              <description>End Point 3 Interrupt</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT4</name>
+              <description>End Point 4 Interrupt</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT5</name>
+              <description>End Point 5 Interrupt</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT6</name>
+              <description>End Point 6 Interrupt</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>EPINT7</name>
+              <description>End Point 7 Interrupt</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>DESCADD</name>
+          <description>Descriptor Address</description>
+          <addressOffset>0x024</addressOffset>
+          <size>32</size>
+          <fields>
+            <field>
+              <name>DESCADD</name>
+              <description>Descriptor Address Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>32</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>PADCAL</name>
+          <description>USB PAD Calibration</description>
+          <addressOffset>0x028</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>TRANSP</name>
+              <description>USB Pad Transp calibration</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TRANSN</name>
+              <description>USB Pad Transn calibration</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>5</bitWidth>
+            </field>
+            <field>
+              <name>TRIM</name>
+              <description>USB Pad Trim calibration</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPCFG%s</name>
+          <description>DEVICE End Point Configuration</description>
+          <addressOffset>0x100</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EPTYPE0</name>
+              <description>End Point Type0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>EPTYPE1</name>
+              <description>End Point Type1</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+            <field>
+              <name>NYETDIS</name>
+              <description>NYET Token Disable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPSTATUSCLR%s</name>
+          <description>DEVICE End Point Pipe Status Clear</description>
+          <addressOffset>0x104</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>DTGLOUT</name>
+              <description>Data Toggle OUT Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>DTGLIN</name>
+              <description>Data Toggle IN Clear</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank Clear</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ0</name>
+              <description>Stall 0 Request Clear</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ1</name>
+              <description>Stall 1 Request Clear</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 Ready Clear</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 Ready Clear</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPSTATUSSET%s</name>
+          <description>DEVICE End Point Pipe Status Set</description>
+          <addressOffset>0x105</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>DTGLOUT</name>
+              <description>Data Toggle OUT Set</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>DTGLIN</name>
+              <description>Data Toggle IN Set</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank Set</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ0</name>
+              <description>Stall 0 Request Set</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>STALLRQ1</name>
+              <description>Stall 1 Request Set</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 Ready Set</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 Ready Set</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>write-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPSTATUS%s</name>
+          <description>DEVICE End Point Pipe Status</description>
+          <addressOffset>0x106</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>DTGLOUT</name>
+              <description>Data Toggle Out</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>DTGLIN</name>
+              <description>Data Toggle In</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>CURBK</name>
+              <description>Current Bank</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>STALLRQ0</name>
+              <description>Stall 0 Request</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>STALLRQ1</name>
+              <description>Stall 1 Request</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BK0RDY</name>
+              <description>Bank 0 ready</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+            <field>
+              <name>BK1RDY</name>
+              <description>Bank 1 ready</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPINTFLAG%s</name>
+          <description>DEVICE End Point Interrupt Flag</description>
+          <addressOffset>0x107</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL0</name>
+              <description>Error Flow 0</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL1</name>
+              <description>Error Flow 1</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXSTP</name>
+              <description>Received Setup</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL0</name>
+              <description>Stall 0 In/out</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL1</name>
+              <description>Stall 1 In/out</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPINTENCLR%s</name>
+          <description>DEVICE End Point Interrupt Clear Flag</description>
+          <addressOffset>0x108</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0 Interrupt Disable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1 Interrupt Disable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL0</name>
+              <description>Error Flow 0 Interrupt Disable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL1</name>
+              <description>Error Flow 1 Interrupt Disable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXSTP</name>
+              <description>Received Setup Interrupt Disable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL0</name>
+              <description>Stall 0 In/Out Interrupt Disable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL1</name>
+              <description>Stall 1 In/Out Interrupt Disable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <dim>8</dim>
+          <dimIncrement>0x20</dimIncrement>
+          <name>EPINTENSET%s</name>
+          <description>DEVICE End Point Interrupt Set Flag</description>
+          <addressOffset>0x109</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>TRCPT0</name>
+              <description>Transfer Complete 0 Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRCPT1</name>
+              <description>Transfer Complete 1 Interrupt Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL0</name>
+              <description>Error Flow 0 Interrupt Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>TRFAIL1</name>
+              <description>Error Flow 1 Interrupt Enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RXSTP</name>
+              <description>Received Setup Interrupt Enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL0</name>
+              <description>Stall 0 In/out Interrupt enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>STALL1</name>
+              <description>Stall 1 In/out Interrupt enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+       </cluster> <!-- UsbDevice -->
+      </registers>
+    </peripheral>
+    <peripheral>
+      <name>WDT</name>
+      <version>2.0.0</version>
+      <description>Watchdog Timer</description>
+      <groupName>WDT</groupName>
+      <prependToName>WDT_</prependToName>
+      <baseAddress>0x40001000</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x10</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>WDT</name>
+        <value>2</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRL</name>
+          <description>Control</description>
+          <addressOffset>0x0</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WEN</name>
+              <description>Watchdog Timer Window Mode Enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ALWAYSON</name>
+              <description>Always-On</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CONFIG</name>
+          <description>Configuration</description>
+          <addressOffset>0x1</addressOffset>
+          <size>8</size>
+          <resetValue>0xBB</resetValue>
+          <fields>
+            <field>
+              <name>PER</name>
+              <description>Time-Out Period</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>PERSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 clock cycles</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 clock cycles</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 clock cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 clock cycles</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 clock cycles</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 clock cycles</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 clock cycles</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1K</name>
+                  <description>1024 clock cycles</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2K</name>
+                  <description>2048 clock cycles</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4K</name>
+                  <description>4096 clock cycles</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8K</name>
+                  <description>8192 clock cycles</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16K</name>
+                  <description>16384 clock cycles</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>WINDOW</name>
+              <description>Window Mode Time-Out Period</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>WINDOWSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 clock cycles</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 clock cycles</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 clock cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 clock cycles</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 clock cycles</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 clock cycles</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 clock cycles</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1K</name>
+                  <description>1024 clock cycles</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2K</name>
+                  <description>2048 clock cycles</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4K</name>
+                  <description>4096 clock cycles</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8K</name>
+                  <description>8192 clock cycles</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16K</name>
+                  <description>16384 clock cycles</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>EWCTRL</name>
+          <description>Early Warning Interrupt Control</description>
+          <addressOffset>0x2</addressOffset>
+          <size>8</size>
+          <resetValue>0x0B</resetValue>
+          <fields>
+            <field>
+              <name>EWOFFSET</name>
+              <description>Early Warning Interrupt Time Offset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>EWOFFSETSelect</name>
+                <enumeratedValue>
+                  <name>8</name>
+                  <description>8 clock cycles</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16</name>
+                  <description>16 clock cycles</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>32</name>
+                  <description>32 clock cycles</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>64</name>
+                  <description>64 clock cycles</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>128</name>
+                  <description>128 clock cycles</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>256</name>
+                  <description>256 clock cycles</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>512</name>
+                  <description>512 clock cycles</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>1K</name>
+                  <description>1024 clock cycles</description>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>2K</name>
+                  <description>2048 clock cycles</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>4K</name>
+                  <description>4096 clock cycles</description>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>8K</name>
+                  <description>8192 clock cycles</description>
+                  <value>0xa</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>16K</name>
+                  <description>16384 clock cycles</description>
+                  <value>0xb</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x4</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EW</name>
+              <description>Early Warning Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x5</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EW</name>
+              <description>Early Warning Interrupt Enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x6</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EW</name>
+              <description>Early Warning</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>STATUS</name>
+          <description>Status</description>
+          <addressOffset>0x7</addressOffset>
+          <size>8</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>SYNCBUSY</name>
+              <description>Synchronization Busy</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CLEAR</name>
+          <description>Clear</description>
+          <addressOffset>0x8</addressOffset>
+          <size>8</size>
+          <access>write-only</access>
+          <fields>
+            <field>
+              <name>CLEAR</name>
+              <description>Watchdog Clear</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>8</bitWidth>
+              <access>write-only</access>
+              <enumeratedValues>
+                <name>CLEARSelect</name>
+                <enumeratedValue>
+                  <name>KEY</name>
+                  <description>Clear Key</description>
+                  <value>0xa5</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+      </registers>
+    </peripheral>
+  </peripherals>
+</device>

--- a/update.sh
+++ b/update.sh
@@ -7,7 +7,7 @@ cargo install --force --version 0.7.0 form
 
 TOP=$PWD
 
-for chip in atsamd21g18a atsamd21e18a atsamd21j18a atsamd51g19a atsamd51j19a atsamd51j20a; do
+for chip in atsamd11c14a atsamd21g18a atsamd21e18a atsamd21j18a atsamd51g19a atsamd51j19a atsamd51j20a; do
   cd $TOP/pac/$chip
   CHIP=$(echo $chip | tr a-z A-Z)
   rm -rf src


### PR DESCRIPTION
This should add initial support for the aforementioned device. Couldn't get the USB module to build so it is not included at this time, but everything else from `hal/src/samd21` should be there. Only really tested with a blinky app so far, but that confirms multiple peripherals are functioning so that's a good sign.

The feature gating in `hal/src/lib.rs` could probably be a bit cleaner, but this should work for the time being. When/if more devices get added it may be worth adding a `samd21` feature as well or something.

I haven't added anything to `travis.yml` regarding the new device as there are not currently any board crates that use it. Not sure if this is an issue or if it's okay for the time being.

If I've omitted anything or anything needs fixing just let me know.