### PR TITLE
pygamer: remove wheel function for smart_leds hsv conversion

### DIFF
--- a/boards/pygamer/examples/neopixel_adc_battery.rs
+++ b/boards/pygamer/examples/neopixel_adc_battery.rs
@@ -15,8 +15,7 @@ use hal::prelude::*;
 use hal::timer::SpinTimer;
 use hal::{clock::GenericClockController, delay::Delay};
 
-use smart_leds::hsv::RGB8;
-use smart_leds::{brightness, SmartLedsWrite};
+use smart_leds::{brightness, hsv::RGB8, SmartLedsWrite};
 
 #[entry]
 fn main() -> ! {
@@ -77,7 +76,6 @@ fn main() -> ! {
         neopixel
             .write(brightness(colors.iter().cloned(), 1))
             .unwrap();
-        delay.delay_ms(5u8);
 
         delay.delay_ms(10u8);
     }

--- a/boards/pygamer/examples/neopixel_adc_light.rs
+++ b/boards/pygamer/examples/neopixel_adc_light.rs
@@ -15,8 +15,10 @@ use hal::prelude::*;
 use hal::timer::SpinTimer;
 use hal::{clock::GenericClockController, delay::Delay};
 
-use smart_leds::hsv::RGB8;
-use smart_leds::{brightness, SmartLedsWrite};
+use smart_leds::{
+    hsv::{hsv2rgb, Hsv, RGB8},
+    SmartLedsWrite,
+};
 
 use embedded_hal::digital::v1_compat::OldOutputPin;
 use ws2812_timer_delay as ws2812;
@@ -62,29 +64,21 @@ fn main() -> ! {
         };
 
         //finally paint the one led wherever the position is
-        let _ = neopixel.write(brightness(
-            (0..NUM_LEDS).map(|i| if i == pos { wheel(j) } else { RGB8::default() }),
-            32,
-        ));
+        let _ = neopixel.write((0..NUM_LEDS).map(|i| {
+            if i == pos {
+                hsv2rgb(Hsv {
+                    hue: j,
+                    sat: 255,
+                    val: 32,
+                })
+            } else {
+                RGB8::default()
+            }
+        }));
 
-        //incremement the wheel easing
+        //incremement the hue easing
         j = j.wrapping_add(1);
 
         delay.delay_ms(10u8);
     }
-}
-
-/// Input a value 0 to 255 to get a color value
-/// The colours are a transition r - g - b - back to r.
-fn wheel(mut wheel_pos: u8) -> RGB8 {
-    wheel_pos = 255 - wheel_pos;
-    if wheel_pos < 85 {
-        return (255 - wheel_pos * 3, 0, wheel_pos * 3).into();
-    }
-    if wheel_pos < 170 {
-        wheel_pos -= 85;
-        return (0, wheel_pos * 3, 255 - wheel_pos * 3).into();
-    }
-    wheel_pos -= 170;
-    (wheel_pos * 3, 255 - wheel_pos * 3, 0).into()
 }

--- a/boards/pygamer/examples/neopixel_easing.rs
+++ b/boards/pygamer/examples/neopixel_easing.rs
@@ -1,4 +1,4 @@
-//! Display light sensor reading on the neopixels.
+//! Randomly choose and led and color to breath in and out
 
 #![no_std]
 #![no_main]
@@ -16,8 +16,10 @@ use hal::prelude::*;
 use hal::timer::SpinTimer;
 use hal::trng::Trng;
 use micromath::F32Ext;
-use smart_leds::hsv::RGB8;
-use smart_leds::{brightness, SmartLedsWrite};
+use smart_leds::{
+    hsv::{hsv2rgb, Hsv, RGB8},
+    SmartLedsWrite,
+};
 
 #[entry]
 fn main() -> ! {
@@ -44,25 +46,36 @@ fn main() -> ! {
     loop {
         let rand = trng.random_u8();
         let pos: usize = rand.wrapping_rem(5) as usize; //random led
-        let rgb = wheel(rand); //random color
 
         //slowly enable led
         for j in 0..255u8 {
-            let _ = neopixel.write(brightness(
-                (0..NUM_LEDS).map(|i| if i == pos { rgb } else { RGB8::default() }),
-                // current step, start output led off=0, max output of only 32, 255 top
-                sine_ease_in(j as f32, 0.0, 32.0, 255.0) as u8,
-            ));
+            let _ = neopixel.write((0..NUM_LEDS).map(|i| {
+                if i == pos {
+                    hsv2rgb(Hsv {
+                        hue: rand,
+                        sat: 255,
+                        val: sine_ease_in(j as f32, 0.0, 32.0, 255.0) as u8,
+                    })
+                } else {
+                    RGB8::default()
+                }
+            }));
             delay.delay_ms(5u8);
         }
 
         //slowly disable led - note the reverse .rev()
         for j in (0..255u8).rev() {
-            let _ = neopixel.write(brightness(
-                (0..NUM_LEDS).map(|i| if i == pos { rgb } else { RGB8::default() }),
-                // current step, start output led off=0, max output of only 32, 255 top
-                sine_ease_in(j as f32, 0.0, 32.0, 255.0) as u8,
-            ));
+            let _ = neopixel.write((0..NUM_LEDS).map(|i| {
+                if i == pos {
+                    hsv2rgb(Hsv {
+                        hue: rand,
+                        sat: 255,
+                        val: sine_ease_in(j as f32, 0.0, 32.0, 255.0) as u8,
+                    })
+                } else {
+                    RGB8::default()
+                }
+            }));
             delay.delay_ms(5u8);
         }
     }
@@ -72,19 +85,4 @@ fn main() -> ! {
 // current step, where oputput starts, where output ends, last step
 fn sine_ease_in(t: f32, b: f32, c: f32, d: f32) -> f32 {
     -c * (t / d * FRAC_PI_2).cos() + c + b
-}
-
-/// Input a value 0 to 255 to get a color value
-/// The colours are a transition r - g - b - back to r.
-fn wheel(mut wheel_pos: u8) -> RGB8 {
-    wheel_pos = 255 - wheel_pos;
-    if wheel_pos < 85 {
-        return (255 - wheel_pos * 3, 0, wheel_pos * 3).into();
-    }
-    if wheel_pos < 170 {
-        wheel_pos -= 85;
-        return (0, wheel_pos * 3, 255 - wheel_pos * 3).into();
-    }
-    wheel_pos -= 170;
-    (wheel_pos * 3, 255 - wheel_pos * 3, 0).into()
 }

--- a/boards/pygamer/examples/neopixel_rainbow_spi.rs
+++ b/boards/pygamer/examples/neopixel_rainbow_spi.rs
@@ -12,8 +12,10 @@ use hal::sercom::PadPin;
 use hal::time::MegaHertz;
 use hal::{clock::GenericClockController, delay::Delay};
 
-use smart_leds::hsv::RGB8;
-use smart_leds::{brightness, SmartLedsWrite};
+use smart_leds::{
+    hsv::{hsv2rgb, Hsv},
+    SmartLedsWrite,
+};
 use ws2812_spi as ws2812;
 
 #[entry]
@@ -58,31 +60,35 @@ fn main() -> ! {
             let colors = [
                 // split the color changes across all 5 leds evenly, 255/5=51
                 // and have them safely wrap over when they go above 255
-                wheel(j),
-                wheel(j.wrapping_add(51)),
-                wheel(j.wrapping_add(102)),
-                wheel(j.wrapping_add(153)),
-                wheel(j.wrapping_add(204)),
+                hsv2rgb(Hsv {
+                    hue: j,
+                    sat: 255,
+                    val: 32,
+                }),
+                hsv2rgb(Hsv {
+                    hue: j.wrapping_add(51),
+                    sat: 255,
+                    val: 32,
+                }),
+                hsv2rgb(Hsv {
+                    hue: j.wrapping_add(102),
+                    sat: 255,
+                    val: 32,
+                }),
+                hsv2rgb(Hsv {
+                    hue: j.wrapping_add(153),
+                    sat: 255,
+                    val: 32,
+                }),
+                hsv2rgb(Hsv {
+                    hue: j.wrapping_add(204),
+                    sat: 255,
+                    val: 32,
+                }),
             ];
-            neopixel
-                .write(brightness(colors.iter().cloned(), 32))
-                .unwrap();
+
+            neopixel.write(colors.iter().cloned()).unwrap();
             delay.delay_ms(5u8);
         }
     }
-}
-
-/// Input a value 0 to 255 to get a color value
-/// The colours are a transition r - g - b - back to r.
-fn wheel(mut wheel_pos: u8) -> RGB8 {
-    wheel_pos = 255 - wheel_pos;
-    if wheel_pos < 85 {
-        return (255 - wheel_pos * 3, 0, wheel_pos * 3).into();
-    }
-    if wheel_pos < 170 {
-        wheel_pos -= 85;
-        return (0, wheel_pos * 3, 255 - wheel_pos * 3).into();
-    }
-    wheel_pos -= 170;
-    (wheel_pos * 3, 255 - wheel_pos * 3, 0).into()
 }

--- a/boards/pygamer/examples/neopixel_rainbow_spintimer.rs
+++ b/boards/pygamer/examples/neopixel_rainbow_spintimer.rs
@@ -11,8 +11,10 @@ use hal::prelude::*;
 use hal::timer::SpinTimer;
 use hal::{clock::GenericClockController, delay::Delay};
 
-use smart_leds::hsv::RGB8;
-use smart_leds::{brightness, SmartLedsWrite};
+use smart_leds::{
+    hsv::{hsv2rgb, Hsv},
+    SmartLedsWrite,
+};
 
 #[entry]
 fn main() -> ! {
@@ -36,31 +38,17 @@ fn main() -> ! {
 
     loop {
         for j in 0..255u8 {
-            let _ = neopixel.write(brightness(
-                (0..NUM_LEDS).map(|i| {
-                    //could have all leds be same color with number = j
-                    //instead lets offset each of them by 255/5 or 51
-                    wheel(j.wrapping_add(51 * i as u8))
-                }),
-                32,
-            ));
+            let _ = neopixel.write((0..NUM_LEDS).map(|i| {
+                //could have all leds be same color with number = j
+                //instead lets offset each of them by 255/5 or 51
+                hsv2rgb(Hsv {
+                    hue: j.wrapping_add(51 * i as u8),
+                    sat: 255,
+                    val: 32,
+                })
+            }));
 
             delay.delay_ms(5u8);
         }
     }
-}
-
-/// Input a value 0 to 255 to get a color value
-/// The colours are a transition r - g - b - back to r.
-fn wheel(mut wheel_pos: u8) -> RGB8 {
-    wheel_pos = 255 - wheel_pos;
-    if wheel_pos < 85 {
-        return (255 - wheel_pos * 3, 0, wheel_pos * 3).into();
-    }
-    if wheel_pos < 170 {
-        wheel_pos -= 85;
-        return (0, wheel_pos * 3, 255 - wheel_pos * 3).into();
-    }
-    wheel_pos -= 170;
-    (wheel_pos * 3, 255 - wheel_pos * 3, 0).into()
 }

--- a/boards/pygamer/examples/neopixel_rainbow_timer.rs
+++ b/boards/pygamer/examples/neopixel_rainbow_timer.rs
@@ -10,8 +10,10 @@ use hal::pac::{CorePeripherals, Peripherals};
 use hal::prelude::*;
 use hal::{clock::GenericClockController, delay::Delay, timer::TimerCounter};
 
-use smart_leds::hsv::RGB8;
-use smart_leds::{brightness, SmartLedsWrite};
+use smart_leds::{
+    hsv::{hsv2rgb, Hsv},
+    SmartLedsWrite,
+};
 
 #[entry]
 fn main() -> ! {
@@ -39,31 +41,34 @@ fn main() -> ! {
             let colors = [
                 // stagger the color changes across all 5 leds evenly, 255/5=51
                 // and have them safely wrap over when they go above 255
-                wheel(j),
-                wheel(j.wrapping_add(51)),
-                wheel(j.wrapping_add(102)),
-                wheel(j.wrapping_add(153)),
-                wheel(j.wrapping_add(204)),
+                hsv2rgb(Hsv {
+                    hue: j,
+                    sat: 255,
+                    val: 32,
+                }),
+                hsv2rgb(Hsv {
+                    hue: j.wrapping_add(51),
+                    sat: 255,
+                    val: 32,
+                }),
+                hsv2rgb(Hsv {
+                    hue: j.wrapping_add(102),
+                    sat: 255,
+                    val: 32,
+                }),
+                hsv2rgb(Hsv {
+                    hue: j.wrapping_add(153),
+                    sat: 255,
+                    val: 32,
+                }),
+                hsv2rgb(Hsv {
+                    hue: j.wrapping_add(204),
+                    sat: 255,
+                    val: 32,
+                }),
             ];
-            neopixel
-                .write(brightness(colors.iter().cloned(), 32))
-                .unwrap();
+            neopixel.write(colors.iter().cloned()).unwrap();
             delay.delay_ms(5u8);
         }
     }
-}
-
-/// Input a value 0 to 255 to get a color value
-/// The colours are a transition r - g - b - back to r.
-fn wheel(mut wheel_pos: u8) -> RGB8 {
-    wheel_pos = 255 - wheel_pos;
-    if wheel_pos < 85 {
-        return (255 - wheel_pos * 3, 0, wheel_pos * 3).into();
-    }
-    if wheel_pos < 170 {
-        wheel_pos -= 85;
-        return (0, wheel_pos * 3, 255 - wheel_pos * 3).into();
-    }
-    wheel_pos -= 170;
-    (wheel_pos * 3, 255 - wheel_pos * 3, 0).into()
 }

--- a/boards/pygamer/examples/neopixel_tilt.rs
+++ b/boards/pygamer/examples/neopixel_tilt.rs
@@ -14,7 +14,10 @@ use hal::time::KiloHertz;
 use hal::timer::SpinTimer;
 use hal::{clock::GenericClockController, delay::Delay};
 
-use smart_leds::{brightness, hsv::RGB8, SmartLedsWrite};
+use smart_leds::{
+    hsv::{hsv2rgb, Hsv, RGB8},
+    SmartLedsWrite,
+};
 
 use lis3dh::{accelerometer::Accelerometer, Lis3dh};
 
@@ -90,30 +93,22 @@ fn main() -> ! {
         }
 
         //finally paint the one led wherever the position is
-        let _ = neopixel.write(brightness(
-            (0..NUM_LEDS).map(|i| if i == pos { wheel(j) } else { RGB8::default() }),
-            32,
-        ));
+        let _ = neopixel.write((0..NUM_LEDS).map(|i| {
+            if i == pos {
+                hsv2rgb(Hsv {
+                    hue: j,
+                    sat: 255,
+                    val: 32,
+                })
+            } else {
+                RGB8::default()
+            }
+        }));
 
-        //incremement the wheel easing
+        //incremement the hue easing
         j = j.wrapping_add(1);
 
         //don't update faster than the accell is reading
         delay.delay_ms(10u8);
     }
-}
-
-/// Input a value 0 to 255 to get a color value
-/// The colours are a transition r - g - b - back to r.
-fn wheel(mut wheel_pos: u8) -> RGB8 {
-    wheel_pos = 255 - wheel_pos;
-    if wheel_pos < 85 {
-        return (255 - wheel_pos * 3, 0, wheel_pos * 3).into();
-    }
-    if wheel_pos < 170 {
-        wheel_pos -= 85;
-        return (0, wheel_pos * 3, 255 - wheel_pos * 3).into();
-    }
-    wheel_pos -= 170;
-    (wheel_pos * 3, 255 - wheel_pos * 3, 0).into()
 }

--- a/boards/pygamer/examples/usb_serial.rs
+++ b/boards/pygamer/examples/usb_serial.rs
@@ -27,8 +27,7 @@ use usbd_serial::{SerialPort, USB_CLASS_CDC};
 
 use hal::timer::SpinTimer;
 
-use smart_leds::hsv::RGB8;
-use smart_leds::SmartLedsWrite;
+use smart_leds::{hsv::RGB8, SmartLedsWrite};
 
 const NUM_LEDS: usize = 5;
 


### PR DESCRIPTION
Closes #111 

Just realized we have hsv conversion in the smart_leds library were already bringing in. Anyone against removing the copy pasted wheel function everywhere? Starting in pygamer for this PR.

