### PR TITLE
Update M0 USB examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
   - nightly
 
 env:
-  - CRATE=boards/metro_m0 EXAMPLES="--example=blinky_basic --example=blinky_rtfm"   
+  - CRATE=boards/metro_m0 EXAMPLES="--example=blinky_basic --example=blinky_rtfm --example=usb_serial"
   - CRATE=boards/metro_m4 FEATURES="--features=unproven"
   - CRATE=boards/feather_m0 FEATURES="--features=unproven"
   - CRATE=boards/feather_m4 FEATURES="--features=unproven"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
   - nightly
 
 env:
-  - CRATE=boards/metro_m0 EXAMPLES="--example=blinky_basic --example=blinky_rtfm --example=usb_serial"
+  - CRATE=boards/metro_m0 FEATURES="--features=usb" EXAMPLES="--example=blinky_basic --example=blinky_rtfm --example=usb_serial"
   - CRATE=boards/metro_m4 FEATURES="--features=unproven"
   - CRATE=boards/feather_m0 FEATURES="--features=unproven"
   - CRATE=boards/feather_m4 FEATURES="--features=unproven"

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -32,13 +32,21 @@ cortex-m-semihosting = "~0.3"
 cortex-m-rtfm = "~0.4"
 sx1509 = "~0.2"
 
+[dependencies.usb-device]
+version = "~0.2"
+optional = true
+
+[dependencies.usbd-serial]
+version = "~0.1"
+optional = true
+
 [features]
 # ask the HAL to enable atsamd21g18a support
 default = ["rt", "atsamd-hal/samd21g18a"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21g18a-rt"]
 unproven = ["atsamd-hal/unproven"]
 use_rtt = ["atsamd-hal/use_rtt"]
-#usb = ["atsamd-hal/usb"]
+usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
 
 [profile.dev]
 incremental = false
@@ -50,3 +58,7 @@ lto = false
 debug = true
 lto = true
 opt-level = "s"
+
+[[example]]
+name = "usb_serial"
+required-features = ["usb"]

--- a/boards/metro_m0/examples/usb_serial.rs
+++ b/boards/metro_m0/examples/usb_serial.rs
@@ -6,167 +6,23 @@ extern crate panic_rtt;
 
 use cortex_m_rt::{exception, ExceptionFrame};
 use hal::clock::GenericClockController;
-use hal::hal::usb::usb_device::bus::UsbBusWrapper;
-use hal::hal::usb::usb_device::prelude::*;
 use hal::prelude::*;
-use hal::{dbgprint, entry};
-use hal::{interrupt, CorePeripherals, Peripherals};
+use hal::{entry};
+use hal::pac::{interrupt, CorePeripherals, Peripherals};
 
-static mut USB_BUS: Option<UsbBusWrapper<hal::UsbBus>> = None;
-static mut USB_DEV: Option<UsbDevice<hal::UsbBus>> = None;
-static mut USB_SERIAL: Option<cdc_acm::SerialPort<hal::UsbBus>> = None;
+use hal::usb::UsbBus;
+use hal::usb_allocator;
+use usb_device::bus::UsbBusAllocator;
+use usb_device::prelude::*;
+use usbd_serial::{SerialPort, USB_CLASS_CDC};
 
-// Minimal CDC-ACM implementation
-mod cdc_acm {
-    use core::cmp::min;
-    use hal::hal::usb::usb_device::class_prelude::*;
-    use hal::hal::usb::usb_device::utils::AtomicMutex;
-    use hal::hal::usb::usb_device::Result;
-
-    pub const USB_CLASS_CDC: u8 = 0x02;
-    const USB_CLASS_DATA: u8 = 0x0a;
-    const CDC_SUBCLASS_ACM: u8 = 0x02;
-    const CDC_PROTOCOL_AT: u8 = 0x01;
-
-    const CS_INTERFACE: u8 = 0x24;
-    const CDC_TYPE_HEADER: u8 = 0x00;
-    const CDC_TYPE_CALL_MANAGEMENT: u8 = 0x01;
-    const CDC_TYPE_ACM: u8 = 0x02;
-    const CDC_TYPE_UNION: u8 = 0x06;
-
-    const REQ_SET_LINE_CODING: u8 = 0x20;
-    const REQ_SET_CONTROL_LINE_STATE: u8 = 0x22;
-
-    const BUFSIZ: usize = 16;
-
-    struct Buf {
-        buf: [u8; BUFSIZ],
-        len: usize,
-    }
-
-    pub struct SerialPort<'a, B: 'a + UsbBus + Sync> {
-        comm_if: InterfaceNumber,
-        comm_ep: EndpointIn<'a, B>,
-        data_if: InterfaceNumber,
-        read_ep: EndpointOut<'a, B>,
-        write_ep: EndpointIn<'a, B>,
-
-        read_buf: AtomicMutex<Buf>,
-    }
-
-    impl<'a, B: UsbBus + Sync> SerialPort<'a, B> {
-        pub fn new(bus: &'a UsbBusWrapper<B>) -> SerialPort<'a, B> {
-            SerialPort {
-                comm_if: bus.interface(),
-                comm_ep: bus.interrupt(8, 255),
-                data_if: bus.interface(),
-                read_ep: bus.bulk(BUFSIZ as u16),
-                write_ep: bus.bulk(BUFSIZ as u16),
-                read_buf: AtomicMutex::new(Buf {
-                    buf: [0; BUFSIZ],
-                    len: 0,
-                }),
-            }
-        }
-
-        pub fn write(&self, data: &[u8]) -> Result<usize> {
-            match self.write_ep.write(data) {
-                Ok(count) => Ok(count),
-                Err(UsbError::Busy) => Ok(0),
-                e => e,
-            }
-        }
-
-        pub fn read(&self, data: &mut [u8]) -> Result<usize> {
-            let mut guard = self.read_buf.try_lock();
-
-            let buf = match guard {
-                Some(ref mut buf) => buf,
-                None => return Ok(0),
-            };
-
-            // Terrible buffering implementation for brevity's sake
-
-            if buf.len == 0 {
-                buf.len = match self.read_ep.read(&mut buf.buf) {
-                    Ok(count) => count,
-                    Err(UsbError::NoData) => return Ok(0),
-                    e => return e,
-                };
-            }
-
-            if buf.len == 0 {
-                return Ok(0);
-            }
-
-            let count = min(data.len(), buf.len);
-
-            &data[..count].copy_from_slice(&buf.buf[0..count]);
-
-            buf.buf.rotate_left(count);
-            buf.len -= count;
-
-            Ok(count)
-        }
-    }
-
-    impl<'a, B: UsbBus + Sync> UsbClass for SerialPort<'a, B> {
-        fn get_configuration_descriptors(&self, writer: &mut DescriptorWriter) -> Result<()> {
-            // TODO: make a better DescriptorWriter to make it harder to make invalid
-            // descriptors
-            writer.interface(
-                self.comm_if,
-                1,
-                USB_CLASS_CDC,
-                CDC_SUBCLASS_ACM,
-                CDC_PROTOCOL_AT,
-            )?;
-
-            writer.write(CS_INTERFACE, &[CDC_TYPE_HEADER, 0x10, 0x01])?;
-
-            writer.write(
-                CS_INTERFACE,
-                &[CDC_TYPE_CALL_MANAGEMENT, 0x00, self.data_if.into()],
-            )?;
-
-            writer.write(CS_INTERFACE, &[CDC_TYPE_ACM, 0x00])?;
-
-            writer.write(
-                CS_INTERFACE,
-                &[CDC_TYPE_UNION, self.comm_if.into(), self.data_if.into()],
-            )?;
-
-            writer.endpoint(&self.comm_ep)?;
-
-            writer.interface(self.data_if, 2, USB_CLASS_DATA, 0x00, 0x00)?;
-
-            writer.endpoint(&self.write_ep)?;
-            writer.endpoint(&self.read_ep)?;
-
-            Ok(())
-        }
-
-        fn control_out(&self, req: &control::Request, buf: &[u8]) -> ControlOutResult {
-            let _ = buf;
-
-            if req.request_type == control::RequestType::Class
-                && req.recipient == control::Recipient::Interface
-            {
-                return match req.request {
-                    REQ_SET_LINE_CODING => ControlOutResult::Ok,
-                    REQ_SET_CONTROL_LINE_STATE => ControlOutResult::Ok,
-                    _ => ControlOutResult::Ignore,
-                };
-            }
-
-            ControlOutResult::Ignore
-        }
-    }
-}
+static mut USB_ALLOCATOR: Option<UsbBusAllocator<UsbBus>> = None;
+static mut USB_BUS: Option<UsbDevice<UsbBus>> = None;
+static mut USB_SERIAL: Option<SerialPort<UsbBus>> = None;
 
 #[entry]
 fn main() -> ! {
-    dbgprint!("main entered");
+    //dbgprint!("main entered");
     let mut peripherals = Peripherals::take().unwrap();
     let mut clocks = GenericClockController::with_external_32kosc(
         peripherals.GCLK,
@@ -181,75 +37,74 @@ fn main() -> ! {
     let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
     red_led.set_high().unwrap();
 
-    dbgprint!("make usb_bus");
+    //dbgprint!("make usb_bus");
 
-    let bus = unsafe {
-        USB_BUS = Some(hal::usb_bus(
-            peripherals.USB,
-            &mut clocks,
-            &mut peripherals.PM,
-            pins.usb_dm,
-            pins.usb_dp,
-            &mut pins.port,
+    let bus_allocator = unsafe {
+        USB_ALLOCATOR = Some(usb_allocator(
+                peripherals.USB,
+                &mut clocks,
+                &mut peripherals.PM,
+                pins.usb_dm,
+                pins.usb_dp,
+                &mut pins.port,
         ));
-        USB_BUS.as_ref().unwrap()
+        USB_ALLOCATOR.as_ref().unwrap()
     };
 
-    dbgprint!("make serial");
-    let serial = unsafe {
-        USB_SERIAL = Some(cdc_acm::SerialPort::new(bus));
-        USB_SERIAL.as_ref().unwrap()
-    };
-
-    dbgprint!("make dev");
     unsafe {
-        USB_DEV = Some(
-            UsbDevice::new(bus, UsbVidPid(0x5824, 0x27dd))
-                .manufacturer("Wez Furlong")
+        USB_BUS = Some(
+            UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x16c0, 0x27dd))
+                .manufacturer("Fake company")
                 .product("Serial port")
-                .serial_number("RUST")
-                .device_class(cdc_acm::USB_CLASS_CDC)
-                .build(&[serial]),
-        );
-    }
+                .serial_number("TEST")
+                .device_class(USB_CLASS_CDC)
+                .build(),
+            );
+    };
+
+    //dbgprint!("make serial");
+    unsafe {
+        USB_SERIAL = Some(SerialPort::new(&bus_allocator));
+    };
 
     unsafe {
-        core.NVIC.set_priority(hal::Interrupt::USB, 0);
+        core.NVIC.set_priority(interrupt::USB, 0);
     }
-    core.NVIC.enable(hal::Interrupt::USB);
+    core.NVIC.enable(interrupt::USB);
 
-    dbgprint!("do loop");
+    //dbgprint!("do loop");
     loop {}
 }
 
 fn poll_usb() {
-    unsafe { USB_DEV.as_ref() }.map(|dev| {
-        dev.poll();
+    unsafe {
+        USB_BUS.as_mut().map(|usb_dev| {
+            USB_SERIAL.as_mut().map(|serial| {
+                usb_dev.poll(&mut [serial]);
 
-        if dev.state() == UsbDeviceState::Configured {
-            let mut buf = [0u8; 8];
-            let serial = unsafe { USB_SERIAL.as_ref().unwrap() };
+                let mut buf = [0u8; 8];
 
-            match serial.read(&mut buf) {
-                Ok(count) if count > 0 => {
-                    // Echo back in upper case
-                    for c in buf[0..count].iter_mut() {
-                        if 0x61 <= *c && *c <= 0x7a {
-                            *c &= !0x20;
+                match serial.read(&mut buf) {
+                    Ok(count) if count > 0 => {
+                        // Echo back in upper case
+                        for c in buf[0..count].iter_mut() {
+                            if 0x61 <= *c && *c <= 0x7a {
+                                *c &= !0x20;
+                            }
                         }
-                    }
 
-                    serial.write(&buf[0..count]).ok();
+                        serial.write(&buf[0..count]).ok();
+                    }
+                    _ => {}
                 }
-                _ => {}
-            }
-        }
-    });
+            });
+        });
+    };
 }
 
 #[exception]
 fn HardFault(ef: &ExceptionFrame) -> ! {
-    dbgprint!("hard_fault");
+    //dbgprint!("hard_fault");
     panic!("{:#?}", ef);
 }
 
@@ -260,6 +115,6 @@ fn USB() {
 
 #[exception]
 fn DefaultHandler(irqn: i16) {
-    dbgprint!("default_handler");
+    //dbgprint!("default_handler");
     panic!("Unhandled exception (IRQn = {})", irqn);
 }

--- a/boards/metro_m0/examples/usb_serial.rs
+++ b/boards/metro_m0/examples/usb_serial.rs
@@ -8,7 +8,7 @@ use cortex_m_rt::{exception, ExceptionFrame};
 use hal::clock::GenericClockController;
 use hal::prelude::*;
 use hal::{entry};
-use hal::pac::{interrupt, CorePeripherals, Peripherals};
+use hal::pac::{interrupt, Interrupt, CorePeripherals, Peripherals};
 
 use hal::usb::UsbBus;
 use hal::usb_allocator;
@@ -68,9 +68,9 @@ fn main() -> ! {
     };
 
     unsafe {
-        core.NVIC.set_priority(interrupt::USB, 0);
+        core.NVIC.set_priority(Interrupt::USB, 0);
     }
-    core.NVIC.enable(interrupt::USB);
+    core.NVIC.enable(Interrupt::USB);
 
     //dbgprint!("do loop");
     loop {}

--- a/boards/metro_m0/examples/usb_serial.rs
+++ b/boards/metro_m0/examples/usb_serial.rs
@@ -78,8 +78,8 @@ fn main() -> ! {
 
 fn poll_usb() {
     unsafe {
-        USB_BUS.as_mut().map(|usb_dev| {
-            USB_SERIAL.as_mut().map(|serial| {
+        match (USB_BUS.as_mut(), USB_SERIAL.as_mut()) {
+            (Some(usb_dev), Some(serial)) => {
                 usb_dev.poll(&mut [serial]);
 
                 let mut buf = [0u8; 8];
@@ -97,8 +97,9 @@ fn poll_usb() {
                     }
                     _ => {}
                 }
-            });
-        });
+            },
+            _ => {}
+        };
     };
 }
 

--- a/boards/metro_m0/src/lib.rs
+++ b/boards/metro_m0/src/lib.rs
@@ -240,8 +240,8 @@ pub fn usb_allocator(
     usb_dp: gpio::Pa25<Input<Floating>>,
     port: &mut Port,
     ) -> UsbBusAllocator<UsbBus> {
-    clocks.configure_gclk_divider_and_source(GEN_A::GCLK2, 1, SRC_A::DFLL48M, false);
-    let usb_gclk = clocks.get_gclk(GEN_A::GCLK2).unwrap();
+    clocks.configure_gclk_divider_and_source(GEN_A::GCLK0, 1, SRC_A::DFLL48M, false);
+    let usb_gclk = clocks.get_gclk(GEN_A::GCLK0).unwrap();
     let usb_clock = &clocks.usb(&usb_gclk).unwrap();
 
     UsbBusAllocator::new(UsbBus::new(


### PR DESCRIPTION
This is still a work in progress.

Building on the great updates from #125, I'm trying to get the M0 USB examples updated. So far I've got the Metro M0 example compiling but I don't have a Metro M0 to test with. I do have a couple other atsamd21 boards around that I'm planning to port the example to.

Extra sets of eyes on here would be great as I did a lot of copy-paste programming to get it in line with the M4 examples.