### PR TITLE
Fix initial value of used_clock bits in GenericClockController

### DIFF
--- a/hal/src/samd11/clock.rs
+++ b/hal/src/samd11/clock.rs
@@ -171,7 +171,7 @@ impl GenericClockController {
                 Hertz(0),
                 Hertz(0),
             ],
-            used_clocks: 1u64 << u8::from(DFLL48M),
+            used_clocks: 1u64 << u8::from(ClockId::DFLL48),
         }
     }
 
@@ -285,13 +285,13 @@ impl GenericClockController {
     /// Returns `None` is the specified generic clock has already been
     /// configured.
     pub fn $id(&mut self, generator: &GClock) -> Option<$Type> {
-        let bits : u64 = 1<<u8::from($clock) as u64;
+        let bits : u64 = 1<<u8::from(ClockId::$clock) as u64;
         if (self.used_clocks & bits) != 0 {
             return None;
         }
         self.used_clocks |= bits;
 
-        self.state.enable_clock_generator($clock, generator.gclk);
+        self.state.enable_clock_generator(ClockId::$clock, generator.gclk);
         let freq = self.gclks[u8::from(generator.gclk) as usize];
         Some($Type{freq})
     }

--- a/hal/src/samd21/clock.rs
+++ b/hal/src/samd21/clock.rs
@@ -171,7 +171,7 @@ impl GenericClockController {
                 Hertz(0),
                 Hertz(0),
             ],
-            used_clocks: 1u64 << u8::from(DFLL48M),
+            used_clocks: 1u64 << u8::from(ClockId::DFLL48),
         }
     }
 

--- a/hal/src/samd21/clock.rs
+++ b/hal/src/samd21/clock.rs
@@ -285,13 +285,13 @@ impl GenericClockController {
     /// Returns `None` is the specified generic clock has already been
     /// configured.
     pub fn $id(&mut self, generator: &GClock) -> Option<$Type> {
-        let bits : u64 = 1<<u8::from($clock) as u64;
+        let bits: u64 = 1<<u8::from(ClockId::$clock) as u64;
         if (self.used_clocks & bits) != 0 {
             return None;
         }
         self.used_clocks |= bits;
 
-        self.state.enable_clock_generator($clock, generator.gclk);
+        self.state.enable_clock_generator(ClockId::$clock, generator.gclk);
         let freq = self.gclks[u8::from(generator.gclk) as usize];
         Some($Type{freq})
     }

--- a/hal/src/samd51/clock.rs
+++ b/hal/src/samd51/clock.rs
@@ -61,9 +61,10 @@ pub enum ClockId {
     SDHC1,
     CM4_TRACE,
 }
-impl ClockId {
-    fn bits(self) -> usize {
-        self as usize
+
+impl From<ClockId> for u8 {
+    fn from(clock: ClockId) -> u8 {
+        clock as u8
     }
 }
 
@@ -120,7 +121,7 @@ impl State {
     }
 
     fn enable_clock_generator(&mut self, clock: ClockId, generator: ClockGenId) {
-        self.gclk.pchctrl[clock.bits()].write(|w| unsafe {
+        self.gclk.pchctrl[u8::from(clock) as usize].write(|w| unsafe {
             w.gen().bits(generator.into());
             w.chen().set_bit()
         });
@@ -350,7 +351,7 @@ impl GenericClockController {
     /// Returns `None` is the specified generic clock has already been
     /// configured.
     pub fn $id(&mut self, generator: &GClock) -> Option<$Type> {
-        let bits: u64 = 1<< ClockId::$clock.bits() as u64;
+        let bits: u64 = 1<< u8::from(ClockId::$clock) as u64;
         if (self.used_clocks & bits) != 0 {
             return None;
         }

--- a/hal/src/samd51/clock.rs
+++ b/hal/src/samd51/clock.rs
@@ -66,7 +66,6 @@ impl ClockId {
         self as usize
     }
 }
-use self::ClockId::*;
 
 /// Represents a configured clock generator.
 /// Can be converted into the effective clock frequency.
@@ -238,8 +237,7 @@ impl GenericClockController {
                 Hertz(0),
                 Hertz(0),
             ],
-            // TODO constrain this to ClockId::XX, FDPLL0?
-            used_clocks: 1u64 << u8::from(DPLL0),
+            used_clocks: 1u64 << u8::from(ClockId::FDPLL0),
         }
     }
 
@@ -437,7 +435,7 @@ fn wait_for_dpllrdy(oscctrl: &mut OSCCTRL) {
 
 /// Configure the dpll0 to run at 120MHz
 fn configure_and_enable_dpll0(oscctrl: &mut OSCCTRL, gclk: &mut GCLK) {
-    gclk.pchctrl[FDPLL0 as usize].write(|w| {
+    gclk.pchctrl[ClockId::FDPLL0 as usize].write(|w| {
         w.chen().set_bit();
         w.gen().gclk5()
     });

--- a/hal/src/samd51/clock.rs
+++ b/hal/src/samd51/clock.rs
@@ -238,6 +238,7 @@ impl GenericClockController {
                 Hertz(0),
                 Hertz(0),
             ],
+            // TODO constrain this to ClockId::XX, FDPLL0?
             used_clocks: 1u64 << u8::from(DPLL0),
         }
     }
@@ -351,13 +352,13 @@ impl GenericClockController {
     /// Returns `None` is the specified generic clock has already been
     /// configured.
     pub fn $id(&mut self, generator: &GClock) -> Option<$Type> {
-        let bits : u64 = 1<<$clock.bits() as u64;
+        let bits: u64 = 1<< ClockId::$clock.bits() as u64;
         if (self.used_clocks & bits) != 0 {
             return None;
         }
         self.used_clocks |= bits;
 
-        self.state.enable_clock_generator($clock, generator.gclk);
+        self.state.enable_clock_generator(ClockId::$clock, generator.gclk);
         let freq = self.gclks[u8::from(generator.gclk) as usize];
         Some($Type{freq})
     }

--- a/hal/src/same54/clock.rs
+++ b/hal/src/same54/clock.rs
@@ -66,7 +66,6 @@ impl ClockId {
         self as usize
     }
 }
-use self::ClockId::*;
 
 /// Represents a configured clock generator.
 /// Can be converted into the effective clock frequency.
@@ -241,8 +240,7 @@ impl GenericClockController {
                 Hertz(0),
                 Hertz(0),
             ],
-            // TODO constrain this to ClockId::XX, should it be FDPLL0?
-            used_clocks: 1u64 << u8::from(DPLL0),
+            used_clocks: 1u64 << u8::from(ClockId::FDPLL0),
         }
     }
 
@@ -440,7 +438,7 @@ fn wait_for_dpllrdy(oscctrl: &mut OSCCTRL) {
 
 /// Configure the dpll0 to run at 120MHz
 fn configure_and_enable_dpll0(oscctrl: &mut OSCCTRL, gclk: &mut GCLK) {
-   gclk.pchctrl[FDPLL0 as usize].write(|w| {
+   gclk.pchctrl[ClockId::FDPLL0 as usize].write(|w| {
         w.chen().set_bit();
         w.gen().gclk5()
     });

--- a/hal/src/same54/clock.rs
+++ b/hal/src/same54/clock.rs
@@ -241,6 +241,7 @@ impl GenericClockController {
                 Hertz(0),
                 Hertz(0),
             ],
+            // TODO constrain this to ClockId::XX, should it be FDPLL0?
             used_clocks: 1u64 << u8::from(DPLL0),
         }
     }
@@ -354,13 +355,13 @@ impl GenericClockController {
     /// Returns `None` is the specified generic clock has already been
     /// configured.
     pub fn $id(&mut self, generator: &GClock) -> Option<$Type> {
-        let bits : u64 = 1<<$clock.bits() as u64;
+        let bits: u64 = 1<<ClockId::$clock.bits() as u64;
         if (self.used_clocks & bits) != 0 {
             return None;
         }
         self.used_clocks |= bits;
 
-        self.state.enable_clock_generator($clock, generator.gclk);
+        self.state.enable_clock_generator(ClockId::$clock, generator.gclk);
         let freq = self.gclks[u8::from(generator.gclk) as usize];
         Some($Type{freq})
     }

--- a/hal/src/same54/clock.rs
+++ b/hal/src/same54/clock.rs
@@ -61,9 +61,10 @@ pub enum ClockId {
     SDHC1,
     CM4_TRACE,
 }
-impl ClockId {
-    fn bits(self) -> usize {
-        self as usize
+
+impl From<ClockId> for u8 {
+    fn from(clock: ClockId) -> u8 {
+        clock as u8
     }
 }
 
@@ -121,7 +122,7 @@ impl State {
     }
 
     fn enable_clock_generator(&mut self, clock: ClockId, generator: ClockGenId) {
-        self.gclk.pchctrl[clock.bits()].write(|w| unsafe {
+        self.gclk.pchctrl[u8::from(clock) as usize].write(|w| unsafe {
             w.gen().bits(generator.into());
             w.chen().set_bit()
         });
@@ -353,7 +354,7 @@ impl GenericClockController {
     /// Returns `None` is the specified generic clock has already been
     /// configured.
     pub fn $id(&mut self, generator: &GClock) -> Option<$Type> {
-        let bits: u64 = 1<<ClockId::$clock.bits() as u64;
+        let bits: u64 = 1<<u8::from(ClockId::$clock) as u64;
         if (self.used_clocks & bits) != 0 {
             return None;
         }
@@ -438,7 +439,7 @@ fn wait_for_dpllrdy(oscctrl: &mut OSCCTRL) {
 
 /// Configure the dpll0 to run at 120MHz
 fn configure_and_enable_dpll0(oscctrl: &mut OSCCTRL, gclk: &mut GCLK) {
-   gclk.pchctrl[ClockId::FDPLL0 as usize].write(|w| {
+   gclk.pchctrl[u8::from(ClockId::FDPLL0) as usize].write(|w| {
         w.chen().set_bit();
         w.gen().gclk5()
     });


### PR DESCRIPTION
I noticed this while trying to enable the `atsamd21g18a::gclk::clkctrl::ID_A::EVSYS_0` clock with a method generated from `clock_generator!`.

`EVSYS_0` has a value of `7` and the generated method was returning `None`. I checked where `used_clocks` was modified and tracked down the seventh bit being set on initialisation in `GenericClockController::new`.

I think this should be setting the first bit, `ID_A::DFLL48` instead of the seventh bit `SRC_A::DFLL48M`. I’ve added type guards to ensure the constants passed in are from the `ClockId` type aliased to `ID_A`.

---

I wasn’t sure what to do for the samd51 or same54 hal clock modules, I think they probably want to use `ClockId::FDPLL0` and set `0b10` instead of `SRC_A::DPLL0` and set `0b10000000` and could use some :eyes: on the TODO I left in the changes.