### PR TITLE
Basic serpente port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
   - CRATE=boards/trellis_m4 FEATURES="--features=keypad-unproven"
   - CRATE=boards/pygamer FEATURES="--features=unproven,usb,ws2812-timer,math"
   - CRATE=boards/pfza_proto1 EXAMPLES="--example=blinky_basic"
+  - CRATE=boards/serpente EXAMPLES="--example=blinky_basic --example=pwm" FEATURES="--features=unproven"
 
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ In addition to the PACs and HAL, there numerous **B**oard **S**upport **P**ackag
 [sodaq_sara_aff]: https://github.com/atsamd-rs/atsamd/tree/master/boards/sodaq_sara_aff/
 [trellis_m4]: https://github.com/atsamd-rs/atsamd/tree/master/boards/trellis_m4/
 [trinket_m0]: https://github.com/atsamd-rs/atsamd/tree/master/boards/trinket_m0/
+[serpente]: https://github.com/atsamd-rs/atsamd/tree/master/boards/serpente/
 
 ## Building
 

--- a/boards/serpente/.cargo/config
+++ b/boards/serpente/.cargo/config
@@ -1,0 +1,10 @@
+# samd21 is a Cortex-M0 and thus thumbv6m
+
+[build]
+target = "thumbv6m-none-eabi"
+
+[target.thumbv6m-none-eabi]
+runner = 'arm-none-eabi-gdb'
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]

--- a/boards/serpente/Cargo.toml
+++ b/boards/serpente/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "serpente"
+version = "0.1.0"
+authors = ["Jens Andersen <jens.andersen@gmail.com>"]
+description = "Board Support crate for the Serpente board"
+keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/atsamd-rs/atsamd"
+readme = "README.md"
+documentation = "https://atsamd-rs.github.io/atsamd/atsamd21e18a/serpente/"
+
+[dependencies]
+cortex-m = "~0.6"
+embedded-hal = "~0.2"
+nb = "~0.1"
+
+[dependencies.cortex-m-rt]
+version = "~0.6"
+optional = true
+
+[dependencies.atsamd-hal]
+path = "../../hal"
+version = "~0.7"
+default-features = false
+
+[dev-dependencies]
+panic-halt = "~0.2"
+
+[features]
+# ask the HAL to enable atsamd21e18a support
+default = ["rt", "atsamd-hal/samd21e18a"]
+rt = ["cortex-m-rt", "atsamd-hal/samd21e18a-rt"]
+unproven = ["atsamd-hal/unproven"]
+use_semihosting = []

--- a/boards/serpente/README.md
+++ b/boards/serpente/README.md
@@ -1,0 +1,9 @@
+# @arturo182 Serpente Board Support Crate
+
+This crate provides a type-safe API for working with the [@arturo182 Serpente board](https://serpente.solder.party).
+
+## Examples?
+
+Check out the repository for examples:
+
+https://github.com/atsamd-rs/atsamd/tree/master/boards/serpente/examples

--- a/boards/serpente/build.rs
+++ b/boards/serpente/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+fn main() {
+    if env::var_os("CARGO_FEATURE_RT").is_some() {
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        File::create(out.join("memory.x"))
+            .unwrap()
+            .write_all(include_bytes!("memory.x"))
+            .unwrap();
+        println!("cargo:rustc-link-search={}", out.display());
+        println!("cargo:rerun-if-changed=memory.x");
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/boards/serpente/examples/blinky_basic.rs
+++ b/boards/serpente/examples/blinky_basic.rs
@@ -1,0 +1,34 @@
+#![no_std]
+#![no_main]
+
+extern crate serpente as hal;
+extern crate panic_halt;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::prelude::*;
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut red_led = pins.led_r.into_open_drain_output(&mut pins.port);
+    let mut blue_led = pins.led_b.into_open_drain_output(&mut pins.port);
+    blue_led.set_high().unwrap();
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+    loop {
+        delay.delay_ms(200u8);
+        red_led.set_high().unwrap();
+        delay.delay_ms(200u8);
+        red_led.set_low().unwrap();
+    }
+}

--- a/boards/serpente/examples/pwm.rs
+++ b/boards/serpente/examples/pwm.rs
@@ -1,0 +1,68 @@
+#![no_std]
+#![no_main]
+
+extern crate serpente as hal;
+extern crate panic_halt;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::prelude::*;
+use hal::pwm::{Channel, Pwm0};
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let gclk0 = clocks.gclk0();
+
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut _red_led = pins.led_r.into_function_f(&mut pins.port);
+    let mut _green_led = pins.led_g.into_function_f(&mut pins.port);
+    let mut _blue_led = pins.led_b.into_function_f(&mut pins.port);
+
+    let mut pwm0 = Pwm0::new(
+        &clocks.tcc0_tcc1(&gclk0).unwrap(),
+        1.khz(),
+        peripherals.TCC0,
+        &mut peripherals.PM,
+    );
+    let max_duty = pwm0.get_max_duty();
+
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+    loop {
+        for i in 0..255 {
+            let rgb = wheel(i);
+            pwm0.set_duty(Channel::_0, max_duty * (rgb.r as u32) / 255);
+            pwm0.set_duty(Channel::_2, max_duty * (rgb.g as u32) / 255);
+            pwm0.set_duty(Channel::_3, max_duty * (rgb.b as u32) / 255);
+            delay.delay_ms(5u16);
+        }
+    }
+}
+
+pub struct RGB {
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
+fn wheel(mut wheel_pos: u8) -> RGB {
+    wheel_pos = 255 - wheel_pos;
+    if wheel_pos < 85 {
+        return RGB{r: 255 - wheel_pos * 3, g: 0, b: wheel_pos * 3};
+    }
+    if wheel_pos < 170 {
+        wheel_pos -= 85;
+        return RGB{r: 0, g: wheel_pos * 3, b: 255 - wheel_pos * 3};
+    }
+    wheel_pos -= 170;
+    RGB{r: wheel_pos * 3, g: 255 - wheel_pos * 3, b: 0}
+}

--- a/boards/serpente/memory.x
+++ b/boards/serpente/memory.x
@@ -1,0 +1,8 @@
+MEMORY
+{
+  /* Leave 8k for the default bootloader on the Serpente */
+  FLASH (rx) : ORIGIN = 0x00000000 + 8K, LENGTH = 256K - 8K - 256 - 256
+  RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 32K
+}
+_stack_start = ORIGIN(RAM) + LENGTH(RAM);
+

--- a/boards/serpente/src/lib.rs
+++ b/boards/serpente/src/lib.rs
@@ -1,0 +1,78 @@
+#![no_std]
+
+extern crate atsamd_hal as hal;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::entry;
+
+use hal::prelude::*;
+use hal::*;
+
+pub use hal::target_device as pac;
+pub use hal::common::*;
+pub use hal::samd21::*;
+
+use gpio::{Floating, Input, PfC, Port};
+
+use hal::clock::GenericClockController;
+use hal::sercom::{PadPin, UART0};
+use hal::time::Hertz;
+
+define_pins!(
+    /// Maps the pins to their arduino names and
+    /// the numbers printed on the board.
+    struct Pins,
+    target_device: target_device,
+
+    /// SPI MOSI UART TX2
+    pin d0 = a4,
+    /// SPI SCK, UART RX2
+    pin d1 = a5,
+    /// SPI MISO
+    pin d2 = a6,
+
+    /// Digital/Analog
+    pin d3 = a7,
+
+    /// I2C SDA, UART TX
+    pin d4 = a8,
+
+    /// I2C SCL, UART RX
+    pin d5 = a9,
+
+    /// RGB LED, PWM capable
+    pin led_g = a19,
+    pin led_r = a22,
+    pin led_b = a23,
+
+    /// SPI Flash
+    pin flash_mosi = a16,
+    pin flash_miso = a18,
+    pin flash_sck = a17,
+    pin flash_cs = a15,
+);
+
+/// Convenience for setting up the D2 and D0 pins to
+/// operate as UART RX/TX (respectively) running at the specified baud.
+pub fn uart<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    baud: F,
+    sercom0: pac::SERCOM0,
+    pm: &mut pac::PM,
+    d5: gpio::Pa9<Input<Floating>>,
+    d4: gpio::Pa8<Input<Floating>>,
+    port: &mut Port,
+) -> UART0<hal::sercom::Sercom0Pad1<gpio::Pa9<PfC>>, hal::sercom::Sercom0Pad0<gpio::Pa8<PfC>>, (), ()>
+{
+    let gclk0 = clocks.gclk0();
+
+    UART0::new(
+        &clocks.sercom0_core(&gclk0).unwrap(),
+        baud.into(),
+        sercom0,
+        pm,
+        (d5.into_pad(port), d4.into_pad(port)),
+    )
+}


### PR DESCRIPTION
This is a basic board with some examples for the Serpente board (https://serpente.solder.party/)
The basic blinky example is included as well as a PWM example with a cheap rainbow-y effect on the built-in RGB led.
