### PR TITLE
Watchdog updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
   - CRATE=boards/pyportal FEATURES="--features=unproven"
   - CRATE=boards/trellis_m4 FEATURES="--features=keypad-unproven"
   - CRATE=boards/pygamer FEATURES="--features=unproven,usb,ws2812-timer,math"
-  - CRATE=boards/pfza_proto1 EXAMPLES="--example=blinky_basic"
+  - CRATE=boards/pfza_proto1 EXAMPLES="--example=blinky_basic" FEATURES="--features=unproven"
   - CRATE=boards/serpente EXAMPLES="--example=blinky_basic --example=pwm" FEATURES="--features=unproven"
 
 matrix:

--- a/boards/edgebadge/examples/blinky_basic.rs
+++ b/boards/edgebadge/examples/blinky_basic.rs
@@ -28,10 +28,12 @@ fn main() -> ! {
     );
     let mut delay = Delay::new(core.SYST, &mut clocks);
     delay.delay_ms(400u16);
-    let wdt = Watchdog::new_with_timeout(peripherals.WDT, WatchdogTimeout::Timeout256ms);
 
     let mut pins = hal::Pins::new(peripherals.PORT);
     let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
+
+    let mut wdt = Watchdog::new(peripherals.WDT);
+    wdt.start(WatchdogTimeout::Cycles256);
 
     loop {
         delay.delay_ms(200u8);

--- a/boards/edgebadge/examples/blinky_basic.rs
+++ b/boards/edgebadge/examples/blinky_basic.rs
@@ -33,7 +33,7 @@ fn main() -> ! {
     let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
 
     let mut wdt = Watchdog::new(peripherals.WDT);
-    wdt.start(WatchdogTimeout::Cycles256);
+    wdt.start(WatchdogTimeout::Cycles256 as u8);
 
     loop {
         delay.delay_ms(200u8);

--- a/boards/itsybitsy_m4/examples/blinky_basic.rs
+++ b/boards/itsybitsy_m4/examples/blinky_basic.rs
@@ -29,7 +29,7 @@ fn main() -> ! {
     let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
 
     let mut wdt = Watchdog::new(peripherals.WDT);
-    wdt.start(WatchdogTimeout::Cycles256);
+    wdt.start(WatchdogTimeout::Cycles256 as u8);
 
     loop {
         delay.delay_ms(200u8);

--- a/boards/itsybitsy_m4/examples/blinky_basic.rs
+++ b/boards/itsybitsy_m4/examples/blinky_basic.rs
@@ -24,17 +24,19 @@ fn main() -> ! {
     );
     let mut delay = Delay::new(core.SYST, &mut clocks);
     delay.delay_ms(400u16);
-    let wdt = Watchdog::new_with_timeout(peripherals.WDT, WatchdogTimeout::Timeout256ms);
 
     let mut pins = hal::Pins::new(peripherals.PORT);
     let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
 
+    let mut wdt = Watchdog::new(peripherals.WDT);
+    wdt.start(WatchdogTimeout::Cycles256);
+
     loop {
         delay.delay_ms(200u8);
-        wdt.clear();
+        wdt.feed();
         red_led.set_high().unwrap();
         delay.delay_ms(200u8);
-        wdt.clear();
+        wdt.feed();
         red_led.set_low().unwrap();
     }
 }

--- a/boards/pygamer/examples/blinky_basic.rs
+++ b/boards/pygamer/examples/blinky_basic.rs
@@ -27,17 +27,19 @@ fn main() -> ! {
     );
     let mut delay = Delay::new(core.SYST, &mut clocks);
     delay.delay_ms(400u16);
-    let wdt = Watchdog::new_with_timeout(peripherals.WDT, WatchdogTimeout::Timeout256ms);
 
     let mut pins = hal::Pins::new(peripherals.PORT);
     let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
 
+    let mut wdt = Watchdog::new(peripherals.WDT);
+    wdt.start(WatchdogTimeout::Cycles256);
+
     loop {
         delay.delay_ms(200u8);
-        wdt.clear();
+        wdt.feed();
         red_led.set_high().unwrap();
         delay.delay_ms(200u8);
-        wdt.clear();
+        wdt.feed();
         red_led.set_low().unwrap();
     }
 }

--- a/boards/pygamer/examples/blinky_basic.rs
+++ b/boards/pygamer/examples/blinky_basic.rs
@@ -32,7 +32,7 @@ fn main() -> ! {
     let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
 
     let mut wdt = Watchdog::new(peripherals.WDT);
-    wdt.start(WatchdogTimeout::Cycles256);
+    wdt.start(WatchdogTimeout::Cycles256 as u8);
 
     loop {
         delay.delay_ms(200u8);

--- a/boards/trinket_m0/Cargo.toml
+++ b/boards/trinket_m0/Cargo.toml
@@ -38,3 +38,6 @@ name = "blinky_basic"
 
 [[example]]
 name = "pwm"
+
+[[example]]
+name = "watchdog"

--- a/boards/trinket_m0/examples/watchdog.rs
+++ b/boards/trinket_m0/examples/watchdog.rs
@@ -1,0 +1,70 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+extern crate trinket_m0 as hal;
+
+use core::fmt::Write;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+use hal::watchdog::{Watchdog, WatchdogTimeout};
+use hal::{entry, reset_cause};
+
+macro_rules! uprint {
+    ($serial:expr, $($arg:tt)*) => {
+        $serial.write_fmt(format_args!($($arg)*)).ok()
+    };
+}
+
+macro_rules! uprintln {
+    ($serial:expr, $fmt:expr) => {
+        uprint!($serial, concat!($fmt, "\r\n"))
+    };
+    ($serial:expr, $fmt:expr, $($arg:tt)*) => {
+        uprint!($serial, concat!($fmt, "\r\n"), $($arg)*)
+    };
+}
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+    let mut pins = hal::Pins::new(peripherals.PORT);
+
+    let mut uart = hal::uart(
+        &mut clocks,
+        115200.hz(),
+        peripherals.SERCOM0,
+        &mut peripherals.PM,
+        pins.d3,
+        pins.d4,
+        &mut pins.port,
+    );
+
+    let cause = reset_cause(&peripherals.PM);
+    uprintln!(uart, "Reset cause: {:?}", cause);
+
+    let mut wdt = Watchdog::new(peripherals.WDT);
+    wdt.start(WatchdogTimeout::Cycles16K as u8);
+
+    loop {
+        // If we don't feed the watchdog, it will reset the device. This
+        // confirms that the watchdog is working when it prints out the reset
+        // cause on next startup. Uncommenting the below line will cause the
+        // device to spin forever without resetting.
+        // wdt.feed();
+
+        delay.delay_ms(100u16);
+    }
+}

--- a/hal/src/samd11/mod.rs
+++ b/hal/src/samd11/mod.rs
@@ -3,6 +3,7 @@ pub mod clock;
 pub mod pwm;
 pub mod sercom;
 pub mod timer;
+pub mod watchdog;
 
 mod serial_number;
 pub use serial_number::*;

--- a/hal/src/samd11/mod.rs
+++ b/hal/src/samd11/mod.rs
@@ -4,5 +4,39 @@ pub mod pwm;
 pub mod sercom;
 pub mod timer;
 
+mod serial_number;
+pub use serial_number::*;
+
 #[cfg(feature = "unproven")]
 pub mod adc;
+
+/// ResetCause represents the reason the MCU was reset.
+#[derive(Debug, Clone, Copy)]
+pub enum ResetCause {
+    Unknown,
+    POR,
+    BOD12,
+    BOD33,
+    External,
+    Watchdog,
+    System,
+}
+
+impl From<u8> for ResetCause {
+    fn from(rcause_val: u8) -> ResetCause {
+        match rcause_val {
+            1 => ResetCause::POR,
+            2 => ResetCause::BOD12,
+            4 => ResetCause::BOD33,
+            16 => ResetCause::External,
+            32 => ResetCause::Watchdog,
+            64 => ResetCause::System,
+            _ => ResetCause::Unknown,
+        }
+    }
+}
+
+/// Returns the cause of the last reset.
+pub fn reset_cause<'a>(pm: &'a crate::target_device::PM) -> ResetCause {
+    ResetCause::from(pm.rcause.read().bits())
+}

--- a/hal/src/samd11/serial_number.rs
+++ b/hal/src/samd11/serial_number.rs
@@ -1,0 +1,46 @@
+//! Serial number
+// See 9.6 Memories --> Serial Number, page 24
+
+use core::ptr;
+
+const SN_1: u32 = 0x0080A00C;
+const SN_2: u32 = 0x0080A040;
+const SN_3: u32 = 0x0080A044;
+const SN_4: u32 = 0x0080A048;
+
+/// Returns the serial number of the chip as 4 32-bit integers. The serial
+/// number is only guaranteed to be unique if all 128 bits are used.
+pub fn split_serial_number() -> (u32, u32, u32, u32) {
+    unsafe {
+        (
+            ptr::read(SN_1 as *const u32),
+            ptr::read(SN_2 as *const u32),
+            ptr::read(SN_3 as *const u32),
+            ptr::read(SN_4 as *const u32),
+        )
+    }
+}
+
+/// Returns the serial number of the chip as an array of bytes. The serial
+/// number is only guaranteed to be unique if all 16 bytes are used.
+pub fn serial_number() -> [u8; 16] {
+    let sn = split_serial_number();
+    [
+        ((sn.0 >> 24) & 0xff) as u8,
+        ((sn.0 >> 16) & 0xff) as u8,
+        ((sn.0 >> 8) & 0xff) as u8,
+        (sn.0 & 0xff) as u8,
+        ((sn.1 >> 24) & 0xff) as u8,
+        ((sn.1 >> 16) & 0xff) as u8,
+        ((sn.1 >> 8) & 0xff) as u8,
+        (sn.1 & 0xff) as u8,
+        ((sn.2 >> 24) & 0xff) as u8,
+        ((sn.2 >> 16) & 0xff) as u8,
+        ((sn.2 >> 8) & 0xff) as u8,
+        (sn.2 & 0xff) as u8,
+        ((sn.3 >> 24) & 0xff) as u8,
+        ((sn.3 >> 16) & 0xff) as u8,
+        ((sn.3 >> 8) & 0xff) as u8,
+        (sn.3 & 0xff) as u8,
+    ]
+}

--- a/hal/src/samd11/watchdog.rs
+++ b/hal/src/samd11/watchdog.rs
@@ -1,0 +1,71 @@
+extern crate embedded_hal;
+use embedded_hal::watchdog;
+
+use crate::target_device::WDT;
+
+/// WatchdogTimeout enumerates usable values for configuring
+/// the timeout of the watchdog peripheral.
+#[repr(u8)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum WatchdogTimeout {
+    Cycles8 = 0,
+    Cycles16,
+    Cycles32,
+    Cycles64,
+    Cycles128,
+    Cycles256,
+    Cycles512,
+    Cycles1K,
+    Cycles2K,
+    Cycles4K,
+    Cycles8K,
+    Cycles16K,
+}
+
+pub struct Watchdog {
+    wdt: WDT,
+}
+
+impl Watchdog {
+    pub fn new(wdt: WDT) -> Self {
+        Self { wdt }
+    }
+}
+
+impl watchdog::Watchdog for Watchdog {
+    /// Feeds an existing watchdog to ensure the processor isn't reset.
+    /// Sometimes commonly referred to as "kicking" or "refreshing".
+    fn feed(&mut self) {
+        self.wdt.clear.write(|w| unsafe { w.clear().bits(0xA5) });
+    }
+}
+
+/// Disables a running watchdog timer so the processor won't be reset.
+impl watchdog::WatchdogDisable for Watchdog {
+    fn disable(&mut self) {
+        // Disable the watchdog timer.
+        self.wdt.ctrl.write(|w| w.enable().clear_bit());
+        // Wait for watchdog timer to be disabled.
+        while self.wdt.status.read().syncbusy().bit_is_set() {}
+    }
+}
+
+impl watchdog::WatchdogEnable for Watchdog {
+    type Time = u8;
+
+    /// Enables a watchdog timer to reset the processor if software is frozen
+    /// or stalled.
+    fn start<T>(&mut self, period: T)
+    where
+        T: Into<Self::Time>,
+    {
+        // Write the timeout configuration.
+        self.wdt
+            .config
+            .write(|w| unsafe { w.per().bits(period.into()) });
+        // Enable the watchdog timer.
+        self.wdt.ctrl.write(|w| w.enable().set_bit());
+        // Wait for watchdog timer to be enabled.
+        while self.wdt.status.read().syncbusy().bit_is_set() {}
+    }
+}

--- a/hal/src/samd21/mod.rs
+++ b/hal/src/samd21/mod.rs
@@ -2,10 +2,44 @@ pub mod calibration;
 pub mod clock;
 pub mod pwm;
 pub mod sercom;
-pub mod timer; 
+pub mod timer;
+
+mod serial_number;
+pub use serial_number::*;
 
 #[cfg(feature = "unproven")]
 pub mod adc;
 
 #[cfg(feature = "usb")]
 pub mod usb;
+
+/// ResetCause represents the reason the MCU was reset.
+#[derive(Debug, Clone, Copy)]
+pub enum ResetCause {
+    Unknown,
+    POR,
+    BOD12,
+    BOD33,
+    External,
+    Watchdog,
+    System,
+}
+
+impl From<u8> for ResetCause {
+    fn from(rcause_val: u8) -> ResetCause {
+        match rcause_val {
+            1 => ResetCause::POR,
+            2 => ResetCause::BOD12,
+            4 => ResetCause::BOD33,
+            16 => ResetCause::External,
+            32 => ResetCause::Watchdog,
+            64 => ResetCause::System,
+            _ => ResetCause::Unknown,
+        }
+    }
+}
+
+/// Returns the cause of the last reset.
+pub fn reset_cause<'a>(pm: &'a crate::target_device::PM) -> ResetCause {
+    ResetCause::from(pm.rcause.read().bits())
+}

--- a/hal/src/samd21/mod.rs
+++ b/hal/src/samd21/mod.rs
@@ -3,6 +3,7 @@ pub mod clock;
 pub mod pwm;
 pub mod sercom;
 pub mod timer;
+pub mod watchdog;
 
 mod serial_number;
 pub use serial_number::*;

--- a/hal/src/samd21/serial_number.rs
+++ b/hal/src/samd21/serial_number.rs
@@ -1,0 +1,46 @@
+//! Serial number
+// See 10.3.3 Memories --> Serial Number, page 45
+
+use core::ptr;
+
+const SN_1: u32 = 0x0080A00C;
+const SN_2: u32 = 0x0080A040;
+const SN_3: u32 = 0x0080A044;
+const SN_4: u32 = 0x0080A048;
+
+/// Returns the serial number of the chip as 4 32-bit integers. The serial
+/// number is only guaranteed to be unique if all 128 bits are used.
+pub fn split_serial_number() -> (u32, u32, u32, u32) {
+    unsafe {
+        (
+            ptr::read(SN_1 as *const u32),
+            ptr::read(SN_2 as *const u32),
+            ptr::read(SN_3 as *const u32),
+            ptr::read(SN_4 as *const u32),
+        )
+    }
+}
+
+/// Returns the serial number of the chip as an array of bytes. The serial
+/// number is only guaranteed to be unique if all 16 bytes are used.
+pub fn serial_number() -> [u8; 16] {
+    let sn = split_serial_number();
+    [
+        ((sn.0 >> 24) & 0xff) as u8,
+        ((sn.0 >> 16) & 0xff) as u8,
+        ((sn.0 >> 8) & 0xff) as u8,
+        (sn.0 & 0xff) as u8,
+        ((sn.1 >> 24) & 0xff) as u8,
+        ((sn.1 >> 16) & 0xff) as u8,
+        ((sn.1 >> 8) & 0xff) as u8,
+        (sn.1 & 0xff) as u8,
+        ((sn.2 >> 24) & 0xff) as u8,
+        ((sn.2 >> 16) & 0xff) as u8,
+        ((sn.2 >> 8) & 0xff) as u8,
+        (sn.2 & 0xff) as u8,
+        ((sn.3 >> 24) & 0xff) as u8,
+        ((sn.3 >> 16) & 0xff) as u8,
+        ((sn.3 >> 8) & 0xff) as u8,
+        (sn.3 & 0xff) as u8,
+    ]
+}

--- a/hal/src/samd21/watchdog.rs
+++ b/hal/src/samd21/watchdog.rs
@@ -1,0 +1,71 @@
+extern crate embedded_hal;
+use embedded_hal::watchdog;
+
+use crate::target_device::WDT;
+
+/// WatchdogTimeout enumerates usable values for configuring
+/// the timeout of the watchdog peripheral.
+#[repr(u8)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum WatchdogTimeout {
+    Cycles8 = 0,
+    Cycles16,
+    Cycles32,
+    Cycles64,
+    Cycles128,
+    Cycles256,
+    Cycles512,
+    Cycles1K,
+    Cycles2K,
+    Cycles4K,
+    Cycles8K,
+    Cycles16K,
+}
+
+pub struct Watchdog {
+    wdt: WDT,
+}
+
+impl Watchdog {
+    pub fn new(wdt: WDT) -> Self {
+        Self { wdt }
+    }
+}
+
+impl watchdog::Watchdog for Watchdog {
+    /// Feeds an existing watchdog to ensure the processor isn't reset.
+    /// Sometimes commonly referred to as "kicking" or "refreshing".
+    fn feed(&mut self) {
+        self.wdt.clear.write(|w| unsafe { w.clear().bits(0xA5) });
+    }
+}
+
+/// Disables a running watchdog timer so the processor won't be reset.
+impl watchdog::WatchdogDisable for Watchdog {
+    fn disable(&mut self) {
+        // Disable the watchdog timer.
+        self.wdt.ctrl.write(|w| w.enable().clear_bit());
+        // Wait for watchdog timer to be disabled.
+        while self.wdt.status.read().syncbusy().bit_is_set() {}
+    }
+}
+
+impl watchdog::WatchdogEnable for Watchdog {
+    type Time = u8;
+
+    /// Enables a watchdog timer to reset the processor if software is frozen
+    /// or stalled.
+    fn start<T>(&mut self, period: T)
+    where
+        T: Into<Self::Time>,
+    {
+        // Write the timeout configuration.
+        self.wdt
+            .config
+            .write(|w| unsafe { w.per().bits(period.into()) });
+        // Enable the watchdog timer.
+        self.wdt.ctrl.write(|w| w.enable().set_bit());
+        // Wait for watchdog timer to be enabled.
+        while self.wdt.status.read().syncbusy().bit_is_set() {}
+    }
+}

--- a/hal/src/samd51/watchdog.rs
+++ b/hal/src/samd51/watchdog.rs
@@ -1,3 +1,6 @@
+extern crate embedded_hal;
+use embedded_hal::watchdog;
+
 use crate::target_device::WDT;
 
 /// WatchdogTimeout enumerates usable values for configuring
@@ -5,15 +8,18 @@ use crate::target_device::WDT;
 #[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum WatchdogTimeout {
-    Timeout8ms = 0,
-    Timeout16ms,
-    Timeout32ms,
-    Timeout64ms,
-    Timeout128ms,
-    Timeout256ms,
-    Timeout512ms,
-    Timeout1024ms,
-    Timeout2048ms,
+    Cycles8 = 0,
+    Cycles16,
+    Cycles32,
+    Cycles64,
+    Cycles128,
+    Cycles256,
+    Cycles512,
+    Cycles1K,
+    Cycles2K,
+    Cycles4K,
+    Cycles8K,
+    Cycles16K,
 }
 
 pub struct Watchdog {
@@ -21,21 +27,45 @@ pub struct Watchdog {
 }
 
 impl Watchdog {
-    /// Enables the watchdog in normal (timeout) mode, with
-    /// the specified timeout. The caller must invoke reset() within
-    /// the timeout duration to avoid a reset.
-    pub fn new_with_timeout(wdt: WDT, timeout: WatchdogTimeout) -> Self {
-        // Write the timeout configuration.
-        wdt.config.write(|w| unsafe { w.per().bits(timeout as u8) });
-        // Enable the watchdog timer.
-        wdt.ctrla.write(|w| w.enable().set_bit());
-        // Wait for watchdog timer to be enabled.
-        while wdt.syncbusy.read().enable().bit_is_set() {}
-
+    pub fn new(wdt: WDT) -> Self {
         Self { wdt }
     }
+}
 
-    pub fn clear(&self) {
+impl watchdog::Watchdog for Watchdog {
+    /// Feeds an existing watchdog to ensure the processor isn't reset.
+    /// Sometimes commonly referred to as "kicking" or "refreshing".
+    fn feed(&mut self) {
         self.wdt.clear.write(|w| unsafe { w.clear().bits(0xA5) });
+    }
+}
+
+/// Disables a running watchdog timer so the processor won't be reset.
+impl watchdog::WatchdogDisable for Watchdog {
+    fn disable(&mut self) {
+        // Disable the watchdog timer.
+        self.wdt.ctrla.write(|w| w.enable().clear_bit());
+        // Wait for watchdog timer to be disabled.
+        while self.wdt.syncbusy.read().enable().bit_is_set() {}
+    }
+}
+
+impl watchdog::WatchdogEnable for Watchdog {
+    type Time = u8;
+
+    /// Enables a watchdog timer to reset the processor if software is frozen
+    /// or stalled.
+    fn start<T>(&mut self, period: T)
+    where
+        T: Into<Self::Time>,
+    {
+        // Write the timeout configuration.
+        self.wdt
+            .config
+            .write(|w| unsafe { w.per().bits(period.into()) });
+        // Enable the watchdog timer.
+        self.wdt.ctrla.write(|w| w.enable().set_bit());
+        // Wait for watchdog timer to be enabled.
+        while self.wdt.syncbusy.read().enable().bit_is_set() {}
     }
 }

--- a/hal/src/same54/watchdog.rs
+++ b/hal/src/same54/watchdog.rs
@@ -1,3 +1,6 @@
+extern crate embedded_hal;
+use embedded_hal::watchdog;
+
 use crate::target_device::WDT;
 
 /// WatchdogTimeout enumerates usable values for configuring
@@ -5,15 +8,18 @@ use crate::target_device::WDT;
 #[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum WatchdogTimeout {
-    Timeout8ms = 0,
-    Timeout16ms,
-    Timeout32ms,
-    Timeout64ms,
-    Timeout128ms,
-    Timeout256ms,
-    Timeout512ms,
-    Timeout1024ms,
-    Timeout2048ms,
+    Cycles8 = 0,
+    Cycles16,
+    Cycles32,
+    Cycles64,
+    Cycles128,
+    Cycles256,
+    Cycles512,
+    Cycles1K,
+    Cycles2K,
+    Cycles4K,
+    Cycles8K,
+    Cycles16K,
 }
 
 pub struct Watchdog {
@@ -21,21 +27,45 @@ pub struct Watchdog {
 }
 
 impl Watchdog {
-    /// Enables the watchdog in normal (timeout) mode, with
-    /// the specified timeout. The caller must invoke reset() within
-    /// the timeout duration to avoid a reset.
-    pub fn new_with_timeout(wdt: WDT, timeout: WatchdogTimeout) -> Self {
-        // Write the timeout configuration.
-        wdt.config.write(|w| unsafe { w.per().bits(timeout as u8) });
-        // Enable the watchdog timer.
-        wdt.ctrla.write(|w| w.enable().set_bit());
-        // Wait for watchdog timer to be enabled.
-        while wdt.syncbusy.read().enable().bit_is_set() {}
-
+    pub fn new(wdt: WDT) -> Self {
         Self { wdt }
     }
+}
 
-    pub fn clear(&self) {
+impl watchdog::Watchdog for Watchdog {
+    /// Feeds an existing watchdog to ensure the processor isn't reset.
+    /// Sometimes commonly referred to as "kicking" or "refreshing".
+    fn feed(&mut self) {
         self.wdt.clear.write(|w| unsafe { w.clear().bits(0xA5) });
+    }
+}
+
+/// Disables a running watchdog timer so the processor won't be reset.
+impl watchdog::WatchdogDisable for Watchdog {
+    fn disable(&mut self) {
+        // Disable the watchdog timer.
+        self.wdt.ctrla.write(|w| w.enable().clear_bit());
+        // Wait for watchdog timer to be disabled.
+        while self.wdt.syncbusy.read().enable().bit_is_set() {}
+    }
+}
+
+impl watchdog::WatchdogEnable for Watchdog {
+    type Time = u8;
+
+    /// Enables a watchdog timer to reset the processor if software is frozen
+    /// or stalled.
+    fn start<T>(&mut self, period: T)
+    where
+        T: Into<Self::Time>,
+    {
+        // Write the timeout configuration.
+        self.wdt
+            .config
+            .write(|w| unsafe { w.per().bits(period.into()) });
+        // Enable the watchdog timer.
+        self.wdt.ctrla.write(|w| w.enable().set_bit());
+        // Wait for watchdog timer to be enabled.
+        while self.wdt.syncbusy.read().enable().bit_is_set() {}
     }
 }


### PR DESCRIPTION
I went ahead an implemented all traits currently available for the Watchdog Timer from `embedded-hal`. I initially did this for `samd11`/`samd21` devices, but have since ported the changes to the `samd51`/`same54` as well. I have tested and confirmed functionality on a `samd21`.

The previous implementation had enumerated the timeout values in milliseconds, but this is not quite correct. The timeout values are actually in clock cycles according to the various datasheets, so I have updated the enumerations to reflect such. I'm not crazy about the current naming for the enum values, but it's not the worst also.

I also worked on improving HAL parity by copying the `reset_cause` and `serial_number` functions over to the `samd11`/`samd21`, as they were low-hanging fruit. These were tested and confirmed working as well.

Just as a note, this PR introduces breaking API changes.

As usual if you'd like any additional changes made just let me know. I think we could probably pull this all into the `common/` module as well, there are only a handful of lines that would require feature gating, so let me know if you'd like that done.