### PR TITLE
Pin exact versions of the ssd1306 and embedded-graphics crates in feather_m0

### DIFF
--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -45,8 +45,8 @@ optional = true
 
 [dev-dependencies]
 cortex-m-semihosting = "~0.3"
-ssd1306 = "0.3.0-alpha.1"
-embedded-graphics = "0.6.0-alpha.2"
+ssd1306 = "=0.3.0-alpha.1"
+embedded-graphics = "=0.6.0-alpha.2"
 
 [features]
 # ask the HAL to enable atsamd21g18a support


### PR DESCRIPTION
These are pre-release and have breaking changes in later versions. A fresh build pulls the latest alpha versions which doesn’t compile, this change should ensure the build works fresh i.e. when generating a new Cargo.lock file.