### PR TITLE
watchdog requires embedded-hal 0.2.2, equalize to 0.2.3

### DIFF
--- a/boards/arduino_mkrzero/Cargo.toml
+++ b/boards/arduino_mkrzero/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g18a/arduino_mkrzero
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g18a/circuit_playgro
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.atsamd-hal]

--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 st7735-lcd = "~0.5"
 

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g18a/feather_m0/"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd51j19a/feather_m4/"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/boards/gemma_m0/Cargo.toml
+++ b/boards/gemma_m0/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd21e18a/gemma_m0/"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g18a/itsybitsy_m0/"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/boards/itsybitsy_m4/Cargo.toml
+++ b/boards/itsybitsy_m4/Cargo.toml
@@ -15,7 +15,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd51g19a/itsybitsy_m4/"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 bitbang-hal = "~0.3"
 apa102-spi = "~0.3"
 smart-leds = "~0.2"

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd51j19a/metro_m4/"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/boards/pfza_proto1/Cargo.toml
+++ b/boards/pfza_proto1/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsame54p20a/pfza_proto1/"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 st7735-lcd = "~0.5"
 

--- a/boards/pyportal/Cargo.toml
+++ b/boards/pyportal/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd11c14a/samd11_bare/"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/boards/samd21_mini/Cargo.toml
+++ b/boards/samd21_mini/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g18a/samd21_mini/"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/boards/serpente/Cargo.toml
+++ b/boards/serpente/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd21e18a/serpente/"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/boards/sodaq_one/Cargo.toml
+++ b/boards/sodaq_one/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g18a/sodaq_one/"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/boards/sodaq_sara_aff/Cargo.toml
+++ b/boards/sodaq_sara_aff/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd21j18a/sodaq_sara_aff/
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -16,7 +16,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd51g19a/trellis_m4/"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/boards/trinket_m0/Cargo.toml
+++ b/boards/trinket_m0/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd21e18a/trinket_m0/"
 
 [dependencies]
 cortex-m = "~0.6"
-embedded-hal = "~0.2"
+embedded-hal = "~0.2.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]

--- a/hal/src/samd11/mod.rs
+++ b/hal/src/samd11/mod.rs
@@ -3,6 +3,8 @@ pub mod clock;
 pub mod pwm;
 pub mod sercom;
 pub mod timer;
+
+#[cfg(feature = "unproven")]
 pub mod watchdog;
 
 mod serial_number;

--- a/hal/src/samd11/watchdog.rs
+++ b/hal/src/samd11/watchdog.rs
@@ -1,7 +1,5 @@
-extern crate embedded_hal;
-use embedded_hal::watchdog;
-
 use crate::target_device::WDT;
+use hal::watchdog;
 
 /// WatchdogTimeout enumerates usable values for configuring
 /// the timeout of the watchdog peripheral.

--- a/hal/src/samd21/mod.rs
+++ b/hal/src/samd21/mod.rs
@@ -3,6 +3,8 @@ pub mod clock;
 pub mod pwm;
 pub mod sercom;
 pub mod timer;
+
+#[cfg(feature = "unproven")]
 pub mod watchdog;
 
 mod serial_number;

--- a/hal/src/samd21/watchdog.rs
+++ b/hal/src/samd21/watchdog.rs
@@ -1,7 +1,5 @@
-extern crate embedded_hal;
-use embedded_hal::watchdog;
-
 use crate::target_device::WDT;
+use hal::watchdog;
 
 /// WatchdogTimeout enumerates usable values for configuring
 /// the timeout of the watchdog peripheral.

--- a/hal/src/samd51/mod.rs
+++ b/hal/src/samd51/mod.rs
@@ -4,6 +4,8 @@ pub mod pwm;
 pub mod sercom;
 pub mod timer;
 pub mod trng;
+
+#[cfg(feature = "unproven")]
 pub mod watchdog;
 
 mod serial_number;

--- a/hal/src/samd51/watchdog.rs
+++ b/hal/src/samd51/watchdog.rs
@@ -1,7 +1,5 @@
-extern crate embedded_hal;
-use embedded_hal::watchdog;
-
 use crate::target_device::WDT;
+use hal::watchdog;
 
 /// WatchdogTimeout enumerates usable values for configuring
 /// the timeout of the watchdog peripheral.

--- a/hal/src/same54/mod.rs
+++ b/hal/src/same54/mod.rs
@@ -4,6 +4,8 @@ pub mod pwm;
 pub mod sercom;
 pub mod timer;
 pub mod trng;
+
+#[cfg(feature = "unproven")]
 pub mod watchdog;
 
 mod serial_number;

--- a/hal/src/same54/watchdog.rs
+++ b/hal/src/same54/watchdog.rs
@@ -1,7 +1,5 @@
-extern crate embedded_hal;
-use embedded_hal::watchdog;
-
 use crate::target_device::WDT;
+use hal::watchdog;
 
 /// WatchdogTimeout enumerates usable values for configuring
 /// the timeout of the watchdog peripheral.


### PR DESCRIPTION
Build is broken occasionally because embedded hal needs to be 0.2.2 for watchdog traits
```
   Compiling atsamd-hal v0.8.0 (/Users/jacobrosenthal/Downloads/atsamd/hal)
error[E0405]: cannot find trait `Watchdog` in module `watchdog`
  --> /Users/jacobrosenthal/Downloads/atsamd/hal/src/samd51/watchdog.rs:35:16
   |
35 | impl watchdog::Watchdog for Watchdog {
   |                ^^^^^^^^ not found in `watchdog`

error[E0405]: cannot find trait `WatchdogDisable` in module `watchdog`
  --> /Users/jacobrosenthal/Downloads/atsamd/hal/src/samd51/watchdog.rs:44:16
   |
44 | impl watchdog::WatchdogDisable for Watchdog {
   |                ^^^^^^^^^^^^^^^ not found in `watchdog`

error[E0405]: cannot find trait `WatchdogEnable` in module `watchdog`
  --> /Users/jacobrosenthal/Downloads/atsamd/hal/src/samd51/watchdog.rs:53:16
   |
53 | impl watchdog::WatchdogEnable for Watchdog {
   |                ^^^^^^^^^^^^^^ not found in `watchdog`

   Compiling nom v4.2.3
warning: use of deprecated item 'core::mem::uninitialized': use `mem::MaybeUninit` instead
   --> /Users/jacobrosenthal/Downloads/atsamd/hal/src/samd51/usb/bus.rs:153:45
    |
153 |     singleton!(: [u8; BUFFER_SIZE] = unsafe{mem::uninitialized()}).unwrap()
    |                                             ^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0405`.
error: could not compile `atsamd-hal`.
```

I think something else was already at ~0.2.3 so I equalized on that instead of 0.2.2