### PR TITLE
Mark pwm module as unproven

### DIFF
--- a/hal/src/samd11/mod.rs
+++ b/hal/src/samd11/mod.rs
@@ -1,8 +1,10 @@
 pub mod calibration;
 pub mod clock;
-pub mod pwm;
 pub mod sercom;
 pub mod timer;
+
+#[cfg(feature = "unproven")]
+pub mod pwm;
 
 #[cfg(feature = "unproven")]
 pub mod watchdog;

--- a/hal/src/samd21/mod.rs
+++ b/hal/src/samd21/mod.rs
@@ -1,8 +1,10 @@
 pub mod calibration;
 pub mod clock;
-pub mod pwm;
 pub mod sercom;
 pub mod timer;
+
+#[cfg(feature = "unproven")]
+pub mod pwm;
 
 #[cfg(feature = "unproven")]
 pub mod watchdog;

--- a/hal/src/samd51/mod.rs
+++ b/hal/src/samd51/mod.rs
@@ -1,9 +1,11 @@
 pub mod calibration;
 pub mod clock;
-pub mod pwm;
 pub mod sercom;
 pub mod timer;
 pub mod trng;
+
+#[cfg(feature = "unproven")]
+pub mod pwm;
 
 #[cfg(feature = "unproven")]
 pub mod watchdog;

--- a/hal/src/same54/mod.rs
+++ b/hal/src/same54/mod.rs
@@ -1,9 +1,11 @@
 pub mod calibration;
 pub mod clock;
-pub mod pwm;
 pub mod sercom;
 pub mod timer;
 pub mod trng;
+
+#[cfg(feature = "unproven")]
+pub mod pwm;
 
 #[cfg(feature = "unproven")]
 pub mod watchdog;


### PR DESCRIPTION
Similar to #145 the Pwm types are unproven in embedded-hal, mark the modules as unproven so they aren't compiled in without the feature.