### PR TITLE
even more pwm fallout

### DIFF
--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -53,7 +53,7 @@ optional = true
 
 [features]
 # ask the HAL to enable atsamd51j20a support
-default = ["rt", "atsamd-hal/samd51j19a", "atsamd-hal/samd51"]
+default = ["rt", "atsamd-hal/samd51j19a", "atsamd-hal/samd51", "unproven"]
 rt = ["cortex-m-rt", "atsamd-hal/samd51j19a-rt"]
 unproven = ["atsamd-hal/unproven"]
 usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
@@ -71,6 +71,7 @@ debug = true
 lto = true
 opt-level = "s"
 
+
 [[example]]
 name = "usb_serial"
 required-features = ["usb", "ws2812-timer"]
@@ -85,11 +86,7 @@ required-features = ["ws2812-timer"]
 
 [[example]]
 name = "neopixel_button"
-required-features = ["ws2812-timer", "unproven"]
-
-[[example]]
-name = "button_rtfm"
-required-features = ["unproven"]
+required-features = ["ws2812-timer"]
 
 [[example]]
 name = "neopixel_rainbow_timer"
@@ -97,12 +94,12 @@ required-features = ["ws2812-timer"]
 
 [[example]]
 name = "neopixel_adc_light"
-required-features = [ "ws2812-timer", "unproven"]
+required-features = [ "ws2812-timer"]
 
 [[example]]
 name = "neopixel_adc_battery"
-required-features = [ "ws2812-timer" ,"unproven"]
+required-features = [ "ws2812-timer"]
 
 [[example]]
 name = "neopixel_easing"
-required-features = [ "ws2812-timer" ,"unproven", "math"]
+required-features = [ "ws2812-timer", "math"]

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -58,7 +58,7 @@ optional = true
 
 [features]
 # ask the HAL to enable atsamd51j20a support
-default = ["rt", "atsamd-hal/samd51j19a", "atsamd-hal/samd51"]
+default = ["rt", "atsamd-hal/samd51j19a", "atsamd-hal/samd51", "unproven"]
 rt = ["cortex-m-rt", "atsamd-hal/samd51j19a-rt"]
 unproven = ["atsamd-hal/unproven"]
 usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
@@ -91,15 +91,11 @@ required-features = ["ws2812-timer"]
 
 [[example]]
 name = "neopixel_button"
-required-features = ["ws2812-timer", "unproven"]
+required-features = ["ws2812-timer"]
 
 [[example]]
 name = "neopixel_rainbow_spintimer"
 required-features = ["ws2812-timer"]
-
-[[example]]
-name = "button_rtfm"
-required-features = ["unproven"]
 
 [[example]]
 name = "neopixel_rainbow_timer"
@@ -107,11 +103,11 @@ required-features = ["ws2812-timer"]
 
 [[example]]
 name = "neopixel_adc_light"
-required-features = [ "ws2812-timer", "unproven",]
+required-features = [ "ws2812-timer"]
 
 [[example]]
 name = "neopixel_adc_battery"
-required-features = [ "ws2812-timer" ,"unproven",]
+required-features = [ "ws2812-timer"]
 
 [[example]]
 name = "sd_card"
@@ -119,4 +115,4 @@ required-features = ["sd-card"]
 
 [[example]]
 name = "neopixel_easing"
-required-features = [ "ws2812-timer" ,"unproven", "math"]
+required-features = [ "ws2812-timer", "math"]

--- a/boards/pyportal/Cargo.toml
+++ b/boards/pyportal/Cargo.toml
@@ -39,13 +39,13 @@ ws2812-nop-samd51 = { git = "https://github.com/smart-leds-rs/ws2812-nop-samd51.
 
 [dev-dependencies.ws2812-timer-delay]
 version = "~0.1"
-features = ["slow"] 
+features = ["slow"]
 
 [features]
 # ask the HAL to enable atsamd51j20a support
-default = ["rt", "atsamd-hal/samd51j20a", "atsamd-hal/samd51"]
-rt = ["cortex-m-rt", "atsamd-hal/samd51j20a-rt"]
+default = ["rt", "atsamd-hal/samd51j20a", "atsamd-hal/samd51", "unproven"]
 unproven = ["atsamd-hal/unproven"]
+rt = ["cortex-m-rt", "atsamd-hal/samd51j20a-rt"]
 
 [profile.dev]
 incremental = false
@@ -55,5 +55,5 @@ lto = false
 
 [profile.release]
 debug = true
-lto = false 
+lto = false
 opt-level = "s"


### PR DESCRIPTION
Blah this gift keeps giving. 

Pygamer is still broken because ferris_img example doesnt have unproven feature.

But instead Im going to default unproven for all the pyboards ive been managing. Basically all the examples use it at this point, and im stripping the ws2812-timer feature in https://github.com/atsamd-rs/atsamd/pull/130 which cleans up a ton of complexity