### PR TITLE
Update Cargo.toml for pwm move to unproven

### DIFF
--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -76,6 +76,8 @@ name = "blinky_basic"
 
 [[example]]
 name = "pwm"
+required-features = ["unproven"]
+
 
 [[example]]
 name = "adc"

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -67,6 +67,7 @@ name = "neopixel_rainbow"
 
 [[example]]
 name = "pwm"
+required-features = ["unproven"]
 
 [[example]]
 name = "serial"

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -42,6 +42,7 @@ name = "blinky_basic"
 
 [[example]]
 name = "pwm"
+required-features = ["unproven"]
 
 [[example]]
 name = "serial"

--- a/boards/serpente/Cargo.toml
+++ b/boards/serpente/Cargo.toml
@@ -32,3 +32,10 @@ default = ["rt", "atsamd-hal/samd21e18a"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21e18a-rt"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
+
+[[example]]
+name = "blinky_basic"
+
+[[example]]
+name = "pwm"
+required-features = ["unproven"]

--- a/boards/trinket_m0/Cargo.toml
+++ b/boards/trinket_m0/Cargo.toml
@@ -38,6 +38,7 @@ name = "blinky_basic"
 
 [[example]]
 name = "pwm"
+required-features = ["unproven"]
 
 [[example]]
 name = "watchdog"


### PR DESCRIPTION
I added a `required-features` attribute(?) to the pwm example section. This forces the compiler to at least display a message saying that you must pass `--features="unproven"` when attempting to build the pwm example. Without this, the error isn't super intuitive and requires some source diving for new users to figure out.