### PR TITLE
samd51: Fix spurious hangs for OUT packets in UsbBus

### DIFF
--- a/boards/pygamer/examples/usb_serial.rs
+++ b/boards/pygamer/examples/usb_serial.rs
@@ -77,10 +77,11 @@ fn main() -> ! {
         core.NVIC.set_priority(interrupt::USB_OTHER, 1);
         core.NVIC.set_priority(interrupt::USB_TRCPT0, 1);
         core.NVIC.set_priority(interrupt::USB_TRCPT1, 1);
-        core.NVIC.set_priority(interrupt::USB_TRCPT1, 1);
+        core.NVIC.set_priority(interrupt::USB_SOF_HSOF, 2);
         NVIC::unmask(interrupt::USB_OTHER);
         NVIC::unmask(interrupt::USB_TRCPT0);
         NVIC::unmask(interrupt::USB_TRCPT1);
+        NVIC::unmask(interrupt::USB_SOF_HSOF);
     }
 
     loop {
@@ -145,4 +146,17 @@ fn USB_TRCPT0() {
 #[interrupt]
 fn USB_TRCPT1() {
     poll_usb();
+}
+
+static mut SOF_COUNTER: u8 = 0;
+
+#[interrupt]
+fn USB_SOF_HSOF() {
+    unsafe {
+        SOF_COUNTER+=1;
+        if SOF_COUNTER >= 4 {
+            poll_usb();
+            SOF_COUNTER = 0;
+        }
+    };
 }


### PR DESCRIPTION
Fixes #105 

I spent hours on this - I can't work out why interrupt line 80 isn't firing in the flood of interrupt URBs that the bug demonstrates.

The fix is to enable the interrupt on the start-of-frame, and use that to periodically poll the handler to handle pending packets.

 I was not able to find any open-source C implementation that did not use the start-of-frame interrupt.

I've also gotten rid of suspend/wakeup interrupt handling, as thats not necessary on samd51 and is kind of broken for self-powered devices anyway.