### PR TITLE
samd51 UsbBus: Fix interrupts not enabling & missing poll events around USB reset

### DIFF
--- a/boards/itsybitsy_m4/examples/usb_serial.rs
+++ b/boards/itsybitsy_m4/examples/usb_serial.rs
@@ -89,7 +89,6 @@ fn main() -> ! {
         core.NVIC.set_priority(interrupt::USB_OTHER, 1);
         core.NVIC.set_priority(interrupt::USB_TRCPT0, 1);
         core.NVIC.set_priority(interrupt::USB_TRCPT1, 1);
-        core.NVIC.set_priority(interrupt::USB_TRCPT1, 1);
         NVIC::unmask(interrupt::USB_OTHER);
         NVIC::unmask(interrupt::USB_TRCPT0);
         NVIC::unmask(interrupt::USB_TRCPT1);
@@ -117,7 +116,6 @@ fn poll_usb() {
         USB_BUS.as_mut().map(|usb_dev| {
             USB_SERIAL.as_mut().map(|serial| {
                 usb_dev.poll(&mut [serial]);
-
                 let mut buf = [0u8; 64];
 
                 if let Ok(count) = serial.read(&mut buf) {

--- a/boards/pygamer/examples/usb_serial.rs
+++ b/boards/pygamer/examples/usb_serial.rs
@@ -77,7 +77,6 @@ fn main() -> ! {
         core.NVIC.set_priority(interrupt::USB_OTHER, 1);
         core.NVIC.set_priority(interrupt::USB_TRCPT0, 1);
         core.NVIC.set_priority(interrupt::USB_TRCPT1, 1);
-        core.NVIC.set_priority(interrupt::USB_TRCPT1, 1);
         NVIC::unmask(interrupt::USB_OTHER);
         NVIC::unmask(interrupt::USB_TRCPT0);
         NVIC::unmask(interrupt::USB_TRCPT1);

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atsamd-hal"
-version = "0.8.0"
+version = "0.8.1"
 authors = [
     "Wez Furlong <wez@wezfurlong.org>",
     "Paul Sajna <sajattack@gmail.com>",

--- a/hal/src/samd51/usb/bus.rs
+++ b/hal/src/samd51/usb/bus.rs
@@ -327,11 +327,8 @@ impl<'a> Bank<'a, InBank> {
             desc.set_byte_count(0);
         }
 
-        if idx == 0 {
-            self.epstatusclr(idx)
-                .write(|w| w.stallrq1().set_bit().dtglin().set_bit().bk1rdy().set_bit());
-            self.clear_transfer_complete();
-        }
+        self.epstatusclr(idx)
+            .write(|w| w.bk1rdy().set_bit());
     }
 
     /// Enables endpoint-specific interrupts. This is separate from reset()
@@ -451,16 +448,8 @@ impl<'a> Bank<'a, OutBank> {
             desc.set_byte_count(0);
         }
 
-        if idx == 0 {
-            self.epstatusclr(idx).write(|w| {
-                w.stallrq0()
-                    .set_bit()
-                    .dtglout()
-                    .set_bit()
-                    .bk0rdy()
-                    .set_bit()
-            });
-        }
+        self.epstatusclr(idx)
+            .write(|w| w.bk0rdy().set_bit());
     }
 
     /// Enables endpoint-specific interrupts. This is separate from reset()


### PR DESCRIPTION
Fixes #105.
Co-authored-by: Jacob Rosenthal <jacobrosenthal@gmail.com>

So it looks like the issue came down to our writes to `EPINTENSET[n]` not sticking. I found one really important sentence:

> This [EPINTENSET] register is cleared by USB reset or when EPEN[n] is zero.

-- Page 1164 / 2129 of the SAM D5x/E5x Family Data Sheet

There is no register or other reference to `EPEN`. I've taken it to mean a non-zero value for `EPCFG[n].EPTYPE[0/1]`, but to be sure we configure the endpoint interrupts last.

The remaining changes are the result of an iterative audit of registers, ordering, and minimizing unnecessary writes so the driver is as reliable as possible.