### PR TITLE
cleanup usb noise

### DIFF
--- a/hal/src/samd21/usb/bus.rs
+++ b/hal/src/samd21/usb/bus.rs
@@ -11,7 +11,7 @@ use crate::target_device::{PM, USB};
 use crate::usb::devicedesc::DeviceDescBank;
 use core::cell::{Ref, RefCell, RefMut};
 use core::marker::PhantomData;
-use core::mem;
+use core::mem::{self, MaybeUninit};
 use cortex_m::interrupt::{free as disable_interrupts, Mutex};
 use cortex_m::singleton;
 use usb_device;
@@ -150,7 +150,7 @@ impl AllEndpoints {
 // FIXME: replace with more general heap?
 const BUFFER_SIZE: usize = 2048;
 fn buffer() -> &'static mut [u8; BUFFER_SIZE] {
-    singleton!(: [u8; BUFFER_SIZE] = unsafe{mem::uninitialized()}).unwrap()
+    singleton!(: [u8; BUFFER_SIZE] = unsafe{MaybeUninit::uninit().assume_init()}).unwrap()
 }
 
 struct BufferAllocator {
@@ -608,9 +608,12 @@ impl Inner {
 
     fn set_stall<EP: Into<EndpointAddress>>(&self, ep: EP, stall: bool) {
         let ep = ep.into();
-        let idx = ep.index();
-        let dir = ep.direction();
-        dbgprint!("UsbBus::stall={} for {:?} {}\n", stall, dir, idx);
+        dbgprint!(
+            "UsbBus::stall={} for {:?} {}\n",
+            stall,
+            ep.direction(),
+            ep.index()
+        );
         if ep.is_out() {
             if let Ok(mut bank) = self.bank0(ep) {
                 bank.set_stall(stall);
@@ -620,11 +623,13 @@ impl Inner {
         }
     }
 
+    #[allow(unused_variables)]
     fn print_epstatus(&self, ep: usize, label: &str) {
         let status = self.epstatus(ep).read();
         let epint = self.epintflag(ep).read();
         let intflag = self.usb().intflag.read();
 
+        #[allow(unused_mut)]
         let mut desc = self.desc.borrow_mut();
 
         dbgprint!("ep{} status {}:\n    bk1rdy={} stallrq1={} stall1={} trcpt1={} trfail1={} byte_count1={} multi_packet_size1={}\n    bk0rdy={} stallrq0={} stall0={} trcpt0={} trfail0={} byte_count0={} multi_packet_size0={}\n    curbk={} dtglin={} dtglout={} rxstp={}   lpmsusp={} lpmnyet={} ramacer={} uprsm={} eorsm={} wakeup={} eorst={} sof={} suspend={}\n",
@@ -682,7 +687,7 @@ impl Inner {
             w.transp().bits(usb_transp_cal());
             w.trim().bits(usb_trim_cal())
         });
-        usb.qosctrl.modify(|_, w| unsafe {
+        usb.qosctrl.modify(|_, w| {
             w.dqos().bits(0b11);
             w.cqos().bits(0b11)
         });
@@ -717,7 +722,7 @@ impl Inner {
                 (FlushConfigMode::ProtocolReset, 0) => {
                     self.setup_ep_interrupts(EndpointAddress::from_parts(idx, UsbDirection::Out));
                     self.setup_ep_interrupts(EndpointAddress::from_parts(idx, UsbDirection::In));
-                },
+                }
                 // A full flush configures all provisioned endpoints + enables interrupts.
                 // Endpoints 1-8 have identical behaviour when flushed due to protocol reset.
                 (FlushConfigMode::Full, _) | (FlushConfigMode::ProtocolReset, _) => {
@@ -963,12 +968,11 @@ impl Inner {
             match size {
                 Ok(size) => {
                     //dbgprint!("UsbBus::read {} bytes ok", size);
-                    let got = &buf[..size as usize];
                     dbgprint!(
                         "UsbBus::read {} bytes from ep {:?} -> {:?}\n",
                         size,
                         ep,
-                        got
+                        &buf[..size as usize]
                     );
                     Ok(size)
                 }

--- a/hal/src/samd21/usb/devicedesc.rs
+++ b/hal/src/samd21/usb/devicedesc.rs
@@ -57,6 +57,7 @@ impl DeviceDescBank {
     /// When enabled, the USB module will manage the ZLP handshake by hardware.
     /// This bit is for IN endpoints only. When disabled the handshake should be
     /// managed by firmware.
+    #[allow(unused)]
     pub fn set_auto_zlp(&mut self, enable: bool) {
         self.pcksize.set_auto_zlp(enable);
     }
@@ -77,6 +78,7 @@ impl DeviceDescBank {
         self.pcksize.set_size(size);
     }
 
+    #[allow(unused)]
     pub fn get_endpoint_size(&self) -> u16 {
         let bits = self.pcksize.size();
         match bits {
@@ -102,6 +104,7 @@ impl DeviceDescBank {
     /// For OUT endpoints, MULTI_PACKET_SIZE holds the total data
     /// size for the complete transfer. This value must be a multiple of the
     /// maximum packet size.
+    #[allow(dead_code)]
     pub fn get_multi_packet_size(&self) -> u16 {
         self.pcksize.multi_packet_size() as u16
     }
@@ -124,16 +127,19 @@ impl DeviceDescBank {
         self.pcksize.byte_count() as u16
     }
 
+    #[allow(unused)]
     pub fn link_state(&self) -> u8 {
         // every value except 1 (L1 sleep) is reserved
         self.extreg.link_state() as u8
     }
 
     /// best effort service latency
+    #[allow(unused)]
     pub fn besl(&self) -> u8 {
         self.extreg.besl() as u8
     }
 
+    #[allow(unused)]
     pub fn remote_wake(&self) -> bool {
         self.extreg.remote_wake()
     }
@@ -141,6 +147,7 @@ impl DeviceDescBank {
     /// These bits define the SUBPID field of a received extended token. These
     /// bits are updated when the USB has answered by an handshake token
     /// ACK to a LPM transaction
+    #[allow(unused)]
     pub fn subpid(&self) -> u8 {
         self.extreg.subpid() as u8
     }
@@ -151,12 +158,14 @@ impl DeviceDescBank {
     /// an overrun condition has occurred.  For IN transfer, this bit is not
     /// valid. EPSTATUS.TRFAIL0 and EPSTATUS.TRFAIL1 should reflect the flow
     /// errors.
+    #[allow(unused)]
     pub fn error_flow(&self) -> bool {
         self.status_bk.error_flow()
     }
 
     /// This bit defines the CRC Error Status.  This bit is set when a CRC
     /// error has been detected in an isochronous OUT endpoint bank
+    #[allow(unused)]
     pub fn crc_error(&self) -> bool {
         self.status_bk.crc_error()
     }

--- a/hal/src/samd51/usb/devicedesc.rs
+++ b/hal/src/samd51/usb/devicedesc.rs
@@ -58,6 +58,7 @@ impl DeviceDescBank {
     /// When enabled, the USB module will manage the ZLP handshake by hardware.
     /// This bit is for IN endpoints only. When disabled the handshake should be
     /// managed by firmware.
+    #[allow(unused_variables)]
     pub fn set_auto_zlp(&mut self, enable: bool) {
         self.pcksize.set_auto_zlp(enable);
     }
@@ -104,6 +105,7 @@ impl DeviceDescBank {
     /// For OUT endpoints, MULTI_PACKET_SIZE holds the total data
     /// size for the complete transfer. This value must be a multiple of the
     /// maximum packet size.
+    #[allow(dead_code)]
     pub fn get_multi_packet_size(&self) -> u16 {
         self.pcksize.multi_packet_size() as u16
     }


### PR DESCRIPTION
If you dont use use_uart_debug theres a ton of noise. 
Oh, also swaps mem::uninitialized for  MaybeUninit::uninit().assume_init()