### PR TITLE
Update HID example to latest version of usbd-hid

### DIFF
--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -32,7 +32,7 @@ version = "~0.1"
 optional = true
 
 [dependencies.usbd-hid]
-version = "~0.3"
+version = "~0.4"
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
Gets rid of `transmute` spookiness using new autogenerated serialization code thingyies