### PR TITLE
Add support for MKR Vidor 4000

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - CRATE=boards/samd11_bare FEATURES="--features=unproven" BUILDMODE="--release"
   - CRATE=boards/samd21_mini FEATURES="--features=unproven"
   - CRATE=boards/arduino_mkrzero FEATURES="--features=unproven"
+  - CRATE=boards/arduino_mkrvidor4000 FEATURES="--features=unproven"
   - CRATE=boards/circuit_playground_express FEATURES="--features=unproven"
   - CRATE=boards/sodaq_one FEATURES="--features=unproven"
   - CRATE=boards/sodaq_sara_aff FEATURES="--features=unproven"

--- a/boards/arduino_mkrvidor4000/.cargo/config
+++ b/boards/arduino_mkrvidor4000/.cargo/config
@@ -1,0 +1,10 @@
+# samd21 is a Cortex-M0 and thus thumbv6m
+
+[build]
+target = "thumbv6m-none-eabi"
+
+[target.thumbv6m-none-eabi]
+runner = 'arm-none-eabi-gdb'
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]

--- a/boards/arduino_mkrvidor4000/Cargo.toml
+++ b/boards/arduino_mkrvidor4000/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "arduino_mkrvidor4000"
+version = "0.1.0"
+authors = ["Sameer Puri <purisame@spuri.io>"]
+description = "Board Support crate for the Arduino MKR VIDOR 4000"
+keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/atsamd-rs/atsamd"
+readme = "README.md"
+documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g18a/arduino_mkrvidor4000/"
+
+[dependencies]
+cortex-m = "~0.6"
+embedded-hal = "~0.2.3"
+nb = "~0.1"
+
+[dependencies.cortex-m-rt]
+version = "~0.6.12"
+optional = true
+
+[dependencies.panic-halt]
+version = "~0.2"
+optional = true
+
+[dependencies.atsamd-hal]
+path = "../../hal"
+version = "~0.8"
+default-features = false
+
+[features]
+# ask the HAL to enable atsamd21g18a support
+default = ["rt", "panic_halt", "atsamd-hal/samd21g18a"]
+rt = ["cortex-m-rt", "atsamd-hal/samd21g18a-rt"]
+panic_halt = ["panic-halt"]
+unproven = ["atsamd-hal/unproven"]
+use_semihosting = []

--- a/boards/arduino_mkrvidor4000/README.md
+++ b/boards/arduino_mkrvidor4000/README.md
@@ -1,0 +1,27 @@
+# Arduino MKR Vidor 4000 Board Support Crate
+
+This crate provides a type-safe API for working with the [Arduino MKR Vidor board](https://store.arduino.cc/usa/mkr-vidor-4000).
+
+## Examples
+### Blinky Basic
+#### Requirements
+ - Arduino IDE installed
+    - samd package installed
+    - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
+    - Probably best to install an example sketch via the IDE just to make sure everything is working
+    - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
+ - arm-none-eabi tools installed, you need gcc and objcopy.
+ - thumbv6m-none-eabi rust target installed via `rustup target add thumbv6m-none-eabi`
+
+#### Steps
+
+```bash
+cargo build --release --example blinky_basic
+arm-none-eabi-objcopy -O binary target/thumbv6m-none-eabi/release/examples/blinky_basic target/blinky_basic.bin
+```
+
+Then, double click the reset button on your board so the red LED is fading in and out. Now you can flash the board.
+
+```bash
+bossac -i -d -U true -i -e -w -v target/blinky_basic.bin -R
+```

--- a/boards/arduino_mkrvidor4000/build.rs
+++ b/boards/arduino_mkrvidor4000/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+fn main() {
+    if env::var_os("CARGO_FEATURE_RT").is_some() {
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        File::create(out.join("memory.x"))
+            .unwrap()
+            .write_all(include_bytes!("memory.x"))
+            .unwrap();
+        println!("cargo:rustc-link-search={}", out.display());
+        println!("cargo:rerun-if-changed=memory.x");
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/boards/arduino_mkrvidor4000/examples/blinky_basic.rs
+++ b/boards/arduino_mkrvidor4000/examples/blinky_basic.rs
@@ -1,0 +1,32 @@
+#![no_std]
+#![no_main]
+
+extern crate arduino_mkrvidor4000 as hal;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::prelude::*;
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut led = pins.led_builtin.into_open_drain_output(&mut pins.port);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    loop {
+        delay.delay_ms(200u8);
+        led.set_high().unwrap();
+        delay.delay_ms(200u8);
+        led.set_low().unwrap();
+    }
+}

--- a/boards/arduino_mkrvidor4000/memory.x
+++ b/boards/arduino_mkrvidor4000/memory.x
@@ -1,0 +1,5 @@
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000+0x2000, LENGTH = 0x00040000-0x2000 /* bootloader 8kb */
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00008000
+}

--- a/boards/arduino_mkrvidor4000/src/lib.rs
+++ b/boards/arduino_mkrvidor4000/src/lib.rs
@@ -1,0 +1,126 @@
+#![no_std]
+
+extern crate atsamd_hal as hal;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::entry;
+
+#[cfg(feature = "panic_halt")]
+pub extern crate panic_halt;
+
+use hal::prelude::*;
+use hal::*;
+
+pub use hal::target_device as pac;
+pub use hal::common::*;
+pub use hal::samd21::*;
+
+use gpio::{Floating, Input, Port};
+
+// The docs could be further improved with details of the specific channels etc
+define_pins!(
+    /// Maps the pins to their arduino names and the numbers printed on the board.
+    /// Information from: <https://github.com/arduino/ArduinoCore-samd/blob/master/variants/mkrvidor4000/variant.cpp>
+    struct Pins,
+    target_device: target_device,
+
+    /// Digital 0: PWM, TC
+    pin d0 = a22,
+
+    /// Digital 1: PWM, TC
+    pin d1 = a23,
+
+    /// Digital 2: PWM, TCC, ADC
+    pin d2 = a10,
+
+    /// Digital 3: PWM, TCC, ADC
+    pin d3 = a11,
+
+    /// Digital 4: PWM, TC
+    pin d4 = b10,
+
+    /// Digital 5: PWM, TC
+    pin d5 = b11,
+
+    /// Digital 6: PWM, TCC
+    pin d6 = a20,
+
+    /// Digital 7: PWM, TCC
+    pin d7 = a21,
+
+    /// SPI MOSI: PWM, TCC
+    pin mosi = a16,
+
+    /// SPI SCK
+    pin sck = a17,
+
+    /// SPI MISO: PWM, TC
+    pin miso = a19,
+
+    /// SDA
+    pin sda = a8,
+
+    /// SCL
+    pin scl = a9,
+
+    /// RX
+    pin rx = b23,
+
+    /// TX
+    pin tx = b22,
+
+    /// Analog 0: DAC
+    pin a0 = a2,
+
+    /// Analog 1
+    pin a1 = b2,
+
+    /// Analog 2
+    pin a2 = b3,
+
+    /// Analog 3: PWM, TCC
+    pin a3 = a4,
+
+    /// Analog 4: PWM, TCC
+    pin a4 = a5,
+
+    /// Analog 5
+    pin a5 = a6,
+
+    /// Analog 6
+    /// Cannot be used because it is actually adc_battery
+    /// pin a6 = a7,
+
+    pin usb_n = a24,
+    pin usb_p = a25,
+    pin usb_id = a18,
+
+    pin aref = a3,
+
+    /// JTAG pins, also accessible from 10-pin pad on the bottom
+    pin fpga_tdi = a12,
+    pin fpga_tck = a13,
+    pin fpga_tms = a14,
+    pin fpga_tdo = a15,
+
+    /// Interrupt pin for SAMD to interrupt FPGA
+    pin fpga_mb_int = a28,
+
+    /// Clock generator for FPGA
+    pin gclk = a27,
+
+    /// Accessible from 6 pin pad on the bottom
+    pin swdio = a31,
+    pin swclk = a30,
+
+    /// LED built into the board
+    pin led_builtin = b8,
+
+    /// PMIC_BAT
+    pin adc_battery = a7,
+
+    pin xin32 = a0,
+    pin xout32 = a1,
+);


### PR DESCRIPTION
Confirmed to work with Blinky example.

There seems to be an extra step where the board is put into flash mode. This is can be done manually by clicking the reset button twice in quick succession, but I haven't figured out whether that can be automated w/ bossac or another tool.

For FPGA support, need to figure out how to load the FPGA bitstream into the bin file...