### PR TITLE
DFll48M External Oscillator: await LCK_C, LCK_F

### DIFF
--- a/hal/src/samd21/clock.rs
+++ b/hal/src/samd21/clock.rs
@@ -460,5 +460,12 @@ fn configure_and_enable_dfll48m(sysctrl: &mut SYSCTRL, use_external_crystal: boo
     // and finally enable it!
     sysctrl.dfllctrl.modify(|_, w| w.enable().set_bit());
 
+    if use_external_crystal {
+        // wait for lock
+        while sysctrl.pclksr.read().dflllckc().bit_is_clear()
+            || sysctrl.pclksr.read().dflllckf().bit_is_clear()
+        {}
+    }
+
     wait_for_dfllrdy(sysctrl);
 }


### PR DESCRIPTION
As seen in [Arduino SAMD Core](https://github.com/arduino/ArduinoCore-samd/blob/master/cores/arduino/startup.c#L214), there should be a loop awaiting a coarse/fine lock when using an external oscillator.