### PR TITLE
MKR ZERO: Use external oscillator by default

### DIFF
--- a/boards/arduino_mkrzero/examples/blinky_basic.rs
+++ b/boards/arduino_mkrzero/examples/blinky_basic.rs
@@ -13,7 +13,7 @@ use hal::pac::{CorePeripherals, Peripherals};
 fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
-    let mut clocks = GenericClockController::with_internal_32kosc(
+    let mut clocks = GenericClockController::with_external_32kosc(
         peripherals.GCLK,
         &mut peripherals.PM,
         &mut peripherals.SYSCTRL,


### PR DESCRIPTION
As indicated in [Arduino-SAMDCore](https://github.com/arduino/ArduinoCore-samd/blob/master/boards.txt#L195) with the CRYSTALLESS flag, all boards except the nano 33 IoT are using the external oscillator by default.

Schematic screenshot to confirm crystal presence:
![image](https://user-images.githubusercontent.com/11097096/77855624-8870af80-71bf-11ea-96fe-a2404fa5613e.png)
Visual confirmation of presence on board
![image](https://user-images.githubusercontent.com/11097096/77855706-1cdb1200-71c0-11ea-8ddc-5d2ff5dda4f7.png)

