### PR TITLE
Add support for MKR Vidor 4000

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - CRATE=boards/samd11_bare FEATURES="--features=unproven" BUILDMODE="--release"
   - CRATE=boards/samd21_mini FEATURES="--features=unproven"
   - CRATE=boards/arduino_mkrzero FEATURES="--features=unproven"
+  - CRATE=boards/arduino_mkrvidor4000 FEATURES="--features=unproven"
   - CRATE=boards/circuit_playground_express FEATURES="--features=unproven"
   - CRATE=boards/sodaq_one FEATURES="--features=unproven"
   - CRATE=boards/sodaq_sara_aff FEATURES="--features=unproven"

--- a/boards/arduino_mkrvidor4000/.cargo/config
+++ b/boards/arduino_mkrvidor4000/.cargo/config
@@ -1,0 +1,10 @@
+# samd21 is a Cortex-M0 and thus thumbv6m
+
+[build]
+target = "thumbv6m-none-eabi"
+
+[target.thumbv6m-none-eabi]
+runner = 'arm-none-eabi-gdb'
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]

--- a/boards/arduino_mkrvidor4000/Cargo.toml
+++ b/boards/arduino_mkrvidor4000/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "arduino_mkrvidor4000"
+version = "0.1.0"
+authors = ["Sameer Puri <purisame@spuri.io>"]
+description = "Board Support crate for the Arduino MKR VIDOR 4000"
+keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/atsamd-rs/atsamd"
+readme = "README.md"
+documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g18a/arduino_mkrvidor4000/"
+
+[dependencies]
+cortex-m = "~0.6"
+embedded-hal = "~0.2.3"
+nb = "~0.1"
+
+[dependencies.cortex-m-rt]
+version = "~0.6.12"
+optional = true
+
+[dependencies.panic-halt]
+version = "~0.2"
+optional = true
+
+[dependencies.atsamd-hal]
+path = "../../hal"
+version = "~0.8"
+default-features = false
+
+[features]
+# ask the HAL to enable atsamd21g18a support
+default = ["rt", "panic_halt", "atsamd-hal/samd21g18a"]
+rt = ["cortex-m-rt", "atsamd-hal/samd21g18a-rt"]
+panic_halt = ["panic-halt"]
+unproven = ["atsamd-hal/unproven"]
+usb = ["atsamd-hal/usb"]
+use_semihosting = []

--- a/boards/arduino_mkrvidor4000/README.md
+++ b/boards/arduino_mkrvidor4000/README.md
@@ -1,0 +1,27 @@
+# Arduino MKR Vidor 4000 Board Support Crate
+
+This crate provides a type-safe API for working with the [Arduino MKR Vidor board](https://store.arduino.cc/usa/mkr-vidor-4000).
+
+## Examples
+### Blinky Basic
+#### Requirements
+ - Arduino IDE installed
+    - samd package installed
+    - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
+    - Probably best to install an example sketch via the IDE just to make sure everything is working
+    - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
+ - arm-none-eabi tools installed, you need gcc and objcopy.
+ - thumbv6m-none-eabi rust target installed via `rustup target add thumbv6m-none-eabi`
+
+#### Steps
+
+```bash
+cargo build --release --example blinky_basic
+arm-none-eabi-objcopy -O binary target/thumbv6m-none-eabi/release/examples/blinky_basic target/blinky_basic.bin
+```
+
+Then, press the reset button twice quickly on the board. The red LED should be fading in and out. Now you can flash the board.
+
+```bash
+bossac -i -d -U true -i -e -w -v target/blinky_basic.bin -R
+```

--- a/boards/arduino_mkrvidor4000/build.rs
+++ b/boards/arduino_mkrvidor4000/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+fn main() {
+    if env::var_os("CARGO_FEATURE_RT").is_some() {
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        File::create(out.join("memory.x"))
+            .unwrap()
+            .write_all(include_bytes!("memory.x"))
+            .unwrap();
+        println!("cargo:rustc-link-search={}", out.display());
+        println!("cargo:rerun-if-changed=memory.x");
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/boards/arduino_mkrvidor4000/examples/blinky_basic.rs
+++ b/boards/arduino_mkrvidor4000/examples/blinky_basic.rs
@@ -1,0 +1,32 @@
+#![no_std]
+#![no_main]
+
+extern crate arduino_mkrvidor4000 as hal;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut led = pins.led_builtin.into_open_drain_output(&mut pins.port);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    loop {
+        delay.delay_ms(200u8);
+        led.set_high().unwrap();
+        delay.delay_ms(200u8);
+        led.set_low().unwrap();
+    }
+}

--- a/boards/arduino_mkrvidor4000/examples/enable_battery_charging.rs
+++ b/boards/arduino_mkrvidor4000/examples/enable_battery_charging.rs
@@ -1,0 +1,48 @@
+#![no_std]
+#![no_main]
+
+extern crate arduino_mkrvidor4000 as hal;
+
+use hal::clock::GenericClockController;
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::pad::PadPin;
+use hal::prelude::*;
+use hal::sercom::I2CMaster0;
+
+// https://www.ti.com/lit/ds/symlink/bq24195l.pdf
+const PMIC_ADDRESS: u8 = 0x6B;
+const PMIC_POWER_ON_CONFIGURATION_REGISTER: u8 = 0x01;
+// Configure for Charge Battery + Minimum System Voltage Limit: 3.5V
+const PMIC_POWER_ON_CONFIGURATION: u8 = 0b00011011;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let _core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut _led = pins.led_builtin.into_open_drain_output(&mut pins.port);
+    let gclk0 = clocks.gclk0();
+
+    let mut i2c: I2CMaster0<
+        hal::sercom::Sercom0Pad0<hal::gpio::Pa8<hal::gpio::PfC>>,
+        hal::sercom::Sercom0Pad1<hal::gpio::Pa9<hal::gpio::PfC>>,
+    > = I2CMaster0::new(
+        &clocks.sercom0_core(&gclk0).unwrap(),
+        100.khz(),
+        peripherals.SERCOM0,
+        &mut peripherals.PM,
+        // Arduino MKR Vidor 4000 has I2C on pins PA08, PA09
+        pins.sda.into_pad(&mut pins.port),
+        pins.scl.into_pad(&mut pins.port),
+    );
+
+    i2c.write(PMIC_ADDRESS, &[PMIC_POWER_ON_CONFIGURATION_REGISTER, PMIC_POWER_ON_CONFIGURATION]).unwrap();
+    loop {}
+}

--- a/boards/arduino_mkrvidor4000/examples/run_fpga.rs
+++ b/boards/arduino_mkrvidor4000/examples/run_fpga.rs
@@ -1,0 +1,27 @@
+#![no_std]
+#![no_main]
+
+extern crate arduino_mkrvidor4000 as hal;
+
+use hal::clock::GenericClockController;
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let _corecore = CorePeripherals::take().unwrap();
+    let _clocks = GenericClockController::with_external_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+
+    // Enable 48MHZ clock output for FPGA
+    // https://github.com/arduino/ArduinoCore-samd/blob/master/variants/mkrvidor4000/variant.cpp#L229
+    let _fpga_clk = pins.gclk.into_function_h(&mut pins.port);
+
+    loop {}
+}

--- a/boards/arduino_mkrvidor4000/memory.x
+++ b/boards/arduino_mkrvidor4000/memory.x
@@ -1,0 +1,6 @@
+MEMORY
+{
+  FLASH_FPGA (r) : ORIGIN = 0x40000, LENGTH = 2M
+  FLASH (rx) : ORIGIN = 0x2000, LENGTH = 256K - 8K /* First 8KB used by bootloader */
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
+}

--- a/boards/arduino_mkrvidor4000/src/lib.rs
+++ b/boards/arduino_mkrvidor4000/src/lib.rs
@@ -1,0 +1,126 @@
+#![no_std]
+
+extern crate atsamd_hal as hal;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::entry;
+
+#[cfg(feature = "panic_halt")]
+pub extern crate panic_halt;
+
+use hal::prelude::*;
+use hal::*;
+
+pub use hal::common::*;
+pub use hal::samd21::*;
+pub use hal::target_device as pac;
+
+use gpio::{Floating, Input, Port};
+
+// The docs could be further improved with details of the specific channels etc
+define_pins!(
+    /// Maps the pins to their arduino names and the numbers printed on the board.
+    /// Information from: <https://github.com/arduino/ArduinoCore-samd/blob/master/variants/mkrvidor4000/variant.cpp>
+    struct Pins,
+    target_device: target_device,
+
+    /// Digital 0: PWM, TC
+    pin d0 = a22,
+
+    /// Digital 1: PWM, TC
+    pin d1 = a23,
+
+    /// Digital 2: PWM, TCC, ADC
+    pin d2 = a10,
+
+    /// Digital 3: PWM, TCC, ADC
+    pin d3 = a11,
+
+    /// Digital 4: PWM, TC
+    pin d4 = b10,
+
+    /// Digital 5: PWM, TC
+    pin d5 = b11,
+
+    /// Digital 6: PWM, TCC
+    pin d6 = a20,
+
+    /// Digital 7: PWM, TCC
+    pin d7 = a21,
+
+    /// SPI MOSI: PWM, TCC
+    pin mosi = a16,
+
+    /// SPI SCK
+    pin sck = a17,
+
+    /// SPI MISO: PWM, TC
+    pin miso = a19,
+
+    /// SDA
+    pin sda = a8,
+
+    /// SCL
+    pin scl = a9,
+
+    /// RX
+    pin rx = b23,
+
+    /// TX
+    pin tx = b22,
+
+    /// Analog 0: DAC
+    pin a0 = a2,
+
+    /// Analog 1
+    pin a1 = b2,
+
+    /// Analog 2
+    pin a2 = b3,
+
+    /// Analog 3: PWM, TCC
+    pin a3 = a4,
+
+    /// Analog 4: PWM, TCC
+    pin a4 = a5,
+
+    /// Analog 5
+    pin a5 = a6,
+
+    /// Analog 6
+    /// Cannot be used because it is actually adc_battery
+    /// pin a6 = a7,
+
+    pin usb_n = a24,
+    pin usb_p = a25,
+    pin usb_id = a18,
+
+    pin aref = a3,
+
+    /// JTAG pins, also accessible from 10-pin pad on the bottom
+    pin fpga_tdi = a12,
+    pin fpga_tck = a13,
+    pin fpga_tms = a14,
+    pin fpga_tdo = a15,
+
+    /// Interrupt pin for SAMD to interrupt FPGA
+    pin fpga_mb_int = a28,
+
+    /// Clock generator for FPGA
+    pin gclk = a27,
+
+    /// Accessible from 6 pin pad on the bottom
+    pin swdio = a31,
+    pin swclk = a30,
+
+    /// LED built into the board
+    pin led_builtin = b8,
+
+    /// PMIC_BAT
+    pin adc_battery = a7,
+
+    pin xin32 = a0,
+    pin xout32 = a1,
+);


### PR DESCRIPTION
Hi Paul,

I've made some changes to the Vidor 4000 board support crate that I think should justify it now. Namely:

* FLASH_FPGA 2MB `memory.x` section for loading the board's FPGA on power up
    * Don't have an example for this yet, needs to be split into bitstream signature and bitstream sections
* Example for clocking the FPGA from the microcontroller
* Example for enabling the onboard battery charger via i2c

Let me know if you have any questions.

Thanks,
Sameer