### PR TITLE
Bugfix in feather-m0 USB example

### DIFF
--- a/boards/edgebadge/examples/usb_serial.rs
+++ b/boards/edgebadge/examples/usb_serial.rs
@@ -112,7 +112,7 @@ fn poll_usb() {
 
                 if let Ok(count) = serial.read(&mut buf) {
                     for (i, c) in buf.iter().enumerate() {
-                        if i > count {
+                        if i >= count {
                             break;
                         }
                         match c.clone() as char {

--- a/boards/feather_m0/examples/usb_echo.rs
+++ b/boards/feather_m0/examples/usb_echo.rs
@@ -84,7 +84,7 @@ fn poll_usb() {
 
                 if let Ok(count) = serial.read(&mut buf) {
                     for (i, c) in buf.iter().enumerate() {
-                        if i > count {
+                        if i >= count {
                             break;
                         }
                         serial.write(&[c.clone()]);

--- a/boards/itsybitsy_m0/examples/usb_echo.rs
+++ b/boards/itsybitsy_m0/examples/usb_echo.rs
@@ -84,7 +84,7 @@ fn poll_usb() {
 
                 if let Ok(count) = serial.read(&mut buf) {
                     for (i, c) in buf.iter().enumerate() {
-                        if i > count {
+                        if i >= count {
                             break;
                         }
                         serial.write(&[c.clone()]);

--- a/boards/itsybitsy_m4/examples/usb_serial.rs
+++ b/boards/itsybitsy_m4/examples/usb_serial.rs
@@ -122,7 +122,7 @@ fn poll_usb() {
 
                 if let Ok(count) = serial.read(&mut buf) {
                     for (i, c) in buf.iter().enumerate() {
-                        if i > count {
+                        if i >= count {
                             break;
                         }
                         match c.clone() as char {

--- a/boards/pygamer/examples/usb_serial.rs
+++ b/boards/pygamer/examples/usb_serial.rs
@@ -109,7 +109,7 @@ fn poll_usb() {
 
                 if let Ok(count) = serial.read(&mut buf) {
                     for (i, c) in buf.iter().enumerate() {
-                        if i > count {
+                        if i >= count {
                             break;
                         }
                         match c.clone() as char {

--- a/boards/trinket_m0/examples/usb_serial.rs
+++ b/boards/trinket_m0/examples/usb_serial.rs
@@ -84,7 +84,7 @@ fn poll_usb() {
 
                 if let Ok(count) = serial.read(&mut buf) {
                     for (i, c) in buf.iter().enumerate() {
-                        if i > count {
+                        if i >= count {
                             break;
                         }
                         serial.write(&[c.clone()]);


### PR DESCRIPTION
The loop always reads one more additional byte than it should.