### PR TITLE
Added link to bossa instructions for Feather M0

### DIFF
--- a/boards/feather_m0/README.md
+++ b/boards/feather_m0/README.md
@@ -24,3 +24,6 @@ $ cargo hf2 --release --example blinky_basic
     Finished in 0.079s
 $
 ```
+
+Note that some older Feather M0 boards do not come with support for HF2. For these boards,
+you can upload using the `bossa` tool as described in the [atsamd crate documentation](https://github.com/markhildreth/atsamd#getting-code-onto-the-device-gemma-m0).


### PR DESCRIPTION
Added a note in the Feather M0 docs to link to the bossa instructions, since some older Feather M0s are not hf2-compatible and instead should use bossa.

I was banging my head getting hf2 to work, but bossa did. I [double-checked with Adafruit](https://forums.adafruit.com/viewtopic.php?f=57&t=164509#p808174) who verified that some older boards do not have an hf2-compatible bootloader. Hopefully a note like this will help others avoid the same headache.