### PR TITLE
Readable open drain

### DIFF
--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -20,7 +20,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "~0.8"
+version = "0.8.3"
 default-features = false
 
 [dependencies.usb-device]

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atsamd-hal"
-version = "0.8.2"
+version = "0.8.3"
 authors = [
     "Wez Furlong <wez@wezfurlong.org>",
     "Paul Sajna <sajattack@gmail.com>",


### PR DESCRIPTION
Create new output kind: `ReadableOpenDrain`, which implements both the input and output traits. Tested with `tm1637`.