### PR TITLE
Fix link in Feather M0 docs.

### DIFF
--- a/boards/feather_m0/README.md
+++ b/boards/feather_m0/README.md
@@ -26,4 +26,4 @@ $
 ```
 
 Note that some older Feather M0 boards do not come with support for HF2. For these boards,
-you can upload using the `bossa` tool as described in the [atsamd crate documentation](https://github.com/markhildreth/atsamd#getting-code-onto-the-device-gemma-m0).
+you can upload using the `bossa` tool as described in the [atsamd crate documentation](https://github.com/atsamd-rs/atsamd#getting-code-onto-the-device-gemma-m0).


### PR DESCRIPTION
Fixed link to bossa docs.

I created the PR yesterday to add this link, but just realized that the link I made was pointing to my repo rather than the base one. Sorry about that! This fixes the link.