### PR TITLE
boards: Add Seeeduino XIAO support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
   - CRATE=boards/pfza_proto1 EXAMPLES="--example=blinky_basic" FEATURES="--features=unproven"
   - CRATE=boards/serpente EXAMPLES="--example=blinky_basic --example=pwm" FEATURES="--features=unproven"
   - CRATE=boards/edgebadge FEATURES="--features=unproven"
+  - CRATE=boards/xiao_m0 EXAMPLES="--example=blink --example=usb_serial" FEATURES="--features=usb"
 
 matrix:
   allow_failures:

--- a/boards/xiao_m0/.cargo/config
+++ b/boards/xiao_m0/.cargo/config
@@ -1,0 +1,8 @@
+[build]
+target = "thumbv6m-none-eabi"
+
+[target.thumbv6m-none-eabi]
+runner = 'arm-none-eabi-gdb'
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]

--- a/boards/xiao_m0/Cargo.toml
+++ b/boards/xiao_m0/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "xiao_m0"
+version = "0.6.1"
+authors = ["Garret Kelly <gdk@google.com>"]
+description = "Board support crate for the Seeed Studio Seeeduino XIAO"
+keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/atsamd-rs/atsamd"
+readme = "README.md"
+documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g18a/xiao_m0/"
+edition = "2018"
+
+[dependencies]
+cortex-m = "~0.6.2"
+embedded-hal = "~0.2.3"
+nb = "~0.1"
+
+[dependencies.cortex-m-rt]
+version = "~0.6.12"
+optional = true
+
+[dependencies.atsamd-hal]
+path = "../../hal"
+version = "~0.8"
+default-features = false
+
+[dependencies.usb-device]
+version = "~0.2"
+optional = true
+
+[dependencies.usbd-serial]
+version = "~0.1"
+optional = true
+
+[dev-dependencies]
+panic-halt = "~0.2"
+
+[features]
+default = ["rt", "atsamd-hal/samd21g18a"]
+rt = ["cortex-m-rt", "atsamd-hal/samd21g18a-rt"]
+unproven = ["atsamd-hal/unproven"]
+usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
+
+[[example]]
+name = "blink"
+
+[[example]]
+name = "usb_serial"
+required-features = ["usb"]
+
+[profile.release]
+debug = true
+lto = true
+opt-level = "s"

--- a/boards/xiao_m0/README.md
+++ b/boards/xiao_m0/README.md
@@ -1,0 +1,23 @@
+# Seeeduino XIAO Board Support Crate
+
+This crate provides a type-safe API for working with the [Seeed Studio
+Seeeduino XIAO](http://wiki.seeedstudio.com/Seeeduino-XIAO/).
+
+## Prerequisites
+* Install the cross compile toolchain `rustup target add thumbv6m-none-eabi`
+* Install the [cargo-hf2 tool](https://crates.io/crates/cargo-hf2) however your
+  platform requires
+
+## Uploading an example
+Check out [the
+repository](https://github.com/atsamd-rs/atsamd/tree/master/boards/xiao_m0/examples)
+for examples.
+
+* Be in this directory `cd boards/xiao_m0`
+* Put your device in bootloader mode by bridging the `RST` pads _twice_ in
+  quick succession. The orange LED will pulse when the device is in bootloader
+  mode.
+* Build and upload in one step: `cargo hf2 --release --example blink`
+  * Note that if you're using an older `cargo-hf2` that you'll need to specify
+    the VID/PID when flashing: `cargo hf2 --vid 0x2886 --pid 0x002f --release
+    --example blink`

--- a/boards/xiao_m0/examples/blink.rs
+++ b/boards/xiao_m0/examples/blink.rs
@@ -1,0 +1,44 @@
+#![no_main]
+#![no_std]
+
+extern crate cortex_m;
+extern crate panic_halt;
+extern crate xiao_m0 as hal;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut led0 = pins.led0.into_open_drain_output(&mut pins.port);
+    let mut led1 = pins.led1.into_open_drain_output(&mut pins.port);
+    let mut led2 = pins.led2.into_open_drain_output(&mut pins.port);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    let mut counter = 0u8;
+    loop {
+        counter = counter.wrapping_add(1);
+        delay.delay_ms(100u8);
+        if counter & (1 << 0) != 0 {
+            led0.toggle();
+        }
+        if counter & (1 << 1) != 0 {
+            led1.toggle();
+        }
+        if counter & (1 << 2) != 0 {
+            led2.toggle();
+        }
+    }
+}

--- a/boards/xiao_m0/examples/usb_serial.rs
+++ b/boards/xiao_m0/examples/usb_serial.rs
@@ -1,0 +1,104 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate panic_halt;
+extern crate usb_device;
+extern crate usbd_serial;
+extern crate xiao_m0 as hal;
+
+use hal::clock::GenericClockController;
+use hal::entry;
+use hal::gpio::{OpenDrain, Output, Pa18};
+use hal::pac::{interrupt, CorePeripherals, Peripherals};
+
+use hal::usb::UsbBus;
+use usb_device::bus::UsbBusAllocator;
+
+use usb_device::prelude::*;
+use usbd_serial::{SerialPort, USB_CLASS_CDC};
+
+use cortex_m::asm::delay as cycle_delay;
+use cortex_m::peripheral::NVIC;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut led0 = pins.led0.into_open_drain_output(&mut pins.port);
+
+    let bus_allocator = unsafe {
+        USB_ALLOCATOR = Some(hal::usb_allocator(
+            peripherals.USB,
+            &mut clocks,
+            &mut peripherals.PM,
+            pins.usb_dm,
+            pins.usb_dp,
+            &mut pins.port,
+        ));
+        USB_ALLOCATOR.as_ref().unwrap()
+    };
+
+    unsafe {
+        USB_SERIAL = Some(SerialPort::new(&bus_allocator));
+        USB_BUS = Some(
+            UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x16c0, 0x27dd))
+                .manufacturer("Fake company")
+                .product("Serial port")
+                .serial_number("TEST")
+                .device_class(USB_CLASS_CDC)
+                .build(),
+        );
+        LED = Some(pins.led1.into_open_drain_output(&mut pins.port));
+    }
+
+    unsafe {
+        core.NVIC.set_priority(interrupt::USB, 1);
+        NVIC::unmask(interrupt::USB);
+    }
+
+    // Flash the LED in a spin loop to demonstrate that USB is
+    // entirely interrupt driven.
+    loop {
+        cycle_delay(15 * 1024 * 1024);
+        led0.toggle();
+    }
+}
+
+static mut USB_ALLOCATOR: Option<UsbBusAllocator<UsbBus>> = None;
+static mut USB_BUS: Option<UsbDevice<UsbBus>> = None;
+static mut USB_SERIAL: Option<SerialPort<UsbBus>> = None;
+static mut LED: Option<Pa18<Output<OpenDrain>>> = None;
+
+fn poll_usb() {
+    unsafe {
+        USB_BUS.as_mut().map(|usb_dev| {
+            USB_SERIAL.as_mut().map(|serial| {
+                usb_dev.poll(&mut [serial]);
+                let mut buf = [0u8; 64];
+
+                if let Ok(count) = serial.read(&mut buf) {
+                    for (i, c) in buf.iter().enumerate() {
+                        if i >= count {
+                            break;
+                        }
+                        serial.write(&[c.clone()]).unwrap();
+                        LED.as_mut().map(|led| led.toggle());
+                    }
+                };
+            });
+        });
+    };
+}
+
+#[interrupt]
+fn USB() {
+    poll_usb();
+}

--- a/boards/xiao_m0/memory.x
+++ b/boards/xiao_m0/memory.x
@@ -1,0 +1,7 @@
+MEMORY
+{
+  /* Leave 8k for the default bootloader on the Seeeduino XIAO */
+  FLASH (rx) : ORIGIN = 0x00000000 + 8K, LENGTH = 256K - 8K
+  RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 32K
+}
+_stack_start = ORIGIN(RAM) + LENGTH(RAM);

--- a/boards/xiao_m0/src/lib.rs
+++ b/boards/xiao_m0/src/lib.rs
@@ -1,0 +1,170 @@
+#![no_std]
+
+pub extern crate atsamd_hal as hal;
+
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::entry;
+
+pub use hal::common::*;
+pub use hal::samd21::*;
+pub use hal::target_device as pac;
+
+use hal::prelude::*;
+use hal::{
+    clock::GenericClockController,
+    define_pins,
+    gpio::PfD,
+    gpio::{Floating, Input, Port},
+    pad::PadPin,
+    sercom::{I2CMaster2, SPIMaster0, UART4},
+    target_device,
+    time::Hertz,
+};
+
+#[cfg(feature = "usb")]
+use hal::gpio::IntoFunction;
+#[cfg(feature = "usb")]
+use hal::usb::usb_device::bus::UsbBusAllocator;
+#[cfg(feature = "usb")]
+pub use hal::usb::UsbBus;
+
+define_pins!(
+    struct Pins,
+    target_device: target_device,
+
+    /// Pin A0/D0/DAC
+    pin a0 = a2,
+    /// Pin A1/D1
+    pin a1 = a4,
+    /// Pin A2/D2
+    pin a2 = a10,
+    /// Pin A3/D3
+    pin a3 = a11,
+    /// Pin A4/D4/SDA
+    pin a4 = a8,
+    /// Pin A5/D5/SCL
+    pin a5 = a9,
+    /// Pin A6/D6/TX
+    pin a6 = b8,
+    /// Pin A7/D7/RX
+    pin a7 = b9,
+    /// Pin A8/D8/SCK
+    pin a8 = a7,
+    /// Pin A9/D9/MISO
+    pin a9 = a5,
+    /// Pin A10/D10/MOSI
+    pin a10 = a6,
+
+    /// On-board yellow 'L' LED.
+    pin led0 = a17,
+    /// On-board blue 'RX' LED.
+    pin led1 = a18,
+    /// On-board blue 'TX' LED.
+    pin led2 = a19,
+
+    /// The USB D- pad.
+    pin usb_dm = a24,
+    /// The USB D+ pad.
+    pin usb_dp = a25,
+);
+
+/// Convenience function for setting up the TX (A6/D6) and RX (A7/D7) pins as a
+/// UART operating at `baud`.
+pub fn uart<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    baud: F,
+    sercom4: pac::SERCOM4,
+    pm: &mut pac::PM,
+    a7: gpio::Pb9<Input<Floating>>,
+    a6: gpio::Pb8<Input<Floating>>,
+    port: &mut Port,
+) -> UART4<hal::sercom::Sercom4Pad1<gpio::Pb9<PfD>>, hal::sercom::Sercom4Pad0<gpio::Pb8<PfD>>, (), ()>
+{
+    let gclk0 = clocks.gclk0();
+
+    UART4::new(
+        &clocks.sercom4_core(&gclk0).unwrap(),
+        baud.into(),
+        sercom4,
+        pm,
+        (a7.into_pad(port), a6.into_pad(port)),
+    )
+}
+
+/// Convenience function for setting up the A4/D4/SDA and A5/D5/SCL pins as an
+/// I2C master operating at `speed`.
+pub fn i2c_master<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    speed: F,
+    sercom2: pac::SERCOM2,
+    pm: &mut pac::PM,
+    a4: gpio::Pa8<Input<Floating>>,
+    a5: gpio::Pa9<Input<Floating>>,
+    port: &mut Port,
+) -> hal::sercom::I2CMaster2<
+    hal::sercom::Sercom2Pad0<gpio::Pa8<gpio::PfD>>,
+    hal::sercom::Sercom2Pad1<gpio::Pa9<gpio::PfD>>,
+> {
+    let gclk0 = clocks.gclk0();
+
+    I2CMaster2::new(
+        &clocks.sercom2_core(&gclk0).unwrap(),
+        speed.into(),
+        sercom2,
+        pm,
+        a4.into_pad(port),
+        a5.into_pad(port),
+    )
+}
+
+/// Convenience function for setting up the A8/D8/SCK, A10/D10/MOSI, and
+/// A9/D9/MISO pins as an SPI master in SPI mode 0.
+pub fn spi_master<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    speed: F,
+    sercom0: pac::SERCOM0,
+    pm: &mut pac::PM,
+    sck: gpio::Pa7<Input<Floating>>,
+    mosi: gpio::Pa6<Input<Floating>>,
+    miso: gpio::Pa5<Input<Floating>>,
+    port: &mut Port,
+) -> SPIMaster0<
+    hal::sercom::Sercom0Pad1<gpio::Pa5<gpio::PfD>>,
+    hal::sercom::Sercom0Pad2<gpio::Pa6<gpio::PfD>>,
+    hal::sercom::Sercom0Pad3<gpio::Pa7<gpio::PfD>>,
+> {
+    let gclk0 = clocks.gclk0();
+
+    SPIMaster0::new(
+        &clocks.sercom0_core(&gclk0).unwrap(),
+        speed.into(),
+        hal::hal::spi::Mode {
+            phase: hal::hal::spi::Phase::CaptureOnFirstTransition,
+            polarity: hal::hal::spi::Polarity::IdleLow,
+        },
+        sercom0,
+        pm,
+        (miso.into_pad(port), mosi.into_pad(port), sck.into_pad(port)),
+    )
+}
+
+#[cfg(feature = "usb")]
+pub fn usb_allocator(
+    usb: pac::USB,
+    clocks: &mut GenericClockController,
+    pm: &mut pac::PM,
+    dm: gpio::Pa24<Input<Floating>>,
+    dp: gpio::Pa25<Input<Floating>>,
+    port: &mut Port,
+) -> UsbBusAllocator<UsbBus> {
+    let gclk0 = clocks.gclk0();
+    let usb_clock = &clocks.usb(&gclk0).unwrap();
+
+    UsbBusAllocator::new(UsbBus::new(
+        usb_clock,
+        pm,
+        dm.into_function(port),
+        dp.into_function(port),
+        usb,
+    ))
+}


### PR DESCRIPTION
Add Seeed Studio Seeedunio XIAO support. The `blink` and `usb_serial`
examples were tested on hardware.

---
The board is commonly called Seeedunio XIAO, but there's references to it being called XIAO M0 in their Arduino support packages so I went with it here in case there's a different variant in the works.