### PR TITLE
Patch invalid SVDs for several ATSAMD5Xs

### DIFF
--- a/svd/devices/atsamd51g19a.yaml
+++ b/svd/devices/atsamd51g19a.yaml
@@ -1,1 +1,5 @@
 _svd: ../ATSAMD51G19A.svd
+
+_include:
+  - "include/nvmctrl-param-see.yaml"
+  - "include/sdhc0-reset-values.yaml"

--- a/svd/devices/atsamd51j19a.yaml
+++ b/svd/devices/atsamd51j19a.yaml
@@ -1,1 +1,5 @@
 _svd: ../ATSAMD51J19A.svd
+
+_include:
+  - "include/nvmctrl-param-see.yaml"
+  - "include/sdhc0-reset-values.yaml"

--- a/svd/devices/atsamd51j20a.yaml
+++ b/svd/devices/atsamd51j20a.yaml
@@ -1,1 +1,5 @@
 _svd: ../ATSAMD51J20A.svd
+
+_include:
+  - "include/nvmctrl-param-see.yaml"
+  - "include/sdhc0-reset-values.yaml"

--- a/svd/devices/atsame54p20a.yaml
+++ b/svd/devices/atsame54p20a.yaml
@@ -1,1 +1,5 @@
 _svd: ../ATSAME54P20A.svd
+
+_include:
+  - "include/nvmctrl-param-see.yaml"
+  - "include/sdhc0-reset-values.yaml"

--- a/svd/devices/include/nvmctrl-param-see.yaml
+++ b/svd/devices/include/nvmctrl-param-see.yaml
@@ -1,0 +1,7 @@
+# The NVMCTRL:PARAM:SEE field is specified as 1 bit wide, but several devices
+# include much wider enumeration values that don't correspond to the actual
+# values expected for this field.
+NVMCTRL:
+  PARAM:
+    _delete:
+      SEE:

--- a/svd/devices/include/sdhc0-reset-values.yaml
+++ b/svd/devices/include/sdhc0-reset-values.yaml
@@ -1,0 +1,11 @@
+# The SDHC0 peripheral on some devices contains reset values for certain fields
+# that are wider than their corresponding storage. Replace the invalid values
+# with the ones from the datasheet.
+SDHC0:
+  _modify:
+    HC1R:
+        resetValue: 0x00
+    HC1R_EMMC_MODE:
+        resetValue: 0x00
+    SISR:
+        resetValue: 0x0000


### PR DESCRIPTION
Several of the ATSAMD5X devices share invalid data in their NVMCTRL and
SDHC0 peripherals. Add common patches for these issues and include them
in the afflicted devices.

See #195.