### PR TITLE
Use bleeding-edge `svd2rust`

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -5,7 +5,7 @@ set -xe
 
 # INSTALL DEPENDENCIES
 
-cargo install --force --version 0.17.0 svd2rust
+cargo install --force --git https://github.com/gkelly/svd2rust --branch bleeding-edge svd2rust
 cargo install --force --version 0.7.0 form
 
 python -m pip install -r requirements.txt

--- a/update.sh
+++ b/update.sh
@@ -5,7 +5,8 @@ set -xe
 
 # INSTALL DEPENDENCIES
 
-cargo install --force --git https://github.com/gkelly/svd2rust --branch bleeding-edge svd2rust
+cargo install --force --git https://github.com/gkelly/svd2rust --branch \
+    bleeding-edge --rev 2bbb60590096bcb67c91f38bedd1f63f98132abe svd2rust
 cargo install --force --version 0.7.0 form
 
 python -m pip install -r requirements.txt


### PR DESCRIPTION
A pair of changes (rust-embedded/svd#119, rust-embedded/svd2rust#444)
recently went into the `svd2rust` and `svd-parser` crates. Until these
changes are part of a release have `update.sh` pull a fork of `svd2rust`
that uses the master version of `svd-parser`.

See #195.