### PR TITLE
Delay implementation that uses a timer to WFI sleep

### DIFF
--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -109,3 +109,6 @@ name = "ssd1306_terminalmode_128x64_spi"
 [[example]]
 name = "usb_echo"
 required-features = ["usb"]
+
+[[example]]
+name = "sleeping_timer"

--- a/boards/feather_m0/examples/sleeping_timer.rs
+++ b/boards/feather_m0/examples/sleeping_timer.rs
@@ -1,0 +1,81 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate feather_m0 as hal;
+#[cfg(not(feature = "use_semihosting"))]
+extern crate panic_halt;
+#[cfg(feature = "use_semihosting")]
+extern crate panic_semihosting;
+
+use hal::clock::GenericClockController;
+use hal::entry;
+use hal::pac::{interrupt, CorePeripherals, Peripherals, TC4};
+use hal::prelude::*;
+use hal::sleeping_delay::SleepingDelay;
+use hal::timer;
+
+use core::sync::atomic;
+use cortex_m::peripheral::NVIC;
+
+/// Shared atomic between TC4 interrupt and sleeping_delay module
+static mut INTERRUPT_FIRED: Option<atomic::AtomicBool> = None;
+
+#[entry]
+fn main() -> ! {
+    // Configure all of our peripherals/clocks
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+    // Set up the int fired global for use in the interrupt handler / SleepingDelay
+    let interrupt_fired = unsafe {
+        INTERRUPT_FIRED = Some(atomic::AtomicBool::default());
+        INTERRUPT_FIRED.as_ref().unwrap()
+    };
+
+    // Get a clock & make a sleeping delay object
+    let gclk0 = clocks.gclk0();
+    let tc45 = &clocks.tc4_tc5(&gclk0).unwrap();
+    let timer = timer::TimerCounter::tc4_(tc45, peripherals.TC4, &mut peripherals.PM);
+    let mut sleeping_delay = SleepingDelay::new(timer, interrupt_fired);
+
+    // enable interrupts
+    unsafe {
+        core.NVIC.set_priority(interrupt::TC4, 2);
+        NVIC::unmask(interrupt::TC4);
+    }
+
+    // Configure our red LED and blink forever, sleeping between!
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
+    red_led.set_high().unwrap();
+    loop {
+        red_led.set_high().unwrap();
+        sleeping_delay.delay_ms(500u32);
+        red_led.set_low().unwrap();
+        sleeping_delay.delay_ms(1000u32);
+    }
+}
+
+#[interrupt]
+fn TC4() {
+    unsafe {
+        // Let the sleepingtimer know that the interrupt fired, and clear it
+        INTERRUPT_FIRED
+            .as_ref()
+            .unwrap()
+            .store(true, atomic::Ordering::Relaxed);
+        TC4::ptr()
+            .as_ref()
+            .unwrap()
+            .count16()
+            .intflag
+            .modify(|_, w| w.ovf().set_bit());
+    }
+}

--- a/boards/feather_m0/examples/sleeping_timer.rs
+++ b/boards/feather_m0/examples/sleeping_timer.rs
@@ -51,9 +51,9 @@ fn main() -> ! {
     red_led.set_high().unwrap();
     loop {
         red_led.set_high().unwrap();
-        sleeping_delay.delay_ms(500u32);
+        sleeping_delay.delay_ms(5_000u32);
         red_led.set_low().unwrap();
-        sleeping_delay.delay_ms(1000u32);
+        sleeping_delay.delay_ms(500u32);
     }
 }
 

--- a/boards/feather_m0/examples/sleeping_timer.rs
+++ b/boards/feather_m0/examples/sleeping_timer.rs
@@ -19,7 +19,7 @@ use core::sync::atomic;
 use cortex_m::peripheral::NVIC;
 
 /// Shared atomic between TC4 interrupt and sleeping_delay module
-static mut INTERRUPT_FIRED: Option<atomic::AtomicBool> = None;
+static mut INTERRUPT_FIRED: atomic::AtomicBool = atomic::AtomicBool::new(false);
 
 #[entry]
 fn main() -> ! {
@@ -34,10 +34,7 @@ fn main() -> ! {
     );
 
     // Set up the int fired global for use in the interrupt handler / SleepingDelay
-    let interrupt_fired = unsafe {
-        INTERRUPT_FIRED = Some(atomic::AtomicBool::default());
-        INTERRUPT_FIRED.as_ref().unwrap()
-    };
+    let interrupt_fired = unsafe { &INTERRUPT_FIRED };
 
     // Get a clock & make a sleeping delay object
     let gclk0 = clocks.gclk0();
@@ -67,10 +64,7 @@ fn main() -> ! {
 fn TC4() {
     unsafe {
         // Let the sleepingtimer know that the interrupt fired, and clear it
-        INTERRUPT_FIRED
-            .as_ref()
-            .unwrap()
-            .store(true, atomic::Ordering::Relaxed);
+        INTERRUPT_FIRED.store(true, atomic::Ordering::Relaxed);
         TC4::ptr()
             .as_ref()
             .unwrap()

--- a/hal/src/common/mod.rs
+++ b/hal/src/common/mod.rs
@@ -4,3 +4,4 @@ pub mod gpio;
 pub mod pad;
 pub mod prelude;
 pub mod time;
+pub mod timer_traits;

--- a/hal/src/common/mod.rs
+++ b/hal/src/common/mod.rs
@@ -1,5 +1,6 @@
 pub mod delay;
 pub mod gpio;
+pub mod sleeping_delay;
 #[macro_use]
 pub mod pad;
 pub mod prelude;

--- a/hal/src/common/prelude.rs
+++ b/hal/src/common/prelude.rs
@@ -1,12 +1,13 @@
 //! Import the prelude to gain convenient access to helper traits
 pub use crate::gpio::GpioExt as _atsamd21_hal_gpio_GpioExt;
 pub use crate::time::U32Ext as _atsamd21_hal_time_U32Ext;
+pub use crate::timer_traits::InterruptDrivenTimer as _atsamd_hal_timer_traits_InterruptDrivenTimer;
 
 // embedded-hal doesn’t yet have v2 in its prelude, so we need to
 // export it ourselves
-pub use hal::digital::v2::OutputPin as _atsamd_hal_embedded_hal_digital_v2_OutputPin;
 #[cfg(feature = "unproven")]
 pub use hal::digital::v2::InputPin as _atsamd_hal_embedded_hal_digital_v2_InputPin;
+pub use hal::digital::v2::OutputPin as _atsamd_hal_embedded_hal_digital_v2_OutputPin;
 #[cfg(feature = "unproven")]
 pub use hal::digital::v2::ToggleableOutputPin as _atsamd_hal_embedded_hal_digital_v2_ToggleableOutputPin;
 

--- a/hal/src/common/sleeping_delay.rs
+++ b/hal/src/common/sleeping_delay.rs
@@ -33,12 +33,13 @@ where
     }
 }
 
-impl<TIM> DelayUs<u32> for SleepingDelay<TIM>
+impl<TIM, TYPE> DelayUs<TYPE> for SleepingDelay<TIM>
 where
     TIM: InterruptDrivenTimer,
+    TYPE: Into<u32>,
 {
-    fn delay_us(&mut self, us: u32) {
-        self.timer.start((1_000_000 / us).hz());
+    fn delay_us(&mut self, us: TYPE) {
+        self.timer.start((1_000_000_u32 / us.into()).hz());
         self.timer.enable_interrupt();
         loop {
             asm::wfi();
@@ -51,47 +52,12 @@ where
     }
 }
 
-impl<TIM> DelayUs<u16> for SleepingDelay<TIM>
+impl<TIM, TYPE> DelayMs<TYPE> for SleepingDelay<TIM>
 where
     TIM: InterruptDrivenTimer,
+    TYPE: Into<u32>,
 {
-    fn delay_us(&mut self, us: u16) {
-        self.delay_us(us as u32)
-    }
-}
-
-impl<TIM> DelayUs<u8> for SleepingDelay<TIM>
-where
-    TIM: InterruptDrivenTimer,
-{
-    fn delay_us(&mut self, us: u8) {
-        self.delay_us(us as u32)
-    }
-}
-
-impl<TIM> DelayMs<u32> for SleepingDelay<TIM>
-where
-    TIM: InterruptDrivenTimer,
-{
-    fn delay_ms(&mut self, ms: u32) {
-        self.delay_us(ms * 1_000);
-    }
-}
-
-impl<TIM> DelayMs<u16> for SleepingDelay<TIM>
-where
-    TIM: InterruptDrivenTimer,
-{
-    fn delay_ms(&mut self, ms: u16) {
-        self.delay_ms(ms as u32);
-    }
-}
-
-impl<TIM> DelayMs<u8> for SleepingDelay<TIM>
-where
-    TIM: InterruptDrivenTimer,
-{
-    fn delay_ms(&mut self, ms: u8) {
-        self.delay_ms(ms as u32);
+    fn delay_ms(&mut self, ms: TYPE) {
+        self.delay_us(ms.into() * 1_000_u32);
     }
 }

--- a/hal/src/common/sleeping_delay.rs
+++ b/hal/src/common/sleeping_delay.rs
@@ -1,0 +1,97 @@
+//! Delays with WFI sleep while we wait using a timer
+use core::sync::atomic;
+use cortex_m::asm;
+
+use crate::time::U32Ext;
+use crate::timer_traits::InterruptDrivenTimer;
+use hal::blocking::delay::{DelayMs, DelayUs};
+
+/// Delay and sleep while we do (WFI) using a timer
+pub struct SleepingDelay<TIM> {
+    timer: TIM,
+    interrupt_fired: &'static atomic::AtomicBool,
+}
+
+impl<TIM> SleepingDelay<TIM>
+where
+    TIM: InterruptDrivenTimer,
+{
+    /// Initializes a new SleepingDelay struct
+    pub fn new(timer: TIM, interrupt_fired: &'static atomic::AtomicBool) -> SleepingDelay<TIM>
+    where
+        TIM: InterruptDrivenTimer,
+    {
+        SleepingDelay {
+            timer,
+            interrupt_fired,
+        }
+    }
+
+    /// Releases the timer resource
+    pub fn free(self) -> TIM {
+        self.timer
+    }
+}
+
+impl<TIM> DelayUs<u32> for SleepingDelay<TIM>
+where
+    TIM: InterruptDrivenTimer,
+{
+    fn delay_us(&mut self, us: u32) {
+        self.timer.start((1_000_000 / us).hz());
+        self.timer.enable_interrupt();
+        loop {
+            asm::wfi();
+            if self.timer.wait().is_ok() || self.interrupt_fired.load(atomic::Ordering::Relaxed) {
+                self.interrupt_fired.store(false, atomic::Ordering::Relaxed);
+                break;
+            }
+        }
+        self.timer.disable_interrupt();
+    }
+}
+
+impl<TIM> DelayUs<u16> for SleepingDelay<TIM>
+where
+    TIM: InterruptDrivenTimer,
+{
+    fn delay_us(&mut self, us: u16) {
+        self.delay_us(us as u32)
+    }
+}
+
+impl<TIM> DelayUs<u8> for SleepingDelay<TIM>
+where
+    TIM: InterruptDrivenTimer,
+{
+    fn delay_us(&mut self, us: u8) {
+        self.delay_us(us as u32)
+    }
+}
+
+impl<TIM> DelayMs<u32> for SleepingDelay<TIM>
+where
+    TIM: InterruptDrivenTimer,
+{
+    fn delay_ms(&mut self, ms: u32) {
+        self.delay_us(ms * 1_000);
+    }
+}
+
+impl<TIM> DelayMs<u16> for SleepingDelay<TIM>
+where
+    TIM: InterruptDrivenTimer,
+{
+    fn delay_ms(&mut self, ms: u16) {
+        self.delay_ms(ms as u32);
+    }
+}
+
+impl<TIM> DelayMs<u8> for SleepingDelay<TIM>
+where
+    TIM: InterruptDrivenTimer,
+{
+    fn delay_ms(&mut self, ms: u8) {
+        self.delay_ms(ms as u32);
+    }
+}

--- a/hal/src/common/timer_traits.rs
+++ b/hal/src/common/timer_traits.rs
@@ -1,7 +1,7 @@
 use crate::hal::timer::{CountDown, Periodic};
 use crate::time;
 
-/// Trait for timers that can enable & disable an interrupt the fires
+/// Trait for timers that can enable & disable an interrupt that fires
 /// when the timer expires
 pub trait InterruptDrivenTimer: CountDown<Time = time::Microseconds> + Periodic {
     /// Enable the timer interrupt

--- a/hal/src/common/timer_traits.rs
+++ b/hal/src/common/timer_traits.rs
@@ -1,0 +1,12 @@
+use crate::hal::timer::{CountDown, Periodic};
+use crate::time;
+
+/// Trait for timers that can enable & disable an interrupt the fires
+/// when the timer expires
+pub trait InterruptDrivenTimer: CountDown<Time = time::Hertz> + Periodic {
+    /// Enable the timer interrupt
+    fn enable_interrupt(&mut self);
+
+    /// Disable the timer interrupt
+    fn disable_interrupt(&mut self);
+}

--- a/hal/src/common/timer_traits.rs
+++ b/hal/src/common/timer_traits.rs
@@ -3,7 +3,7 @@ use crate::time;
 
 /// Trait for timers that can enable & disable an interrupt the fires
 /// when the timer expires
-pub trait InterruptDrivenTimer: CountDown<Time = time::Hertz> + Periodic {
+pub trait InterruptDrivenTimer: CountDown<Time = time::Microseconds> + Periodic {
     /// Enable the timer interrupt
     fn enable_interrupt(&mut self);
 

--- a/hal/src/samd11/timer.rs
+++ b/hal/src/samd11/timer.rs
@@ -2,6 +2,7 @@
 use crate::target_device::tc1::COUNT16;
 #[allow(unused)]
 use crate::target_device::{PM, TC1};
+use crate::timer_traits::InterruptDrivenTimer;
 use hal::timer::{CountDown, Periodic};
 
 use crate::clock;
@@ -100,7 +101,7 @@ where
     }
 }
 
-impl<TC> TimerCounter<TC>
+impl<TC> InterruptDrivenTimer for TimerCounter<TC>
 where
     TC: Count16,
 {
@@ -108,7 +109,7 @@ where
     /// This method only sets the clock configuration to trigger
     /// the interrupt; it does not configure the interrupt controller
     /// or define an interrupt handler.
-    pub fn enable_interrupt(&mut self) {
+    fn enable_interrupt(&mut self) {
         self.tc.count_16().intenset.write(|w| w.ovf().set_bit());
     }
 
@@ -116,7 +117,7 @@ where
     /// This method only sets the clock configuration to prevent
     /// triggering the interrupt; it does not configure the interrupt
     /// controller.
-    pub fn disable_interrupt(&mut self) {
+    fn disable_interrupt(&mut self) {
         self.tc.count_16().intenclr.write(|w| w.ovf().set_bit());
     }
 }

--- a/hal/src/samd21/timer.rs
+++ b/hal/src/samd21/timer.rs
@@ -6,6 +6,7 @@ use hal::timer::{CountDown, Periodic};
 
 use crate::clock;
 use crate::time::{Hertz, Microseconds};
+use crate::timer_traits::InterruptDrivenTimer;
 use nb;
 use void::Void;
 
@@ -104,7 +105,7 @@ where
     }
 }
 
-impl<TC> TimerCounter<TC>
+impl<TC> InterruptDrivenTimer for TimerCounter<TC>
 where
     TC: Count16,
 {
@@ -112,7 +113,7 @@ where
     /// This method only sets the clock configuration to trigger
     /// the interrupt; it does not configure the interrupt controller
     /// or define an interrupt handler.
-    pub fn enable_interrupt(&mut self) {
+    fn enable_interrupt(&mut self) {
         self.tc.count_16().intenset.write(|w| w.ovf().set_bit());
     }
 
@@ -120,7 +121,7 @@ where
     /// This method only sets the clock configuration to prevent
     /// triggering the interrupt; it does not configure the interrupt
     /// controller.
-    pub fn disable_interrupt(&mut self) {
+    fn disable_interrupt(&mut self) {
         self.tc.count_16().intenclr.write(|w| w.ovf().set_bit());
     }
 }

--- a/hal/src/samd51/timer.rs
+++ b/hal/src/samd51/timer.rs
@@ -4,6 +4,7 @@ use crate::target_device::tc0::COUNT16;
 #[allow(unused)]
 use crate::target_device::{MCLK, TC2, TC3};
 
+use crate::timer_traits::InterruptDrivenTimer;
 // Only the G variants are missing these timers
 #[cfg(all(not(feature = "samd51g19a"), not(feature = "samd51g18a")))]
 use crate::target_device::{TC4, TC5};
@@ -111,7 +112,7 @@ where
     }
 }
 
-impl<TC> TimerCounter<TC>
+impl<TC> InterruptDrivenTimer for TimerCounter<TC>
 where
     TC: Count16,
 {
@@ -119,7 +120,7 @@ where
     /// This method only sets the clock configuration to trigger
     /// the interrupt; it does not configure the interrupt controller
     /// or define an interrupt handler.
-    pub fn enable_interrupt(&mut self) {
+    fn enable_interrupt(&mut self) {
         self.tc.count_16().intenset.write(|w| w.ovf().set_bit());
     }
 
@@ -127,7 +128,7 @@ where
     /// This method only sets the clock configuration to prevent
     /// triggering the interrupt; it does not configure the interrupt
     /// controller.
-    pub fn disable_interrupt(&mut self) {
+    fn disable_interrupt(&mut self) {
         self.tc.count_16().intenclr.write(|w| w.ovf().set_bit());
     }
 }

--- a/hal/src/same54/timer.rs
+++ b/hal/src/same54/timer.rs
@@ -9,6 +9,7 @@ use crate::target_device::{TC4, TC5};
 
 use crate::clock;
 use crate::time::{Hertz, Microseconds};
+use crate::timer_traits::InterruptDrivenTimer;
 use nb;
 use void::Void;
 
@@ -110,7 +111,7 @@ where
     }
 }
 
-impl<TC> TimerCounter<TC>
+impl<TC> InterruptDrivenTimer for TimerCounter<TC>
 where
     TC: Count16,
 {
@@ -118,7 +119,7 @@ where
     /// This method only sets the clock configuration to trigger
     /// the interrupt; it does not configure the interrupt controller
     /// or define an interrupt handler.
-    pub fn enable_interrupt(&mut self) {
+    fn enable_interrupt(&mut self) {
         self.tc.count_16().intenset.write(|w| w.ovf().set_bit());
     }
 
@@ -126,7 +127,7 @@ where
     /// This method only sets the clock configuration to prevent
     /// triggering the interrupt; it does not configure the interrupt
     /// controller.
-    pub fn disable_interrupt(&mut self) {
+    fn disable_interrupt(&mut self) {
         self.tc.count_16().intenclr.write(|w| w.ovf().set_bit());
     }
 }


### PR DESCRIPTION
Using any timer as an interrupt source, delay for the given amount of time but WFI for improved power performance. On my feather_m0, I went from ~11mA to ~5mA consumption. I'd expect even less if you had a more efficient regulator or were more careful about peripherals being powered.

Currently the added example doesn't compile due to [this issue](https://github.com/rust-embedded/cortex-m/issues/221). TLDR, the `unmask` NVIC method isn't available when compiling the example. Everything works fine in [my project](https://github.com/TDHolmes/oven-temp-rs/blob/master/src/main.rs#L96) though, as well as [this minimal reproduction](https://github.com/TDHolmes/nvic-error).

- [x] ~~Fix example so it compiles - help on this would be appreciated~~ seems like this was fixed after updating my nightly compiler
- [x] Fix examples that fail to compile due to `InterruptDrivenTimer` trait not being in scope
- [x] ~~Potentially hide this behind some sort of feature? (`unproven`?)~~ probably not needed?
- [x] Allow for >1s delays