### PR TITLE
Convert timers to using period instead of frequency

### DIFF
--- a/hal/src/common/time.rs
+++ b/hal/src/common/time.rs
@@ -1,5 +1,7 @@
 //! Time units
 
+// Frequency based
+
 /// Bits per second
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct Bps(pub u32);
@@ -16,6 +18,20 @@ pub struct KiloHertz(pub u32);
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct MegaHertz(pub u32);
 
+// Period based
+
+/// Seconds
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Seconds(pub u32);
+
+/// Miliseconds
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Miliseconds(pub u32);
+
+/// Microseconds
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Microseconds(pub u32);
+
 /// Extension trait that adds convenience methods to the `u32` type
 pub trait U32Ext {
     /// Wrap in `Bps`
@@ -29,9 +45,21 @@ pub trait U32Ext {
 
     /// Wrap in `MegaHertz`
     fn mhz(self) -> MegaHertz;
+
+    /// Wrap in `Seconds`
+    fn s(self) -> Seconds;
+
+    /// Wrap in `Miliseconds`
+    fn ms(self) -> Miliseconds;
+
+    /// Wrap in `Microseconds`
+    fn us(self) -> Microseconds;
 }
 
 impl U32Ext for u32 {
+
+    // Frequency based
+
     fn bps(self) -> Bps {
         Bps(self)
     }
@@ -47,7 +75,23 @@ impl U32Ext for u32 {
     fn mhz(self) -> MegaHertz {
         MegaHertz(self)
     }
+
+    // Period based
+
+    fn s(self) -> Seconds {
+        Seconds(self)
+    }
+
+    fn ms(self) -> Miliseconds {
+        Miliseconds(self)
+    }
+
+    fn us(self) -> Microseconds {
+        Microseconds(self)
+    }
 }
+
+// Frequency based
 
 impl Into<Hertz> for KiloHertz {
     fn into(self) -> Hertz {
@@ -64,5 +108,98 @@ impl Into<Hertz> for MegaHertz {
 impl Into<KiloHertz> for MegaHertz {
     fn into(self) -> KiloHertz {
         KiloHertz(self.0 * 1_000)
+    }
+}
+
+impl Into<KiloHertz> for Hertz {
+    fn into(self) -> KiloHertz {
+        KiloHertz(self.0 / 1_000)
+    }
+}
+
+impl Into<MegaHertz> for Hertz {
+    fn into(self) -> MegaHertz {
+        MegaHertz(self.0 / 1_000_000)
+    }
+}
+
+impl Into<MegaHertz> for KiloHertz {
+    fn into(self) -> MegaHertz {
+        MegaHertz(self.0 / 1_000)
+    }
+}
+
+// Period based
+
+impl Into<Miliseconds> for Seconds {
+    fn into(self) -> Miliseconds {
+        Miliseconds(self.0 * 1_000)
+    }
+}
+
+impl Into<Microseconds> for Seconds {
+    fn into(self) -> Microseconds {
+        Microseconds(self.0 * 1_000_000)
+    }
+}
+
+impl Into<Microseconds> for Miliseconds {
+    fn into(self) -> Microseconds {
+        Microseconds(self.0 * 1_000)
+    }
+}
+
+impl Into<Seconds> for Miliseconds {
+    fn into(self) -> Seconds {
+        Seconds(self.0 / 1_000)
+    }
+}
+
+impl Into<Seconds> for Microseconds {
+    fn into(self) -> Seconds {
+        Seconds(self.0 / 1_000_000)
+    }
+}
+
+impl Into<Miliseconds> for Microseconds {
+    fn into(self) -> Miliseconds {
+        Miliseconds(self.0 / 1_000)
+    }
+}
+
+// Frequency <-> Period
+
+impl Into<Hertz> for Microseconds {
+    fn into(self) -> Hertz {
+        Hertz(1_000_000_u32 / self.0)
+    }
+}
+
+impl Into<Microseconds> for Hertz {
+    fn into(self) -> Microseconds {
+        Microseconds(1_000_000_u32 / self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::time::*;
+
+    #[test]
+    fn convert_us_to_hz() {
+        let as_us: Microseconds = 3.hz().into();
+        assert_eq!(as_us.0, 333_333_u32);
+    }
+
+    #[test]
+    fn convert_ms_to_us() {
+        let as_us: Microseconds = 3.ms().into();
+        assert_eq!(as_us.0, 3_000_u32);
+    }
+
+    #[test]
+    fn convert_mhz_to_hz() {
+        let as_hz: Hertz = 48.mhz().into();
+        assert_eq!(as_hz.0, 48_000_000_u32);
     }
 }

--- a/hal/src/samd11/timer.rs
+++ b/hal/src/samd11/timer.rs
@@ -177,12 +177,12 @@ impl TimerParams {
         Self::new_from_ticks(ticks)
     }
 
-    pub fn new_us<T>(timeout: T, src_freq: Hertz) -> Self
+    pub fn new_us<T>(timeout: T, src_freq: u32) -> Self
     where
         T: Into<Microseconds>,
     {
         let timeout = timeout.into();
-        let ticks: u32 = (timeout.0 as u64 * src_freq.0 as u64 / 1_000_000_u64) as u32;
+        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_u64) as u32;
         Self::new_from_ticks(ticks)
     }
 

--- a/hal/src/samd11/timer.rs
+++ b/hal/src/samd11/timer.rs
@@ -5,7 +5,7 @@ use crate::target_device::{PM, TC1};
 use hal::timer::{CountDown, Periodic};
 
 use crate::clock;
-use crate::time::Hertz;
+use crate::time::{Hertz, Microseconds};
 use nb;
 use void::Void;
 
@@ -36,13 +36,13 @@ impl<TC> CountDown for TimerCounter<TC>
 where
     TC: Count16,
 {
-    type Time = Hertz;
+    type Time = Microseconds;
 
     fn start<T>(&mut self, timeout: T)
     where
-        T: Into<Hertz>,
+        T: Into<Self::Time>,
     {
-        let params = TimerParams::new(timeout, self.freq.0);
+        let params = TimerParams::new_us(timeout, self.freq.0);
         let divider = params.divider;
         let cycles = params.cycles;
 
@@ -174,6 +174,20 @@ impl TimerParams {
     {
         let timeout = timeout.into();
         let ticks: u32 = src_freq / timeout.0.max(1);
+        Self::new_from_ticks(ticks)
+    }
+
+    pub fn new_us<T>(timeout: T, src_freq: Hertz) -> Self
+    where
+        T: Into<Microseconds>,
+    {
+        let timeout = timeout.into();
+        let ticks: u32 = (timeout.0 as u64 * src_freq.0 as u64 / 1_000_000_u64) as u32;
+        Self::new_from_ticks(ticks)
+    }
+
+    fn new_from_ticks(ticks: u32) -> Self
+    {
         let divider = ((ticks >> 16) + 1).next_power_of_two();
         let divider = match divider {
             1 | 2 | 4 | 8 | 16 | 64 | 256 | 1024 => divider,
@@ -191,8 +205,8 @@ impl TimerParams {
 
         if cycles > u16::max_value() as u32 {
             panic!(
-                "cycles {} is out of range for a 16 bit counter (timeout={})",
-                cycles, timeout.0
+                "cycles {} is out of range for a 16 bit counter",
+                cycles,
             );
         }
 

--- a/hal/src/samd21/timer.rs
+++ b/hal/src/samd21/timer.rs
@@ -46,7 +46,7 @@ where
     where
         T: Into<Self::Time>,
     {
-        let params = TimerParams::new_us(timeout, self.freq);
+        let params = TimerParams::new_us(timeout, self.freq.0);
         let divider = params.divider;
         let cycles = params.cycles;
 
@@ -172,21 +172,21 @@ pub struct TimerParams {
 }
 
 impl TimerParams {
-    pub fn new<T>(timeout: T, src_freq: Hertz) -> Self
+    pub fn new<T>(timeout: T, src_freq: u32) -> Self
     where
         T: Into<Hertz>,
     {
         let timeout = timeout.into();
-        let ticks: u32 = src_freq.0 / timeout.0.max(1);
+        let ticks: u32 = src_freq / timeout.0.max(1);
         TimerParams::new_from_ticks(ticks)
     }
 
-    pub fn new_us<T>(timeout: T, src_freq: Hertz) -> Self
+    pub fn new_us<T>(timeout: T, src_freq: u32) -> Self
     where
         T: Into<Microseconds>,
     {
         let timeout = timeout.into();
-        let ticks: u32 = (timeout.0 as u64 * src_freq.0 as u64 / 1_000_000_u64) as u32;
+        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_u64) as u32;
         Self::new_from_ticks(ticks)
     }
 
@@ -236,8 +236,8 @@ mod tests {
 
     #[test]
     fn timer_params_hz_and_us_same_1hz() {
-        let tp_from_hz = TimerParams::new(1_u32.hz(), 48_000_000_u32.hz());
-        let tp_from_us = TimerParams::new_us(1_000_000_u32.us(), 48_000_000_u32.hz());
+        let tp_from_hz = TimerParams::new(1_u32.hz(), 48_000_000_u32);
+        let tp_from_us = TimerParams::new_us(1_000_000_u32.us(), 48_000_000_u32);
 
         assert_eq!(tp_from_hz.divider, tp_from_us.divider);
         assert_eq!(tp_from_hz.cycles, tp_from_us.cycles);
@@ -245,8 +245,8 @@ mod tests {
 
     #[test]
     fn timer_params_hz_and_us_same_3hz() {
-        let tp_from_hz = TimerParams::new(3_u32.hz(), 48_000_000_u32.hz());
-        let tp_from_us = TimerParams::new_us(333_333_u32.us(), 48_000_000_u32.hz());
+        let tp_from_hz = TimerParams::new(3_u32.hz(), 48_000_000_u32);
+        let tp_from_us = TimerParams::new_us(333_333_u32.us(), 48_000_000_u32);
 
         // There's some rounding error here, but it is extremely small (1 cycle difference)
         assert_eq!(tp_from_hz.divider, tp_from_us.divider);

--- a/hal/src/samd21/timer.rs
+++ b/hal/src/samd21/timer.rs
@@ -5,7 +5,7 @@ use crate::target_device::{PM, TC3, TC4, TC5};
 use hal::timer::{CountDown, Periodic};
 
 use crate::clock;
-use crate::time::Hertz;
+use crate::time::{Hertz, Microseconds};
 use nb;
 use void::Void;
 
@@ -40,13 +40,13 @@ impl<TC> CountDown for TimerCounter<TC>
 where
     TC: Count16,
 {
-    type Time = Hertz;
+    type Time = Microseconds;
 
     fn start<T>(&mut self, timeout: T)
     where
-        T: Into<Hertz>,
+        T: Into<Self::Time>,
     {
-        let params = TimerParams::new(timeout, self.freq.0);
+        let params = TimerParams::new_us(timeout, self.freq);
         let divider = params.divider;
         let cycles = params.cycles;
 
@@ -172,12 +172,26 @@ pub struct TimerParams {
 }
 
 impl TimerParams {
-    pub fn new<T> (timeout: T, src_freq: u32) -> Self
+    pub fn new<T>(timeout: T, src_freq: Hertz) -> Self
     where
         T: Into<Hertz>,
     {
         let timeout = timeout.into();
-        let ticks: u32 = src_freq/timeout.0.max(1);
+        let ticks: u32 = src_freq.0 / timeout.0.max(1);
+        TimerParams::new_from_ticks(ticks)
+    }
+
+    pub fn new_us<T>(timeout: T, src_freq: Hertz) -> Self
+    where
+        T: Into<Microseconds>,
+    {
+        let timeout = timeout.into();
+        let ticks: u32 = (timeout.0 as u64 * src_freq.0 as u64 / 1_000_000_u64) as u32;
+        Self::new_from_ticks(ticks)
+    }
+
+    fn new_from_ticks(ticks: u32) -> Self
+    {
         let divider = ((ticks >> 16) + 1).next_power_of_two();
         let divider = match divider {
             1 | 2 | 4 | 8 | 16 | 64 | 256 | 1024 => divider,
@@ -195,8 +209,8 @@ impl TimerParams {
 
         if cycles > u16::max_value() as u32 {
             panic!(
-                "cycles {} is out of range for a 16 bit counter (timeout={})",
-                cycles, timeout.0
+                "cycles {} is out of range for a 16 bit counter",
+                cycles
             );
         }
 
@@ -208,9 +222,34 @@ impl TimerParams {
 }
 
 
-
 tc! {
     TimerCounter3: (TC3, tc3_, Tcc2Tc3Clock),
     TimerCounter4: (TC4, tc4_, Tc4Tc5Clock),
     TimerCounter5: (TC5, tc5_, Tc4Tc5Clock),
+}
+
+
+#[cfg(test)]
+mod tests {
+    use crate::samd21::timer::TimerParams;
+    use crate::time::U32Ext;
+
+    #[test]
+    fn timer_params_hz_and_us_same_1hz() {
+        let tp_from_hz = TimerParams::new(1_u32.hz(), 48_000_000_u32.hz());
+        let tp_from_us = TimerParams::new_us(1_000_000_u32.us(), 48_000_000_u32.hz());
+
+        assert_eq!(tp_from_hz.divider, tp_from_us.divider);
+        assert_eq!(tp_from_hz.cycles, tp_from_us.cycles);
+    }
+
+    #[test]
+    fn timer_params_hz_and_us_same_3hz() {
+        let tp_from_hz = TimerParams::new(3_u32.hz(), 48_000_000_u32.hz());
+        let tp_from_us = TimerParams::new_us(333_333_u32.us(), 48_000_000_u32.hz());
+
+        // There's some rounding error here, but it is extremely small (1 cycle difference)
+        assert_eq!(tp_from_hz.divider, tp_from_us.divider);
+        assert!((tp_from_hz.cycles as i32 - tp_from_us.cycles as i32).abs() <= 1);
+    }
 }

--- a/hal/src/samd51/timer.rs
+++ b/hal/src/samd51/timer.rs
@@ -9,7 +9,7 @@ use crate::target_device::{MCLK, TC2, TC3};
 use crate::target_device::{TC4, TC5};
 
 use crate::clock;
-use crate::time::Hertz;
+use crate::time::{Hertz, Microseconds};
 use nb;
 use void::Void;
 
@@ -46,13 +46,13 @@ impl<TC> CountDown for TimerCounter<TC>
 where
     TC: Count16,
 {
-    type Time = Hertz;
+    type Time = Microseconds;
 
     fn start<T>(&mut self, timeout: T)
     where
-        T: Into<Hertz>,
+        T: Into<Self::Time>,
     {
-        let params = TimerParams::new(timeout, self.freq.0);
+        let params = TimerParams::new_us(timeout, self.freq.0);
         let divider = params.divider;
         let cycles = params.cycles;
         let count = self.tc.count_16();
@@ -179,12 +179,26 @@ pub struct TimerParams {
 }
 
 impl TimerParams {
-    pub fn new<T>(timeout: T, src_freq: u32) -> Self
+        pub fn new_hz<T>(timeout: T, src_freq: u32) -> Self
     where
         T: Into<Hertz>,
     {
         let timeout = timeout.into();
         let ticks: u32 = src_freq / timeout.0.max(1);
+        Self::new_from_ticks(ticks)
+    }
+
+    pub fn new_us<T>(timeout: T, src_freq: Hertz) -> Self
+    where
+        T: Into<Microseconds>,
+    {
+        let timeout = timeout.into();
+        let ticks: u32 = (timeout.0 as u64 * src_freq.0 as u64 / 1_000_000_u64) as u32;
+        Self::new_from_ticks(ticks)
+    }
+
+    fn new_from_ticks(ticks: u32) -> Self
+    {
         let divider = ((ticks >> 16) + 1).next_power_of_two();
         let divider = match divider {
             1 | 2 | 4 | 8 | 16 | 64 | 256 | 1024 => divider,

--- a/hal/src/samd51/timer.rs
+++ b/hal/src/samd51/timer.rs
@@ -216,8 +216,8 @@ impl TimerParams {
 
         if cycles > u16::max_value() as u32 {
             panic!(
-                "cycles {} is out of range for a 16 bit counter (timeout={})",
-                cycles, timeout.0
+                "cycles {} is out of range for a 16 bit counter",
+                cycles
             );
         }
 

--- a/hal/src/samd51/timer.rs
+++ b/hal/src/samd51/timer.rs
@@ -179,7 +179,7 @@ pub struct TimerParams {
 }
 
 impl TimerParams {
-        pub fn new_hz<T>(timeout: T, src_freq: u32) -> Self
+        pub fn new<T>(timeout: T, src_freq: u32) -> Self
     where
         T: Into<Hertz>,
     {

--- a/hal/src/samd51/timer.rs
+++ b/hal/src/samd51/timer.rs
@@ -188,12 +188,12 @@ impl TimerParams {
         Self::new_from_ticks(ticks)
     }
 
-    pub fn new_us<T>(timeout: T, src_freq: Hertz) -> Self
+    pub fn new_us<T>(timeout: T, src_freq: u32) -> Self
     where
         T: Into<Microseconds>,
     {
         let timeout = timeout.into();
-        let ticks: u32 = (timeout.0 as u64 * src_freq.0 as u64 / 1_000_000_u64) as u32;
+        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_u64) as u32;
         Self::new_from_ticks(ticks)
     }
 

--- a/hal/src/same54/timer.rs
+++ b/hal/src/same54/timer.rs
@@ -8,7 +8,7 @@ use crate::target_device::{MCLK, TC2, TC3};
 use crate::target_device::{TC4, TC5};
 
 use crate::clock;
-use crate::time::Hertz;
+use crate::time::{Hertz, Microseconds};
 use nb;
 use void::Void;
 
@@ -45,13 +45,13 @@ impl<TC> CountDown for TimerCounter<TC>
 where
     TC: Count16,
 {
-    type Time = Hertz;
+    type Time = Microseconds;
 
     fn start<T>(&mut self, timeout: T)
     where
-        T: Into<Hertz>,
+        T: Into<Self::Time>,
     {
-        let params = TimerParams::new(timeout, self.freq.0);
+        let params = TimerParams::new_us(timeout, self.freq.0);
         let divider = params.divider;
         let cycles = params.cycles;
         let count = self.tc.count_16();
@@ -184,6 +184,20 @@ impl TimerParams {
     {
         let timeout = timeout.into();
         let ticks: u32 = src_freq / timeout.0.max(1);
+        Self::new_from_ticks(ticks)
+    }
+
+    pub fn new_us<T>(timeout: T, src_freq: Hertz) -> Self
+    where
+        T: Into<Microseconds>,
+    {
+        let timeout = timeout.into();
+        let ticks: u32 = (timeout.0 as u64 * src_freq.0 as u64 / 1_000_000_u64) as u32;
+        Self::new_from_ticks(ticks)
+    }
+
+    fn new_from_ticks(ticks: u32) -> Self
+    {
         let divider = ((ticks >> 16) + 1).next_power_of_two();
         let divider = match divider {
             1 | 2 | 4 | 8 | 16 | 64 | 256 | 1024 => divider,

--- a/hal/src/same54/timer.rs
+++ b/hal/src/same54/timer.rs
@@ -187,12 +187,12 @@ impl TimerParams {
         Self::new_from_ticks(ticks)
     }
 
-    pub fn new_us<T>(timeout: T, src_freq: Hertz) -> Self
+    pub fn new_us<T>(timeout: T, src_freq: u32) -> Self
     where
         T: Into<Microseconds>,
     {
         let timeout = timeout.into();
-        let ticks: u32 = (timeout.0 as u64 * src_freq.0 as u64 / 1_000_000_u64) as u32;
+        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_u64) as u32;
         Self::new_from_ticks(ticks)
     }
 

--- a/hal/src/same54/timer.rs
+++ b/hal/src/same54/timer.rs
@@ -215,8 +215,8 @@ impl TimerParams {
 
         if cycles > u16::max_value() as u32 {
             panic!(
-                "cycles {} is out of range for a 16 bit counter (timeout={})",
-                cycles, timeout.0
+                "cycles {} is out of range for a 16 bit counter",
+                cycles
             );
         }
 


### PR DESCRIPTION
By using frequency to track a timer's period, you limit yourself in the possible timer options. For one, a timer longer than 1s is not possible, and many fractional periods are not possible. There are some instances where frequency works a little better, for example 3 Hz which has a rounding error if you convert to microseconds, but that error is extremely small.

I was able to test this on a feather_m0 board, but not the other boards.

This change came out of a discussion in #205 around the accuracy of timers, and the ability to set timers for > 1s