### PR TITLE
Add Arduino Nano 33 IOT board

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   - CRATE=boards/samd11_bare FEATURES="--features=unproven" BUILDMODE="--release"
   - CRATE=boards/samd21_mini FEATURES="--features=unproven"
   - CRATE=boards/arduino_mkrzero FEATURES="--features=unproven"
+  - CRATE=boards/arduino_nano33iot FEATURES="--features=unproven"
   - CRATE=boards/arduino_mkrvidor4000 FEATURES="--features=unproven"
   - CRATE=boards/circuit_playground_express FEATURES="--features=unproven"
   - CRATE=boards/sodaq_one FEATURES="--features=unproven"

--- a/boards/arduino_mkrzero/README.md
+++ b/boards/arduino_mkrzero/README.md
@@ -8,6 +8,7 @@ This crate provides a type-safe API for working with the [Arduino mkrzero board]
  - Arduino IDE installed
     - samd package installed
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
+       - `ArduinoData` is likely something like `~/.arduino15/`
     - Probably best to install an example sketch via the IDE just to make sure everything is working
     - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
  - arm-none-eabi tools installed, you need gcc and objcopy.

--- a/boards/arduino_nano33iot/.cargo/config
+++ b/boards/arduino_nano33iot/.cargo/config
@@ -1,0 +1,10 @@
+# samd21 is a Cortex-M0 and thus thumbv6m
+
+[build]
+target = "thumbv6m-none-eabi"
+
+[target.thumbv6m-none-eabi]
+runner = 'arm-none-eabi-gdb'
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]

--- a/boards/arduino_nano33iot/Cargo.toml
+++ b/boards/arduino_nano33iot/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "arduino_nano33iot"
-version = "0.6.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>", "David McGillicuddy <contact@djmcgill.co.uk>"]
+version = "0.1.0"
+authors = ["Gus Wynn <guswynn@gmail.com>"]
 description = "Board Support crate for the Arduino Nano 33 IOT"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
 license = "MIT OR Apache-2.0"

--- a/boards/arduino_nano33iot/Cargo.toml
+++ b/boards/arduino_nano33iot/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "arduino_nano33iot"
+version = "0.6.0"
+authors = ["Wez Furlong <wez@wezfurlong.org>", "David McGillicuddy <contact@djmcgill.co.uk>"]
+description = "Board Support crate for the Arduino Nano 33 IOT"
+keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/atsamd-rs/atsamd"
+readme = "README.md"
+documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g18a/arduino_nano33iot/"
+
+[dependencies]
+cortex-m = "~0.6"
+embedded-hal = "~0.2.3"
+nb = "~0.1"
+
+[dependencies.cortex-m-rt]
+version = "~0.6.12"
+optional = true
+
+[dependencies.panic-halt]
+version = "~0.2"
+optional = true
+
+[dependencies.atsamd-hal]
+path = "../../hal"
+version = "~0.8"
+default-features = false
+
+[features]
+# ask the HAL to enable atsamd21g18a support
+default = ["rt", "panic_halt", "atsamd-hal/samd21g18a"]
+rt = ["cortex-m-rt", "atsamd-hal/samd21g18a-rt"]
+panic_halt = ["panic-halt"]
+unproven = ["atsamd-hal/unproven"]
+use_semihosting = []

--- a/boards/arduino_nano33iot/Cargo.toml
+++ b/boards/arduino_nano33iot/Cargo.toml
@@ -27,10 +27,27 @@ path = "../../hal"
 version = "~0.8"
 default-features = false
 
+[dependencies.usb-device]
+version = "~0.2"
+optional = true
+
+[dependencies.usbd-serial]
+version = "~0.1"
+optional = true
+
+
 [features]
 # ask the HAL to enable atsamd21g18a support
 default = ["rt", "panic_halt", "atsamd-hal/samd21g18a"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21g18a-rt"]
+usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
 panic_halt = ["panic-halt"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
+
+[[example]]
+name = "blinky_basic"
+
+[[example]]
+name = "usb_logging"
+required-features = ["usb"]

--- a/boards/arduino_nano33iot/README.md
+++ b/boards/arduino_nano33iot/README.md
@@ -20,6 +20,8 @@ cargo build --release --example blinky_basic
 arm-none-eabi-objcopy -O binary target/thumbv6m-none-eabi/release/examples/blinky_basic target/blinky_basic.bin
 bossac -i -d -U true -i -e -w -v target/blinky_basic.bin -R
 ```
+(You may need to use `--port` with something like `/dev/ttyACM0` or `/dev/ttyACM1`
 
 #### Notes
- - It may help to double-press the center button to reset when re-flashing the device
+ - It may help to double-press the center button to reset when re-flashing the device. This sets the device in a bootloader mode.
+

--- a/boards/arduino_nano33iot/README.md
+++ b/boards/arduino_nano33iot/README.md
@@ -1,4 +1,4 @@
-# Arduino Mkrzero Board Support Crate
+# Arduino Nano 33 IOT Board Support Crate
 
 This crate provides a type-safe API for working with the [Arduino nano 33 IOT board](https://store.arduino.cc/usa/nano-33-iot).
 

--- a/boards/arduino_nano33iot/README.md
+++ b/boards/arduino_nano33iot/README.md
@@ -24,4 +24,5 @@ bossac -i -d -U true -i -e -w -v target/blinky_basic.bin -R
 
 #### Notes
  - It may help to double-press the center button to reset when re-flashing the device. This sets the device in a bootloader mode.
+ - For the usb example, `picocom` is a good simple terminal serial emulator
 

--- a/boards/arduino_nano33iot/README.md
+++ b/boards/arduino_nano33iot/README.md
@@ -1,0 +1,25 @@
+# Arduino Mkrzero Board Support Crate
+
+This crate provides a type-safe API for working with the [Arduino nano 33 IOT board](https://store.arduino.cc/usa/nano-33-iot).
+
+## Examples
+### Blinky Basic
+#### Requirements
+ - Arduino IDE installed
+    - samd package installed
+    - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
+       - `ArduinoData` is likely something like `~/.arduino15/`
+    - Probably best to install an example sketch via the IDE just to make sure everything is working
+    - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
+ - arm-none-eabi tools installed, you need gcc and objcopy.
+ - thumbv6m-none-eabi rust target installed via `rustup target add thumbv6m-none-eabi`
+
+#### Steps
+```bash
+cargo build --release --example blinky_basic
+arm-none-eabi-objcopy -O binary target/thumbv6m-none-eabi/release/examples/blinky_basic target/blinky_basic.bin
+bossac -i -d -U true -i -e -w -v target/blinky_basic.bin -R
+```
+
+#### Notes
+ - It may help to double-press the center button to reset when re-flashing the device

--- a/boards/arduino_nano33iot/build.rs
+++ b/boards/arduino_nano33iot/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+fn main() {
+    if env::var_os("CARGO_FEATURE_RT").is_some() {
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        File::create(out.join("memory.x"))
+            .unwrap()
+            .write_all(include_bytes!("memory.x"))
+            .unwrap();
+        println!("cargo:rustc-link-search={}", out.display());
+        println!("cargo:rerun-if-changed=memory.x");
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/boards/arduino_nano33iot/examples/blinky_basic.rs
+++ b/boards/arduino_nano33iot/examples/blinky_basic.rs
@@ -1,0 +1,32 @@
+#![no_std]
+#![no_main]
+
+extern crate arduino_nano33iot as hal;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut led = pins.led_sck.into_open_drain_output(&mut pins.port);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    loop {
+        delay.delay_ms(200u8);
+        led.set_high().unwrap();
+        delay.delay_ms(200u8);
+        led.set_low().unwrap();
+    }
+}

--- a/boards/arduino_nano33iot/examples/usb_logging.rs
+++ b/boards/arduino_nano33iot/examples/usb_logging.rs
@@ -1,0 +1,107 @@
+#![no_std]
+#![no_main]
+
+extern crate arduino_nano33iot as hal;
+extern crate cortex_m;
+extern crate panic_halt;
+extern crate usb_device;
+extern crate usbd_serial;
+
+use hal::clock::GenericClockController;
+use hal::entry;
+use hal::pac::{interrupt, CorePeripherals, Peripherals};
+use hal::prelude::*;
+
+use hal::usb::UsbBus;
+use usb_device::bus::UsbBusAllocator;
+use usb_device::prelude::*;
+use usbd_serial::{SerialPort, USB_CLASS_CDC};
+
+use cortex_m::asm::delay as cycle_delay;
+use cortex_m::peripheral::NVIC;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut red_led = pins.led_sck.into_open_drain_output(&mut pins.port);
+
+    let bus_allocator = unsafe {
+        USB_ALLOCATOR = Some(hal::usb_allocator(
+            peripherals.USB,
+            &mut clocks,
+            &mut peripherals.PM,
+            pins.usb_dm,
+            pins.usb_dp,
+            &mut pins.port,
+        ));
+        USB_ALLOCATOR.as_ref().unwrap()
+    };
+
+    unsafe {
+        USB_SERIAL = Some(SerialPort::new(&bus_allocator));
+        USB_BUS = Some(
+            UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x2222, 0x3333))
+                .manufacturer("Fake company")
+                .product("Serial port")
+                .serial_number("TEST")
+                .device_class(USB_CLASS_CDC)
+                .build(),
+        );
+    }
+
+    unsafe {
+        core.NVIC.set_priority(interrupt::USB, 1);
+        NVIC::unmask(interrupt::USB);
+    }
+
+    // Flash the LED in a spin loop to demonstrate that USB is
+    // entirely interrupt driven.
+    loop {
+        cycle_delay(15 * 1024 * 1024);
+        red_led.toggle();
+        unsafe {
+            USB_SERIAL.as_mut().map(|serial| {
+                serial.write("test print".as_bytes()).unwrap();
+            });
+        }
+    }
+}
+
+static mut USB_ALLOCATOR: Option<UsbBusAllocator<UsbBus>> = None;
+static mut USB_BUS: Option<UsbDevice<UsbBus>> = None;
+static mut USB_SERIAL: Option<SerialPort<UsbBus>> = None;
+
+fn poll_usb() {
+    unsafe {
+        USB_BUS.as_mut().map(|usb_dev| {
+            USB_SERIAL.as_mut().map(|serial| {
+                usb_dev.poll(&mut [serial]);
+                /*
+                let mut buf = [0u8; 64];
+
+                if let Ok(count) = serial.read(&mut buf) {
+                    for (i, c) in buf.iter().enumerate() {
+                        if i >= count {
+                            break;
+                        }
+                        serial.write("gus".as_bytes());
+                    }
+                };
+                */
+            });
+        });
+    };
+}
+
+#[interrupt]
+fn USB() {
+    poll_usb();
+}

--- a/boards/arduino_nano33iot/memory.x
+++ b/boards/arduino_nano33iot/memory.x
@@ -1,0 +1,5 @@
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00000000+0x2000, LENGTH = 0x00040000-0x2000 /* bootloader 8kb */
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00008000
+}

--- a/boards/arduino_nano33iot/src/lib.rs
+++ b/boards/arduino_nano33iot/src/lib.rs
@@ -29,7 +29,7 @@ pub use hal::usb::UsbBus;
 // The docs could be further improved with details of the specific channels etc
 define_pins!(
     /// Maps the pins to their arduino names and the numbers printed on the board.
-    /// Information from: <https://github.com/arduino/ArduinoCore-samd/blob/master/variants/mkrzero/variant.cpp>
+    /// Information from: <https://github.com/arduino/ArduinoCore-samd/blob/master/variants/nano_33_iot/variant.cpp>
     struct Pins,
     target_device: target_device,
 

--- a/boards/arduino_nano33iot/src/lib.rs
+++ b/boards/arduino_nano33iot/src/lib.rs
@@ -1,0 +1,118 @@
+#![no_std]
+
+extern crate atsamd_hal as hal;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::entry;
+
+#[cfg(feature = "panic_halt")]
+pub extern crate panic_halt;
+
+use hal::prelude::*;
+use hal::*;
+
+pub use hal::common::*;
+pub use hal::samd21::*;
+pub use hal::target_device as pac;
+
+use gpio::{Floating, Input, Port};
+
+// The docs could be further improved with details of the specific channels etc
+define_pins!(
+    /// Maps the pins to their arduino names and the numbers printed on the board.
+    /// Information from: <https://github.com/arduino/ArduinoCore-samd/blob/master/variants/mkrzero/variant.cpp>
+    struct Pins,
+    target_device: target_device,
+
+    /// RX
+    pin rx = b23,
+
+    /// TX
+    pin tx = b22,
+
+    /// Digital 2: PWM, TC
+    pin d2 = b10,
+
+    /// Digital 3: PWM, TC
+    pin d3 = b11,
+
+    /// Digital 4: TCC
+    pin d4 = a7,
+
+    /// Digital 5: PWM, TCC, ADC
+    pin d5 = a5,
+
+    /// Digital 6: PWM, TCC, ADC
+    pin d6 = a4,
+
+    /// Digital 7: ADC
+    pin d7 = a6,
+
+    /// Digital 8
+    pin d8 = a18,
+
+    /// Digital 9: PWM, TCC
+    pin d9 = a20,
+
+    /// Digital 10: PWM, TCC
+    pin d10 = a21,
+
+    /// Digital 11/SCI MISO: PWM, TCC
+    pin miso = a16,
+
+    /// Digital 12/SCI MOSI: PWM, TCC
+    pin mosi = a19,
+
+    /// Digital 13/LED/SPI SCK: ON-BOARD-LED
+    pin led_sck = a17,
+
+    /// Analog 0: DAC
+    pin a0 = a2,
+
+    /// Analog 1
+    pin a1 = b2,
+
+    /// Analog 2: PWM, TCC
+    pin a2 = a11,
+
+    /// Analog 3: PWM, TCC
+    pin a3 = a10,
+
+    /// Analog 4/SDA
+    pin sda = b8,
+
+    /// Analog 5/SCL: PWM< TCC
+    pin scl = b9,
+
+    /// Analog 6
+    pin a6 = a9,
+
+    /// Analog 7
+    pin a7 = b3,
+
+    /// SPI (Lefacy ICSP) 1 / NINA MOSI
+    pin nina_mosi = a12,
+    /// SPI (Lefacy ICSP) 2 / NINA MISO
+    pin nina_miso = a13,
+    /// SPI (Lefacy ICSP) 3 / NINA CS
+    pin nina_cs = a14,
+    /// SPI (Lefacy ICSP) 4 / NINA SCK
+    pin nina_sck = a15,
+    pin nina_gpio0 = a27,
+    pin nina_resetn = a8,
+    pin nina_ack = a28,
+
+    /// SerialNina 29: PWM, TC
+    pin serial_nina29 = a22,
+    /// SerialNina 30: PWM, TC
+    pin serial_nina30 = a23,
+
+    pin usb_n = a24,
+    pin usb_p = a25,
+    pin aref = a3,
+
+    pin p34 = a30,
+    pin p35 = a31,
+);


### PR DESCRIPTION
This is very similar to the mkr zero board, but ends up being somewhat different.

Couple notes:

- I don't really have a way right now of testing every pin, just the led and usb, so there may be inaccuracies. As far as I can tell, this is considered somewhat understandable in the embedded rust world, but it would be nice if someone could cross check: https://github.com/arduino/ArduinoCore-samd/blob/master/variants/nano_33_iot/variant.cpp against my pins.
- I found that variant.cpp file hard to read, so some of my comments about TC vs TCC on pins may be wrong.
- **Many pins double or triple up in functionality on this board, so I need help with naming**
- This board is highly under-documented, and for the life of me I couldn't find a reference on its bootloader size. I used the same value as the mkrzero, and it seemed to work
- You can see here: https://content.arduino.cc/assets/NANO33IoTV2.0_sch.pdf that this chip, unlike the mkrzero doesn't have an external clock on xin and xout. This is curious, but requires the use of with_external for the clock. That took me a while to figure out lol, I don't have a debugger so panic's are basically "the led didn't blink"
- I opted for an example of usb serial for logging, as that's what I need to debug in the future, and it was slightly subtle, with the "maybe not needed but better" `free` block, and the need to read blind data in the interrupt to make `picocom` cooperate.
- I added some notes and improvements to the mkrzero and nano33iot docs to make it easier for people to pick up.
- This board has no documentation other than forum posts on the double-press to get it into a flashable bootloader mode, so I added it to the docs.

In the future, I plan on using https://lib.rs/crates/wifi-nina to get wifi to work (maybe with tls, we shall see) as well as write my own driver crate for the lcm imu on board that there seems to be no support for in rust-embedded yet.