### PR TITLE
SPI: set baud, phase, polarity and disable/enable

### DIFF
--- a/hal/src/samd11/sercom/spi.rs
+++ b/hal/src/samd11/sercom/spi.rs
@@ -166,6 +166,61 @@ macro_rules! spi_master {
                     }
                 }
 
+                /// Disable the SPI
+                pub fn disable(&mut self) {
+                    unsafe {
+                        self.sercom.spi().ctrla.modify(|_, w| w.enable().clear_bit());
+                        // wait for configuration to take effect
+                        while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
+                    }
+                }
+
+                /// Enable the SPI
+                pub fn enable(&mut self) {
+                    unsafe {
+                        self.sercom.spi().ctrla.modify(|_, w| w.enable().set_bit());
+                        // wait for configuration to take effect
+                        while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
+                    }
+                }
+
+                /// Set the baud rate
+                pub fn set_baud<F: Into<Hertz>(
+                    &mut self,
+                    freq: F,
+                    clock:&clock::$clock,
+                ) {
+                    self.disable();
+                    unsafe {
+                        let gclk = clock.freq();
+                        let baud = (gclk.0 / (2 * freq.into().0) - 1) as u8;
+                        sercom.spi().baud.modify(|_, w| w.baud().bits(baud));
+                    }
+                    self.enable();
+                }
+
+                /// Set the polarity (CPOL) and phase (CPHA) of the SPI
+                pub fn set_mode(
+                    &mut self,
+                    mode: Mode
+                ) {
+                    self.disable();
+                    unsafe {
+                         sercom.spi().ctrla.modify(|_, w| {
+                            match mode.polarity {
+                                Polarity::IdleLow => w.cpol().clear_bit(),
+                                Polarity::IdleHigh => w.cpol().set_bit(),
+                            };
+
+                            match mode.phase {
+                                Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
+                                Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
+                            };
+                        });
+                    }
+                    self.enable();
+                }
+
                 /// Tear down the SPI instance and yield the constituent pins and
                 /// SERCOM instance.  No explicit de-initialization is performed.
                 pub fn free(self) -> ([<$Type Padout>]<MISO, MOSI, SCK>, $SERCOM) {

--- a/hal/src/samd11/sercom/spi.rs
+++ b/hal/src/samd11/sercom/spi.rs
@@ -168,33 +168,29 @@ macro_rules! spi_master {
 
                 /// Disable the SPI
                 pub fn disable(&mut self) {
-                    unsafe {
-                        self.sercom.spi().ctrla.modify(|_, w| w.enable().clear_bit());
-                        // wait for configuration to take effect
-                        while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
-                    }
+                    self.sercom.spi().ctrla.modify(|_, w| w.enable().clear_bit());
+                    // wait for configuration to take effect
+                    while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
                 }
 
                 /// Enable the SPI
                 pub fn enable(&mut self) {
-                    unsafe {
-                        self.sercom.spi().ctrla.modify(|_, w| w.enable().set_bit());
-                        // wait for configuration to take effect
-                        while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
-                    }
+                    self.sercom.spi().ctrla.modify(|_, w| w.enable().set_bit());
+                    // wait for configuration to take effect
+                    while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
                 }
 
                 /// Set the baud rate
-                pub fn set_baud<F: Into<Hertz>(
+                pub fn set_baud<F: Into<Hertz>>(
                     &mut self,
                     freq: F,
-                    clock:&clock::$clock,
+                    clock:&clock::$clock
                 ) {
                     self.disable();
                     unsafe {
                         let gclk = clock.freq();
                         let baud = (gclk.0 / (2 * freq.into().0) - 1) as u8;
-                        sercom.spi().baud.modify(|_, w| w.baud().bits(baud));
+                        self.sercom.spi().baud.modify(|_, w| w.baud().bits(baud));
                     }
                     self.enable();
                 }
@@ -205,19 +201,17 @@ macro_rules! spi_master {
                     mode: Mode
                 ) {
                     self.disable();
-                    unsafe {
-                         sercom.spi().ctrla.modify(|_, w| {
-                            match mode.polarity {
-                                Polarity::IdleLow => w.cpol().clear_bit(),
-                                Polarity::IdleHigh => w.cpol().set_bit(),
-                            };
+                    self.sercom.spi().ctrla.modify(|_, w| {
+                        match mode.polarity {
+                            Polarity::IdleLow => w.cpol().clear_bit(),
+                            Polarity::IdleHigh => w.cpol().set_bit(),
+                        };
 
-                            match mode.phase {
-                                Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
-                                Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
-                            };
-                        });
-                    }
+                        match mode.phase {
+                            Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
+                            Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
+                        }
+                    });
                     self.enable();
                 }
 

--- a/hal/src/samd21/sercom/spi.rs
+++ b/hal/src/samd21/sercom/spi.rs
@@ -170,33 +170,29 @@ macro_rules! spi_master {
 
                 /// Disable the SPI
                 pub fn disable(&mut self) {
-                    unsafe {
-                        self.sercom.spi().ctrla.modify(|_, w| w.enable().clear_bit());
-                        // wait for configuration to take effect
-                        while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
-                    }
+                    self.sercom.spi().ctrla.modify(|_, w| w.enable().clear_bit());
+                    // wait for configuration to take effect
+                    while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
                 }
 
                 /// Enable the SPI
                 pub fn enable(&mut self) {
-                    unsafe {
-                        self.sercom.spi().ctrla.modify(|_, w| w.enable().set_bit());
-                        // wait for configuration to take effect
-                        while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
-                    }
+                    self.sercom.spi().ctrla.modify(|_, w| w.enable().set_bit());
+                    // wait for configuration to take effect
+                    while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
                 }
 
                 /// Set the baud rate
-                pub fn set_baud<F: Into<Hertz>(
+                pub fn set_baud<F: Into<Hertz>>(
                     &mut self,
                     freq: F,
-                    clock:&clock::$clock,
+                    clock:&clock::$clock
                 ) {
                     self.disable();
                     unsafe {
                         let gclk = clock.freq();
                         let baud = (gclk.0 / (2 * freq.into().0) - 1) as u8;
-                        sercom.spi().baud.modify(|_, w| w.baud().bits(baud));
+                        self.sercom.spi().baud.modify(|_, w| w.baud().bits(baud));
                     }
                     self.enable();
                 }
@@ -207,19 +203,17 @@ macro_rules! spi_master {
                     mode: Mode
                 ) {
                     self.disable();
-                    unsafe {
-                         sercom.spi().ctrla.modify(|_, w| {
-                            match mode.polarity {
-                                Polarity::IdleLow => w.cpol().clear_bit(),
-                                Polarity::IdleHigh => w.cpol().set_bit(),
-                            };
+                    self.sercom.spi().ctrla.modify(|_, w| {
+                        match mode.polarity {
+                            Polarity::IdleLow => w.cpol().clear_bit(),
+                            Polarity::IdleHigh => w.cpol().set_bit(),
+                        };
 
-                            match mode.phase {
-                                Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
-                                Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
-                            };
-                        });
-                    }
+                        match mode.phase {
+                            Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
+                            Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
+                        }
+                    });
                     self.enable();
                 }
 

--- a/hal/src/samd51/sercom/spi.rs
+++ b/hal/src/samd51/sercom/spi.rs
@@ -164,33 +164,29 @@ macro_rules! spi_master {
 
                 /// Disable the SPI
                 pub fn disable(&mut self) {
-                    unsafe {
-                        self.sercom.spi().ctrla.modify(|_, w| w.enable().clear_bit());
-                        // wait for configuration to take effect
-                        while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
-                    }
+                    self.sercom.spi().ctrla.modify(|_, w| w.enable().clear_bit());
+                    // wait for configuration to take effect
+                    while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
                 }
 
                 /// Enable the SPI
                 pub fn enable(&mut self) {
-                    unsafe {
-                        self.sercom.spi().ctrla.modify(|_, w| w.enable().set_bit());
-                        // wait for configuration to take effect
-                        while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
-                    }
+                    self.sercom.spi().ctrla.modify(|_, w| w.enable().set_bit());
+                    // wait for configuration to take effect
+                    while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
                 }
 
                 /// Set the baud rate
-                pub fn set_baud<F: Into<Hertz>(
+                pub fn set_baud<F: Into<Hertz>>(
                     &mut self,
                     freq: F,
-                    clock:&clock::$clock,
+                    clock:&clock::$clock
                 ) {
                     self.disable();
                     unsafe {
                         let gclk = clock.freq();
                         let baud = (gclk.0 / (2 * freq.into().0) - 1) as u8;
-                        sercom.spi().baud.modify(|_, w| w.baud().bits(baud));
+                        self.sercom.spi().baud.modify(|_, w| w.baud().bits(baud));
                     }
                     self.enable();
                 }
@@ -201,19 +197,17 @@ macro_rules! spi_master {
                     mode: Mode
                 ) {
                     self.disable();
-                    unsafe {
-                         sercom.spi().ctrla.modify(|_, w| {
-                            match mode.polarity {
-                                Polarity::IdleLow => w.cpol().clear_bit(),
-                                Polarity::IdleHigh => w.cpol().set_bit(),
-                            };
+                    self.sercom.spi().ctrla.modify(|_, w| {
+                        match mode.polarity {
+                            Polarity::IdleLow => w.cpol().clear_bit(),
+                            Polarity::IdleHigh => w.cpol().set_bit(),
+                        };
 
-                            match mode.phase {
-                                Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
-                                Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
-                            };
-                        });
-                    }
+                        match mode.phase {
+                            Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
+                            Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
+                        }
+                    });
                     self.enable();
                 }
 

--- a/hal/src/samd51/sercom/spi.rs
+++ b/hal/src/samd51/sercom/spi.rs
@@ -162,6 +162,61 @@ macro_rules! spi_master {
                     }
                 }
 
+                /// Disable the SPI
+                pub fn disable(&mut self) {
+                    unsafe {
+                        self.sercom.spi().ctrla.modify(|_, w| w.enable().clear_bit());
+                        // wait for configuration to take effect
+                        while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
+                    }
+                }
+
+                /// Enable the SPI
+                pub fn enable(&mut self) {
+                    unsafe {
+                        self.sercom.spi().ctrla.modify(|_, w| w.enable().set_bit());
+                        // wait for configuration to take effect
+                        while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
+                    }
+                }
+
+                /// Set the baud rate
+                pub fn set_baud<F: Into<Hertz>(
+                    &mut self,
+                    freq: F,
+                    clock:&clock::$clock,
+                ) {
+                    self.disable();
+                    unsafe {
+                        let gclk = clock.freq();
+                        let baud = (gclk.0 / (2 * freq.into().0) - 1) as u8;
+                        sercom.spi().baud.modify(|_, w| w.baud().bits(baud));
+                    }
+                    self.enable();
+                }
+
+                /// Set the polarity (CPOL) and phase (CPHA) of the SPI
+                pub fn set_mode(
+                    &mut self,
+                    mode: Mode
+                ) {
+                    self.disable();
+                    unsafe {
+                         sercom.spi().ctrla.modify(|_, w| {
+                            match mode.polarity {
+                                Polarity::IdleLow => w.cpol().clear_bit(),
+                                Polarity::IdleHigh => w.cpol().set_bit(),
+                            };
+
+                            match mode.phase {
+                                Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
+                                Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
+                            };
+                        });
+                    }
+                    self.enable();
+                }
+
                 /// Tear down the SPI instance and yield the constituent pins and
                 /// SERCOM instance.  No explicit de-initialization is performed.
                 pub fn free(self) -> ([<$Type Padout>]<MISO, MOSI, SCK>, $SERCOM) {

--- a/hal/src/same54/sercom/spi.rs
+++ b/hal/src/same54/sercom/spi.rs
@@ -163,33 +163,29 @@ macro_rules! spi_master {
 
                 /// Disable the SPI
                 pub fn disable(&mut self) {
-                    unsafe {
-                        self.sercom.spi().ctrla.modify(|_, w| w.enable().clear_bit());
-                        // wait for configuration to take effect
-                        while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
-                    }
+                    self.sercom.spi().ctrla.modify(|_, w| w.enable().clear_bit());
+                    // wait for configuration to take effect
+                    while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
                 }
 
                 /// Enable the SPI
                 pub fn enable(&mut self) {
-                    unsafe {
-                        self.sercom.spi().ctrla.modify(|_, w| w.enable().set_bit());
-                        // wait for configuration to take effect
-                        while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
-                    }
+                    self.sercom.spi().ctrla.modify(|_, w| w.enable().set_bit());
+                    // wait for configuration to take effect
+                    while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
                 }
 
                 /// Set the baud rate
-                pub fn set_baud<F: Into<Hertz>(
+                pub fn set_baud<F: Into<Hertz>>(
                     &mut self,
                     freq: F,
-                    clock:&clock::$clock,
+                    clock:&clock::$clock
                 ) {
                     self.disable();
                     unsafe {
                         let gclk = clock.freq();
                         let baud = (gclk.0 / (2 * freq.into().0) - 1) as u8;
-                        sercom.spi().baud.modify(|_, w| w.baud().bits(baud));
+                        self.sercom.spi().baud.modify(|_, w| w.baud().bits(baud));
                     }
                     self.enable();
                 }
@@ -200,19 +196,17 @@ macro_rules! spi_master {
                     mode: Mode
                 ) {
                     self.disable();
-                    unsafe {
-                         sercom.spi().ctrla.modify(|_, w| {
-                            match mode.polarity {
-                                Polarity::IdleLow => w.cpol().clear_bit(),
-                                Polarity::IdleHigh => w.cpol().set_bit(),
-                            };
+                    self.sercom.spi().ctrla.modify(|_, w| {
+                        match mode.polarity {
+                            Polarity::IdleLow => w.cpol().clear_bit(),
+                            Polarity::IdleHigh => w.cpol().set_bit(),
+                        };
 
-                            match mode.phase {
-                                Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
-                                Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
-                            };
-                        });
-                    }
+                        match mode.phase {
+                            Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
+                            Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
+                        }
+                    });
                     self.enable();
                 }
 

--- a/hal/src/same54/sercom/spi.rs
+++ b/hal/src/same54/sercom/spi.rs
@@ -161,6 +161,61 @@ macro_rules! spi_master {
                     }
                 }
 
+                /// Disable the SPI
+                pub fn disable(&mut self) {
+                    unsafe {
+                        self.sercom.spi().ctrla.modify(|_, w| w.enable().clear_bit());
+                        // wait for configuration to take effect
+                        while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
+                    }
+                }
+
+                /// Enable the SPI
+                pub fn enable(&mut self) {
+                    unsafe {
+                        self.sercom.spi().ctrla.modify(|_, w| w.enable().set_bit());
+                        // wait for configuration to take effect
+                        while self.sercom.spi().syncbusy.read().enable().bit_is_set() {}
+                    }
+                }
+
+                /// Set the baud rate
+                pub fn set_baud<F: Into<Hertz>(
+                    &mut self,
+                    freq: F,
+                    clock:&clock::$clock,
+                ) {
+                    self.disable();
+                    unsafe {
+                        let gclk = clock.freq();
+                        let baud = (gclk.0 / (2 * freq.into().0) - 1) as u8;
+                        sercom.spi().baud.modify(|_, w| w.baud().bits(baud));
+                    }
+                    self.enable();
+                }
+
+                /// Set the polarity (CPOL) and phase (CPHA) of the SPI
+                pub fn set_mode(
+                    &mut self,
+                    mode: Mode
+                ) {
+                    self.disable();
+                    unsafe {
+                         sercom.spi().ctrla.modify(|_, w| {
+                            match mode.polarity {
+                                Polarity::IdleLow => w.cpol().clear_bit(),
+                                Polarity::IdleHigh => w.cpol().set_bit(),
+                            };
+
+                            match mode.phase {
+                                Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
+                                Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
+                            };
+                        });
+                    }
+                    self.enable();
+                }
+
                 /// Tear down the SPI instance and yield the constituent pins and
                 /// SERCOM instance.  No explicit de-initialization is performed.
                 pub fn free(self) -> ([<$Type Padout>]<MISO, MOSI, SCK>, $SERCOM) {


### PR DESCRIPTION
On SERCOM spi, add methods to set the baud rate and phase/polarity of the SPI. Also add enable/disable methods.