### PR TITLE
timer: nanosecond base

### DIFF
--- a/hal/src/common/time.rs
+++ b/hal/src/common/time.rs
@@ -32,6 +32,10 @@ pub struct Miliseconds(pub u32);
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct Microseconds(pub u32);
 
+/// Nanoseconds
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Nanoseconds(pub u32);
+
 /// Extension trait that adds convenience methods to the `u32` type
 pub trait U32Ext {
     /// Wrap in `Bps`
@@ -54,6 +58,9 @@ pub trait U32Ext {
 
     /// Wrap in `Microseconds`
     fn us(self) -> Microseconds;
+
+    /// Wrap in `NanoSeconds`
+    fn ns(self) -> Nanoseconds;
 }
 
 impl U32Ext for u32 {
@@ -87,6 +94,10 @@ impl U32Ext for u32 {
 
     fn us(self) -> Microseconds {
         Microseconds(self)
+    }
+
+    fn ns(self) -> Nanoseconds {
+        Nanoseconds(self)
     }
 }
 
@@ -135,16 +146,27 @@ impl Into<Miliseconds> for Seconds {
         Miliseconds(self.0 * 1_000)
     }
 }
-
 impl Into<Microseconds> for Seconds {
     fn into(self) -> Microseconds {
         Microseconds(self.0 * 1_000_000)
     }
 }
 
+impl Into<Nanoseconds> for Seconds {
+    fn into(self) -> Nanoseconds {
+        Nanoseconds(self.0 * 1_000_000_000)
+    }
+}
+
 impl Into<Microseconds> for Miliseconds {
     fn into(self) -> Microseconds {
         Microseconds(self.0 * 1_000)
+    }
+}
+
+impl Into<Nanoseconds> for Microseconds {
+    fn into(self) -> Nanoseconds {
+        Nanoseconds(self.0 * 1_000)
     }
 }
 
@@ -166,7 +188,19 @@ impl Into<Miliseconds> for Microseconds {
     }
 }
 
+impl Into<Nanoseconds> for Miliseconds {
+    fn into(self) -> Nanoseconds {
+        Nanoseconds(self.0 * 1_000_000)
+    }
+}
+
 // Frequency <-> Period
+
+impl Into<Hertz> for Nanoseconds {
+    fn into(self) -> Hertz {
+        Hertz(1_000_000_000_u32 / self.0)
+    }
+}
 
 impl Into<Hertz> for Microseconds {
     fn into(self) -> Hertz {
@@ -174,9 +208,39 @@ impl Into<Hertz> for Microseconds {
     }
 }
 
+impl Into<KiloHertz> for Nanoseconds {
+    fn into(self) -> KiloHertz {
+        KiloHertz(1_000_000_u32 / self.0)
+    }
+}
+
+impl Into<MegaHertz> for Nanoseconds {
+    fn into(self) -> MegaHertz {
+        MegaHertz(1_000_u32 / self.0)
+    }
+}
+
 impl Into<Microseconds> for Hertz {
     fn into(self) -> Microseconds {
         Microseconds(1_000_000_u32 / self.0)
+    }
+}
+
+impl Into<Nanoseconds> for Hertz {
+    fn into(self) -> Nanoseconds {
+        Nanoseconds(1_000_000_000u32 / self.0)
+    }
+}
+
+impl Into<Nanoseconds> for KiloHertz {
+    fn into(self) -> Nanoseconds {
+        Nanoseconds(1_000_000u32 / self.0)
+    }
+}
+
+impl Into<Nanoseconds> for MegaHertz {
+    fn into(self) -> Nanoseconds {
+        Nanoseconds(1_000u32 / self.0)
     }
 }
 
@@ -200,5 +264,17 @@ mod tests {
     fn convert_mhz_to_hz() {
         let as_hz: Hertz = 48.mhz().into();
         assert_eq!(as_hz.0, 48_000_000_u32);
+    }
+
+    #[test]
+    fn convert_hz_to_ns() {
+        let as_ns: Nanoseconds = 3.mhz().into();
+        assert_eq!(as_ns.0, 333_u32);
+    }
+
+    #[test]
+    fn convert_hz_to_ns_even() {
+        let as_ns: Nanoseconds = 2.mhz().into();
+        assert_eq!(as_ns.0, 500_u32);
     }
 }

--- a/hal/src/common/timer_traits.rs
+++ b/hal/src/common/timer_traits.rs
@@ -3,7 +3,7 @@ use crate::time;
 
 /// Trait for timers that can enable & disable an interrupt that fires
 /// when the timer expires
-pub trait InterruptDrivenTimer: CountDown<Time = time::Microseconds> + Periodic {
+pub trait InterruptDrivenTimer: CountDown<Time = time::Nanoseconds> + Periodic {
     /// Enable the timer interrupt
     fn enable_interrupt(&mut self);
 

--- a/hal/src/samd11/timer.rs
+++ b/hal/src/samd11/timer.rs
@@ -6,7 +6,7 @@ use crate::timer_traits::InterruptDrivenTimer;
 use hal::timer::{CountDown, Periodic};
 
 use crate::clock;
-use crate::time::{Hertz, Microseconds};
+use crate::time::{Hertz, Nanoseconds};
 use void::Void;
 
 /// A generic hardware timer counter.
@@ -36,7 +36,7 @@ impl<TC> CountDown for TimerCounter<TC>
 where
     TC: Count16,
 {
-    type Time = Microseconds;
+    type Time = Nanoseconds;
 
     fn start<T>(&mut self, timeout: T)
     where
@@ -179,10 +179,10 @@ impl TimerParams {
 
     pub fn new_us<T>(timeout: T, src_freq: u32) -> Self
     where
-        T: Into<Microseconds>,
+        T: Into<Nanoseconds>,
     {
         let timeout = timeout.into();
-        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_u64) as u32;
+        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_000_u64) as u32;
         Self::new_from_ticks(ticks)
     }
 

--- a/hal/src/samd21/timer.rs
+++ b/hal/src/samd21/timer.rs
@@ -5,7 +5,7 @@ use crate::target_device::{PM, TC3, TC4, TC5};
 use hal::timer::{CountDown, Periodic};
 
 use crate::clock;
-use crate::time::{Hertz, Microseconds};
+use crate::time::{Hertz, Nanoseconds};
 use crate::timer_traits::InterruptDrivenTimer;
 use void::Void;
 
@@ -40,7 +40,7 @@ impl<TC> CountDown for TimerCounter<TC>
 where
     TC: Count16,
 {
-    type Time = Microseconds;
+    type Time = Nanoseconds;
 
     fn start<T>(&mut self, timeout: T)
     where
@@ -183,10 +183,10 @@ impl TimerParams {
 
     pub fn new_us<T>(timeout: T, src_freq: u32) -> Self
     where
-        T: Into<Microseconds>,
+        T: Into<Nanoseconds>,
     {
         let timeout = timeout.into();
-        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_u64) as u32;
+        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_000_u64) as u32;
         Self::new_from_ticks(ticks)
     }
 

--- a/hal/src/samd51/timer.rs
+++ b/hal/src/samd51/timer.rs
@@ -10,7 +10,7 @@ use crate::timer_traits::InterruptDrivenTimer;
 use crate::target_device::{TC4, TC5};
 
 use crate::clock;
-use crate::time::{Hertz, Microseconds};
+use crate::time::{Hertz, Nanoseconds};
 use void::Void;
 
 use cortex_m::asm::delay as cycle_delay;
@@ -46,7 +46,7 @@ impl<TC> CountDown for TimerCounter<TC>
 where
     TC: Count16,
 {
-    type Time = Microseconds;
+    type Time = Nanoseconds;
 
     fn start<T>(&mut self, timeout: T)
     where
@@ -190,10 +190,10 @@ impl TimerParams {
 
     pub fn new_us<T>(timeout: T, src_freq: u32) -> Self
     where
-        T: Into<Microseconds>,
+        T: Into<Nanoseconds>,
     {
         let timeout = timeout.into();
-        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_u64) as u32;
+        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_000_u64) as u32;
         Self::new_from_ticks(ticks)
     }
 

--- a/hal/src/same54/timer.rs
+++ b/hal/src/same54/timer.rs
@@ -8,7 +8,7 @@ use crate::target_device::{MCLK, TC2, TC3};
 use crate::target_device::{TC4, TC5};
 
 use crate::clock;
-use crate::time::{Hertz, Microseconds};
+use crate::time::{Hertz, Nanoseconds};
 use crate::timer_traits::InterruptDrivenTimer;
 use void::Void;
 
@@ -45,7 +45,7 @@ impl<TC> CountDown for TimerCounter<TC>
 where
     TC: Count16,
 {
-    type Time = Microseconds;
+    type Time = Nanoseconds;
 
     fn start<T>(&mut self, timeout: T)
     where
@@ -189,10 +189,10 @@ impl TimerParams {
 
     pub fn new_us<T>(timeout: T, src_freq: u32) -> Self
     where
-        T: Into<Microseconds>,
+        T: Into<Nanoseconds>,
     {
         let timeout = timeout.into();
-        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_u64) as u32;
+        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_000_u64) as u32;
         Self::new_from_ticks(ticks)
     }
 


### PR DESCRIPTION
as of https://github.com/atsamd-rs/atsamd/pull/207 clocks were based on microsecond base with integer storage 
https://github.com/atsamd-rs/atsamd/pull/207/files#diff-50f81082e17d3ce037e13f0f58cf454fR174
which means 1_000_000/2_000_000 = .5 :(

To support both 1hz and 1mhz I think wed have to base on a nanosecond instead of microsecond
1000mhz is 1ns, so were good up to that
1hz in nanoseconds is 1_000_000_000 and is still under u32 max 4_294_967_295u32 
so I think were ok?