### PR TITLE
Pygamer and edge neopixels (probably the rest too)

### DIFF
--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "edgebadge"
 version = "0.5.0"
-authors = [
-    "Jacob Rosenthal <@jacobrosenthal>",
-]
+authors = ["Jacob Rosenthal <@jacobrosenthal>"]
 description = "Board Support crate for the Adafruit EdgeBadge"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 license = "MIT OR Apache-2.0"
@@ -59,25 +57,24 @@ usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
 math = ["micromath"]
 
 [profile.dev]
+# opt-level = 2 # uncomment for neopixel functionality during debug
 incremental = false
-codegen-units = 1
 debug = true
-lto = true
+lto = "thin" # thin for debug speed
 
 [profile.release]
 debug = true
-lto = true
-opt-level = "s"
-
+lto = "fat"
+opt-level = 3 # neopixel prefers 3 over s
 
 [[example]]
 name = "usb_serial"
-required-features = [ "usb" ]
+required-features = ["usb"]
 
 [[example]]
 name = "usb_poll"
-required-features = [ "usb" ]
+required-features = ["usb"]
 
 [[example]]
 name = "neopixel_easing"
-required-features = [ "math"]
+required-features = ["math"]

--- a/boards/edgebadge/examples/neopixel_adc_battery.rs
+++ b/boards/edgebadge/examples/neopixel_adc_battery.rs
@@ -1,4 +1,7 @@
 //! Display battery percentage on the neopixels.
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
 
 #![no_std]
 #![no_main]

--- a/boards/edgebadge/examples/neopixel_adc_light.rs
+++ b/boards/edgebadge/examples/neopixel_adc_light.rs
@@ -1,4 +1,7 @@
 //! Display light sensor reading on the neopixels.
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
 
 #![no_std]
 #![no_main]

--- a/boards/edgebadge/examples/neopixel_button.rs
+++ b/boards/edgebadge/examples/neopixel_button.rs
@@ -2,6 +2,9 @@
 //! automatically rotating through the color wheel
 //! Select and Start control a second neopixel
 //! When they overlap, joystick takes precedence
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
 
 #![no_std]
 #![no_main]

--- a/boards/edgebadge/examples/neopixel_easing.rs
+++ b/boards/edgebadge/examples/neopixel_easing.rs
@@ -1,4 +1,7 @@
 //! Blink an led without using the BSP split() method.
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
 
 #![no_std]
 #![no_main]

--- a/boards/edgebadge/examples/neopixel_rainbow_timer.rs
+++ b/boards/edgebadge/examples/neopixel_rainbow_timer.rs
@@ -1,4 +1,7 @@
 //! Rotate all neopixel leds through a rainbow. Uses a Timer as a timer source.
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
 
 #![no_std]
 #![no_main]
@@ -34,7 +37,7 @@ fn main() -> ! {
     let gclk0 = clocks.gclk0();
     let timer_clock = clocks.tc2_tc3(&gclk0).unwrap();
     let mut timer = TimerCounter::tc3_(&timer_clock, peripherals.TC3, &mut peripherals.MCLK);
-    timer.start(3_000_000u32.hz());
+    timer.start(3.mhz());
 
     let mut neopixel = pins.neopixel.init(timer, &mut pins.port);
     let mut delay = Delay::new(core.SYST, &mut clocks);

--- a/boards/edgebadge/examples/neopixel_tilt.rs
+++ b/boards/edgebadge/examples/neopixel_tilt.rs
@@ -1,4 +1,7 @@
 //! LIS3DH accelerometer example. Move the neopixel led by tilting left and right.
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
 
 #![no_std]
 #![no_main]

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -65,15 +65,15 @@ sd-card = ["embedded-sdmmc"]
 math = ["micromath"]
 
 [profile.dev]
+# opt-level = 2 # uncomment for neopixel functionality during debug
 incremental = false
-codegen-units = 1
 debug = true
-lto = true
+lto = "thin" # thin for debug speed
 
 [profile.release]
 debug = true
-lto = true
-opt-level = "s"
+lto = "fat"
+opt-level = 3 # neopixel prefers 3 over s
 
 [[example]]
 name = "usb_serial"

--- a/boards/pygamer/examples/neopixel_adc_battery.rs
+++ b/boards/pygamer/examples/neopixel_adc_battery.rs
@@ -1,4 +1,7 @@
 //! Display battery percentage on the neopixels.
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
 
 #![no_std]
 #![no_main]

--- a/boards/pygamer/examples/neopixel_adc_light.rs
+++ b/boards/pygamer/examples/neopixel_adc_light.rs
@@ -1,4 +1,7 @@
 //! Display light sensor reading on the neopixels.
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
 
 #![no_std]
 #![no_main]

--- a/boards/pygamer/examples/neopixel_button.rs
+++ b/boards/pygamer/examples/neopixel_button.rs
@@ -3,6 +3,9 @@
 //! Select and Start control a second neopixel left and right while it is
 //! automatically rotating through the color wheel
 //! When they overlap, joystick takes precedence
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
 
 #![no_std]
 #![no_main]

--- a/boards/pygamer/examples/neopixel_easing.rs
+++ b/boards/pygamer/examples/neopixel_easing.rs
@@ -1,4 +1,7 @@
 //! Randomly choose and led and color to breath in and out
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
 
 #![no_std]
 #![no_main]

--- a/boards/pygamer/examples/neopixel_rainbow_spi.rs
+++ b/boards/pygamer/examples/neopixel_rainbow_spi.rs
@@ -1,4 +1,7 @@
 //! Rotate all neopixel leds through a rainbow. Uses a luckily placed set of SPI pins as a timer source.
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
 
 #![no_std]
 #![no_main]

--- a/boards/pygamer/examples/neopixel_rainbow_timer.rs
+++ b/boards/pygamer/examples/neopixel_rainbow_timer.rs
@@ -1,4 +1,7 @@
 //! Rotate all neopixel leds through a rainbow. Uses a Timer as a timer source.
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
 
 #![no_std]
 #![no_main]
@@ -33,7 +36,7 @@ fn main() -> ! {
     let gclk0 = clocks.gclk0();
     let timer_clock = clocks.tc2_tc3(&gclk0).unwrap();
     let mut timer = TimerCounter::tc3_(&timer_clock, peripherals.TC3, &mut peripherals.MCLK);
-    timer.start(3_000_000u32.hz());
+    timer.start(3.mhz());
 
     let mut neopixel = pins.neopixel.init(timer, &mut pins.port);
     let mut delay = Delay::new(core.SYST, &mut clocks);

--- a/boards/pygamer/examples/neopixel_tilt.rs
+++ b/boards/pygamer/examples/neopixel_tilt.rs
@@ -1,4 +1,7 @@
 //! LIS3DH accelerometer example. Move the neopixel led by tilting left and right.
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
 
 #![no_std]
 #![no_main]

--- a/boards/pygamer/examples/timer.rs
+++ b/boards/pygamer/examples/timer.rs
@@ -30,8 +30,10 @@ fn main() -> ! {
     let gclk0 = clocks.gclk0();
     let timer_clock = clocks.tc2_tc3(&gclk0).unwrap();
     let mut timer = TimerCounter::tc3_(&timer_clock, peripherals.TC3, &mut peripherals.MCLK);
-    timer.start(3_000_000u32.hz());
+    timer.start(250.khz());
     let mut d5 = pins.d5.into_push_pull_output(&mut pins.port);
+
+    //50% duty cycle, so 500khz period
     loop {
         let _ = d5.set_high();
         let _ = block!(timer.wait());

--- a/boards/pygamer/examples/usb_serial.rs
+++ b/boards/pygamer/examples/usb_serial.rs
@@ -1,15 +1,19 @@
 #![no_std]
 #![no_main]
 
-/// Makes the pygamer appear as a USB serial port. The color of the
-/// neopixel LED can be changed by sending bytes to the serial port.
-///
-/// Sending the characters R, G, and O set the LED red, green, and off
-/// respectively. For example:
-/// $> sudo stty -F /dev/ttyACM0 115200 raw -echo
-/// $> sudo bash -c "echo 'R' > /dev/ttyACM0"
-/// $> sudo bash -c "echo 'G' > /dev/ttyACM0"
-/// $> sudo bash -c "echo 'O' > /dev/ttyACM0"
+//! Makes the pygamer appear as a USB serial port. The color of the
+//! neopixel LED can be changed by sending bytes to the serial port.
+//!
+//! Sending the characters R, G, and O set the LED red, green, and off
+//! respectively. For example:
+//! $> sudo stty -F /dev/ttyACM0 115200 raw -echo
+//! $> sudo bash -c "echo 'R' > /dev/ttyACM0"
+//! $> sudo bash -c "echo 'G' > /dev/ttyACM0"
+//! $> sudo bash -c "echo 'O' > /dev/ttyACM0"
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
+
 #[allow(unused_imports)]
 use panic_halt;
 use pygamer as hal;


### PR DESCRIPTION
Draft to discuss if someone else can do better than me.

Sigh neopixels are strange again. Both the timer version and the spintimer show white on debug.Still fine on release.

I can sort of hack them working with slow feature on ws2812 timer and optimizations, but then they look bad on release mode. And I dont feel great about optimizing all debug builds? Or maybe it doesnt matter?

I tried every combination of dev dependencies and I can not find a dep override that works!
```
 [profile.dev.package.micromath]
 opt-level = "s"

 [profile.dev.package.ws2812-timer-delay]
 opt-level = "s"

 [profile.dev.package.smart-leds]
 opt-level = "s"
```
```
[profile.dev.package."*"]
opt-level = 3 # enable optimizations for all dependencies for neopixel
```
But no go

Thoughts? Im leaving everyone elses boards to them.. who knows maybe yours are fine?