### PR TITLE
Update uf2conv references to match its documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ For more information, refer to the `README` files for each crate:
 
 ## Getting code onto the devices with bootloaders: uf2conv-rs
 
-[uf2conv-rs](https://github.com/sajattack/uf2conv-rs) adds a uf2 header [Microsofts HID Flashing Format (UF2)](https://github.com/microsoft/uf2/blob/86e101e3a282553756161fe12206c7a609975e70/README.md) for copying over to UF2 bootloader mass storage devices. UF2 is factory programmed extensively by [Microsoft MakeCode](https://www.microsoft.com/en-us/makecode) and [Adafruit](https://www.adafruit.com/) hardware.
+[uf2conv](https://github.com/sajattack/uf2conv-rs) adds a uf2 header [Microsofts HID Flashing Format (UF2)](https://github.com/microsoft/uf2/blob/86e101e3a282553756161fe12206c7a609975e70/README.md) for copying over to UF2 bootloader mass storage devices. UF2 is factory programmed extensively by [Microsoft MakeCode](https://www.microsoft.com/en-us/makecode) and [Adafruit](https://www.adafruit.com/) hardware.
 [cargo-binutils](https://github.com/rust-embedded/cargo-binutils) replaces the `cargo build` command to find and convert elf files into binary. 
 
 Install the dependencies
@@ -153,12 +153,12 @@ $ cargo install uf2conv cargo-binutils
 Then for say, metro_m0 examples
 ```bash
 $ cargo objcopy --example blinky_basic --features unproven --release -- -O binary blinky_basic.bin
-$ uf2conv-rs blinky_basic.bin --base 0x2000 --output blinky_basic.uf2
+$ uf2conv blinky_basic.bin --base 0x2000 --output blinky_basic.uf2
 $ cp blinky_basic.uf2 /Volumes/PYGAMERBOOT/
 ```
 
 For more information, refer to the `README` files for each crate:
-* [uf2conv-rs (`uf2conv-rs`)](https://github.com/sajattack/uf2conv-rs)
+* [uf2conv (`uf2conv-rs`)](https://github.com/sajattack/uf2conv-rs)
 * [cargo-binutils (`cargo-binutils`)](https://github.com/rust-embedded/cargo-binutils)
 
 ## Adding a new board


### PR DESCRIPTION
Just a minor change - both the [referenced source](https://github.com/sajattack/uf2conv-rs) and the uf2conv installed by Cargo on my system reference a `uf2conv` not `uf2conv-rs`.

