### PR TITLE
Fix rx/tx pin assignments for Feather M4

### DIFF
--- a/boards/feather_m4/examples/serial.rs
+++ b/boards/feather_m4/examples/serial.rs
@@ -35,11 +35,11 @@ fn main() -> ! {
     let mut pins = hal::Pins::new(peripherals.PORT);
     let mut delay = Delay::new(core.SYST, &mut clocks);
     
-    let tx: Sercom5Pad1<_> = pins
+    let tx: Sercom5Pad0<_> = pins
         .d1
         .into_pull_down_input(&mut pins.port)
         .into_pad(&mut pins.port);
-    let rx: Sercom5Pad0<_> = pins
+    let rx: Sercom5Pad1<_> = pins
         .d0
         .into_pull_down_input(&mut pins.port)
         .into_pad(&mut pins.port);
@@ -52,7 +52,7 @@ fn main() -> ! {
         Hertz(19200),
         peripherals.SERCOM5,
         &mut peripherals.MCLK,
-        (tx, rx),
+        (rx, tx),
     );
     
     loop {

--- a/boards/feather_m4/examples/uart_poll_echo.rs
+++ b/boards/feather_m4/examples/uart_poll_echo.rs
@@ -43,11 +43,11 @@ fn main() -> ! {
     let mut delay = Delay::new(core.SYST, &mut clocks);
     let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
     
-    let tx: Sercom5Pad1<_> = pins
+    let tx: Sercom5Pad0<_> = pins
         .d1
         .into_pull_down_input(&mut pins.port)
         .into_pad(&mut pins.port);
-    let rx: Sercom5Pad0<_> = pins
+    let rx: Sercom5Pad1<_> = pins
         .d0
         .into_pull_down_input(&mut pins.port)
         .into_pad(&mut pins.port);
@@ -60,7 +60,7 @@ fn main() -> ! {
         Hertz(19200),
         peripherals.SERCOM5,
         &mut peripherals.MCLK,
-        (tx, rx),
+        (rx, tx),
     );
 
     // Write out a message on start up

--- a/boards/feather_m4/src/lib.rs
+++ b/boards/feather_m4/src/lib.rs
@@ -48,9 +48,9 @@ define_pins!(
     pin a5 = a6,
 
     /// Pin 0, rx
-    pin d0 = b16,
+    pin d0 = b17,
     /// Pin 1, tx
-    pin d1 = b17,
+    pin d1 = b16,
     /// Pin 4, PWM capable
     pin d4 = a14,
 
@@ -158,7 +158,9 @@ pub fn uart<F: Into<Hertz>>(
     port: &mut Port,
 ) -> UART5<
         hal::sercom::Sercom5Pad1<gpio::Pb17<PfC>>,
-        hal::sercom::Sercom5Pad0<gpio::Pb16<PfC>>, (), ()
+        hal::sercom::Sercom5Pad0<gpio::Pb16<PfC>>,
+        (),
+        ()
     > {
     let gclk0 = clocks.gclk0();
 


### PR DESCRIPTION
The `rx` and `tx` pin assignments for this board were swapped in `lib.rs`. This PR corrects them.

Closes #229.