### PR TITLE
panic_led feature to light d13 on panic

### DIFF
--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -62,6 +62,7 @@ unproven = ["atsamd-hal/unproven"]
 usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
 sd-card = ["embedded-sdmmc"]
 math = ["micromath"]
+panic_led = []
 
 [profile.dev]
 # opt-level = 2 # uncomment for neopixel functionality during debug

--- a/boards/pygamer/examples/blinky_basic.rs
+++ b/boards/pygamer/examples/blinky_basic.rs
@@ -3,6 +3,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/button_rtic.rs
+++ b/boards/pygamer/examples/button_rtic.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/clock_out.rs
+++ b/boards/pygamer/examples/clock_out.rs
@@ -3,6 +3,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/ferris_img.rs
+++ b/boards/pygamer/examples/ferris_img.rs
@@ -10,6 +10,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/neopixel_adc_battery.rs
+++ b/boards/pygamer/examples/neopixel_adc_battery.rs
@@ -6,6 +6,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/neopixel_adc_light.rs
+++ b/boards/pygamer/examples/neopixel_adc_light.rs
@@ -6,6 +6,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/neopixel_button.rs
+++ b/boards/pygamer/examples/neopixel_button.rs
@@ -10,6 +10,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/neopixel_easing.rs
+++ b/boards/pygamer/examples/neopixel_easing.rs
@@ -6,6 +6,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/neopixel_rainbow_spi.rs
+++ b/boards/pygamer/examples/neopixel_rainbow_spi.rs
@@ -7,6 +7,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/neopixel_rainbow_timer.rs
+++ b/boards/pygamer/examples/neopixel_rainbow_timer.rs
@@ -6,6 +6,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/neopixel_tilt.rs
+++ b/boards/pygamer/examples/neopixel_tilt.rs
@@ -7,6 +7,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/pwm_tc4.rs
+++ b/boards/pygamer/examples/pwm_tc4.rs
@@ -3,6 +3,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/pwm_tcc0.rs
+++ b/boards/pygamer/examples/pwm_tcc0.rs
@@ -3,6 +3,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/sd_card.rs
+++ b/boards/pygamer/examples/sd_card.rs
@@ -14,6 +14,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/timer.rs
+++ b/boards/pygamer/examples/timer.rs
@@ -4,6 +4,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/usb_poll.rs
+++ b/boards/pygamer/examples/usb_poll.rs
@@ -4,6 +4,7 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/examples/usb_serial.rs
+++ b/boards/pygamer/examples/usb_serial.rs
@@ -1,6 +1,3 @@
-#![no_std]
-#![no_main]
-
 //! Makes the pygamer appear as a USB serial port. The color of the
 //! neopixel LED can be changed by sending bytes to the serial port.
 //!
@@ -14,6 +11,10 @@
 //! Note leds may appear white during debug. Either build for release or add
 //! opt-level = 2 to profile.dev in Cargo.toml
 
+#![no_std]
+#![no_main]
+
+#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 use pygamer as hal;
 

--- a/boards/pygamer/src/lib.rs
+++ b/boards/pygamer/src/lib.rs
@@ -28,3 +28,18 @@ pub mod util {
         ((input - from_range.0) as f32 / from * to + to_range.0 as f32) as i16
     }
 }
+
+#[cfg(feature = "panic_led")]
+#[inline(never)]
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    use embedded_hal::digital::v2::OutputPin;
+
+    let peripherals = unsafe { crate::pac::Peripherals::steal() };
+    let mut pins = Pins::new(peripherals.PORT);
+    let _ = pins.d13.into_open_drain_output(&mut pins.port).set_high();
+
+    loop {
+        cortex_m::asm::udf()
+    }
+}


### PR DESCRIPTION
I often have a debugger but folks in users groups dont and this keeps coming up. 

I keep thinking of doing a panic to screen, or use panic persist and then read to screen on next reboot, but that would sacrifice memory and a non standard memory.x just doesnt fit in for general usage. I think this is the next best thing. 

I thought maybe I could put this in a crate but invariably it needs to have access to pac or hal, and I was getting duplicated interrupts and things. Maybe its solvable? Also it would have to keep in sync with versions. So maybe just in a bsp is a good place after all?

Also Id be happy to use the hal to set the led if I could find a way to conjure the gpio pin. Anyone know a way to do that? 

