### PR TITLE
Fix typo in pin assignment on nano33

### DIFF
--- a/boards/arduino_nano33iot/src/lib.rs
+++ b/boards/arduino_nano33iot/src/lib.rs
@@ -108,7 +108,7 @@ define_pins!(
     /// SPI (Lefacy ICSP) 4 / NINA SCK
     pin nina_sck = a15,
     pin nina_gpio0 = a27,
-    pin nina_resetn = a8,
+    pin nina_resetn = b8,
     pin nina_ack = a28,
 
     /// SerialNina 29: PWM, TC


### PR DESCRIPTION
Noted this while hacking on adding the mkrwifi1010; I think the current pin assignment has a typo?

According to page 3 on https://content.arduino.cc/assets/Pinout-NANO33IoT_latest.pdf, nina_resetn is at b8, not a8