### PR TITLE
Make SERCOM6/7 available for SPI on ATSAMD51P19A

### DIFF
--- a/hal/src/samd51/clock.rs
+++ b/hal/src/samd51/clock.rs
@@ -309,7 +309,7 @@ impl GenericClockController {
 }
 
 macro_rules! clock_generator {
-    ($(($id:ident, $Type:ident, $clock:ident),)+) => {
+    ($($(#[$attr:meta])* ($id:ident, $Type:ident, $clock:ident),)+) => {
 
 $(
 /// A typed token that indicates that the clock for the peripheral(s)
@@ -319,17 +319,20 @@ $(
 /// The peripheral initialization code will typically require passing
 /// in this object to prove at compile time that the clock has been
 /// correctly initialized.
+$(#[$attr])*
 #[derive(Debug)]
 pub struct $Type {
     freq: Hertz,
 }
 
+$(#[$attr])*
 impl $Type {
     /// Returns the frequency of the configured clock
     pub fn freq(&self) -> Hertz {
         self.freq
     }
 }
+$(#[$attr])*
 impl Into<Hertz> for $Type {
     fn into(self) -> Hertz {
         self.freq
@@ -351,6 +354,7 @@ impl GenericClockController {
     /// appropriately.
     /// Returns `None` is the specified generic clock has already been
     /// configured.
+    $(#[$attr])*
     pub fn $id(&mut self, generator: &GClock) -> Option<$Type> {
         let bits: u64 = 1<< u8::from(ClockId::$clock) as u64;
         if (self.used_clocks & bits) != 0 {
@@ -381,6 +385,10 @@ clock_generator!(
     (sercom3_core, Sercom3CoreClock, SERCOM3_CORE),
     (sercom4_core, Sercom4CoreClock, SERCOM4_CORE),
     (sercom5_core, Sercom5CoreClock, SERCOM5_CORE),
+    #[cfg(feature = "samd51p19a")]
+    (sercom6_core, Sercom6CoreClock, SERCOM6_CORE),
+    #[cfg(feature = "samd51p19a")]
+    (sercom7_core, Sercom7CoreClock, SERCOM7_CORE),
     (usb, UsbClock, USB),
     (adc0, Adc0Clock, ADC0),
     (adc1, Adc1Clock, ADC1),

--- a/hal/src/samd51/sercom/spi.rs
+++ b/hal/src/samd51/sercom/spi.rs
@@ -5,6 +5,8 @@ use crate::spi_common::CommonSpi;
 use crate::target_device::sercom0::SPIM;
 use crate::target_device::{MCLK, SERCOM0, SERCOM1, SERCOM2, SERCOM3};
 use crate::target_device::{SERCOM4, SERCOM5};
+#[cfg(feature = "samd51p19a")]
+use crate::target_device::{SERCOM6, SERCOM7};
 use crate::time::Hertz;
 
 #[derive(Debug)]
@@ -240,3 +242,7 @@ spi_master!(SPIMaster2: (Sercom2, SERCOM2, sercom2_, Sercom2CoreClock, apbbmask)
 spi_master!(SPIMaster3: (Sercom3, SERCOM3, sercom3_, Sercom3CoreClock, apbbmask));
 spi_master!(SPIMaster4: (Sercom4, SERCOM4, sercom4_, Sercom4CoreClock, apbdmask));
 spi_master!(SPIMaster5: (Sercom5, SERCOM5, sercom5_, Sercom5CoreClock, apbdmask));
+#[cfg(feature = "samd51p19a")]
+spi_master!(SPIMaster6: (Sercom6, SERCOM6, sercom6_, Sercom6CoreClock, apbdmask));
+#[cfg(feature = "samd51p19a")]
+spi_master!(SPIMaster7: (Sercom7, SERCOM7, sercom7_, Sercom7CoreClock, apbdmask));


### PR DESCRIPTION
This PR allows SPI on the "extra" SERCOMs of the ATSAMD51P19A.