### PR TITLE
Add missing SERCOM pins for SAMD51

### DIFF
--- a/hal/src/samd51/sercom/pads.rs
+++ b/hal/src/samd51/sercom/pads.rs
@@ -284,6 +284,7 @@ pad!(Sercom7Pad0 {
     Pb21(PfD),
     Pc12(PfC),
     Pd8(PfC),
+    Pb30(PfC),
 });
 
 #[cfg(feature = "samd51p19a")]
@@ -291,6 +292,7 @@ pad!(Sercom7Pad1 {
     Pb20(PfD),
     Pc13(PfC),
     Pd9(PfC),
+    Pb31(PfC),
 });
 
 #[cfg(feature = "samd51p19a")]


### PR DESCRIPTION
Add missing pins PB30 and PB31 to the SERCOM HAL as options for SERCOM7
in SAMD51 chips