### PR TITLE
Add support for Dotstar on Trinket M0

### DIFF
--- a/boards/trinket_m0/Cargo.toml
+++ b/boards/trinket_m0/Cargo.toml
@@ -13,6 +13,9 @@ documentation = "https://atsamd-rs.github.io/atsamd/atsamd21e18a/trinket_m0/"
 [dependencies]
 cortex-m = "~0.6.2"
 embedded-hal = "~0.2.3"
+bitbang-hal = "~0.3"
+apa102-spi = "~0.3"
+smart-leds = "~0.3"
 nb = "~0.1"
 
 [dependencies.cortex-m-rt]
@@ -56,3 +59,7 @@ name = "watchdog"
 [[example]]
 name = "usb_serial"
 required-features = ["usb"]
+
+[[example]]
+name = "dotstar"
+required-features = ["unproven"]

--- a/boards/trinket_m0/Cargo.toml
+++ b/boards/trinket_m0/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.7.0"
 authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit Trinket M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"

--- a/boards/trinket_m0/examples/blinky_basic.rs
+++ b/boards/trinket_m0/examples/blinky_basic.rs
@@ -1,8 +1,8 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
-extern crate trinket_m0 as hal;
+use panic_halt as _;
+use trinket_m0 as hal;
 
 use hal::clock::GenericClockController;
 use hal::delay::Delay;

--- a/boards/trinket_m0/examples/dotstar.rs
+++ b/boards/trinket_m0/examples/dotstar.rs
@@ -1,0 +1,58 @@
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+use trinket_m0 as hal;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+use hal::timer::SpinTimer;
+
+use smart_leds::{hsv::RGB8, SmartLedsWrite};
+
+fn rgb_wheel(position: u8) -> RGB8 {
+    match position {
+        0..=85 => {
+            RGB8 { r: (255 - position * 3), g: (position * 3), b: 0 }
+        }
+        86..=170 => {
+            let position = position - 85;
+            RGB8 { r: 0, g: (255 - position * 3), b: (position * 3) }
+        }
+        _ => {
+            let position = position - 170;
+            RGB8 { r: (position * 3), g: 0, b: (255 - position * 3) }
+        }
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT).split();
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+    let mut rgb = pins.dotstar.init(SpinTimer::new(12), &mut pins.port);
+
+
+    let mut val = 0;
+    loop {
+        // Can't use the modulo operator on a u8 with an overflowing u8 or with a u16
+        val = match val {
+            255 => 0,
+            _ => val + 1
+        };
+        let color: [RGB8; 1] = [rgb_wheel(val)];
+        rgb.write(color.iter().cloned()).unwrap();
+        delay.delay_ms(60u8);
+    }
+}

--- a/boards/trinket_m0/examples/pwm.rs
+++ b/boards/trinket_m0/examples/pwm.rs
@@ -1,9 +1,8 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
-extern crate trinket_m0 as hal;
-extern crate cortex_m_rt;
+use panic_halt as _;
+use trinket_m0 as hal;
 
 use hal::clock::GenericClockController;
 use hal::pac::{Peripherals, CorePeripherals};

--- a/boards/trinket_m0/examples/usb_serial.rs
+++ b/boards/trinket_m0/examples/usb_serial.rs
@@ -1,11 +1,8 @@
 #![no_std]
 #![no_main]
 
-extern crate trinket_m0 as hal;
-extern crate panic_halt;
-extern crate usbd_serial;
-extern crate usb_device;
-extern crate cortex_m;
+use panic_halt as _;
+use trinket_m0 as hal;
 
 use hal::clock::GenericClockController;
 use hal::prelude::*;

--- a/boards/trinket_m0/examples/watchdog.rs
+++ b/boards/trinket_m0/examples/watchdog.rs
@@ -1,8 +1,8 @@
 #![no_std]
 #![no_main]
 
-extern crate panic_halt;
-extern crate trinket_m0 as hal;
+use panic_halt as _;
+use trinket_m0 as hal;
 
 use core::fmt::Write;
 

--- a/boards/trinket_m0/src/lib.rs
+++ b/boards/trinket_m0/src/lib.rs
@@ -14,11 +14,17 @@ pub use hal::target_device as pac;
 pub use hal::common::*;
 pub use hal::samd21::*;
 
-use gpio::{Floating, Input, PfD, Port};
+use gpio::{self, *};
 
 use hal::clock::GenericClockController;
+use hal::define_pins;
 use hal::sercom::{I2CMaster2, PadPin, UART0};
 use hal::time::Hertz;
+
+#[cfg(feature = "unproven")]
+use embedded_hal::timer::{CountDown, Periodic};
+#[cfg(feature = "unproven")]
+use apa102_spi::Apa102;
 
 #[cfg(feature = "usb")]
 use hal::usb::usb_device::bus::UsbBusAllocator;
@@ -49,6 +55,9 @@ define_pins!(
     pin dotstar_ci = a1,
     /// The DotStar data line
     pin dotstar_di = a0,
+    /// Not connected, but usable as the MISO when addressing
+    /// the dotstar over SPI.
+    pin dotstar_nc = a14,
 
     pin swdio = a31,
     pin swdclk = a30,
@@ -63,6 +72,172 @@ define_pins!(
     /// The USB D+ pad
     pin usb_dp = a25,
 );
+
+impl Pins {
+    /// Split the device pins into subsets
+    pub fn split(self) -> Sets {
+        let dotstar = Dotstar {
+            ci: self.dotstar_ci,
+            di: self.dotstar_di,
+            nc: self.dotstar_nc,
+        };
+
+        let i2c = I2C {
+            sda: self.d0,
+            scl: self.d2,
+        };
+
+        let usb = USB {
+            dm: self.usb_dm,
+            dp: self.usb_dp,
+        };
+
+        let uart = UART {
+            rx: self.d3,
+            tx: self.d4,
+        };
+
+        Sets {
+            dotstar,
+            i2c,
+            usb,
+            uart,
+            port: self.port,
+        }
+    }
+}
+
+
+/// Sets of pins split apart by category
+pub struct Sets {
+
+    /// Dotstar (RGB LED) pins
+    pub dotstar: Dotstar,
+
+    /// I2C (external pinout) pins
+    pub i2c: I2C,
+
+    /// USB pins
+    pub usb: USB,
+
+    /// UART (external pinout) pins
+    pub uart: UART,
+
+    /// Port
+    pub port: Port,
+}
+
+/// Dotstar pins
+pub struct Dotstar {
+    pub ci: gpio::Pa1<Input<Floating>>,
+    pub di: gpio::Pa0<Input<Floating>>,
+    // Pa14 is NC on the Trinket M0, so its safe to use
+    // as the MISO given the HAL requires it.
+    pub nc: gpio::Pa14<Input<Floating>>,
+}
+
+impl Dotstar {
+    #[cfg(feature = "unproven")]
+    pub fn init<T: CountDown + Periodic>(
+        self,
+        timer: T,
+        port: &mut Port,
+    ) -> apa102_spi::Apa102<
+        bitbang_hal::spi::SPI<gpio::Pa14<Input<PullUp>>, gpio::Pa0<Output<PushPull>>, gpio::Pa1<Output<PushPull>>, T>,
+    > {
+        let di = self.di.into_push_pull_output(port);
+        let ci = self.ci.into_push_pull_output(port);
+        let nc = self.nc.into_pull_up_input(port);
+
+        let spi = bitbang_hal::spi::SPI::new(apa102_spi::MODE, nc, di, ci, timer);
+        Apa102::new_with_custom_postamble(spi, 4, false)
+    }
+}
+
+/// I2C pins
+pub struct I2C {
+    pub sda: gpio::Pa8<Input<Floating>>,
+    pub scl: gpio::Pa9<Input<Floating>>,
+}
+
+impl I2C {
+    pub fn init<F: Into<Hertz>>(
+        self,
+        clocks: &mut GenericClockController,
+        bus_speed: F,
+        sercom2: pac::SERCOM2,
+        pm: &mut pac::PM,
+        port: &mut Port,
+    ) -> I2CMaster2<
+        hal::sercom::Sercom2Pad0<gpio::Pa8<PfD>>,
+        hal::sercom::Sercom2Pad1<gpio::Pa9<PfD>>,
+    > {
+        let gclk0 = clocks.gclk0();
+
+        I2CMaster2::new(
+            &clocks.sercom2_core(&gclk0).unwrap(),
+            bus_speed.into(),
+            sercom2,
+            pm,
+            self.sda.into_pad(port),
+            self.scl.into_pad(port),
+        )
+    }
+}
+
+/// Convenience for setting up the D0 and D2 pins to operate as I²C
+/// SDA/SDL (respectively) running at the specified baud.
+pub fn i2c_master<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    bus_speed: F,
+    sercom2: pac::SERCOM2,
+    pm: &mut pac::PM,
+    sda: gpio::Pa8<Input<Floating>>,
+    scl: gpio::Pa9<Input<Floating>>,
+    port: &mut Port,
+) -> I2CMaster2<
+    hal::sercom::Sercom2Pad0<gpio::Pa8<PfD>>,
+    hal::sercom::Sercom2Pad1<gpio::Pa9<PfD>>,
+> {
+    let gclk0 = clocks.gclk0();
+
+    I2CMaster2::new(
+        &clocks.sercom2_core(&gclk0).unwrap(),
+        bus_speed.into(),
+        sercom2,
+        pm,
+        sda.into_pad(port),
+        scl.into_pad(port),
+    )
+}
+
+/// UART pins
+pub struct UART {
+    pub rx: gpio::Pa7<Input<Floating>>,
+    pub tx: gpio::Pa6<Input<Floating>>,
+}
+
+impl UART {
+    pub fn init<F: Into<Hertz>>(
+        self,
+        clocks: &mut GenericClockController,
+        baud: F,
+        sercom0: pac::SERCOM0,
+        pm: &mut pac::PM,
+        port: &mut Port,
+    ) -> UART0<hal::sercom::Sercom0Pad3<gpio::Pa7<PfD>>, hal::sercom::Sercom0Pad2<gpio::Pa6<PfD>>, (), ()>
+    {
+        let gclk0 = clocks.gclk0();
+
+        UART0::new(
+            &clocks.sercom0_core(&gclk0).unwrap(),
+            baud.into(),
+            sercom0,
+            pm,
+            (self.rx.into_pad(port), self.tx.into_pad(port)),
+        )
+    }
+}
 
 /// Convenience for setting up the D3 and D4 pins to
 /// operate as UART RX/TX (respectively) running at the specified baud.
@@ -87,30 +262,34 @@ pub fn uart<F: Into<Hertz>>(
     )
 }
 
-/// Convenience for setting up the D0 and D2 pins to operate as I²C
-/// SDA/SDL (respectively) running at the specified baud.
-pub fn i2c_master<F: Into<Hertz>>(
-    clocks: &mut GenericClockController,
-    bus_speed: F,
-    sercom2: pac::SERCOM2,
-    pm: &mut pac::PM,
-    sda: gpio::Pa8<Input<Floating>>,
-    scl: gpio::Pa9<Input<Floating>>,
-    port: &mut Port,
-) -> I2CMaster2<
-    hal::sercom::Sercom2Pad0<gpio::Pa8<gpio::PfD>>,
-    hal::sercom::Sercom2Pad1<gpio::Pa9<gpio::PfD>>,
-> {
-    let gclk0 = clocks.gclk0();
 
-    I2CMaster2::new(
-        &clocks.sercom2_core(&gclk0).unwrap(),
-        bus_speed.into(),
-        sercom2,
-        pm,
-        sda.into_pad(port),
-        scl.into_pad(port),
-    )
+/// USB pins
+pub struct USB {
+    pub dm: gpio::Pa24<Input<Floating>>,
+    pub dp: gpio::Pa25<Input<Floating>>,
+}
+
+impl USB {
+    #[cfg(feature = "usb")]
+    pub fn init(
+        self,
+        usb: pac::USB,
+        clocks: &mut GenericClockController,
+        pm: &mut pac::PM,
+        port: &mut Port,
+    ) -> UsbBusAllocator<UsbBus> {
+
+        let gclk0 = clocks.gclk0();
+        let usb_clock = &clocks.usb(&gclk0).unwrap();
+
+        UsbBusAllocator::new(UsbBus::new(
+            usb_clock,
+            pm,
+            self.dm.into_function(port),
+            self.dp.into_function(port),
+            usb,
+        ))
+    }
 }
 
 #[cfg(feature = "usb")]
@@ -122,7 +301,6 @@ pub fn usb_allocator(
     dp: gpio::Pa25<Input<Floating>>,
     port: &mut Port,
 ) -> UsbBusAllocator<UsbBus> {
-    use gpio::IntoFunction;
 
     let gclk0 = clocks.gclk0();
     let usb_clock = &clocks.usb(&gclk0).unwrap();


### PR DESCRIPTION
### Summary
Adding Dotstar support & example to boards/trinket_m0.

Built and flashed to board with rustc 1.44.1

### Changelog
- Specified Rust 2018 edition (for `apa102_spi` and `embedded_hal` support)
  - Also migrated previous examples from extern to use syntax (all tested)
- Added examples/dotstar.rs based on previous work
- Updated Cargo.toml with required dependencies for dotstar
- Added Pins and convenience structs to lib.rs
  - Not separated to a pins.rs, but this could be done

### History
Based on previously accepted dotstar PR #244 