### PR TITLE
fix(pwm): Limit pwm re-export to unproven

### DIFF
--- a/hal/src/samd51/mod.rs
+++ b/hal/src/samd51/mod.rs
@@ -7,4 +7,5 @@ pub mod usb;
 
 // This is merely to avoid breaking the public API.
 // Added after the PWM module was refactored into common.
+#[cfg(feature = "unproven")]
 pub use crate::pwm;

--- a/hal/src/same54/mod.rs
+++ b/hal/src/same54/mod.rs
@@ -7,4 +7,5 @@ pub mod usb;
 
 // This is merely to avoid breaking the public API.
 // Added after the PWM module was refactored into common.
+#[cfg(feature = "unproven")]
 pub use crate::pwm;


### PR DESCRIPTION
The SAMD51 and SAME54 HALs re-export the `pwm` module to avoid breaking
the previous, public API. The `pwm` module is currently unproven, but
the re-export occurred regardless, creating an error when building
without the `unproven` feature. Add a `cfg` attribute to limit the
re-export to builds with the `unproven` feature.