### PR TITLE
Add dependencies for the I2C SSD1306 example

### DIFF
--- a/boards/arduino_nano33iot/Cargo.toml
+++ b/boards/arduino_nano33iot/Cargo.toml
@@ -41,7 +41,7 @@ default-features = false
 features = ["small_rng"]
 
 [dependencies.ssd1306]
-version ="0.3.1"
+version ="~0.4"
 features=["graphics"]
 
 [features]

--- a/boards/arduino_nano33iot/Cargo.toml
+++ b/boards/arduino_nano33iot/Cargo.toml
@@ -35,6 +35,14 @@ optional = true
 version = "~0.1"
 optional = true
 
+[dependencies.rand]
+version = "~0.7.3"
+default-features = false
+features = ["small_rng"]
+
+[dependencies.ssd1306]
+version ="0.3.1"
+features=["graphics"]
 
 [features]
 # ask the HAL to enable atsamd21g18a support
@@ -51,3 +59,6 @@ name = "blinky_basic"
 [[example]]
 name = "usb_logging"
 required-features = ["usb"]
+
+[[example]]
+name = "i2c_ssd1306"


### PR DESCRIPTION
Note: at the moment the newest version of the SSD1306 crate must be 0.3.1 as specified: v0.4 introduced some changes that break this code.