### PR TITLE
Add the `fast_finish` flag to the Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,10 @@ env:
   - CRATE=boards/edgebadge FEATURES="--features=unproven"
   - CRATE=boards/xiao_m0 EXAMPLES="--example=blink --example=usb_serial" FEATURES="--features=usb"
 
-matrix:
+jobs:
   allow_failures:
     - rust: nightly
+  fast_finish: true
 
 before_install:
   - rustup target add thumbv6m-none-eabi
@@ -42,6 +43,3 @@ before_install:
 script:
   - "cd $CRATE"
   - "cargo build ${EXAMPLES:---examples} $FEATURES $BUILDMODE"
-
-stages:
-  - test


### PR DESCRIPTION
I changed `matrix` to `jobs` because I had a hell of a time trying to find any information on `matrix` before discovering it was an alias for `jobs`.

This gives us a pass/fail after ~10 minutes rather than ~20.