### PR TITLE
Improve instructions for OSX users (and nudge people towards cargo-binutils)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ In addition to the PACs and HAL, there numerous **B**oard **S**upport **P**ackag
 
 Make sure that you have a new enough version of the gcc toolchain; the one installable even on recent versions of Ubuntu can fail to correctly link the vector table:
 
+**Note** you may be able to avoid this step if using `cargo-binutils`. See board specific instructions in `boards/` for more details.
+
 ```bash
 $ sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
 $ sudo apt update
@@ -104,6 +106,7 @@ $ cargo build --example blinky_basic
 $ arm-none-eabi-objcopy -O binary \
     target/thumbv6m-none-eabi/debug/examples/blinky_basic \
     target/thumbv6m-none-eabi/debug/examples/blinky_basic.bin
+# if using cargo-binutils, you can `rust-objcopy` with the same flags, or combine the previous 2 steps with `cargo objcopy`
 $ stty -F /dev/ttyACM1 ospeed 1200
 $ ~/.arduino15/packages/arduino/tools/bossac/1.7.0/bossac -i -d \
     --port=ttyACM1 -U -e -w -v \

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ In addition to the PACs and HAL, there numerous **B**oard **S**upport **P**ackag
 
 Make sure that you have a new enough version of the gcc toolchain; the one installable even on recent versions of Ubuntu can fail to correctly link the vector table:
 
-**Note** you may be able to avoid this step if using `cargo-binutils`. See board specific instructions in `boards/` for more details.
+**Note**: you may be able to avoid this step if using `cargo-binutils`. See board specific instructions in `boards/` for more details.
 
 ```bash
 $ sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y

--- a/boards/arduino_mkr1000/README.md
+++ b/boards/arduino_mkr1000/README.md
@@ -9,12 +9,16 @@ This crate provides a type-safe API for working with the [Arduino MKR WiFi 1000 
 #### Requirements
 
  - Arduino IDE installed
-    - samd package installed
+    - samd package installed (You can do this by going to Tools->Board->BoardManager and then searching for `samd`
+    - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0[-arduino3]/` add it to your path
+       - *linux* `ArduinoData` is likely something like `~/.arduino15/`
+       - *OSX* `ArduinoData` is likely something like `~/Library/Arduino15`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
        - `ArduinoData` is likely something like `~/.arduino15/`
     - Probably best to install an example sketch via the IDE just to make sure everything is working
     - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
  - arm-none-eabi tools installed, you need gcc and objcopy.
+   -  **Note** Alternatively, you can use [cargo-binutils](https://github.com/rust-embedded/cargo-binutils), which is likely easier to install on OSX and also easier to use, as it will automatically detect the target
  - thumbv6m-none-eabi rust target installed via `rustup target add thumbv6m-none-eabi`
 
 #### Steps
@@ -25,6 +29,7 @@ This sets the device in a bootloader mode.
 ```bash
 cargo build --release --example blinky_basic
 arm-none-eabi-objcopy -O binary target/thumbv6m-none-eabi/release/examples/blinky_basic target/blinky_basic.bin
+# if using cargo-binutils, you can `rust-objcopy` with the same flags, or combine the previous 2 steps with `cargo objcopy`
 bossac -i -d -U true -i -e -w -v target/blinky_basic.bin -R
 ```
 

--- a/boards/arduino_mkr1000/README.md
+++ b/boards/arduino_mkr1000/README.md
@@ -11,8 +11,8 @@ This crate provides a type-safe API for working with the [Arduino MKR WiFi 1000 
  - Arduino IDE installed
     - samd package installed (You can do this by going to Tools->Board->BoardManager and then searching for `samd`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0[-arduino3]/` add it to your path
-       - *linux* `ArduinoData` is likely something like `~/.arduino15/`
-       - *OSX* `ArduinoData` is likely something like `~/Library/Arduino15`
+       - **linux** `ArduinoData` is likely something like `~/.arduino15/`
+       - **OSX** `ArduinoData` is likely something like `~/Library/Arduino15`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
        - `ArduinoData` is likely something like `~/.arduino15/`
     - Probably best to install an example sketch via the IDE just to make sure everything is working

--- a/boards/arduino_mkr1000/README.md
+++ b/boards/arduino_mkr1000/README.md
@@ -11,14 +11,14 @@ This crate provides a type-safe API for working with the [Arduino MKR WiFi 1000 
  - Arduino IDE installed
     - samd package installed (You can do this by going to Tools->Board->BoardManager and then searching for `samd`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0[-arduino3]/` add it to your path
-       - **linux** `ArduinoData` is likely something like `~/.arduino15/`
-       - **OSX** `ArduinoData` is likely something like `~/Library/Arduino15`
+       - **linux**: `ArduinoData` is likely something like `~/.arduino15/`
+       - **OSX**: `ArduinoData` is likely something like `~/Library/Arduino15`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
        - `ArduinoData` is likely something like `~/.arduino15/`
     - Probably best to install an example sketch via the IDE just to make sure everything is working
     - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
  - arm-none-eabi tools installed, you need gcc and objcopy.
-   -  **Note** Alternatively, you can use [cargo-binutils](https://github.com/rust-embedded/cargo-binutils), which is likely easier to install on OSX and also easier to use, as it will automatically detect the target
+   -  **Note**: Alternatively, you can use [cargo-binutils](https://github.com/rust-embedded/cargo-binutils), which is likely easier to install on OSX and also easier to use, as it will automatically detect the target
  - thumbv6m-none-eabi rust target installed via `rustup target add thumbv6m-none-eabi`
 
 #### Steps

--- a/boards/arduino_mkrvidor4000/README.md
+++ b/boards/arduino_mkrvidor4000/README.md
@@ -6,11 +6,15 @@ This crate provides a type-safe API for working with the [Arduino MKR Vidor boar
 ### Blinky Basic
 #### Requirements
  - Arduino IDE installed
-    - samd package installed
+    - samd package installed (You can do this by going to Tools->Board->BoardManager and then searching for `samd`
+    - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0[-arduino3]/` add it to your path
+       - *linux* `ArduinoData` is likely something like `~/.arduino15/`
+       - *OSX* `ArduinoData` is likely something like `~/Library/Arduino15`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
     - Probably best to install an example sketch via the IDE just to make sure everything is working
     - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
  - arm-none-eabi tools installed, you need gcc and objcopy.
+   -  **Note** Alternatively, you can use [cargo-binutils](https://github.com/rust-embedded/cargo-binutils), which is likely easier to install on OSX and also easier to use, as it will automatically detect the target
  - thumbv6m-none-eabi rust target installed via `rustup target add thumbv6m-none-eabi`
 
 #### Steps
@@ -18,6 +22,7 @@ This crate provides a type-safe API for working with the [Arduino MKR Vidor boar
 ```bash
 cargo build --release --example blinky_basic
 arm-none-eabi-objcopy -O binary target/thumbv6m-none-eabi/release/examples/blinky_basic target/blinky_basic.bin
+# if using cargo-binutils, you can `rust-objcopy` with the same flags, or combine the previous 2 steps with `cargo objcopy`
 ```
 
 Then, press the reset button twice quickly on the board. The red LED should be fading in and out. Now you can flash the board.

--- a/boards/arduino_mkrvidor4000/README.md
+++ b/boards/arduino_mkrvidor4000/README.md
@@ -8,13 +8,13 @@ This crate provides a type-safe API for working with the [Arduino MKR Vidor boar
  - Arduino IDE installed
     - samd package installed (You can do this by going to Tools->Board->BoardManager and then searching for `samd`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0[-arduino3]/` add it to your path
-       - **linux** `ArduinoData` is likely something like `~/.arduino15/`
-       - **OSX** `ArduinoData` is likely something like `~/Library/Arduino15`
+       - **linux**: `ArduinoData` is likely something like `~/.arduino15/`
+       - **OSX**: `ArduinoData` is likely something like `~/Library/Arduino15`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
     - Probably best to install an example sketch via the IDE just to make sure everything is working
     - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
  - arm-none-eabi tools installed, you need gcc and objcopy.
-   -  **Note** Alternatively, you can use [cargo-binutils](https://github.com/rust-embedded/cargo-binutils), which is likely easier to install on OSX and also easier to use, as it will automatically detect the target
+   -  **Note**: Alternatively, you can use [cargo-binutils](https://github.com/rust-embedded/cargo-binutils), which is likely easier to install on OSX and also easier to use, as it will automatically detect the target
  - thumbv6m-none-eabi rust target installed via `rustup target add thumbv6m-none-eabi`
 
 #### Steps

--- a/boards/arduino_mkrvidor4000/README.md
+++ b/boards/arduino_mkrvidor4000/README.md
@@ -8,8 +8,8 @@ This crate provides a type-safe API for working with the [Arduino MKR Vidor boar
  - Arduino IDE installed
     - samd package installed (You can do this by going to Tools->Board->BoardManager and then searching for `samd`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0[-arduino3]/` add it to your path
-       - *linux* `ArduinoData` is likely something like `~/.arduino15/`
-       - *OSX* `ArduinoData` is likely something like `~/Library/Arduino15`
+       - **linux** `ArduinoData` is likely something like `~/.arduino15/`
+       - **OSX** `ArduinoData` is likely something like `~/Library/Arduino15`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
     - Probably best to install an example sketch via the IDE just to make sure everything is working
     - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section

--- a/boards/arduino_mkrzero/README.md
+++ b/boards/arduino_mkrzero/README.md
@@ -6,17 +6,22 @@ This crate provides a type-safe API for working with the [Arduino mkrzero board]
 ### Blinky Basic
 #### Requirements
  - Arduino IDE installed
-    - samd package installed
+    - samd package installed (You can do this by going to Tools->Board->BoardManager and then searching for `samd`
+    - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0[-arduino3]/` add it to your path
+       - *linux* `ArduinoData` is likely something like `~/.arduino15/`
+       - *OSX* `ArduinoData` is likely something like `~/Library/Arduino15`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
        - `ArduinoData` is likely something like `~/.arduino15/`
     - Probably best to install an example sketch via the IDE just to make sure everything is working
     - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
  - arm-none-eabi tools installed, you need gcc and objcopy.
+   -  **Note** Alternatively, you can use [cargo-binutils](https://github.com/rust-embedded/cargo-binutils), which is likely easier to install on OSX and also easier to use, as it will automatically detect the target
  - thumbv6m-none-eabi rust target installed via `rustup target add thumbv6m-none-eabi`
 
 #### Steps
 ```bash
 cargo build --release --example blinky_basic
 arm-none-eabi-objcopy -O binary target/thumbv6m-none-eabi/release/examples/blinky_basic target/blinky_basic.bin
+# if using cargo-binutils, you can `rust-objcopy` with the same flags, or combine the previous 2 steps with `cargo objcopy`
 bossac -i -d -U true -i -e -w -v target/blinky_basic.bin -R
 ```

--- a/boards/arduino_mkrzero/README.md
+++ b/boards/arduino_mkrzero/README.md
@@ -8,14 +8,14 @@ This crate provides a type-safe API for working with the [Arduino mkrzero board]
  - Arduino IDE installed
     - samd package installed (You can do this by going to Tools->Board->BoardManager and then searching for `samd`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0[-arduino3]/` add it to your path
-       - **linux** `ArduinoData` is likely something like `~/.arduino15/`
-       - **OSX** `ArduinoData` is likely something like `~/Library/Arduino15`
+       - **linux**: `ArduinoData` is likely something like `~/.arduino15/`
+       - **OSX**: `ArduinoData` is likely something like `~/Library/Arduino15`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
        - `ArduinoData` is likely something like `~/.arduino15/`
     - Probably best to install an example sketch via the IDE just to make sure everything is working
     - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
  - arm-none-eabi tools installed, you need gcc and objcopy.
-   -  **Note** Alternatively, you can use [cargo-binutils](https://github.com/rust-embedded/cargo-binutils), which is likely easier to install on OSX and also easier to use, as it will automatically detect the target
+   -  **Note**: Alternatively, you can use [cargo-binutils](https://github.com/rust-embedded/cargo-binutils), which is likely easier to install on OSX and also easier to use, as it will automatically detect the target
  - thumbv6m-none-eabi rust target installed via `rustup target add thumbv6m-none-eabi`
 
 #### Steps

--- a/boards/arduino_mkrzero/README.md
+++ b/boards/arduino_mkrzero/README.md
@@ -8,8 +8,8 @@ This crate provides a type-safe API for working with the [Arduino mkrzero board]
  - Arduino IDE installed
     - samd package installed (You can do this by going to Tools->Board->BoardManager and then searching for `samd`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0[-arduino3]/` add it to your path
-       - *linux* `ArduinoData` is likely something like `~/.arduino15/`
-       - *OSX* `ArduinoData` is likely something like `~/Library/Arduino15`
+       - **linux** `ArduinoData` is likely something like `~/.arduino15/`
+       - **OSX** `ArduinoData` is likely something like `~/Library/Arduino15`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
        - `ArduinoData` is likely something like `~/.arduino15/`
     - Probably best to install an example sketch via the IDE just to make sure everything is working

--- a/boards/arduino_nano33iot/README.md
+++ b/boards/arduino_nano33iot/README.md
@@ -1,4 +1,4 @@
-# Arduino Nano 33 IOT Board Support Crate
+jkkkkk Arduino Nano 33 IOT Board Support Crate
 
 This crate provides a type-safe API for working with the [Arduino nano 33 IOT board](https://store.arduino.cc/usa/nano-33-iot).
 
@@ -6,23 +6,27 @@ This crate provides a type-safe API for working with the [Arduino nano 33 IOT bo
 ### Blinky Basic
 #### Requirements
  - Arduino IDE installed
-    - samd package installed
-    - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
-       - `ArduinoData` is likely something like `~/.arduino15/`
+    - samd package installed (You can do this by going to Tools->Board->BoardManager and then searching for `samd`
+    - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0[-arduino3]/` add it to your path
+       - *linux* `ArduinoData` is likely something like `~/.arduino15/`
+       - *OSX* `ArduinoData` is likely something like `~/Library/Arduino15`
     - Probably best to install an example sketch via the IDE just to make sure everything is working
     - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
  - arm-none-eabi tools installed, you need gcc and objcopy.
+   -  **Note** Alternatively, you can use [cargo-binutils](https://github.com/rust-embedded/cargo-binutils), which is likely easier to install on OSX and also easier to use, as it will automatically detect the target
  - thumbv6m-none-eabi rust target installed via `rustup target add thumbv6m-none-eabi`
 
 #### Steps
 ```bash
 cargo build --release --example blinky_basic
 arm-none-eabi-objcopy -O binary target/thumbv6m-none-eabi/release/examples/blinky_basic target/blinky_basic.bin
+# if using cargo-binutils, you can `rust-objcopy` with the same flags, or combine the previous 2 steps with `cargo objcopy`
 bossac -i -d -U true -i -e -w -v target/blinky_basic.bin -R
 ```
-(You may need to use `--port` with something like `/dev/ttyACM0` or `/dev/ttyACM1`
+(You may need to use `--port` with something like `/dev/ttyACM0`/`/dev/ttyACM1`, or `/dev/tty.usbmodemNNNNN` on OSX)
 
 #### Notes
  - It may help to double-press the center button to reset when re-flashing the device. This sets the device in a bootloader mode.
- - For the usb example, `picocom` is a good simple terminal serial emulator
+ - For the usb example, `picocom` is a good simple terminal serial emulator, installable with your os's package manager or `brew`
+   - On OSX, after flashing the tty for serial communication may be different, for example `/dev/tty.usbmodemTEST1`
 

--- a/boards/arduino_nano33iot/README.md
+++ b/boards/arduino_nano33iot/README.md
@@ -8,12 +8,12 @@ This crate provides a type-safe API for working with the [Arduino nano 33 IOT bo
  - Arduino IDE installed
     - samd package installed (You can do this by going to Tools->Board->BoardManager and then searching for `samd`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0[-arduino3]/` add it to your path
-       - **linux** `ArduinoData` is likely something like `~/.arduino15/`
-       - **OSX** `ArduinoData` is likely something like `~/Library/Arduino15`
+       - **linux**: `ArduinoData` is likely something like `~/.arduino15/`
+       - **OSX**: `ArduinoData` is likely something like `~/Library/Arduino15`
     - Probably best to install an example sketch via the IDE just to make sure everything is working
     - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
  - arm-none-eabi tools installed, you need gcc and objcopy.
-   -  **Note** Alternatively, you can use [cargo-binutils](https://github.com/rust-embedded/cargo-binutils), which is likely easier to install on OSX and also easier to use, as it will automatically detect the target
+   -  **Note**: Alternatively, you can use [cargo-binutils](https://github.com/rust-embedded/cargo-binutils), which is likely easier to install on OSX and also easier to use, as it will automatically detect the target
  - thumbv6m-none-eabi rust target installed via `rustup target add thumbv6m-none-eabi`
 
 #### Steps

--- a/boards/arduino_nano33iot/README.md
+++ b/boards/arduino_nano33iot/README.md
@@ -8,8 +8,8 @@ This crate provides a type-safe API for working with the [Arduino nano 33 IOT bo
  - Arduino IDE installed
     - samd package installed (You can do this by going to Tools->Board->BoardManager and then searching for `samd`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0[-arduino3]/` add it to your path
-       - *linux* `ArduinoData` is likely something like `~/.arduino15/`
-       - *OSX* `ArduinoData` is likely something like `~/Library/Arduino15`
+       - **linux** `ArduinoData` is likely something like `~/.arduino15/`
+       - **OSX** `ArduinoData` is likely something like `~/Library/Arduino15`
     - Probably best to install an example sketch via the IDE just to make sure everything is working
     - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
  - arm-none-eabi tools installed, you need gcc and objcopy.

--- a/boards/arduino_nano33iot/examples/usb_logging.rs
+++ b/boards/arduino_nano33iot/examples/usb_logging.rs
@@ -10,7 +10,6 @@ extern crate usbd_serial;
 use hal::clock::GenericClockController;
 use hal::entry;
 use hal::pac::{interrupt, CorePeripherals, Peripherals};
-use hal::prelude::*;
 
 use hal::usb::UsbBus;
 use usb_device::bus::UsbBusAllocator;

--- a/boards/wio_lite_mg126/README.md
+++ b/boards/wio_lite_mg126/README.md
@@ -8,8 +8,8 @@ This crate provides a type-safe API for working with the WIO Lite MG126(https://
  - Arduino IDE installed
     - samd package installed (You can do this by going to Tools->Board->BoardManager and then searching for `samd`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0[-arduino3]/` add it to your path
-       - *linux* `ArduinoData` is likely something like `~/.arduino15/`
-       - *OSX* `ArduinoData` is likely something like `~/Library/Arduino15`
+       - **linux** `ArduinoData` is likely something like `~/.arduino15/`
+       - **OSX** `ArduinoData` is likely something like `~/Library/Arduino15`
     - Probably best to install an example sketch via the IDE just to make sure everything is working
     - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
  - arm-none-eabi tools installed, you need gcc and objcopy.

--- a/boards/wio_lite_mg126/README.md
+++ b/boards/wio_lite_mg126/README.md
@@ -6,16 +6,20 @@ This crate provides a type-safe API for working with the WIO Lite MG126(https://
 ### Blinky Basic
 #### Requirements
  - Arduino IDE installed
-    - samd package installed
-    - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
+    - samd package installed (You can do this by going to Tools->Board->BoardManager and then searching for `samd`
+    - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0[-arduino3]/` add it to your path
+       - *linux* `ArduinoData` is likely something like `~/.arduino15/`
+       - *OSX* `ArduinoData` is likely something like `~/Library/Arduino15`
     - Probably best to install an example sketch via the IDE just to make sure everything is working
     - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
  - arm-none-eabi tools installed, you need gcc and objcopy.
+   -  **Note** Alternatively, you can use [cargo-binutils](https://github.com/rust-embedded/cargo-binutils), which is likely easier to install on OSX and also easier to use, as it will automatically detect the target
  - thumbv6m-none-eabi rust target installed via `rustup target add thumbv6m-none-eabi`
 
 #### Steps
 ```bash
 cargo build --release --example blinky_basic
 arm-none-eabi-objcopy -O binary target/thumbv6m-none-eabi/release/examples/blinky_basic target/blinky_basic.bin
+# if using cargo-binutils, you can `rust-objcopy` with the same flags, or combine the previous 2 steps with `cargo objcopy`
 bossac -i -d -U true -i -e -w -v target/blinky_basic.bin -R
 ```

--- a/boards/wio_lite_mg126/README.md
+++ b/boards/wio_lite_mg126/README.md
@@ -8,12 +8,12 @@ This crate provides a type-safe API for working with the WIO Lite MG126(https://
  - Arduino IDE installed
     - samd package installed (You can do this by going to Tools->Board->BoardManager and then searching for `samd`
     - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0[-arduino3]/` add it to your path
-       - **linux** `ArduinoData` is likely something like `~/.arduino15/`
-       - **OSX** `ArduinoData` is likely something like `~/Library/Arduino15`
+       - **linux**: `ArduinoData` is likely something like `~/.arduino15/`
+       - **OSX**: `ArduinoData` is likely something like `~/Library/Arduino15`
     - Probably best to install an example sketch via the IDE just to make sure everything is working
     - Note that the [arduino cli](https://github.com/arduino/arduino-cli) (or just regular bossac) may soon replace this section
  - arm-none-eabi tools installed, you need gcc and objcopy.
-   -  **Note** Alternatively, you can use [cargo-binutils](https://github.com/rust-embedded/cargo-binutils), which is likely easier to install on OSX and also easier to use, as it will automatically detect the target
+   -  **Note**: Alternatively, you can use [cargo-binutils](https://github.com/rust-embedded/cargo-binutils), which is likely easier to install on OSX and also easier to use, as it will automatically detect the target
  - thumbv6m-none-eabi rust target installed via `rustup target add thumbv6m-none-eabi`
 
 #### Steps

--- a/boards/wio_terminal/examples/README.md
+++ b/boards/wio_terminal/examples/README.md
@@ -54,6 +54,7 @@ $ arm-none-eabi-objcopy \
 >   -O binary \
 >   /target/thumbv7em-none-eabihf/release/examples/blinky \
 >   /target/thumbv7em-none-eabihf/release/examples/blinky.bin
+> # alternatively, use cargo-binutils, you can `rust-objcopy` with the same flags, or combine it with the `cargo build` step and use `cargo objcopy`
 $ bossac \
 >   -i -d -v \
 >   --port=<PORT> -U \


### PR DESCRIPTION
I recently switched to using a macbook, so my own workflow was disrupted for my arduino_nano33iot

I updated the instructions to
1. give advice on where stuff is and how it works on macbooks (at least for arduino boards)
2. push people to use `cargo-binutils`, which is far easier to install on OSX, and somewhat nicer to use

as well as
3. fix a messed up double import for the `usb feature`