### PR TITLE
Implement QSPI for thumbv7em

### DIFF
--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -80,3 +80,6 @@ required-features = ["usb"]
 
 [[example]]
 name = "sdcard"
+
+[[example]]
+name = "qspi"

--- a/boards/wio_terminal/examples/qspi.rs
+++ b/boards/wio_terminal/examples/qspi.rs
@@ -1,0 +1,95 @@
+#![no_std]
+#![no_main]
+
+/// Demonstrates reading and writing to the onboard 4MB flash.
+/// The entire chip is erased, some data written, and then read back.
+/// The Blue LED blink incessantly if the data written + read back
+/// was not the same.
+use panic_halt as _;
+use wio_terminal as wio;
+
+use wio::hal::clock::GenericClockController;
+use wio::hal::delay::Delay;
+use wio::hal::qspi::Command;
+use wio::pac::{CorePeripherals, Peripherals};
+use wio::prelude::*;
+use wio::{entry, Pins, Sets};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.MCLK,
+        &mut peripherals.OSC32KCTRL,
+        &mut peripherals.OSCCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    let mut sets: Sets = Pins::new(peripherals.PORT).split();
+    let mut user_led = sets.user_led.into_open_drain_output(&mut sets.port);
+    user_led.set_high().unwrap();
+
+    let mut flash = sets
+        .flash
+        .init(&mut peripherals.MCLK, &mut sets.port, peripherals.QSPI);
+
+    // We don't know the current state of the chip, so lets chill out and
+    // reset it.
+    delay.delay_ms(20u8);
+    wait_ready(&mut flash);
+    flash.run_command(Command::EnableReset).unwrap();
+    flash.run_command(Command::Reset).unwrap();
+    delay.delay_ms(50u8);
+
+    // WARP SPEEEED (133Mhz = divide by 1 (plus one)).
+    flash.set_clk_divider(2);
+
+    // Enable Quad SPI mode.
+    wait_ready(&mut flash);
+    flash.run_command(Command::WriteEnable).unwrap();
+    flash
+        .write_command(Command::WriteStatus, &[0x00, 0x02])
+        .unwrap();
+
+    // Erase this bad boi.
+    wait_ready(&mut flash);
+    flash.run_command(Command::WriteEnable).unwrap();
+    flash.erase_command(Command::EraseChip, 0x0).unwrap();
+
+    let write_buf = [0x0d, 0xd0, 0x01, 0xc0];
+    wait_ready(&mut flash);
+    flash.write_memory(0, &write_buf);
+
+    let mut read_buf = [0u8; 4];
+    wait_ready(&mut flash);
+    flash.read_memory(0, &mut read_buf);
+
+    if read_buf != write_buf {
+        // If we did not read back the same data flash the status
+        // LED.
+        loop {
+            user_led.toggle();
+            delay.delay_ms(200u8);
+        }
+    }
+
+    user_led.set_low().unwrap();
+    loop {}
+}
+
+/// Wait for the write-in-progress and suspended write/erase.
+fn wait_ready(flash: &mut wio::hal::qspi::Qspi) {
+    while flash_status(flash, Command::ReadStatus) & 0x01 != 0 {}
+    while flash_status(flash, Command::ReadStatus2) & 0x80 != 0 {}
+}
+
+/// Returns the contents of the status register indicated by cmd.
+fn flash_status(flash: &mut wio::hal::qspi::Qspi, cmd: Command) -> u8 {
+    let mut out = [0u8; 1];
+    flash.read_command(cmd, &mut out).ok().unwrap();
+    out[0]
+}

--- a/boards/wio_terminal/src/storage.rs
+++ b/boards/wio_terminal/src/storage.rs
@@ -6,8 +6,9 @@ use atsamd_hal::gpio::{
 };
 use atsamd_hal::hal::spi;
 use atsamd_hal::prelude::*;
+use atsamd_hal::qspi;
 use atsamd_hal::sercom::{PadPin, SPIMaster6, Sercom6Pad0, Sercom6Pad1, Sercom6Pad2};
-use atsamd_hal::target_device::{MCLK, SERCOM6};
+use atsamd_hal::target_device::{MCLK, QSPI, SERCOM6};
 use atsamd_hal::time::Hertz;
 use embedded_sdmmc::{SdMmcSpi, TimeSource};
 
@@ -30,6 +31,14 @@ pub struct QSPIFlash {
 
     /// QSPI Flash `d3` pin
     pub d3: Pa11<Input<Floating>>,
+}
+
+impl QSPIFlash {
+    pub fn init(self, mclk: &mut MCLK, port: &mut Port, qspi: QSPI) -> qspi::Qspi {
+        qspi::Qspi::new(
+            mclk, port, qspi, self.sck, self.cs, self.d0, self.d1, self.d2, self.d3,
+        )
+    }
 }
 
 /// SD Card pins (uses `SERCOM6`)

--- a/hal/src/common/thumbv7em/mod.rs
+++ b/hal/src/common/thumbv7em/mod.rs
@@ -2,6 +2,7 @@ pub mod calibration;
 pub mod clock;
 pub mod eic;
 pub mod gpio;
+pub mod qspi;
 pub mod rtc;
 pub mod sercom;
 pub mod timer;

--- a/hal/src/common/thumbv7em/qspi.rs
+++ b/hal/src/common/thumbv7em/qspi.rs
@@ -1,0 +1,350 @@
+use crate::{
+    gpio::{Floating, Input, Pa10, Pa11, Pa8, Pa9, Pb10, Pb11, PfH, Port},
+    target_device::qspi::instrframe,
+    target_device::{MCLK, QSPI},
+};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum Error {
+    /// The command you selected cannot be performed by this function
+    CommandFunctionMismatch,
+}
+
+pub struct Qspi {
+    qspi: QSPI,
+    _sck: Pb10<PfH>,
+    _cs: Pb11<PfH>,
+    _io0: Pa8<PfH>,
+    _io1: Pa9<PfH>,
+    _io2: Pa10<PfH>,
+    _io3: Pa11<PfH>,
+}
+
+impl Qspi {
+    pub fn new(
+        mclk: &mut MCLK,
+        port: &mut Port,
+        qspi: QSPI,
+        _sck: Pb10<Input<Floating>>,
+        _cs: Pb11<Input<Floating>>,
+        _io0: Pa8<Input<Floating>>,
+        _io1: Pa9<Input<Floating>>,
+        _io2: Pa10<Input<Floating>>,
+        _io3: Pa11<Input<Floating>>,
+    ) -> Qspi {
+        mclk.apbcmask.modify(|_, w| w.qspi_().set_bit());
+        // Enable the clocks for the qspi peripheral in single data rate mode.
+        mclk.ahbmask.modify(|_, w| {
+            w.qspi_().set_bit();
+            w.qspi_2x_().clear_bit()
+        });
+
+        let _sck = _sck.into_function_h(port);
+        let _cs = _cs.into_function_h(port);
+        let _io0 = _io0.into_function_h(port);
+        let _io1 = _io1.into_function_h(port);
+        let _io2 = _io2.into_function_h(port);
+        let _io3 = _io3.into_function_h(port);
+
+        qspi.ctrla.write(|w| w.swrst().set_bit());
+        qspi.baud.write(|w| unsafe {
+            w.baud().bits((120_000_000u32 / 4_000_000u32) as u8); // 4Mhz
+                                                                  // SPI MODE 0
+            w.cpol().clear_bit();
+            w.cpha().clear_bit()
+        });
+
+        qspi.ctrlb.write(|w| {
+            w.mode().memory();
+            w.csmode().noreload();
+            w.csmode().lastxfer();
+            w.datalen()._8bits()
+        });
+
+        qspi.ctrla.modify(|_, w| w.enable().set_bit());
+
+        Qspi {
+            qspi,
+            _sck,
+            _cs,
+            _io0,
+            _io1,
+            _io2,
+            _io3,
+        }
+    }
+
+    unsafe fn run_write_instruction(
+        &self,
+        command: Command,
+        tfm: TransferMode,
+        addr: u32,
+        buf: &[u8],
+    ) {
+        if command == Command::EraseSector || command == Command::EraseBlock {
+            self.qspi.instraddr.write(|w| w.addr().bits(addr));
+        }
+        self.qspi
+            .instrctrl
+            .modify(|_, w| w.instr().bits(command.bits()));
+        self.qspi.instrframe.write(|w| {
+            tfm.instrframe(
+                w,
+                if command == Command::QuadPageProgram {
+                    instrframe::TFRTYPE_A::WRITEMEMORY
+                } else {
+                    instrframe::TFRTYPE_A::WRITE
+                },
+            )
+        });
+        self.qspi.instrframe.read().bits();
+
+        if buf.len() > 0 {
+            core::ptr::copy(buf.as_ptr(), (QSPI_AHB + addr) as *mut u8, buf.len());
+        }
+
+        self.qspi.ctrla.write(|w| {
+            w.enable().set_bit();
+            w.lastxfer().set_bit()
+        });
+
+        while self.qspi.intflag.read().instrend().bit_is_clear() {}
+        self.qspi.intflag.write(|w| w.instrend().set_bit());
+    }
+
+    unsafe fn run_read_instruction(
+        &self,
+        command: Command,
+        tfm: TransferMode,
+        addr: u32,
+        buf: &mut [u8],
+    ) {
+        self.qspi
+            .instrctrl
+            .modify(|_, w| w.instr().bits(command.bits()));
+        self.qspi.instrframe.write(|w| {
+            tfm.instrframe(
+                w,
+                if command == Command::QuadRead {
+                    instrframe::TFRTYPE_A::READMEMORY
+                } else {
+                    instrframe::TFRTYPE_A::READ
+                },
+            )
+        });
+        self.qspi.instrframe.read().bits();
+
+        if buf.len() > 0 {
+            core::ptr::copy((QSPI_AHB + addr) as *mut u8, buf.as_mut_ptr(), buf.len());
+        }
+        self.qspi.ctrla.write(|w| {
+            w.enable().set_bit();
+            w.lastxfer().set_bit()
+        });
+
+        while self.qspi.intflag.read().instrend().bit_is_clear() {}
+        self.qspi.intflag.write(|w| w.instrend().set_bit());
+    }
+
+    /// Run a generic command that neither takes nor receives data
+    pub fn run_command(&self, command: Command) -> Result<(), Error> {
+        match command {
+            //TODO verify this list of commands
+            Command::WriteEnable
+            | Command::WriteDisable
+            | Command::Reset
+            | Command::EnableReset => (),
+            _ => return Err(Error::CommandFunctionMismatch),
+        }
+
+        let tfm = TransferMode {
+            instruction_enable: true,
+            ..TransferMode::default()
+        };
+        unsafe {
+            self.run_read_instruction(command, tfm, 0, &mut []);
+        }
+        Ok(())
+    }
+
+    /// Run one of the read commands
+    pub fn read_command(&self, command: Command, response: &mut [u8]) -> Result<(), Error> {
+        match command {
+            //TODO verify this list of commands
+            Command::Read
+            | Command::QuadRead
+            | Command::ReadId
+            | Command::ReadStatus
+            | Command::ReadStatus2 => (),
+            _ => return Err(Error::CommandFunctionMismatch),
+        }
+
+        let tfm = TransferMode {
+            data_enable: true,
+            instruction_enable: true,
+            ..TransferMode::default()
+        };
+        unsafe {
+            self.run_read_instruction(command, tfm, 0, response);
+        }
+        Ok(())
+    }
+
+    /// Run one of the write commands
+    pub fn write_command(&self, command: Command, data: &[u8]) -> Result<(), Error> {
+        match command {
+            //TODO verify this list of commands
+            Command::PageProgram
+            | Command::QuadPageProgram
+            | Command::WriteStatus
+            | Command::WriteStatus2 => (),
+            _ => return Err(Error::CommandFunctionMismatch),
+        }
+
+        let tfm = TransferMode {
+            data_enable: data.len() > 0,
+            instruction_enable: true,
+            ..TransferMode::default()
+        };
+        unsafe {
+            self.run_write_instruction(command, tfm, 0, data);
+        }
+        Ok(())
+    }
+
+    /// Run one of the erase commands
+    pub fn erase_command(&self, command: Command, address: u32) -> Result<(), Error> {
+        match command {
+            //TODO verify this list of commands
+            Command::EraseSector | Command::EraseBlock | Command::EraseChip => (),
+            _ => return Err(Error::CommandFunctionMismatch),
+        }
+
+        let tfm = TransferMode {
+            address_enable: true,
+            instruction_enable: true,
+            ..TransferMode::default()
+        };
+        unsafe {
+            self.run_write_instruction(command, tfm, address, &[]);
+        }
+        Ok(())
+    }
+
+    /// Read a sequential block of memory to buf
+    pub fn read_memory(&mut self, addr: u32, buf: &mut [u8]) {
+        let tfm = TransferMode {
+            quad_width: true,
+            address_enable: true,
+            data_enable: true,
+            instruction_enable: true,
+            dummy_cycles: 8,
+            ..TransferMode::default()
+        };
+
+        unsafe { self.run_read_instruction(Command::QuadRead, tfm, addr, buf) };
+    }
+
+    /// Write a sequential block of memory to addr
+    pub fn write_memory(&mut self, addr: u32, buf: &[u8]) {
+        self.qspi.instrframe.write(|w| {
+            w.width().quad_output();
+            w.addrlen()._24bits();
+            w.tfrtype().writememory();
+            w.instren().set_bit();
+            w.dataen().set_bit();
+            w.addren().set_bit()
+        });
+
+        let tfm = TransferMode {
+            quad_width: true,
+            address_enable: true,
+            data_enable: true,
+            instruction_enable: true,
+            ..TransferMode::default()
+        };
+        unsafe { self.run_write_instruction(Command::QuadPageProgram, tfm, addr, buf) };
+    }
+
+    /// Set the clock divider, relative to the main clock
+    pub fn set_clk_divider(&mut self, value: u8) {
+        // The baud register is divisor - 1
+        self.qspi
+            .baud
+            .write(|w| unsafe { w.baud().bits(value.saturating_sub(1)) });
+    }
+}
+
+#[derive(Default, Debug, Copy, Clone)]
+struct TransferMode {
+    quad_width: bool,
+    data_enable: bool,
+    opcode_enable: bool,
+    address_enable: bool,
+    instruction_enable: bool,
+    dummy_cycles: u8,
+}
+
+impl TransferMode {
+    unsafe fn instrframe(
+        self,
+        instrframe: &mut instrframe::W,
+        tfrtype: instrframe::TFRTYPE_A,
+    ) -> &mut instrframe::W {
+        if self.quad_width {
+            instrframe.width().quad_output();
+        } else {
+            instrframe.width().single_bit_spi();
+        }
+
+        if self.data_enable {
+            instrframe.dataen().set_bit();
+        }
+        if self.opcode_enable {
+            instrframe.dataen().set_bit();
+        }
+        if self.address_enable {
+            instrframe.addren().set_bit();
+        }
+        if self.instruction_enable {
+            instrframe.instren().set_bit();
+        }
+
+        if self.dummy_cycles > 0 {
+            instrframe.dummylen().bits(self.dummy_cycles);
+        }
+        instrframe.addrlen()._24bits();
+        instrframe.optcodeen().clear_bit();
+        instrframe.tfrtype().variant(tfrtype);
+        instrframe
+    }
+}
+
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Command {
+    Read = 0x03,
+    QuadRead = 0x6B,
+    ReadId = 0x9F,
+    PageProgram = 0x02,
+    QuadPageProgram = 0x32,
+    ReadStatus = 0x05,
+    ReadStatus2 = 0x35,
+    WriteStatus = 0x01,
+    WriteStatus2 = 0x31,
+    EnableReset = 0x66,
+    Reset = 0x99,
+    WriteEnable = 0x06,
+    WriteDisable = 0x04,
+    EraseSector = 0x20,
+    EraseBlock = 0xD8,
+    EraseChip = 0xC7,
+}
+
+impl Command {
+    fn bits(self) -> u8 {
+        self as u8
+    }
+}
+
+const QSPI_AHB: u32 = 0x04000000;


### PR DESCRIPTION
This is a re-work of #103 - thanks to @sajattack for doing the hard yakka XD
Apologies about the old commits - i could not get the rebase working properly.

The main issues that were fixed are:
1. Chip was never put into quad-SPI mode, but quad-SPI commands were used for read/write
2. Write-enable was never latched, so writes were never accepted
3. Status was never checked to determine if chip was ready to receive the next command
3. `instrframe` was written in the wrong order relative to the other registers
4. Pinmux was configured before the peripheral (probs no a big deal, but not what the datasheet says)
