### PR TITLE
Arduino Nano33 iot project fails to compile when using feature "usb"

### DIFF
--- a/boards/arduino_nano33iot/src/lib.rs
+++ b/boards/arduino_nano33iot/src/lib.rs
@@ -23,8 +23,6 @@ pub use hal::samd21::*;
 pub use hal::target_device as pac;
 
 #[cfg(feature = "usb")]
-use hal::clock::GenericClockController;
-#[cfg(feature = "usb")]
 use hal::usb::usb_device::bus::UsbBusAllocator;
 #[cfg(feature = "usb")]
 pub use hal::usb::UsbBus;


### PR DESCRIPTION
When compiling projects with 'usb' feature, it fails because 'GenericClockController' is used twice.