### PR TITLE
8 MHz RC oscillator clock option

### DIFF
--- a/hal/src/samd11/clock.rs
+++ b/hal/src/samd11/clock.rs
@@ -176,8 +176,8 @@ impl GenericClockController {
         }
     }
 
-    /// Reset the clock controller, configure the system to run at 8Mhz from internal 8 MHz RC clock (no PLL)
-    /// and reset various clock dividers.
+    /// Reset the clock controller, configure the system to run at 8Mhz from
+    /// internal 8 MHz RC clock (no PLL) and reset various clock dividers.
     pub fn with_internal_8mhz(
         gclk: GCLK,
         pm: &mut PM,

--- a/hal/src/samd11/clock.rs
+++ b/hal/src/samd11/clock.rs
@@ -381,7 +381,7 @@ fn enable_gclk_apb(pm: &mut PM) {
 }
 
 /// Turn on the internal 32hkz oscillator
-fn enable_internal_32kosc(sysctrl: &mut SYSCTRL) {
+pub fn enable_internal_32kosc(sysctrl: &mut SYSCTRL) {
     let calibration = super::calibration::osc32k_cal();
     sysctrl.osc32k.write(|w| {
         unsafe {
@@ -399,7 +399,7 @@ fn enable_internal_32kosc(sysctrl: &mut SYSCTRL) {
 }
 
 /// Turn on the external 32hkz oscillator
-fn enable_external_32kosc(sysctrl: &mut SYSCTRL) {
+pub fn enable_external_32kosc(sysctrl: &mut SYSCTRL) {
     sysctrl.xosc32k.modify(|_, w| {
         unsafe {
             // 6 here means: use 64k cycles of OSCULP32k to start up this oscillator

--- a/hal/src/samd11/clock.rs
+++ b/hal/src/samd11/clock.rs
@@ -276,7 +276,7 @@ impl GenericClockController {
         let freq: Hertz = match src {
             XOSC32K | OSC32K | OSCULP32K => OSC32K_FREQ,
             GCLKGEN1 => self.gclks[1],
-            OSC8M => 8.mhz().into(),
+            OSC8M => OSC8M_FREQ,
             DFLL48M => OSC48M_FREQ,
             DPLL96M => 96.mhz().into(),
             GCLKIN | XOSC => unimplemented!(),
@@ -369,6 +369,8 @@ clock_generator!(
 
 /// The frequency of the 48Mhz source.
 pub const OSC48M_FREQ: Hertz = Hertz(48_000_000);
+/// The frequency of the 8 Mhz source.
+pub const OSC8M_FREQ: Hertz = Hertz(8_000_000);
 /// The frequency of the 32Khz source.
 pub const OSC32K_FREQ: Hertz = Hertz(32_768);
 

--- a/hal/src/samd21/clock.rs
+++ b/hal/src/samd21/clock.rs
@@ -403,7 +403,7 @@ fn enable_gclk_apb(pm: &mut PM) {
 }
 
 /// Turn on the internal 32hkz oscillator
-fn enable_internal_32kosc(sysctrl: &mut SYSCTRL) {
+pub fn enable_internal_32kosc(sysctrl: &mut SYSCTRL) {
     let calibration = super::calibration::osc32k_cal();
     sysctrl.osc32k.write(|w| {
         unsafe {
@@ -421,7 +421,7 @@ fn enable_internal_32kosc(sysctrl: &mut SYSCTRL) {
 }
 
 /// Turn on the external 32hkz oscillator
-fn enable_external_32kosc(sysctrl: &mut SYSCTRL) {
+pub fn enable_external_32kosc(sysctrl: &mut SYSCTRL) {
     sysctrl.xosc32k.modify(|_, w| {
         unsafe {
             // 6 here means: use 64k cycles of OSCULP32k to start up this oscillator

--- a/hal/src/samd21/clock.rs
+++ b/hal/src/samd21/clock.rs
@@ -177,8 +177,8 @@ impl GenericClockController {
         }
     }
 
-    /// Reset the clock controller, configure the system to run at 8Mhz from internal 8 MHz RC clock (no PLL)
-    /// and reset various clock dividers.
+    /// Reset the clock controller, configure the system to run at 8Mhz from
+    /// internal 8 MHz RC clock (no PLL) and reset various clock dividers.
     pub fn with_internal_8mhz(
         gclk: GCLK,
         pm: &mut PM,


### PR DESCRIPTION
Make an 8 MHz RC oscillator clock option. Currently there's no option other than 48 MHz clock fed by a 32k clock using a PLL. There is also an 8 MHz RC oscillator that can be used as the main clock, which is lower power due to the lower clock speed as well as not using the PLL hardware.

To still allow the use of the 32k clocks, I also made the 32k clock enable functions public