### PR TITLE
UART uses internal clock mode

### DIFF
--- a/hal/src/common/thumbv7em/sercom/uart.rs
+++ b/hal/src/common/thumbv7em/sercom/uart.rs
@@ -156,7 +156,7 @@ macro_rules! uart {
                             w.runstdby().set_bit(); // Run in standby
                             w.form().bits(0); // 0 is no parity bits
 
-                            // w.mode().usart_int_clk(); // Internal clock mode
+                            w.mode().usart_int_clk(); // Internal clock mode
                             w.cmode().clear_bit() // Asynchronous mode
                         });
 


### PR DESCRIPTION
fix #295 

It might be erroneously commented out in #271.
I did some tests on the ATSAMD51P19A (Wio Terminal).