### PR TITLE
Implement EIC for thumbv6m targets

### DIFF
--- a/boards/trinket_m0/Cargo.toml
+++ b/boards/trinket_m0/Cargo.toml
@@ -49,6 +49,9 @@ use_semihosting = []
 name = "blinky_basic"
 
 [[example]]
+name = "eic"
+
+[[example]]
 name = "pwm"
 required-features = ["unproven"]
 

--- a/boards/trinket_m0/examples/eic.rs
+++ b/boards/trinket_m0/examples/eic.rs
@@ -1,0 +1,43 @@
+#![no_std]
+#![no_main]
+
+use panic_halt as _;
+use trinket_m0 as hal;
+
+use hal::clock::GenericClockController;
+use hal::eic::{pin::Sense, EIC};
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let _core = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut led = pins.d13.into_push_pull_output(&mut pins.port);
+    led.set_high().unwrap();
+
+    let gclk0 = clocks.gclk0();
+    let clock = clocks.eic(&gclk0).unwrap();
+    let mut eic = EIC::init(&mut peripherals.PM, clock, peripherals.EIC);
+
+    let mut d3 = pins.d3.into_ei(&mut pins.port);
+    d3.sense(&mut eic, Sense::FALL);
+    d3.enable_interrupt(&mut eic);
+
+    loop {
+        if d3.is_interrupt() {
+            d3.clear_interrupt();
+            led.toggle();
+        }
+    }
+}

--- a/hal/src/common/prelude.rs
+++ b/hal/src/common/prelude.rs
@@ -1,10 +1,4 @@
 //! Import the prelude to gain convenient access to helper traits
-#[cfg(any(
-    feature = "samd51",
-    feature = "same51",
-    feature = "same53",
-    feature = "same54"
-))]
 pub use crate::eic::pin::EicPin;
 pub use crate::gpio::GpioExt as _atsamd21_hal_gpio_GpioExt;
 pub use crate::spi_common::CommonSpi as _atsamd_hal_spi_common_CommonSpi;

--- a/hal/src/common/thumbv6m/eic/mod.rs
+++ b/hal/src/common/thumbv6m/eic/mod.rs
@@ -1,0 +1,21 @@
+use crate::clock::EicClock;
+use crate::target_device;
+
+pub mod pin;
+
+pub struct EIC {
+    eic: target_device::EIC,
+}
+
+impl EIC {
+    pub fn init(pm: &mut target_device::PM, _clock: EicClock, eic: target_device::EIC) -> Self {
+        pm.apbamask.modify(|_, w| w.eic_().set_bit());
+
+        eic.ctrl.modify(|_, w| w.enable().set_bit());
+        while eic.status.read().syncbusy().bit_is_set() {
+            cortex_m::asm::nop();
+        }
+
+        EIC { eic }
+    }
+}

--- a/hal/src/common/thumbv6m/eic/pin.rs
+++ b/hal/src/common/thumbv6m/eic/pin.rs
@@ -1,0 +1,327 @@
+use crate::gpio::{self, IntoFunction, Port};
+use crate::target_device;
+
+/// The EicPin trait makes it more ergonomic to convert a gpio pin into an EIC
+/// pin. You should not implement this trait for yourself; only the
+/// implementations in the EIC module make sense.
+pub trait EicPin<T> {
+    fn into_ei(self, port: &mut Port) -> T;
+}
+
+pub type Sense = target_device::eic::config::SENSE0_A;
+
+pub type ExternalInterruptID = usize;
+
+/// ExternalInterrupt describes something with an external interrupt ID.
+pub trait ExternalInterrupt {
+    fn id(self) -> ExternalInterruptID;
+}
+
+/// The pad macro defines the given EIC pin and implements EicPin for the
+/// given pins. The EicPin implementation will configure the pin for the
+/// appropriate function and return the pin wrapped in the EIC type.
+macro_rules! ei {
+    (
+        $PadType:ident [ $num:expr ] {
+            $(
+                $(#[$attr:meta])*
+                $PinType:ident,
+            )+
+        }
+    ) => {
+
+crate::paste::item! {
+    /// Represents a numbered external interrupt. The external interrupt is generic
+    /// over any pin, only the EicPin implementations in this module make sense.
+    pub struct [<$PadType $num>]<GPIO>(GPIO);
+
+    // impl !Send for [<$PadType $num>]<GPIO> {}
+    // impl !Sync for [<$PadType $num>]<GPIO> {}
+
+    impl<GPIO> [<$PadType $num>]<GPIO> {
+        /// Construct pad from the appropriate pin in any mode.
+        /// You may find it more convenient to use the `into_pad` trait
+        /// and avoid referencing the pad type.
+        pub fn new(pin: GPIO) -> Self {
+            [<$PadType $num>](pin)
+        }
+
+        /// Configure the eic with options for this external interrupt
+        pub fn enable_event(&mut self, eic: &mut super::EIC) {
+            eic.eic.evctrl.modify(|_, w| {
+                w.[<extinteo $num>]().set_bit()
+            });
+        }
+
+        pub fn enable_interrupt(&mut self, eic: &mut super::EIC) {
+            eic.eic.intenset.modify(|_, w| {
+                w.[<extint $num>]().set_bit()
+            });
+        }
+
+        pub fn enable_interrupt_wake(&mut self, eic: &mut super::EIC) {
+            eic.eic.wakeup.modify(|_, w| {
+                w.[<wakeupen $num>]().set_bit()
+            })
+        }
+
+        pub fn disable_interrupt(&mut self, eic: &mut super::EIC) {
+            eic.eic.intenclr.modify(|_, w| {
+                w.[<extint $num>]().set_bit()
+            });
+        }
+
+        pub fn is_interrupt(&mut self) -> bool {
+            unsafe { &(*target_device::EIC::ptr()) }.intflag.read().[<extint $num>]().bit_is_set()
+        }
+
+        pub fn clear_interrupt(&mut self) {
+            unsafe { &(*target_device::EIC::ptr()) }.intflag.modify(|_, w| {
+                w.[<extint $num>]().set_bit()
+            });
+        }
+
+        pub fn sense(&mut self, _eic: &mut super::EIC, sense: Sense) {
+            // Which of the two config blocks this eic config is in
+            let offset = ($num >> 3) & 0b0001;
+            let config = unsafe { &(*target_device::EIC::ptr()).config[offset] };
+
+            config.modify(|_, w| unsafe {
+                // Which of the eight eic configs in this config block
+                match $num & 0b111 {
+                    0b000 => w.sense0().bits(sense as u8),
+                    0b001 => w.sense1().bits(sense as u8),
+                    0b010 => w.sense2().bits(sense as u8),
+                    0b011 => w.sense3().bits(sense as u8),
+                    0b100 => w.sense4().bits(sense as u8),
+                    0b101 => w.sense5().bits(sense as u8),
+                    0b110 => w.sense6().bits(sense as u8),
+                    0b111 => w.sense7().bits(sense as u8),
+                    _ => unreachable!(),
+                }
+            });
+        }
+
+        pub fn filter(&mut self, _eic: &mut super::EIC, filter: bool) {
+            // Which of the two config blocks this eic config is in
+            let offset = ($num >> 3) & 0b0001;
+            let config = unsafe { &(*target_device::EIC::ptr()).config[offset] };
+
+            config.modify(|_, w| {
+                // Which of the eight eic configs in this config block
+                match $num & 0b111 {
+                    0b000 => w.filten0().bit(filter),
+                    0b001 => w.filten1().bit(filter),
+                    0b010 => w.filten2().bit(filter),
+                    0b011 => w.filten3().bit(filter),
+                    0b100 => w.filten4().bit(filter),
+                    0b101 => w.filten5().bit(filter),
+                    0b110 => w.filten6().bit(filter),
+                    0b111 => w.filten7().bit(filter),
+                    _ => unreachable!(),
+                }
+            });
+        }
+    }
+
+    $(
+        $(#[$attr])*
+        impl<MODE> EicPin<[<$PadType $num>]<gpio::$PinType<gpio::PfA>>> for gpio::$PinType<MODE> {
+            fn into_ei(self, port: &mut Port) -> [<$PadType $num>]<gpio::$PinType<gpio::PfA>> {
+                [<$PadType $num>]::new(self.into_function(port))
+            }
+        }
+
+        $(#[$attr])*
+        impl<MODE> ExternalInterrupt for &gpio::$PinType<MODE> {
+            fn id(self) -> ExternalInterruptID {
+                $num
+            }
+        }
+    )+
+}
+
+    };
+}
+
+// The SAMD11 and SAMD21 devices have different ExtInt designations. Just for
+// clarity's sake, the `ei!()` invocations below have been split into SAMD11-
+// and SAMD21-specific declarations.
+
+// SAMD11
+
+#[cfg(feature = "samd11")]
+ei!(ExtInt[1] {
+    Pa15,
+});
+
+#[cfg(feature = "samd11")]
+ei!(ExtInt[2] {
+    Pa2,
+});
+
+#[cfg(feature = "samd11")]
+ei!(ExtInt[3] {
+    Pa31,
+});
+
+#[cfg(feature = "samd11")]
+ei!(ExtInt[4] {
+    Pa4,
+    Pa24,
+});
+
+#[cfg(feature = "samd11")]
+ei!(ExtInt[5] {
+    Pa5,
+    Pa25,
+});
+
+#[cfg(feature = "samd11")]
+ei!(ExtInt[6] {
+    Pa8,
+});
+
+#[cfg(feature = "samd11")]
+ei!(ExtInt[7] {
+    Pa9,
+});
+
+// SAMD21
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[0] {
+    Pa0,
+    Pa16,
+    #[cfg(feature = "min-samd21g")]
+    Pb0,
+    #[cfg(feature = "min-samd21g")]
+    Pb16,
+});
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[1] {
+    Pa1,
+    Pa17,
+    #[cfg(feature = "min-samd21g")]
+    Pb1,
+    #[cfg(feature = "min-samd21g")]
+    Pb17,
+});
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[2] {
+    Pa2,
+    Pa18,
+    #[cfg(feature = "min-samd21g")]
+    Pb2,
+});
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[3] {
+    Pa3,
+    Pa19,
+    #[cfg(feature = "min-samd21g")]
+    Pb3,
+});
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[4] {
+    Pa4,
+    Pa20,
+    #[cfg(feature = "min-samd21g")]
+    Pb4,
+});
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[5] {
+    Pa5,
+    Pa21,
+    #[cfg(feature = "min-samd21g")]
+    Pb5,
+});
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[6] {
+    Pa6,
+    Pa22,
+    #[cfg(feature = "min-samd21g")]
+    Pb6,
+    #[cfg(feature = "min-samd21g")]
+    Pb22,
+});
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[7] {
+    Pa7,
+    Pa23,
+    #[cfg(feature = "min-samd21g")]
+    Pb7,
+    #[cfg(feature = "min-samd21g")]
+    Pb23,
+});
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[8] {
+    Pa28,
+    #[cfg(feature = "min-samd21g")]
+    Pb8,
+});
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[9] {
+    Pa9,
+    #[cfg(feature = "min-samd21g")]
+    Pb9,
+});
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[10] {
+    Pa10,
+    Pa30,
+    #[cfg(feature = "min-samd21g")]
+    Pb10,
+});
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[11] {
+   Pa11,
+   Pa31,
+   #[cfg(feature = "min-samd21g")]
+   Pb11,
+});
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[12] {
+    Pa12,
+    Pa24,
+    #[cfg(feature = "min-samd21g")]
+    Pb12,
+});
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[13] {
+    Pa13,
+    Pa25,
+    #[cfg(feature = "min-samd21g")]
+    Pb13,
+});
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[14] {
+    Pa14,
+    #[cfg(feature = "min-samd21g")]
+    Pb14,
+    #[cfg(feature = "min-samd21g")]
+    Pb30,
+});
+
+#[cfg(feature = "samd21")]
+ei!(ExtInt[15] {
+    Pa15,
+    Pa27,
+    #[cfg(feature = "min-samd21g")]
+    Pb15,
+    #[cfg(feature = "min-samd21g")]
+    Pb31,
+});

--- a/hal/src/common/thumbv6m/mod.rs
+++ b/hal/src/common/thumbv6m/mod.rs
@@ -1,3 +1,4 @@
+pub mod eic;
 pub mod gpio;
 
 mod reset_cause;


### PR DESCRIPTION
Unfortunately these devices don't seem to have the debounce or clock select fields in any of the registers, so the `ConfigurableEic` struct doesn't really serve any purpose; because of this it has been omitted. Otherwise it's nearly identical to the `thumbv7em` targets with the exception of the registers and fields being modified and the pins.

I did some minimal testing on hardware and it seems to be working.