### PR TITLE
wio_terminal: Derive Debug/Eq/PartialEq for button enums

### DIFF
--- a/boards/wio_terminal/src/buttons.rs
+++ b/boards/wio_terminal/src/buttons.rs
@@ -93,6 +93,7 @@ impl ButtonPins {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum Button {
     TopLeft,
     TopMiddle,
@@ -104,6 +105,7 @@ pub enum Button {
     Click,
 }
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct ButtonEvent {
     pub button: Button,
     pub down: bool,


### PR DESCRIPTION
Been using this functionality from another crate, and its super annoying without Debug/Eq.