### PR TITLE
Align the sleeping timer examples & add power measurements

### DIFF
--- a/boards/feather_m0/examples/sleeping_timer_rtc.rs
+++ b/boards/feather_m0/examples/sleeping_timer_rtc.rs
@@ -1,3 +1,15 @@
+//! Uses an RTC in standby mode to blink an LED for maximum power savings.
+//!
+//! We also use the internal 8MHz RC oscillator & the internal 32k oscillator
+//! to save power as it doesn't require the PLL. In standby on my feather_m0,
+//! we draw 318 uA when the LED is off and 965 uA when the LED is on at 4.3v.
+//! We are slightly limited by the quiescent current draw of the regulator of
+//! 90-150 uA.
+//!
+//! Some more power numbers that I measured:
+//! In IDLE2 we draw 740 uA (CPU & AHB & APB domain off)
+//! In IDLE1 we draw 870 uA (CPU & AHB domain off)
+//! In IDLE0 we draw 870 uA (CPU domain off)
 #![no_std]
 #![no_main]
 
@@ -8,7 +20,7 @@ extern crate panic_halt;
 #[cfg(feature = "use_semihosting")]
 extern crate panic_semihosting;
 
-use hal::clock::{ClockGenId, GenericClockController};
+use hal::clock::{enable_internal_32kosc, ClockGenId, ClockSource, GenericClockController};
 use hal::entry;
 use hal::pac::{interrupt, CorePeripherals, Peripherals, RTC};
 use hal::prelude::*;
@@ -26,18 +38,22 @@ fn main() -> ! {
     // Configure all of our peripherals/clocks
     let mut peripherals = Peripherals::take().unwrap();
     let mut core = CorePeripherals::take().unwrap();
-    let mut clocks = GenericClockController::with_external_32kosc(
+    let mut clocks = GenericClockController::with_internal_8mhz(
         peripherals.GCLK,
         &mut peripherals.PM,
         &mut peripherals.SYSCTRL,
         &mut peripherals.NVMCTRL,
     );
 
-    // Get a clock & make a sleeping delay object
-    let gclk1 = clocks.gclk1();
+    // Get a clock & make a sleeping delay object. use internal 32k clock that runs
+    // in standby
+    enable_internal_32kosc(&mut peripherals.SYSCTRL);
+    let timer_clock = clocks
+        .configure_gclk_divider_and_source(ClockGenId::GCLK1, 1, ClockSource::OSC32K, false)
+        .unwrap();
     clocks.configure_standby(ClockGenId::GCLK1, true);
     let timer = rtc_timer::RealTimeCounterTimer::new(
-        &gclk1,
+        &timer_clock,
         &mut peripherals.PM,
         &mut clocks,
         peripherals.RTC.mode0(),
@@ -52,6 +68,27 @@ fn main() -> ! {
         core.NVIC.set_priority(interrupt::RTC, 2);
         NVIC::unmask(interrupt::RTC);
     }
+
+    // Turn off unnecessary peripherals
+    peripherals.PM.ahbmask.modify(|_, w| {
+        w.usb_().clear_bit();
+        w.dmac_().clear_bit()
+    });
+    peripherals.PM.apbamask.modify(|_, w| {
+        w.eic_().clear_bit();
+        w.wdt_().clear_bit();
+        w.sysctrl_().clear_bit();
+        w.pac0_().clear_bit()
+    });
+    peripherals.PM.apbbmask.modify(|_, w| {
+        w.usb_().clear_bit();
+        w.dmac_().clear_bit();
+        w.nvmctrl_().clear_bit();
+        w.dsu_().clear_bit();
+        w.pac1_().clear_bit()
+    });
+    // Thankfully the only one default on here is ADC
+    peripherals.PM.apbcmask.modify(|_, w| w.adc_().clear_bit());
 
     // Configure our red LED and blink forever, sleeping between!
     let mut pins = hal::Pins::new(peripherals.PORT);


### PR DESCRIPTION
I was surprised to see that the timer seems to be less power efficient than the RTC. This does not jive with the data sheet, but I couldn't figure out what I was missing. 

I believe from my measurements that running with the sleeping timer in standby mode, you can get to pretty much just the quiescent current draw of everything else on the board. Hopefully Adafruit switches regulators to something more power efficient in the future