### PR TITLE
Fix QSPI, improve example code + make more robust

### DIFF
--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -24,6 +24,7 @@ categories = [
 ]
 
 [dependencies]
+bitfield = "0.13"
 cortex-m = "0.6"
 cortex-m-rt = { version = "0.6", optional = true }
 display-interface-spi = "0.4"


### PR DESCRIPTION
 - `EraseChip` should not have had address enable for its instruction frame, and should be a read transfer
 - Fixed data corruption by clocking chip below its max value (80Mhz)
 - Use bitfields in the example code when checking registers to eliminate magic numbers + make it easier to debug
 - Make the example write what its doing to the screen, so its obvious whats going on and if it worked
 - Wait for chip select to rise after a transaction, probably not needed but both the samd and the flash IC datasheets mention the it
 - Remove superfluous write to `instframe` in `write_memory`, which was causing an additional transaction (due to the side effects of `instframe`) and hence data corruption