### PR TITLE
thumbv7em ADC: Load calibration values when initializing

### DIFF
--- a/hal/src/common/thumbv7em/calibration.rs
+++ b/hal/src/common/thumbv7em/calibration.rs
@@ -29,3 +29,33 @@ pub fn usb_transp_cal() -> u8 {
 pub fn usb_trim_cal() -> u8 {
     cal(4, 10, 0b111) as u8
 }
+
+/// ADC0 BIASCOMP calibration value. Should be written to ADC0 CALIB register.
+pub fn adc0_biascomp_scale_cal() -> u8 {
+    cal(0, 2, 0b111) as u8
+}
+
+/// ADC0 BIASREFBUF calibration value. Should be written to ADC0 CALIB register.
+pub fn adc0_biasref_scale_cal() -> u8 {
+    cal(0, 5, 0b111) as u8
+}
+
+/// ADC0 BIASR2R calibration value. Should be written to ADC0 CALIB register.
+pub fn adc0_biasr2r_scale_cal() -> u8 {
+    cal(1, 0, 0b111) as u8
+}
+
+/// ADC1 BIASCOMP calibration value. Should be written to ADC1 CALIB register.
+pub fn adc1_biascomp_scale_cal() -> u8 {
+    cal(2, 2, 0b111) as u8
+}
+
+/// ADC1 BIASREFBUF calibration value. Should be written to ADC1 CALIB register.
+pub fn adc1_biasref_scale_cal() -> u8 {
+    cal(2, 5, 0b111) as u8
+}
+
+/// ADC1 BIASR2R calibration value. Should be written to ADC1 CALIB register.
+pub fn adc1_biasr2r_scale_cal() -> u8 {
+    cal(3, 0, 0b111) as u8
+}


### PR DESCRIPTION
Appears to make the reading more accurate (less diff compared to my multimeter), but I don't own any precision test equipment so who knows lol