### PR TITLE
add nmagic linker arg

### DIFF
--- a/boards/arduino_mkr1000/.cargo/config
+++ b/boards/arduino_mkr1000/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+  
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/arduino_mkrvidor4000/.cargo/config
+++ b/boards/arduino_mkrvidor4000/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+  
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/arduino_mkrzero/.cargo/config
+++ b/boards/arduino_mkrzero/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/arduino_nano33iot/.cargo/config
+++ b/boards/arduino_nano33iot/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/circuit_playground_express/.cargo/config
+++ b/boards/circuit_playground_express/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+  
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/edgebadge/.cargo/config
+++ b/boards/edgebadge/.cargo/config
@@ -5,5 +5,10 @@ runner = 'arm-none-eabi-gdb'
 [build]
 target = "thumbv7em-none-eabihf"
 rustflags = [
+
+   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+   # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+   "-C", "link-arg=--nmagic",
+
    "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/feather_m0/.cargo/config
+++ b/boards/feather_m0/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+  
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/feather_m4/.cargo/config
+++ b/boards/feather_m4/.cargo/config
@@ -5,5 +5,10 @@ runner = 'arm-none-eabi-gdb'
 [build]
 target = "thumbv7em-none-eabihf"
 rustflags = [
+
+   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+   # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+   "-C", "link-arg=--nmagic",
+
    "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/gemma_m0/.cargo/config
+++ b/boards/gemma_m0/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+  
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/grand_central_m4/.cargo/config
+++ b/boards/grand_central_m4/.cargo/config
@@ -5,5 +5,10 @@ runner = 'arm-none-eabi-gdb'
 [build]
 target = "thumbv7em-none-eabihf"
 rustflags = [
+
+   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+   # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+   "-C", "link-arg=--nmagic",
+
    "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/itsybitsy_m0/.cargo/config
+++ b/boards/itsybitsy_m0/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/itsybitsy_m4/.cargo/config
+++ b/boards/itsybitsy_m4/.cargo/config
@@ -5,5 +5,10 @@ runner = 'arm-none-eabi-gdb'
 [build]
 target = "thumbv7em-none-eabihf"
 rustflags = [
+
+   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+   # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+   "-C", "link-arg=--nmagic",
+
    "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/metro_m0/.cargo/config
+++ b/boards/metro_m0/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+  
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/metro_m4/.cargo/config
+++ b/boards/metro_m4/.cargo/config
@@ -5,5 +5,10 @@ runner = 'arm-none-eabi-gdb'
 [build]
 target = "thumbv7em-none-eabihf"
 rustflags = [
+
+   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+   # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+   "-C", "link-arg=--nmagic",
+
    "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/pfza_proto1/.cargo/config
+++ b/boards/pfza_proto1/.cargo/config
@@ -5,5 +5,10 @@ runner = 'arm-none-eabi-gdb'
 [build]
 target = "thumbv7em-none-eabihf"
 rustflags = [
+
+   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+   # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+   "-C", "link-arg=--nmagic",
+
    "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/pygamer/.cargo/config
+++ b/boards/pygamer/.cargo/config
@@ -5,5 +5,10 @@ runner = 'arm-none-eabi-gdb'
 [build]
 target = "thumbv7em-none-eabihf"
 rustflags = [
+
+   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+   # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+   "-C", "link-arg=--nmagic",
+
    "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/pyportal/.cargo/config
+++ b/boards/pyportal/.cargo/config
@@ -5,5 +5,10 @@ runner = 'arm-none-eabi-gdb'
 [build]
 target = "thumbv7em-none-eabihf"
 rustflags = [
+
+   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+   # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+   "-C", "link-arg=--nmagic",
+
    "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/samd11_bare/.cargo/config
+++ b/boards/samd11_bare/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/samd21_mini/.cargo/config
+++ b/boards/samd21_mini/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/serpente/.cargo/config
+++ b/boards/serpente/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/sodaq_one/.cargo/config
+++ b/boards/sodaq_one/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/sodaq_sara_aff/.cargo/config
+++ b/boards/sodaq_sara_aff/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/trellis_m4/.cargo/config
+++ b/boards/trellis_m4/.cargo/config
@@ -5,5 +5,10 @@ runner = 'arm-none-eabi-gdb'
 [build]
 target = "thumbv7em-none-eabihf"
 rustflags = [
+
+   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+   # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+   "-C", "link-arg=--nmagic",
+
    "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/trinket_m0/.cargo/config
+++ b/boards/trinket_m0/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/wio_lite_mg126/.cargo/config
+++ b/boards/wio_lite_mg126/.cargo/config
@@ -6,5 +6,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+  
   "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/wio_terminal/.cargo/config
+++ b/boards/wio_terminal/.cargo/config
@@ -4,5 +4,10 @@ runner = "arm-none-eabi-gdb"
 [build]
 target = "thumbv7em-none-eabihf"
 rustflags = [
+
+   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+   # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+   "-C", "link-arg=--nmagic",
+
    "-C", "link-arg=-Tlink.x",
 ]

--- a/boards/xiao_m0/.cargo/config
+++ b/boards/xiao_m0/.cargo/config
@@ -4,5 +4,10 @@ target = "thumbv6m-none-eabi"
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
 rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+  
   "-C", "link-arg=-Tlink.x",
 ]


### PR DESCRIPTION
More bullshit to carry around. LLVM changes in 1.47 changed the default alignment. 

It seems to mainly come up when you move your start address (ie you have a bootloader) which we almost always do except for the bare boards. The downstream effect is tools like hf2
https://github.com/jacobrosenthal/hf2-rs/pull/33
and probe-rs 
https://github.com/probe-rs/probe-rs/pull/426

Which look for elf sections see garbage. Hf2 worked around by ignoring those sections, but probe-rs is wont fix and the community has decided adding the nmagic flag to linker is the fix. 

This is in the quickstart nowadays https://github.com/rust-embedded/cortex-m-quickstart/pull/95
