### PR TITLE
Add feather features

### DIFF
--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -63,6 +63,10 @@ usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
 panic_halt = ["panic-halt"]
 panic_abort = ["panic-abort"]
 panic_semihosting = ["panic-semihosting"]
+# Enable pins for the radio on "RadioFruits" with RFM95, RFM96, RFM69
+rfm = []
+# Enable pins for the flash and neopixel on the Feather M0 Express
+express = []
 
 [profile.dev]
 incremental = false

--- a/boards/feather_m0/src/lib.rs
+++ b/boards/feather_m0/src/lib.rs
@@ -82,6 +82,38 @@ define_pins!(
     pin usb_dm = a24,
     /// The USB D+ pad
     pin usb_dp = a25,
+
+    /// SPI chip select for the RFM module
+    #[cfg(feature = "rfm")]
+    pin rfm_cs = a6,
+
+    /// Reset for the RFM module
+    #[cfg(feature = "rfm")]
+    pin rfm_reset = a8,
+
+    /// Interrupt from the RFM module
+    #[cfg(feature = "rfm")]
+    pin rfm_irq = a9,
+
+    /// Neopixel data
+    #[cfg(feature = "express")]
+    pin neopixel = a6,
+
+    /// SPI clock for the external flash
+    #[cfg(feature = "express")]
+    pin flash_sck = a9,
+
+    /// SPI MOSI for the external flash
+    #[cfg(feature = "express")]
+    pin flash_mosi = a8,
+
+    /// SPI MISO for the external flash
+    #[cfg(feature = "express")]
+    pin flash_miso = a14,
+
+    /// SPI chip select for the external flash
+    #[cfg(feature = "express")]
+    pin flash_cs = a13,
 );
 
 /// Convenience for setting up the labelled SPI peripheral.

--- a/boards/feather_m0/src/lib.rs
+++ b/boards/feather_m0/src/lib.rs
@@ -30,6 +30,9 @@ define_pins!(
     struct Pins,
     target_device: target_device,
 
+    /// AREF pin - has 1uF capacitor to ground
+    pin aref = a3,
+
     /// Analog pin 0.  Can act as a true analog output
     /// as it has a DAC (which is not currently supported
     /// by this hal) as well as input.

--- a/hal/src/common/thumbv6m/gpio.rs
+++ b/hal/src/common/thumbv6m/gpio.rs
@@ -593,6 +593,7 @@ impl $Type {
             $Type {
                 port: pins.port,
                 $(
+                $(#[$attr])*
                 $name: pins.[<p $pin_ident>]
                 ),+
             }


### PR DESCRIPTION
As discussed in atsamd-rs/community Matrix chat - this adds two features to the Feather M0 BSP to support the various RFM radio modules, and the "Express" board with an SPI flash and Neopixel.

While adding those pins, I noticed that there wasn't a pin definition for the AREF pin which is brought out on the Feather boards so added that too.