### PR TITLE
wio_terminal: Enable overclocking of ILI9341 (works fine)

### DIFF
--- a/boards/wio_terminal/examples/buttons.rs
+++ b/boards/wio_terminal/examples/buttons.rs
@@ -13,6 +13,7 @@ use eg::style::{PrimitiveStyle, PrimitiveStyleBuilder};
 use wio::hal::clock::GenericClockController;
 use wio::hal::delay::Delay;
 use wio::pac::{interrupt, CorePeripherals, Peripherals};
+use wio::prelude::*;
 use wio::{button_interrupt, entry, Button, ButtonController, ButtonEvent, Pins, Sets};
 
 use cortex_m::interrupt::{free as disable_interrupts, CriticalSection};
@@ -48,6 +49,7 @@ fn main() -> ! {
             peripherals.SERCOM7,
             &mut peripherals.MCLK,
             &mut sets.port,
+            58.mhz(),
             &mut delay,
         )
         .unwrap();

--- a/boards/wio_terminal/examples/clock.rs
+++ b/boards/wio_terminal/examples/clock.rs
@@ -66,6 +66,7 @@ fn main() -> ! {
             peripherals.SERCOM7,
             &mut peripherals.MCLK,
             &mut sets.port,
+            58.mhz(),
             &mut delay,
         )
         .unwrap();

--- a/boards/wio_terminal/examples/orientation.rs
+++ b/boards/wio_terminal/examples/orientation.rs
@@ -62,6 +62,7 @@ fn main() -> ! {
             peripherals.SERCOM7,
             &mut peripherals.MCLK,
             &mut sets.port,
+            58.mhz(),
             &mut delay,
         )
         .unwrap();

--- a/boards/wio_terminal/examples/qspi.rs
+++ b/boards/wio_terminal/examples/qspi.rs
@@ -50,6 +50,7 @@ fn main() -> ! {
             peripherals.SERCOM7,
             &mut peripherals.MCLK,
             &mut sets.port,
+            24.mhz(),
             &mut delay,
         )
         .unwrap();

--- a/boards/wio_terminal/examples/sdcard.rs
+++ b/boards/wio_terminal/examples/sdcard.rs
@@ -63,6 +63,7 @@ fn main() -> ! {
             peripherals.SERCOM7,
             &mut peripherals.MCLK,
             &mut sets.port,
+            24.mhz(),
             &mut delay,
         )
         .unwrap();

--- a/boards/wio_terminal/examples/usb_serial_display.rs
+++ b/boards/wio_terminal/examples/usb_serial_display.rs
@@ -59,6 +59,7 @@ fn main() -> ! {
             peripherals.SERCOM7,
             &mut peripherals.MCLK,
             &mut sets.port,
+            58.mhz(),
             &mut delay,
         )
         .unwrap();

--- a/boards/wio_terminal/src/display.rs
+++ b/boards/wio_terminal/src/display.rs
@@ -5,6 +5,7 @@ use atsamd_hal::hal::spi;
 use atsamd_hal::prelude::*;
 use atsamd_hal::sercom::{PadPin, SPIMaster7, Sercom7Pad1, Sercom7Pad2, Sercom7Pad3};
 use atsamd_hal::target_device::{MCLK, SERCOM7};
+use atsamd_hal::time::Hertz;
 use display_interface_spi::SPIInterface;
 use ili9341::{Ili9341, Orientation};
 
@@ -48,20 +49,20 @@ impl Display {
     /// Initialize the display and its corresponding SPI bus peripheral. Return
     /// a tuple containing the configured display driver struct and backlight
     /// pin.
-    pub fn init(
+    pub fn init<F: Into<Hertz>>(
         self,
         clocks: &mut GenericClockController,
         sercom7: SERCOM7,
         mclk: &mut MCLK,
         port: &mut Port,
+        clock_speed: F,
         delay: &mut Delay,
     ) -> Result<(LCD, Pc5<Output<PushPull>>), ()> {
-        // Initialize the SPI peripherial on the configured pins, using SERCOM7 and
-        // running at 20MHz.
+        // Initialize the SPI peripherial on the configured pins, using SERCOM7.
         let gclk0 = clocks.gclk0();
         let spi = SPIMaster7::new(
             &clocks.sercom7_core(&gclk0).ok_or(())?,
-            20.mhz(),
+            clock_speed,
             spi::Mode {
                 phase: spi::Phase::CaptureOnFirstTransition,
                 polarity: spi::Polarity::IdleLow,


### PR DESCRIPTION
Looks like the datasheet only specs the lowest speed at the lowest voltage, but people have even managed to get it going at 80Mhz from a teensy.

This PR lets you specify the clock speed at configuration. We also conservatively overclock at 58Mhz for some of the examples where you notice the display refresh speed.