### PR TITLE
Add enumerations for DMA trigger source to PACs

### DIFF
--- a/pac/atsamd11c/src/dmac/chctrlb.rs
+++ b/pac/atsamd11c/src/dmac/chctrlb.rs
@@ -288,6 +288,44 @@ impl<'a> LVL_W<'a> {
 pub enum TRIGSRC_A {
     #[doc = "0: Only software/event triggers"]
     DISABLE = 0,
+    #[doc = "1: SERCOM0 RX Trigger"]
+    SERCOM0_RX = 1,
+    #[doc = "2: SERCOM0 TX Trigger"]
+    SERCOM0_TX = 2,
+    #[doc = "3: SERCOM1 RX Trigger"]
+    SERCOM1_RX = 3,
+    #[doc = "4: SERCOM1 TX Trigger"]
+    SERCOM1_TX = 4,
+    #[doc = "5: SERCOM2 RX Trigger"]
+    SERCOM2_RX = 5,
+    #[doc = "6: SERCOM2 TX Trigger"]
+    SERCOM2_TX = 6,
+    #[doc = "7: TCC0 Overflow Trigger"]
+    TCC0_OVF = 7,
+    #[doc = "8: TCC0 Match/Compare 0 Trigger"]
+    TCC0_MC0 = 8,
+    #[doc = "9: TCC0 Match/Compare 1 Trigger"]
+    TCC0_MC1 = 9,
+    #[doc = "10: TCC0 Match/Compare 2 Trigger"]
+    TCC0_MC2 = 10,
+    #[doc = "11: TCC0 Match/Compare 3 Trigger"]
+    TCC0_MC3 = 11,
+    #[doc = "12: TC1 Overflow Trigger"]
+    TC1_OVF = 12,
+    #[doc = "13: TC1 Match/Compare 0 Trigger"]
+    TC1_MC0 = 13,
+    #[doc = "14: TC1 Match/Compare 1 Trigger"]
+    TC1_MC1 = 14,
+    #[doc = "15: TC2 Overflow Trigger"]
+    TC2_OVF = 15,
+    #[doc = "16: TC2 Match/Compare 0 Trigger"]
+    TC2_MC0 = 16,
+    #[doc = "17: TC2 Match/Compare 1 Trigger"]
+    TC2_MC1 = 17,
+    #[doc = "18: ADC Result Ready Trigger"]
+    ADC_RESRDY = 18,
+    #[doc = "19: DAC Empty Trigger"]
+    DAC_EMPTY = 19,
 }
 impl From<TRIGSRC_A> for u8 {
     #[inline(always)]
@@ -304,6 +342,25 @@ impl TRIGSRC_R {
         use crate::Variant::*;
         match self.bits {
             0 => Val(TRIGSRC_A::DISABLE),
+            1 => Val(TRIGSRC_A::SERCOM0_RX),
+            2 => Val(TRIGSRC_A::SERCOM0_TX),
+            3 => Val(TRIGSRC_A::SERCOM1_RX),
+            4 => Val(TRIGSRC_A::SERCOM1_TX),
+            5 => Val(TRIGSRC_A::SERCOM2_RX),
+            6 => Val(TRIGSRC_A::SERCOM2_TX),
+            7 => Val(TRIGSRC_A::TCC0_OVF),
+            8 => Val(TRIGSRC_A::TCC0_MC0),
+            9 => Val(TRIGSRC_A::TCC0_MC1),
+            10 => Val(TRIGSRC_A::TCC0_MC2),
+            11 => Val(TRIGSRC_A::TCC0_MC3),
+            12 => Val(TRIGSRC_A::TC1_OVF),
+            13 => Val(TRIGSRC_A::TC1_MC0),
+            14 => Val(TRIGSRC_A::TC1_MC1),
+            15 => Val(TRIGSRC_A::TC2_OVF),
+            16 => Val(TRIGSRC_A::TC2_MC0),
+            17 => Val(TRIGSRC_A::TC2_MC1),
+            18 => Val(TRIGSRC_A::ADC_RESRDY),
+            19 => Val(TRIGSRC_A::DAC_EMPTY),
             i => Res(i),
         }
     }
@@ -311,6 +368,101 @@ impl TRIGSRC_R {
     #[inline(always)]
     pub fn is_disable(&self) -> bool {
         *self == TRIGSRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_RX`"]
+    #[inline(always)]
+    pub fn is_sercom0_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_TX`"]
+    #[inline(always)]
+    pub fn is_sercom0_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_RX`"]
+    #[inline(always)]
+    pub fn is_sercom1_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_TX`"]
+    #[inline(always)]
+    pub fn is_sercom1_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_RX`"]
+    #[inline(always)]
+    pub fn is_sercom2_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_TX`"]
+    #[inline(always)]
+    pub fn is_sercom2_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_TX
+    }
+    #[doc = "Checks if the value of the field is `TCC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC0`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC0
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC1`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC1
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC2`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc2(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC2
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC3`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc3(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC3
+    }
+    #[doc = "Checks if the value of the field is `TC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC0`"]
+    #[inline(always)]
+    pub fn is_tc1_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC1`"]
+    #[inline(always)]
+    pub fn is_tc1_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC0`"]
+    #[inline(always)]
+    pub fn is_tc2_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC1`"]
+    #[inline(always)]
+    pub fn is_tc2_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC1
+    }
+    #[doc = "Checks if the value of the field is `ADC_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY`"]
+    #[inline(always)]
+    pub fn is_dac_empty(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY
     }
 }
 #[doc = "Write proxy for field `TRIGSRC`"]
@@ -327,6 +479,101 @@ impl<'a> TRIGSRC_W<'a> {
     #[inline(always)]
     pub fn disable(self) -> &'a mut W {
         self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = "SERCOM0 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom0_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_RX)
+    }
+    #[doc = "SERCOM0 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom0_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_TX)
+    }
+    #[doc = "SERCOM1 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom1_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_RX)
+    }
+    #[doc = "SERCOM1 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom1_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_TX)
+    }
+    #[doc = "SERCOM2 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom2_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_RX)
+    }
+    #[doc = "SERCOM2 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom2_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_TX)
+    }
+    #[doc = "TCC0 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tcc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_OVF)
+    }
+    #[doc = "TCC0 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC0)
+    }
+    #[doc = "TCC0 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC1)
+    }
+    #[doc = "TCC0 Match/Compare 2 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC2)
+    }
+    #[doc = "TCC0 Match/Compare 3 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC3)
+    }
+    #[doc = "TC1 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_OVF)
+    }
+    #[doc = "TC1 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc1_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC0)
+    }
+    #[doc = "TC1 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc1_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC1)
+    }
+    #[doc = "TC2 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_OVF)
+    }
+    #[doc = "TC2 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc2_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC0)
+    }
+    #[doc = "TC2 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc2_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC1)
+    }
+    #[doc = "ADC Result Ready Trigger"]
+    #[inline(always)]
+    pub fn adc_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC_RESRDY)
+    }
+    #[doc = "DAC Empty Trigger"]
+    #[inline(always)]
+    pub fn dac_empty(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY)
     }
     #[doc = r"Writes raw bits to the field"]
     #[inline(always)]

--- a/pac/atsamd21e/src/dmac/chctrlb.rs
+++ b/pac/atsamd21e/src/dmac/chctrlb.rs
@@ -288,6 +288,104 @@ impl<'a> LVL_W<'a> {
 pub enum TRIGSRC_A {
     #[doc = "0: Only software/event triggers"]
     DISABLE = 0,
+    #[doc = "1: SERCOM0 RX Trigger"]
+    SERCOM0_RX = 1,
+    #[doc = "2: SERCOM0 TX Trigger"]
+    SERCOM0_TX = 2,
+    #[doc = "3: SERCOM1 RX Trigger"]
+    SERCOM1_RX = 3,
+    #[doc = "4: SERCOM1 TX Trigger"]
+    SERCOM1_TX = 4,
+    #[doc = "5: SERCOM2 RX Trigger"]
+    SERCOM2_RX = 5,
+    #[doc = "6: SERCOM2 TX Trigger"]
+    SERCOM2_TX = 6,
+    #[doc = "7: SERCOM3 RX Trigger"]
+    SERCOM3_RX = 7,
+    #[doc = "8: SERCOM3 TX Trigger"]
+    SERCOM3_TX = 8,
+    #[doc = "9: SERCOM4 RX Trigger"]
+    SERCOM4_RX = 9,
+    #[doc = "10: SERCOM4 TX Trigger"]
+    SERCOM4_TX = 10,
+    #[doc = "11: SERCOM5 RX Trigger"]
+    SERCOM5_RX = 11,
+    #[doc = "12: SERCOM5 TX Trigger"]
+    SERCOM5_TX = 12,
+    #[doc = "13: TCC0 Overflow Trigger"]
+    TCC0_OVF = 13,
+    #[doc = "14: TCC0 Match/Compare 0 Trigger"]
+    TCC0_MC0 = 14,
+    #[doc = "15: TCC0 Match/Compare 1 Trigger"]
+    TCC0_MC1 = 15,
+    #[doc = "16: TCC0 Match/Compare 2 Trigger"]
+    TCC0_MC2 = 16,
+    #[doc = "17: TCC0 Match/Compare 3 Trigger"]
+    TCC0_MC3 = 17,
+    #[doc = "18: TCC1 Overflow Trigger"]
+    TCC1_OVF = 18,
+    #[doc = "19: TCC1 Match/Compare 0 Trigger"]
+    TCC1_MC0 = 19,
+    #[doc = "20: TCC1 Match/Compare 1 Trigger"]
+    TCC1_MC1 = 20,
+    #[doc = "21: TCC2 Overflow Trigger"]
+    TCC2_OVF = 21,
+    #[doc = "22: TCC2 Match/Compare 0 Trigger"]
+    TCC2_MC0 = 22,
+    #[doc = "23: TCC2 Match/Compare 1 Trigger"]
+    TCC2_MC1 = 23,
+    #[doc = "24: TC3 Overflow Trigger"]
+    TC3_OVF = 24,
+    #[doc = "25: TC3 Match/Compare 0 Trigger"]
+    TC3_MC0 = 25,
+    #[doc = "26: TC3 Match/Compare 1 Trigger"]
+    TC3_MC1 = 26,
+    #[doc = "27: TC4 Overflow Trigger"]
+    TC4_OVF = 27,
+    #[doc = "28: TC4 Match/Compare 0 Trigger"]
+    TC4_MC0 = 28,
+    #[doc = "29: TC4 Match/Compare 1 Trigger"]
+    TC4_MC1 = 29,
+    #[doc = "30: TC5 Overflow Trigger"]
+    TC5_OVF = 30,
+    #[doc = "31: TC5 Match/Compare 0 Trigger"]
+    TC5_MC0 = 31,
+    #[doc = "32: TC5 Match/Compare 1 Trigger"]
+    TC5_MC1 = 32,
+    #[doc = "33: TC6 Overflow Trigger"]
+    TC6_OVF = 33,
+    #[doc = "34: TC6 Match/Compare 0 Trigger"]
+    TC6_MC0 = 34,
+    #[doc = "35: TC6 Match/Compare 1 Trigger"]
+    TC6_MC1 = 35,
+    #[doc = "36: TC7 Overflow Trigger"]
+    TC7_OVF = 36,
+    #[doc = "37: TC7 Match/Compare 0 Trigger"]
+    TC7_MC0 = 37,
+    #[doc = "38: TC7 Match/Compare 1 Trigger"]
+    TC7_MC1 = 38,
+    #[doc = "39: ADC Result Ready Trigger"]
+    ADC_RESRDY = 39,
+    #[doc = "40: DAC Empty Trigger"]
+    DAC_EMPTY = 40,
+    #[doc = "41: I2S RX 0 Trigger"]
+    I2S_RX_0 = 41,
+    #[doc = "42: I2S RX 1 Trigger"]
+    I2S_RX_1 = 42,
+    #[doc = "43: I2S TX 0 Trigger"]
+    I2S_TX_0 = 43,
+    #[doc = "44: I2S TX 1 Trigger"]
+    I2S_TX_1 = 44,
+    #[doc = "45: TCC3 Overflow Trigger"]
+    TCC3_OVF = 45,
+    #[doc = "46: TCC3 Match/Compare 0 Trigger"]
+    TCC3_MC0 = 46,
+    #[doc = "47: TCC3 Match/Compare 1 Trigger"]
+    TCC3_MC1 = 47,
+    #[doc = "48: Match/Compare 2 Trigger"]
+    TCC3_MC2 = 48,
+    #[doc = "49: Match/Compare 3 Trigger"]
+    TCC3_MC3 = 49,
 }
 impl From<TRIGSRC_A> for u8 {
     #[inline(always)]
@@ -304,6 +402,55 @@ impl TRIGSRC_R {
         use crate::Variant::*;
         match self.bits {
             0 => Val(TRIGSRC_A::DISABLE),
+            1 => Val(TRIGSRC_A::SERCOM0_RX),
+            2 => Val(TRIGSRC_A::SERCOM0_TX),
+            3 => Val(TRIGSRC_A::SERCOM1_RX),
+            4 => Val(TRIGSRC_A::SERCOM1_TX),
+            5 => Val(TRIGSRC_A::SERCOM2_RX),
+            6 => Val(TRIGSRC_A::SERCOM2_TX),
+            7 => Val(TRIGSRC_A::SERCOM3_RX),
+            8 => Val(TRIGSRC_A::SERCOM3_TX),
+            9 => Val(TRIGSRC_A::SERCOM4_RX),
+            10 => Val(TRIGSRC_A::SERCOM4_TX),
+            11 => Val(TRIGSRC_A::SERCOM5_RX),
+            12 => Val(TRIGSRC_A::SERCOM5_TX),
+            13 => Val(TRIGSRC_A::TCC0_OVF),
+            14 => Val(TRIGSRC_A::TCC0_MC0),
+            15 => Val(TRIGSRC_A::TCC0_MC1),
+            16 => Val(TRIGSRC_A::TCC0_MC2),
+            17 => Val(TRIGSRC_A::TCC0_MC3),
+            18 => Val(TRIGSRC_A::TCC1_OVF),
+            19 => Val(TRIGSRC_A::TCC1_MC0),
+            20 => Val(TRIGSRC_A::TCC1_MC1),
+            21 => Val(TRIGSRC_A::TCC2_OVF),
+            22 => Val(TRIGSRC_A::TCC2_MC0),
+            23 => Val(TRIGSRC_A::TCC2_MC1),
+            24 => Val(TRIGSRC_A::TC3_OVF),
+            25 => Val(TRIGSRC_A::TC3_MC0),
+            26 => Val(TRIGSRC_A::TC3_MC1),
+            27 => Val(TRIGSRC_A::TC4_OVF),
+            28 => Val(TRIGSRC_A::TC4_MC0),
+            29 => Val(TRIGSRC_A::TC4_MC1),
+            30 => Val(TRIGSRC_A::TC5_OVF),
+            31 => Val(TRIGSRC_A::TC5_MC0),
+            32 => Val(TRIGSRC_A::TC5_MC1),
+            33 => Val(TRIGSRC_A::TC6_OVF),
+            34 => Val(TRIGSRC_A::TC6_MC0),
+            35 => Val(TRIGSRC_A::TC6_MC1),
+            36 => Val(TRIGSRC_A::TC7_OVF),
+            37 => Val(TRIGSRC_A::TC7_MC0),
+            38 => Val(TRIGSRC_A::TC7_MC1),
+            39 => Val(TRIGSRC_A::ADC_RESRDY),
+            40 => Val(TRIGSRC_A::DAC_EMPTY),
+            41 => Val(TRIGSRC_A::I2S_RX_0),
+            42 => Val(TRIGSRC_A::I2S_RX_1),
+            43 => Val(TRIGSRC_A::I2S_TX_0),
+            44 => Val(TRIGSRC_A::I2S_TX_1),
+            45 => Val(TRIGSRC_A::TCC3_OVF),
+            46 => Val(TRIGSRC_A::TCC3_MC0),
+            47 => Val(TRIGSRC_A::TCC3_MC1),
+            48 => Val(TRIGSRC_A::TCC3_MC2),
+            49 => Val(TRIGSRC_A::TCC3_MC3),
             i => Res(i),
         }
     }
@@ -311,6 +458,251 @@ impl TRIGSRC_R {
     #[inline(always)]
     pub fn is_disable(&self) -> bool {
         *self == TRIGSRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_RX`"]
+    #[inline(always)]
+    pub fn is_sercom0_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_TX`"]
+    #[inline(always)]
+    pub fn is_sercom0_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_RX`"]
+    #[inline(always)]
+    pub fn is_sercom1_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_TX`"]
+    #[inline(always)]
+    pub fn is_sercom1_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_RX`"]
+    #[inline(always)]
+    pub fn is_sercom2_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_TX`"]
+    #[inline(always)]
+    pub fn is_sercom2_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_RX`"]
+    #[inline(always)]
+    pub fn is_sercom3_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_TX`"]
+    #[inline(always)]
+    pub fn is_sercom3_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_RX`"]
+    #[inline(always)]
+    pub fn is_sercom4_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_TX`"]
+    #[inline(always)]
+    pub fn is_sercom4_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_RX`"]
+    #[inline(always)]
+    pub fn is_sercom5_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_TX`"]
+    #[inline(always)]
+    pub fn is_sercom5_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_TX
+    }
+    #[doc = "Checks if the value of the field is `TCC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC0`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC0
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC1`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC1
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC2`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc2(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC2
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC3`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc3(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC3
+    }
+    #[doc = "Checks if the value of the field is `TCC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC0`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC0
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC1`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC1
+    }
+    #[doc = "Checks if the value of the field is `TCC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC0`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC0
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC1`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC0`"]
+    #[inline(always)]
+    pub fn is_tc3_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC1`"]
+    #[inline(always)]
+    pub fn is_tc3_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC0`"]
+    #[inline(always)]
+    pub fn is_tc4_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC1`"]
+    #[inline(always)]
+    pub fn is_tc4_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC5_OVF`"]
+    #[inline(always)]
+    pub fn is_tc5_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC5_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC0`"]
+    #[inline(always)]
+    pub fn is_tc5_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC1`"]
+    #[inline(always)]
+    pub fn is_tc5_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC6_OVF`"]
+    #[inline(always)]
+    pub fn is_tc6_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC6_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC0`"]
+    #[inline(always)]
+    pub fn is_tc6_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC1`"]
+    #[inline(always)]
+    pub fn is_tc6_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC7_OVF`"]
+    #[inline(always)]
+    pub fn is_tc7_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC7_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC0`"]
+    #[inline(always)]
+    pub fn is_tc7_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC1`"]
+    #[inline(always)]
+    pub fn is_tc7_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC1
+    }
+    #[doc = "Checks if the value of the field is `ADC_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY`"]
+    #[inline(always)]
+    pub fn is_dac_empty(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_1
+    }
+    #[doc = "Checks if the value of the field is `TCC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC0`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC0
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC1`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC1
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC2`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc2(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC2
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC3`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc3(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC3
     }
 }
 #[doc = "Write proxy for field `TRIGSRC`"]
@@ -327,6 +719,251 @@ impl<'a> TRIGSRC_W<'a> {
     #[inline(always)]
     pub fn disable(self) -> &'a mut W {
         self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = "SERCOM0 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom0_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_RX)
+    }
+    #[doc = "SERCOM0 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom0_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_TX)
+    }
+    #[doc = "SERCOM1 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom1_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_RX)
+    }
+    #[doc = "SERCOM1 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom1_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_TX)
+    }
+    #[doc = "SERCOM2 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom2_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_RX)
+    }
+    #[doc = "SERCOM2 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom2_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_TX)
+    }
+    #[doc = "SERCOM3 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom3_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_RX)
+    }
+    #[doc = "SERCOM3 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom3_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_TX)
+    }
+    #[doc = "SERCOM4 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom4_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_RX)
+    }
+    #[doc = "SERCOM4 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom4_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_TX)
+    }
+    #[doc = "SERCOM5 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom5_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_RX)
+    }
+    #[doc = "SERCOM5 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom5_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_TX)
+    }
+    #[doc = "TCC0 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tcc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_OVF)
+    }
+    #[doc = "TCC0 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC0)
+    }
+    #[doc = "TCC0 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC1)
+    }
+    #[doc = "TCC0 Match/Compare 2 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC2)
+    }
+    #[doc = "TCC0 Match/Compare 3 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC3)
+    }
+    #[doc = "TCC1 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tcc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_OVF)
+    }
+    #[doc = "TCC1 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tcc1_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC0)
+    }
+    #[doc = "TCC1 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tcc1_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC1)
+    }
+    #[doc = "TCC2 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tcc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_OVF)
+    }
+    #[doc = "TCC2 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tcc2_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC0)
+    }
+    #[doc = "TCC2 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tcc2_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC1)
+    }
+    #[doc = "TC3 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_OVF)
+    }
+    #[doc = "TC3 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc3_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC0)
+    }
+    #[doc = "TC3 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc3_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC1)
+    }
+    #[doc = "TC4 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_OVF)
+    }
+    #[doc = "TC4 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc4_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC0)
+    }
+    #[doc = "TC4 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc4_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC1)
+    }
+    #[doc = "TC5 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc5_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_OVF)
+    }
+    #[doc = "TC5 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc5_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC0)
+    }
+    #[doc = "TC5 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc5_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC1)
+    }
+    #[doc = "TC6 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc6_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_OVF)
+    }
+    #[doc = "TC6 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc6_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC0)
+    }
+    #[doc = "TC6 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc6_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC1)
+    }
+    #[doc = "TC7 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc7_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_OVF)
+    }
+    #[doc = "TC7 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc7_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC0)
+    }
+    #[doc = "TC7 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc7_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC1)
+    }
+    #[doc = "ADC Result Ready Trigger"]
+    #[inline(always)]
+    pub fn adc_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC_RESRDY)
+    }
+    #[doc = "DAC Empty Trigger"]
+    #[inline(always)]
+    pub fn dac_empty(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY)
+    }
+    #[doc = "I2S RX 0 Trigger"]
+    #[inline(always)]
+    pub fn i2s_rx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_0)
+    }
+    #[doc = "I2S RX 1 Trigger"]
+    #[inline(always)]
+    pub fn i2s_rx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_1)
+    }
+    #[doc = "I2S TX 0 Trigger"]
+    #[inline(always)]
+    pub fn i2s_tx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_0)
+    }
+    #[doc = "I2S TX 1 Trigger"]
+    #[inline(always)]
+    pub fn i2s_tx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_1)
+    }
+    #[doc = "TCC3 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tcc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_OVF)
+    }
+    #[doc = "TCC3 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tcc3_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC0)
+    }
+    #[doc = "TCC3 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tcc3_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC1)
+    }
+    #[doc = "Match/Compare 2 Trigger"]
+    #[inline(always)]
+    pub fn tcc3_mc2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC2)
+    }
+    #[doc = "Match/Compare 3 Trigger"]
+    #[inline(always)]
+    pub fn tcc3_mc3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC3)
     }
     #[doc = r"Writes raw bits to the field"]
     #[inline(always)]

--- a/pac/atsamd21g/src/dmac/chctrlb.rs
+++ b/pac/atsamd21g/src/dmac/chctrlb.rs
@@ -288,6 +288,104 @@ impl<'a> LVL_W<'a> {
 pub enum TRIGSRC_A {
     #[doc = "0: Only software/event triggers"]
     DISABLE = 0,
+    #[doc = "1: SERCOM0 RX Trigger"]
+    SERCOM0_RX = 1,
+    #[doc = "2: SERCOM0 TX Trigger"]
+    SERCOM0_TX = 2,
+    #[doc = "3: SERCOM1 RX Trigger"]
+    SERCOM1_RX = 3,
+    #[doc = "4: SERCOM1 TX Trigger"]
+    SERCOM1_TX = 4,
+    #[doc = "5: SERCOM2 RX Trigger"]
+    SERCOM2_RX = 5,
+    #[doc = "6: SERCOM2 TX Trigger"]
+    SERCOM2_TX = 6,
+    #[doc = "7: SERCOM3 RX Trigger"]
+    SERCOM3_RX = 7,
+    #[doc = "8: SERCOM3 TX Trigger"]
+    SERCOM3_TX = 8,
+    #[doc = "9: SERCOM4 RX Trigger"]
+    SERCOM4_RX = 9,
+    #[doc = "10: SERCOM4 TX Trigger"]
+    SERCOM4_TX = 10,
+    #[doc = "11: SERCOM5 RX Trigger"]
+    SERCOM5_RX = 11,
+    #[doc = "12: SERCOM5 TX Trigger"]
+    SERCOM5_TX = 12,
+    #[doc = "13: TCC0 Overflow Trigger"]
+    TCC0_OVF = 13,
+    #[doc = "14: TCC0 Match/Compare 0 Trigger"]
+    TCC0_MC0 = 14,
+    #[doc = "15: TCC0 Match/Compare 1 Trigger"]
+    TCC0_MC1 = 15,
+    #[doc = "16: TCC0 Match/Compare 2 Trigger"]
+    TCC0_MC2 = 16,
+    #[doc = "17: TCC0 Match/Compare 3 Trigger"]
+    TCC0_MC3 = 17,
+    #[doc = "18: TCC1 Overflow Trigger"]
+    TCC1_OVF = 18,
+    #[doc = "19: TCC1 Match/Compare 0 Trigger"]
+    TCC1_MC0 = 19,
+    #[doc = "20: TCC1 Match/Compare 1 Trigger"]
+    TCC1_MC1 = 20,
+    #[doc = "21: TCC2 Overflow Trigger"]
+    TCC2_OVF = 21,
+    #[doc = "22: TCC2 Match/Compare 0 Trigger"]
+    TCC2_MC0 = 22,
+    #[doc = "23: TCC2 Match/Compare 1 Trigger"]
+    TCC2_MC1 = 23,
+    #[doc = "24: TC3 Overflow Trigger"]
+    TC3_OVF = 24,
+    #[doc = "25: TC3 Match/Compare 0 Trigger"]
+    TC3_MC0 = 25,
+    #[doc = "26: TC3 Match/Compare 1 Trigger"]
+    TC3_MC1 = 26,
+    #[doc = "27: TC4 Overflow Trigger"]
+    TC4_OVF = 27,
+    #[doc = "28: TC4 Match/Compare 0 Trigger"]
+    TC4_MC0 = 28,
+    #[doc = "29: TC4 Match/Compare 1 Trigger"]
+    TC4_MC1 = 29,
+    #[doc = "30: TC5 Overflow Trigger"]
+    TC5_OVF = 30,
+    #[doc = "31: TC5 Match/Compare 0 Trigger"]
+    TC5_MC0 = 31,
+    #[doc = "32: TC5 Match/Compare 1 Trigger"]
+    TC5_MC1 = 32,
+    #[doc = "33: TC6 Overflow Trigger"]
+    TC6_OVF = 33,
+    #[doc = "34: TC6 Match/Compare 0 Trigger"]
+    TC6_MC0 = 34,
+    #[doc = "35: TC6 Match/Compare 1 Trigger"]
+    TC6_MC1 = 35,
+    #[doc = "36: TC7 Overflow Trigger"]
+    TC7_OVF = 36,
+    #[doc = "37: TC7 Match/Compare 0 Trigger"]
+    TC7_MC0 = 37,
+    #[doc = "38: TC7 Match/Compare 1 Trigger"]
+    TC7_MC1 = 38,
+    #[doc = "39: ADC Result Ready Trigger"]
+    ADC_RESRDY = 39,
+    #[doc = "40: DAC Empty Trigger"]
+    DAC_EMPTY = 40,
+    #[doc = "41: I2S RX 0 Trigger"]
+    I2S_RX_0 = 41,
+    #[doc = "42: I2S RX 1 Trigger"]
+    I2S_RX_1 = 42,
+    #[doc = "43: I2S TX 0 Trigger"]
+    I2S_TX_0 = 43,
+    #[doc = "44: I2S TX 1 Trigger"]
+    I2S_TX_1 = 44,
+    #[doc = "45: TCC3 Overflow Trigger"]
+    TCC3_OVF = 45,
+    #[doc = "46: TCC3 Match/Compare 0 Trigger"]
+    TCC3_MC0 = 46,
+    #[doc = "47: TCC3 Match/Compare 1 Trigger"]
+    TCC3_MC1 = 47,
+    #[doc = "48: Match/Compare 2 Trigger"]
+    TCC3_MC2 = 48,
+    #[doc = "49: Match/Compare 3 Trigger"]
+    TCC3_MC3 = 49,
 }
 impl From<TRIGSRC_A> for u8 {
     #[inline(always)]
@@ -304,6 +402,55 @@ impl TRIGSRC_R {
         use crate::Variant::*;
         match self.bits {
             0 => Val(TRIGSRC_A::DISABLE),
+            1 => Val(TRIGSRC_A::SERCOM0_RX),
+            2 => Val(TRIGSRC_A::SERCOM0_TX),
+            3 => Val(TRIGSRC_A::SERCOM1_RX),
+            4 => Val(TRIGSRC_A::SERCOM1_TX),
+            5 => Val(TRIGSRC_A::SERCOM2_RX),
+            6 => Val(TRIGSRC_A::SERCOM2_TX),
+            7 => Val(TRIGSRC_A::SERCOM3_RX),
+            8 => Val(TRIGSRC_A::SERCOM3_TX),
+            9 => Val(TRIGSRC_A::SERCOM4_RX),
+            10 => Val(TRIGSRC_A::SERCOM4_TX),
+            11 => Val(TRIGSRC_A::SERCOM5_RX),
+            12 => Val(TRIGSRC_A::SERCOM5_TX),
+            13 => Val(TRIGSRC_A::TCC0_OVF),
+            14 => Val(TRIGSRC_A::TCC0_MC0),
+            15 => Val(TRIGSRC_A::TCC0_MC1),
+            16 => Val(TRIGSRC_A::TCC0_MC2),
+            17 => Val(TRIGSRC_A::TCC0_MC3),
+            18 => Val(TRIGSRC_A::TCC1_OVF),
+            19 => Val(TRIGSRC_A::TCC1_MC0),
+            20 => Val(TRIGSRC_A::TCC1_MC1),
+            21 => Val(TRIGSRC_A::TCC2_OVF),
+            22 => Val(TRIGSRC_A::TCC2_MC0),
+            23 => Val(TRIGSRC_A::TCC2_MC1),
+            24 => Val(TRIGSRC_A::TC3_OVF),
+            25 => Val(TRIGSRC_A::TC3_MC0),
+            26 => Val(TRIGSRC_A::TC3_MC1),
+            27 => Val(TRIGSRC_A::TC4_OVF),
+            28 => Val(TRIGSRC_A::TC4_MC0),
+            29 => Val(TRIGSRC_A::TC4_MC1),
+            30 => Val(TRIGSRC_A::TC5_OVF),
+            31 => Val(TRIGSRC_A::TC5_MC0),
+            32 => Val(TRIGSRC_A::TC5_MC1),
+            33 => Val(TRIGSRC_A::TC6_OVF),
+            34 => Val(TRIGSRC_A::TC6_MC0),
+            35 => Val(TRIGSRC_A::TC6_MC1),
+            36 => Val(TRIGSRC_A::TC7_OVF),
+            37 => Val(TRIGSRC_A::TC7_MC0),
+            38 => Val(TRIGSRC_A::TC7_MC1),
+            39 => Val(TRIGSRC_A::ADC_RESRDY),
+            40 => Val(TRIGSRC_A::DAC_EMPTY),
+            41 => Val(TRIGSRC_A::I2S_RX_0),
+            42 => Val(TRIGSRC_A::I2S_RX_1),
+            43 => Val(TRIGSRC_A::I2S_TX_0),
+            44 => Val(TRIGSRC_A::I2S_TX_1),
+            45 => Val(TRIGSRC_A::TCC3_OVF),
+            46 => Val(TRIGSRC_A::TCC3_MC0),
+            47 => Val(TRIGSRC_A::TCC3_MC1),
+            48 => Val(TRIGSRC_A::TCC3_MC2),
+            49 => Val(TRIGSRC_A::TCC3_MC3),
             i => Res(i),
         }
     }
@@ -311,6 +458,251 @@ impl TRIGSRC_R {
     #[inline(always)]
     pub fn is_disable(&self) -> bool {
         *self == TRIGSRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_RX`"]
+    #[inline(always)]
+    pub fn is_sercom0_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_TX`"]
+    #[inline(always)]
+    pub fn is_sercom0_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_RX`"]
+    #[inline(always)]
+    pub fn is_sercom1_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_TX`"]
+    #[inline(always)]
+    pub fn is_sercom1_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_RX`"]
+    #[inline(always)]
+    pub fn is_sercom2_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_TX`"]
+    #[inline(always)]
+    pub fn is_sercom2_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_RX`"]
+    #[inline(always)]
+    pub fn is_sercom3_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_TX`"]
+    #[inline(always)]
+    pub fn is_sercom3_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_RX`"]
+    #[inline(always)]
+    pub fn is_sercom4_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_TX`"]
+    #[inline(always)]
+    pub fn is_sercom4_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_RX`"]
+    #[inline(always)]
+    pub fn is_sercom5_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_TX`"]
+    #[inline(always)]
+    pub fn is_sercom5_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_TX
+    }
+    #[doc = "Checks if the value of the field is `TCC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC0`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC0
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC1`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC1
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC2`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc2(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC2
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC3`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc3(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC3
+    }
+    #[doc = "Checks if the value of the field is `TCC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC0`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC0
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC1`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC1
+    }
+    #[doc = "Checks if the value of the field is `TCC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC0`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC0
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC1`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC0`"]
+    #[inline(always)]
+    pub fn is_tc3_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC1`"]
+    #[inline(always)]
+    pub fn is_tc3_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC0`"]
+    #[inline(always)]
+    pub fn is_tc4_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC1`"]
+    #[inline(always)]
+    pub fn is_tc4_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC5_OVF`"]
+    #[inline(always)]
+    pub fn is_tc5_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC5_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC0`"]
+    #[inline(always)]
+    pub fn is_tc5_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC1`"]
+    #[inline(always)]
+    pub fn is_tc5_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC6_OVF`"]
+    #[inline(always)]
+    pub fn is_tc6_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC6_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC0`"]
+    #[inline(always)]
+    pub fn is_tc6_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC1`"]
+    #[inline(always)]
+    pub fn is_tc6_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC7_OVF`"]
+    #[inline(always)]
+    pub fn is_tc7_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC7_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC0`"]
+    #[inline(always)]
+    pub fn is_tc7_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC1`"]
+    #[inline(always)]
+    pub fn is_tc7_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC1
+    }
+    #[doc = "Checks if the value of the field is `ADC_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY`"]
+    #[inline(always)]
+    pub fn is_dac_empty(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_1
+    }
+    #[doc = "Checks if the value of the field is `TCC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC0`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC0
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC1`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC1
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC2`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc2(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC2
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC3`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc3(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC3
     }
 }
 #[doc = "Write proxy for field `TRIGSRC`"]
@@ -327,6 +719,251 @@ impl<'a> TRIGSRC_W<'a> {
     #[inline(always)]
     pub fn disable(self) -> &'a mut W {
         self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = "SERCOM0 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom0_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_RX)
+    }
+    #[doc = "SERCOM0 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom0_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_TX)
+    }
+    #[doc = "SERCOM1 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom1_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_RX)
+    }
+    #[doc = "SERCOM1 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom1_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_TX)
+    }
+    #[doc = "SERCOM2 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom2_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_RX)
+    }
+    #[doc = "SERCOM2 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom2_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_TX)
+    }
+    #[doc = "SERCOM3 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom3_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_RX)
+    }
+    #[doc = "SERCOM3 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom3_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_TX)
+    }
+    #[doc = "SERCOM4 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom4_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_RX)
+    }
+    #[doc = "SERCOM4 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom4_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_TX)
+    }
+    #[doc = "SERCOM5 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom5_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_RX)
+    }
+    #[doc = "SERCOM5 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom5_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_TX)
+    }
+    #[doc = "TCC0 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tcc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_OVF)
+    }
+    #[doc = "TCC0 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC0)
+    }
+    #[doc = "TCC0 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC1)
+    }
+    #[doc = "TCC0 Match/Compare 2 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC2)
+    }
+    #[doc = "TCC0 Match/Compare 3 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC3)
+    }
+    #[doc = "TCC1 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tcc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_OVF)
+    }
+    #[doc = "TCC1 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tcc1_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC0)
+    }
+    #[doc = "TCC1 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tcc1_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC1)
+    }
+    #[doc = "TCC2 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tcc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_OVF)
+    }
+    #[doc = "TCC2 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tcc2_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC0)
+    }
+    #[doc = "TCC2 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tcc2_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC1)
+    }
+    #[doc = "TC3 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_OVF)
+    }
+    #[doc = "TC3 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc3_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC0)
+    }
+    #[doc = "TC3 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc3_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC1)
+    }
+    #[doc = "TC4 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_OVF)
+    }
+    #[doc = "TC4 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc4_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC0)
+    }
+    #[doc = "TC4 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc4_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC1)
+    }
+    #[doc = "TC5 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc5_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_OVF)
+    }
+    #[doc = "TC5 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc5_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC0)
+    }
+    #[doc = "TC5 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc5_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC1)
+    }
+    #[doc = "TC6 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc6_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_OVF)
+    }
+    #[doc = "TC6 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc6_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC0)
+    }
+    #[doc = "TC6 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc6_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC1)
+    }
+    #[doc = "TC7 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc7_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_OVF)
+    }
+    #[doc = "TC7 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc7_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC0)
+    }
+    #[doc = "TC7 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc7_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC1)
+    }
+    #[doc = "ADC Result Ready Trigger"]
+    #[inline(always)]
+    pub fn adc_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC_RESRDY)
+    }
+    #[doc = "DAC Empty Trigger"]
+    #[inline(always)]
+    pub fn dac_empty(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY)
+    }
+    #[doc = "I2S RX 0 Trigger"]
+    #[inline(always)]
+    pub fn i2s_rx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_0)
+    }
+    #[doc = "I2S RX 1 Trigger"]
+    #[inline(always)]
+    pub fn i2s_rx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_1)
+    }
+    #[doc = "I2S TX 0 Trigger"]
+    #[inline(always)]
+    pub fn i2s_tx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_0)
+    }
+    #[doc = "I2S TX 1 Trigger"]
+    #[inline(always)]
+    pub fn i2s_tx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_1)
+    }
+    #[doc = "TCC3 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tcc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_OVF)
+    }
+    #[doc = "TCC3 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tcc3_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC0)
+    }
+    #[doc = "TCC3 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tcc3_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC1)
+    }
+    #[doc = "Match/Compare 2 Trigger"]
+    #[inline(always)]
+    pub fn tcc3_mc2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC2)
+    }
+    #[doc = "Match/Compare 3 Trigger"]
+    #[inline(always)]
+    pub fn tcc3_mc3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC3)
     }
     #[doc = r"Writes raw bits to the field"]
     #[inline(always)]

--- a/pac/atsamd21j/src/dmac/chctrlb.rs
+++ b/pac/atsamd21j/src/dmac/chctrlb.rs
@@ -288,6 +288,104 @@ impl<'a> LVL_W<'a> {
 pub enum TRIGSRC_A {
     #[doc = "0: Only software/event triggers"]
     DISABLE = 0,
+    #[doc = "1: SERCOM0 RX Trigger"]
+    SERCOM0_RX = 1,
+    #[doc = "2: SERCOM0 TX Trigger"]
+    SERCOM0_TX = 2,
+    #[doc = "3: SERCOM1 RX Trigger"]
+    SERCOM1_RX = 3,
+    #[doc = "4: SERCOM1 TX Trigger"]
+    SERCOM1_TX = 4,
+    #[doc = "5: SERCOM2 RX Trigger"]
+    SERCOM2_RX = 5,
+    #[doc = "6: SERCOM2 TX Trigger"]
+    SERCOM2_TX = 6,
+    #[doc = "7: SERCOM3 RX Trigger"]
+    SERCOM3_RX = 7,
+    #[doc = "8: SERCOM3 TX Trigger"]
+    SERCOM3_TX = 8,
+    #[doc = "9: SERCOM4 RX Trigger"]
+    SERCOM4_RX = 9,
+    #[doc = "10: SERCOM4 TX Trigger"]
+    SERCOM4_TX = 10,
+    #[doc = "11: SERCOM5 RX Trigger"]
+    SERCOM5_RX = 11,
+    #[doc = "12: SERCOM5 TX Trigger"]
+    SERCOM5_TX = 12,
+    #[doc = "13: TCC0 Overflow Trigger"]
+    TCC0_OVF = 13,
+    #[doc = "14: TCC0 Match/Compare 0 Trigger"]
+    TCC0_MC0 = 14,
+    #[doc = "15: TCC0 Match/Compare 1 Trigger"]
+    TCC0_MC1 = 15,
+    #[doc = "16: TCC0 Match/Compare 2 Trigger"]
+    TCC0_MC2 = 16,
+    #[doc = "17: TCC0 Match/Compare 3 Trigger"]
+    TCC0_MC3 = 17,
+    #[doc = "18: TCC1 Overflow Trigger"]
+    TCC1_OVF = 18,
+    #[doc = "19: TCC1 Match/Compare 0 Trigger"]
+    TCC1_MC0 = 19,
+    #[doc = "20: TCC1 Match/Compare 1 Trigger"]
+    TCC1_MC1 = 20,
+    #[doc = "21: TCC2 Overflow Trigger"]
+    TCC2_OVF = 21,
+    #[doc = "22: TCC2 Match/Compare 0 Trigger"]
+    TCC2_MC0 = 22,
+    #[doc = "23: TCC2 Match/Compare 1 Trigger"]
+    TCC2_MC1 = 23,
+    #[doc = "24: TC3 Overflow Trigger"]
+    TC3_OVF = 24,
+    #[doc = "25: TC3 Match/Compare 0 Trigger"]
+    TC3_MC0 = 25,
+    #[doc = "26: TC3 Match/Compare 1 Trigger"]
+    TC3_MC1 = 26,
+    #[doc = "27: TC4 Overflow Trigger"]
+    TC4_OVF = 27,
+    #[doc = "28: TC4 Match/Compare 0 Trigger"]
+    TC4_MC0 = 28,
+    #[doc = "29: TC4 Match/Compare 1 Trigger"]
+    TC4_MC1 = 29,
+    #[doc = "30: TC5 Overflow Trigger"]
+    TC5_OVF = 30,
+    #[doc = "31: TC5 Match/Compare 0 Trigger"]
+    TC5_MC0 = 31,
+    #[doc = "32: TC5 Match/Compare 1 Trigger"]
+    TC5_MC1 = 32,
+    #[doc = "33: TC6 Overflow Trigger"]
+    TC6_OVF = 33,
+    #[doc = "34: TC6 Match/Compare 0 Trigger"]
+    TC6_MC0 = 34,
+    #[doc = "35: TC6 Match/Compare 1 Trigger"]
+    TC6_MC1 = 35,
+    #[doc = "36: TC7 Overflow Trigger"]
+    TC7_OVF = 36,
+    #[doc = "37: TC7 Match/Compare 0 Trigger"]
+    TC7_MC0 = 37,
+    #[doc = "38: TC7 Match/Compare 1 Trigger"]
+    TC7_MC1 = 38,
+    #[doc = "39: ADC Result Ready Trigger"]
+    ADC_RESRDY = 39,
+    #[doc = "40: DAC Empty Trigger"]
+    DAC_EMPTY = 40,
+    #[doc = "41: I2S RX 0 Trigger"]
+    I2S_RX_0 = 41,
+    #[doc = "42: I2S RX 1 Trigger"]
+    I2S_RX_1 = 42,
+    #[doc = "43: I2S TX 0 Trigger"]
+    I2S_TX_0 = 43,
+    #[doc = "44: I2S TX 1 Trigger"]
+    I2S_TX_1 = 44,
+    #[doc = "45: TCC3 Overflow Trigger"]
+    TCC3_OVF = 45,
+    #[doc = "46: TCC3 Match/Compare 0 Trigger"]
+    TCC3_MC0 = 46,
+    #[doc = "47: TCC3 Match/Compare 1 Trigger"]
+    TCC3_MC1 = 47,
+    #[doc = "48: Match/Compare 2 Trigger"]
+    TCC3_MC2 = 48,
+    #[doc = "49: Match/Compare 3 Trigger"]
+    TCC3_MC3 = 49,
 }
 impl From<TRIGSRC_A> for u8 {
     #[inline(always)]
@@ -304,6 +402,55 @@ impl TRIGSRC_R {
         use crate::Variant::*;
         match self.bits {
             0 => Val(TRIGSRC_A::DISABLE),
+            1 => Val(TRIGSRC_A::SERCOM0_RX),
+            2 => Val(TRIGSRC_A::SERCOM0_TX),
+            3 => Val(TRIGSRC_A::SERCOM1_RX),
+            4 => Val(TRIGSRC_A::SERCOM1_TX),
+            5 => Val(TRIGSRC_A::SERCOM2_RX),
+            6 => Val(TRIGSRC_A::SERCOM2_TX),
+            7 => Val(TRIGSRC_A::SERCOM3_RX),
+            8 => Val(TRIGSRC_A::SERCOM3_TX),
+            9 => Val(TRIGSRC_A::SERCOM4_RX),
+            10 => Val(TRIGSRC_A::SERCOM4_TX),
+            11 => Val(TRIGSRC_A::SERCOM5_RX),
+            12 => Val(TRIGSRC_A::SERCOM5_TX),
+            13 => Val(TRIGSRC_A::TCC0_OVF),
+            14 => Val(TRIGSRC_A::TCC0_MC0),
+            15 => Val(TRIGSRC_A::TCC0_MC1),
+            16 => Val(TRIGSRC_A::TCC0_MC2),
+            17 => Val(TRIGSRC_A::TCC0_MC3),
+            18 => Val(TRIGSRC_A::TCC1_OVF),
+            19 => Val(TRIGSRC_A::TCC1_MC0),
+            20 => Val(TRIGSRC_A::TCC1_MC1),
+            21 => Val(TRIGSRC_A::TCC2_OVF),
+            22 => Val(TRIGSRC_A::TCC2_MC0),
+            23 => Val(TRIGSRC_A::TCC2_MC1),
+            24 => Val(TRIGSRC_A::TC3_OVF),
+            25 => Val(TRIGSRC_A::TC3_MC0),
+            26 => Val(TRIGSRC_A::TC3_MC1),
+            27 => Val(TRIGSRC_A::TC4_OVF),
+            28 => Val(TRIGSRC_A::TC4_MC0),
+            29 => Val(TRIGSRC_A::TC4_MC1),
+            30 => Val(TRIGSRC_A::TC5_OVF),
+            31 => Val(TRIGSRC_A::TC5_MC0),
+            32 => Val(TRIGSRC_A::TC5_MC1),
+            33 => Val(TRIGSRC_A::TC6_OVF),
+            34 => Val(TRIGSRC_A::TC6_MC0),
+            35 => Val(TRIGSRC_A::TC6_MC1),
+            36 => Val(TRIGSRC_A::TC7_OVF),
+            37 => Val(TRIGSRC_A::TC7_MC0),
+            38 => Val(TRIGSRC_A::TC7_MC1),
+            39 => Val(TRIGSRC_A::ADC_RESRDY),
+            40 => Val(TRIGSRC_A::DAC_EMPTY),
+            41 => Val(TRIGSRC_A::I2S_RX_0),
+            42 => Val(TRIGSRC_A::I2S_RX_1),
+            43 => Val(TRIGSRC_A::I2S_TX_0),
+            44 => Val(TRIGSRC_A::I2S_TX_1),
+            45 => Val(TRIGSRC_A::TCC3_OVF),
+            46 => Val(TRIGSRC_A::TCC3_MC0),
+            47 => Val(TRIGSRC_A::TCC3_MC1),
+            48 => Val(TRIGSRC_A::TCC3_MC2),
+            49 => Val(TRIGSRC_A::TCC3_MC3),
             i => Res(i),
         }
     }
@@ -311,6 +458,251 @@ impl TRIGSRC_R {
     #[inline(always)]
     pub fn is_disable(&self) -> bool {
         *self == TRIGSRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_RX`"]
+    #[inline(always)]
+    pub fn is_sercom0_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_TX`"]
+    #[inline(always)]
+    pub fn is_sercom0_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_RX`"]
+    #[inline(always)]
+    pub fn is_sercom1_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_TX`"]
+    #[inline(always)]
+    pub fn is_sercom1_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_RX`"]
+    #[inline(always)]
+    pub fn is_sercom2_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_TX`"]
+    #[inline(always)]
+    pub fn is_sercom2_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_RX`"]
+    #[inline(always)]
+    pub fn is_sercom3_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_TX`"]
+    #[inline(always)]
+    pub fn is_sercom3_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_RX`"]
+    #[inline(always)]
+    pub fn is_sercom4_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_TX`"]
+    #[inline(always)]
+    pub fn is_sercom4_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_RX`"]
+    #[inline(always)]
+    pub fn is_sercom5_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_TX`"]
+    #[inline(always)]
+    pub fn is_sercom5_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_TX
+    }
+    #[doc = "Checks if the value of the field is `TCC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC0`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC0
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC1`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC1
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC2`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc2(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC2
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC3`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc3(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC3
+    }
+    #[doc = "Checks if the value of the field is `TCC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC0`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC0
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC1`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC1
+    }
+    #[doc = "Checks if the value of the field is `TCC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC0`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC0
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC1`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC0`"]
+    #[inline(always)]
+    pub fn is_tc3_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC1`"]
+    #[inline(always)]
+    pub fn is_tc3_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC0`"]
+    #[inline(always)]
+    pub fn is_tc4_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC1`"]
+    #[inline(always)]
+    pub fn is_tc4_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC5_OVF`"]
+    #[inline(always)]
+    pub fn is_tc5_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC5_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC0`"]
+    #[inline(always)]
+    pub fn is_tc5_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC1`"]
+    #[inline(always)]
+    pub fn is_tc5_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC6_OVF`"]
+    #[inline(always)]
+    pub fn is_tc6_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC6_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC0`"]
+    #[inline(always)]
+    pub fn is_tc6_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC1`"]
+    #[inline(always)]
+    pub fn is_tc6_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC1
+    }
+    #[doc = "Checks if the value of the field is `TC7_OVF`"]
+    #[inline(always)]
+    pub fn is_tc7_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC7_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC0`"]
+    #[inline(always)]
+    pub fn is_tc7_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC0
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC1`"]
+    #[inline(always)]
+    pub fn is_tc7_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC1
+    }
+    #[doc = "Checks if the value of the field is `ADC_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY`"]
+    #[inline(always)]
+    pub fn is_dac_empty(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_1
+    }
+    #[doc = "Checks if the value of the field is `TCC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC0`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc0(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC0
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC1`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc1(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC1
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC2`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc2(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC2
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC3`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc3(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC3
     }
 }
 #[doc = "Write proxy for field `TRIGSRC`"]
@@ -327,6 +719,251 @@ impl<'a> TRIGSRC_W<'a> {
     #[inline(always)]
     pub fn disable(self) -> &'a mut W {
         self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = "SERCOM0 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom0_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_RX)
+    }
+    #[doc = "SERCOM0 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom0_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_TX)
+    }
+    #[doc = "SERCOM1 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom1_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_RX)
+    }
+    #[doc = "SERCOM1 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom1_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_TX)
+    }
+    #[doc = "SERCOM2 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom2_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_RX)
+    }
+    #[doc = "SERCOM2 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom2_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_TX)
+    }
+    #[doc = "SERCOM3 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom3_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_RX)
+    }
+    #[doc = "SERCOM3 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom3_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_TX)
+    }
+    #[doc = "SERCOM4 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom4_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_RX)
+    }
+    #[doc = "SERCOM4 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom4_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_TX)
+    }
+    #[doc = "SERCOM5 RX Trigger"]
+    #[inline(always)]
+    pub fn sercom5_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_RX)
+    }
+    #[doc = "SERCOM5 TX Trigger"]
+    #[inline(always)]
+    pub fn sercom5_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_TX)
+    }
+    #[doc = "TCC0 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tcc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_OVF)
+    }
+    #[doc = "TCC0 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC0)
+    }
+    #[doc = "TCC0 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC1)
+    }
+    #[doc = "TCC0 Match/Compare 2 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC2)
+    }
+    #[doc = "TCC0 Match/Compare 3 Trigger"]
+    #[inline(always)]
+    pub fn tcc0_mc3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC3)
+    }
+    #[doc = "TCC1 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tcc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_OVF)
+    }
+    #[doc = "TCC1 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tcc1_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC0)
+    }
+    #[doc = "TCC1 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tcc1_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC1)
+    }
+    #[doc = "TCC2 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tcc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_OVF)
+    }
+    #[doc = "TCC2 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tcc2_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC0)
+    }
+    #[doc = "TCC2 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tcc2_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC1)
+    }
+    #[doc = "TC3 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_OVF)
+    }
+    #[doc = "TC3 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc3_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC0)
+    }
+    #[doc = "TC3 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc3_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC1)
+    }
+    #[doc = "TC4 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_OVF)
+    }
+    #[doc = "TC4 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc4_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC0)
+    }
+    #[doc = "TC4 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc4_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC1)
+    }
+    #[doc = "TC5 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc5_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_OVF)
+    }
+    #[doc = "TC5 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc5_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC0)
+    }
+    #[doc = "TC5 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc5_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC1)
+    }
+    #[doc = "TC6 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc6_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_OVF)
+    }
+    #[doc = "TC6 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc6_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC0)
+    }
+    #[doc = "TC6 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc6_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC1)
+    }
+    #[doc = "TC7 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tc7_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_OVF)
+    }
+    #[doc = "TC7 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tc7_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC0)
+    }
+    #[doc = "TC7 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tc7_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC1)
+    }
+    #[doc = "ADC Result Ready Trigger"]
+    #[inline(always)]
+    pub fn adc_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC_RESRDY)
+    }
+    #[doc = "DAC Empty Trigger"]
+    #[inline(always)]
+    pub fn dac_empty(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY)
+    }
+    #[doc = "I2S RX 0 Trigger"]
+    #[inline(always)]
+    pub fn i2s_rx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_0)
+    }
+    #[doc = "I2S RX 1 Trigger"]
+    #[inline(always)]
+    pub fn i2s_rx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_1)
+    }
+    #[doc = "I2S TX 0 Trigger"]
+    #[inline(always)]
+    pub fn i2s_tx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_0)
+    }
+    #[doc = "I2S TX 1 Trigger"]
+    #[inline(always)]
+    pub fn i2s_tx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_1)
+    }
+    #[doc = "TCC3 Overflow Trigger"]
+    #[inline(always)]
+    pub fn tcc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_OVF)
+    }
+    #[doc = "TCC3 Match/Compare 0 Trigger"]
+    #[inline(always)]
+    pub fn tcc3_mc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC0)
+    }
+    #[doc = "TCC3 Match/Compare 1 Trigger"]
+    #[inline(always)]
+    pub fn tcc3_mc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC1)
+    }
+    #[doc = "Match/Compare 2 Trigger"]
+    #[inline(always)]
+    pub fn tcc3_mc2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC2)
+    }
+    #[doc = "Match/Compare 3 Trigger"]
+    #[inline(always)]
+    pub fn tcc3_mc3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC3)
     }
     #[doc = r"Writes raw bits to the field"]
     #[inline(always)]

--- a/pac/atsamd51g/src/dmac/channel/chctrla.rs
+++ b/pac/atsamd51g/src/dmac/channel/chctrla.rs
@@ -88,6 +88,174 @@ impl<'a> RUNSTDBY_W<'a> {
 pub enum TRIGSRC_A {
     #[doc = "0: Only software/event triggers"]
     DISABLE = 0,
+    #[doc = "1: DMA RTC timestamp trigger"]
+    RTC_TIMESTAMP = 1,
+    #[doc = "2: DMAC ID for DCC0 register"]
+    DSU_DCC0 = 2,
+    #[doc = "3: DMAC ID for DCC1 register"]
+    DSU_DCC1 = 3,
+    #[doc = "4: Index of DMA RX trigger"]
+    SERCOM0_RX = 4,
+    #[doc = "5: Index of DMA TX trigger"]
+    SERCOM0_TX = 5,
+    #[doc = "6: Index of DMA RX trigger"]
+    SERCOM1_RX = 6,
+    #[doc = "7: Index of DMA TX trigger"]
+    SERCOM1_TX = 7,
+    #[doc = "8: Index of DMA RX trigger"]
+    SERCOM2_RX = 8,
+    #[doc = "9: Index of DMA TX trigger"]
+    SERCOM2_TX = 9,
+    #[doc = "10: Index of DMA RX trigger"]
+    SERCOM3_RX = 10,
+    #[doc = "11: Index of DMA TX trigger"]
+    SERCOM3_TX = 11,
+    #[doc = "12: Index of DMA RX trigger"]
+    SERCOM4_RX = 12,
+    #[doc = "13: Index of DMA TX trigger"]
+    SERCOM4_TX = 13,
+    #[doc = "14: Index of DMA RX trigger"]
+    SERCOM5_RX = 14,
+    #[doc = "15: Index of DMA TX trigger"]
+    SERCOM5_TX = 15,
+    #[doc = "16: Index of DMA RX trigger"]
+    SERCOM6_RX = 16,
+    #[doc = "17: Index of DMA TX trigger"]
+    SERCOM6_TX = 17,
+    #[doc = "18: Index of DMA RX trigger"]
+    SERCOM7_RX = 18,
+    #[doc = "19: Index of DMA TX trigger"]
+    SERCOM7_TX = 19,
+    #[doc = "20: DMA CAN Debug Req"]
+    CAN0_DEBUG = 20,
+    #[doc = "21: DMA CAN Debug Req"]
+    CAN1_DEBUG = 21,
+    #[doc = "22: DMA overflow/underflow/retrigger trigger"]
+    TCC0_OVF = 22,
+    #[doc = "23: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_0 = 23,
+    #[doc = "24: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_1 = 24,
+    #[doc = "25: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_2 = 25,
+    #[doc = "26: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_3 = 26,
+    #[doc = "27: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_4 = 27,
+    #[doc = "28: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_5 = 28,
+    #[doc = "29: DMA overflow/underflow/retrigger trigger"]
+    TCC1_OVF = 29,
+    #[doc = "30: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_0 = 30,
+    #[doc = "31: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_1 = 31,
+    #[doc = "32: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_2 = 32,
+    #[doc = "33: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_3 = 33,
+    #[doc = "34: DMA overflow/underflow/retrigger trigger"]
+    TCC2_OVF = 34,
+    #[doc = "35: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_0 = 35,
+    #[doc = "36: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_1 = 36,
+    #[doc = "37: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_2 = 37,
+    #[doc = "38: DMA overflow/underflow/retrigger trigger"]
+    TCC3_OVF = 38,
+    #[doc = "39: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_0 = 39,
+    #[doc = "40: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_1 = 40,
+    #[doc = "41: DMA overflow/underflow/retrigger trigger"]
+    TCC4_OVF = 41,
+    #[doc = "42: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_0 = 42,
+    #[doc = "43: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_1 = 43,
+    #[doc = "44: Indexes of DMA Overflow trigger"]
+    TC0_OVF = 44,
+    #[doc = "45: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_0 = 45,
+    #[doc = "46: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_1 = 46,
+    #[doc = "47: Indexes of DMA Overflow trigger"]
+    TC1_OVF = 47,
+    #[doc = "48: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_0 = 48,
+    #[doc = "49: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_1 = 49,
+    #[doc = "50: Indexes of DMA Overflow trigger"]
+    TC2_OVF = 50,
+    #[doc = "51: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_0 = 51,
+    #[doc = "52: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_1 = 52,
+    #[doc = "53: Indexes of DMA Overflow trigger"]
+    TC3_OVF = 53,
+    #[doc = "54: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_0 = 54,
+    #[doc = "55: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_1 = 55,
+    #[doc = "56: Indexes of DMA Overflow trigger"]
+    TC4_OVF = 56,
+    #[doc = "57: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_0 = 57,
+    #[doc = "58: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_1 = 58,
+    #[doc = "59: Indexes of DMA Overflow trigger"]
+    TC5_OVF = 59,
+    #[doc = "60: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_0 = 60,
+    #[doc = "61: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_1 = 61,
+    #[doc = "62: Indexes of DMA Overflow trigger"]
+    TC6_OVF = 62,
+    #[doc = "63: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_0 = 63,
+    #[doc = "64: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_1 = 64,
+    #[doc = "65: Indexes of DMA Overflow trigger"]
+    TC7_OVF = 65,
+    #[doc = "66: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_0 = 66,
+    #[doc = "67: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_1 = 67,
+    #[doc = "68: index of DMA RESRDY trigger"]
+    ADC0_RESRDY = 68,
+    #[doc = "69: Index of DMA SEQ trigger"]
+    ADC0_SEQ = 69,
+    #[doc = "70: Index of DMA RESRDY trigger"]
+    ADC1_RESRDY = 70,
+    #[doc = "71: Index of DMA SEQ trigger"]
+    ADC1_SEQ = 71,
+    #[doc = "72: DMA DAC Empty Req"]
+    DAC_EMPTY_0 = 72,
+    #[doc = "73: DMA DAC Empty Req"]
+    DAC_EMPTY_1 = 73,
+    #[doc = "74: DMA DAC Result Ready Req"]
+    DAC_RESRDY_0 = 74,
+    #[doc = "75: DMA DAC Result Ready Req"]
+    DAC_RESRDY_1 = 75,
+    #[doc = "76: Indexes of DMA RX triggers"]
+    I2S_RX_0 = 76,
+    #[doc = "77: Indexes of DMA RX triggers"]
+    I2S_RX_1 = 77,
+    #[doc = "78: Indexes of DMA TX triggers"]
+    I2S_TX_0 = 78,
+    #[doc = "79: Indexes of DMA TX triggers"]
+    I2S_TX_1 = 79,
+    #[doc = "80: Indexes of PCC RX trigger"]
+    PCC_RX = 80,
+    #[doc = "81: DMA DATA Write trigger"]
+    AES_WR = 81,
+    #[doc = "82: DMA DATA Read trigger"]
+    AES_RD = 82,
+    #[doc = "83: Indexes of QSPI RX trigger"]
+    QSPI_RX = 83,
+    #[doc = "84: Indexes of QSPI TX trigger"]
+    QSPI_TX = 84,
 }
 impl From<TRIGSRC_A> for u8 {
     #[inline(always)]
@@ -104,6 +272,90 @@ impl TRIGSRC_R {
         use crate::Variant::*;
         match self.bits {
             0 => Val(TRIGSRC_A::DISABLE),
+            1 => Val(TRIGSRC_A::RTC_TIMESTAMP),
+            2 => Val(TRIGSRC_A::DSU_DCC0),
+            3 => Val(TRIGSRC_A::DSU_DCC1),
+            4 => Val(TRIGSRC_A::SERCOM0_RX),
+            5 => Val(TRIGSRC_A::SERCOM0_TX),
+            6 => Val(TRIGSRC_A::SERCOM1_RX),
+            7 => Val(TRIGSRC_A::SERCOM1_TX),
+            8 => Val(TRIGSRC_A::SERCOM2_RX),
+            9 => Val(TRIGSRC_A::SERCOM2_TX),
+            10 => Val(TRIGSRC_A::SERCOM3_RX),
+            11 => Val(TRIGSRC_A::SERCOM3_TX),
+            12 => Val(TRIGSRC_A::SERCOM4_RX),
+            13 => Val(TRIGSRC_A::SERCOM4_TX),
+            14 => Val(TRIGSRC_A::SERCOM5_RX),
+            15 => Val(TRIGSRC_A::SERCOM5_TX),
+            16 => Val(TRIGSRC_A::SERCOM6_RX),
+            17 => Val(TRIGSRC_A::SERCOM6_TX),
+            18 => Val(TRIGSRC_A::SERCOM7_RX),
+            19 => Val(TRIGSRC_A::SERCOM7_TX),
+            20 => Val(TRIGSRC_A::CAN0_DEBUG),
+            21 => Val(TRIGSRC_A::CAN1_DEBUG),
+            22 => Val(TRIGSRC_A::TCC0_OVF),
+            23 => Val(TRIGSRC_A::TCC0_MC_0),
+            24 => Val(TRIGSRC_A::TCC0_MC_1),
+            25 => Val(TRIGSRC_A::TCC0_MC_2),
+            26 => Val(TRIGSRC_A::TCC0_MC_3),
+            27 => Val(TRIGSRC_A::TCC0_MC_4),
+            28 => Val(TRIGSRC_A::TCC0_MC_5),
+            29 => Val(TRIGSRC_A::TCC1_OVF),
+            30 => Val(TRIGSRC_A::TCC1_MC_0),
+            31 => Val(TRIGSRC_A::TCC1_MC_1),
+            32 => Val(TRIGSRC_A::TCC1_MC_2),
+            33 => Val(TRIGSRC_A::TCC1_MC_3),
+            34 => Val(TRIGSRC_A::TCC2_OVF),
+            35 => Val(TRIGSRC_A::TCC2_MC_0),
+            36 => Val(TRIGSRC_A::TCC2_MC_1),
+            37 => Val(TRIGSRC_A::TCC2_MC_2),
+            38 => Val(TRIGSRC_A::TCC3_OVF),
+            39 => Val(TRIGSRC_A::TCC3_MC_0),
+            40 => Val(TRIGSRC_A::TCC3_MC_1),
+            41 => Val(TRIGSRC_A::TCC4_OVF),
+            42 => Val(TRIGSRC_A::TCC4_MC_0),
+            43 => Val(TRIGSRC_A::TCC4_MC_1),
+            44 => Val(TRIGSRC_A::TC0_OVF),
+            45 => Val(TRIGSRC_A::TC0_MC_0),
+            46 => Val(TRIGSRC_A::TC0_MC_1),
+            47 => Val(TRIGSRC_A::TC1_OVF),
+            48 => Val(TRIGSRC_A::TC1_MC_0),
+            49 => Val(TRIGSRC_A::TC1_MC_1),
+            50 => Val(TRIGSRC_A::TC2_OVF),
+            51 => Val(TRIGSRC_A::TC2_MC_0),
+            52 => Val(TRIGSRC_A::TC2_MC_1),
+            53 => Val(TRIGSRC_A::TC3_OVF),
+            54 => Val(TRIGSRC_A::TC3_MC_0),
+            55 => Val(TRIGSRC_A::TC3_MC_1),
+            56 => Val(TRIGSRC_A::TC4_OVF),
+            57 => Val(TRIGSRC_A::TC4_MC_0),
+            58 => Val(TRIGSRC_A::TC4_MC_1),
+            59 => Val(TRIGSRC_A::TC5_OVF),
+            60 => Val(TRIGSRC_A::TC5_MC_0),
+            61 => Val(TRIGSRC_A::TC5_MC_1),
+            62 => Val(TRIGSRC_A::TC6_OVF),
+            63 => Val(TRIGSRC_A::TC6_MC_0),
+            64 => Val(TRIGSRC_A::TC6_MC_1),
+            65 => Val(TRIGSRC_A::TC7_OVF),
+            66 => Val(TRIGSRC_A::TC7_MC_0),
+            67 => Val(TRIGSRC_A::TC7_MC_1),
+            68 => Val(TRIGSRC_A::ADC0_RESRDY),
+            69 => Val(TRIGSRC_A::ADC0_SEQ),
+            70 => Val(TRIGSRC_A::ADC1_RESRDY),
+            71 => Val(TRIGSRC_A::ADC1_SEQ),
+            72 => Val(TRIGSRC_A::DAC_EMPTY_0),
+            73 => Val(TRIGSRC_A::DAC_EMPTY_1),
+            74 => Val(TRIGSRC_A::DAC_RESRDY_0),
+            75 => Val(TRIGSRC_A::DAC_RESRDY_1),
+            76 => Val(TRIGSRC_A::I2S_RX_0),
+            77 => Val(TRIGSRC_A::I2S_RX_1),
+            78 => Val(TRIGSRC_A::I2S_TX_0),
+            79 => Val(TRIGSRC_A::I2S_TX_1),
+            80 => Val(TRIGSRC_A::PCC_RX),
+            81 => Val(TRIGSRC_A::AES_WR),
+            82 => Val(TRIGSRC_A::AES_RD),
+            83 => Val(TRIGSRC_A::QSPI_RX),
+            84 => Val(TRIGSRC_A::QSPI_TX),
             i => Res(i),
         }
     }
@@ -111,6 +363,426 @@ impl TRIGSRC_R {
     #[inline(always)]
     pub fn is_disable(&self) -> bool {
         *self == TRIGSRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `RTC_TIMESTAMP`"]
+    #[inline(always)]
+    pub fn is_rtc_timestamp(&self) -> bool {
+        *self == TRIGSRC_A::RTC_TIMESTAMP
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC0`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc0(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC0
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC1`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc1(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC1
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_RX`"]
+    #[inline(always)]
+    pub fn is_sercom0_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_TX`"]
+    #[inline(always)]
+    pub fn is_sercom0_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_RX`"]
+    #[inline(always)]
+    pub fn is_sercom1_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_TX`"]
+    #[inline(always)]
+    pub fn is_sercom1_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_RX`"]
+    #[inline(always)]
+    pub fn is_sercom2_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_TX`"]
+    #[inline(always)]
+    pub fn is_sercom2_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_RX`"]
+    #[inline(always)]
+    pub fn is_sercom3_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_TX`"]
+    #[inline(always)]
+    pub fn is_sercom3_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_RX`"]
+    #[inline(always)]
+    pub fn is_sercom4_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_TX`"]
+    #[inline(always)]
+    pub fn is_sercom4_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_RX`"]
+    #[inline(always)]
+    pub fn is_sercom5_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_TX`"]
+    #[inline(always)]
+    pub fn is_sercom5_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_RX`"]
+    #[inline(always)]
+    pub fn is_sercom6_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_TX`"]
+    #[inline(always)]
+    pub fn is_sercom6_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_RX`"]
+    #[inline(always)]
+    pub fn is_sercom7_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_TX`"]
+    #[inline(always)]
+    pub fn is_sercom7_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_TX
+    }
+    #[doc = "Checks if the value of the field is `CAN0_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can0_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN0_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `CAN1_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can1_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN1_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `TCC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_4`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_4(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_4
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_5`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_5(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_5
+    }
+    #[doc = "Checks if the value of the field is `TCC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC5_OVF`"]
+    #[inline(always)]
+    pub fn is_tc5_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC5_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC6_OVF`"]
+    #[inline(always)]
+    pub fn is_tc6_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC6_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC7_OVF`"]
+    #[inline(always)]
+    pub fn is_tc7_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC7_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_1
+    }
+    #[doc = "Checks if the value of the field is `ADC0_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc0_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC0_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc0_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_SEQ
+    }
+    #[doc = "Checks if the value of the field is `ADC1_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc1_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC1_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc1_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_SEQ
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_0`"]
+    #[inline(always)]
+    pub fn is_dac_empty_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_1`"]
+    #[inline(always)]
+    pub fn is_dac_empty_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_1
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_0`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_1`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_1
+    }
+    #[doc = "Checks if the value of the field is `PCC_RX`"]
+    #[inline(always)]
+    pub fn is_pcc_rx(&self) -> bool {
+        *self == TRIGSRC_A::PCC_RX
+    }
+    #[doc = "Checks if the value of the field is `AES_WR`"]
+    #[inline(always)]
+    pub fn is_aes_wr(&self) -> bool {
+        *self == TRIGSRC_A::AES_WR
+    }
+    #[doc = "Checks if the value of the field is `AES_RD`"]
+    #[inline(always)]
+    pub fn is_aes_rd(&self) -> bool {
+        *self == TRIGSRC_A::AES_RD
+    }
+    #[doc = "Checks if the value of the field is `QSPI_RX`"]
+    #[inline(always)]
+    pub fn is_qspi_rx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_RX
+    }
+    #[doc = "Checks if the value of the field is `QSPI_TX`"]
+    #[inline(always)]
+    pub fn is_qspi_tx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_TX
     }
 }
 #[doc = "Write proxy for field `TRIGSRC`"]
@@ -127,6 +799,426 @@ impl<'a> TRIGSRC_W<'a> {
     #[inline(always)]
     pub fn disable(self) -> &'a mut W {
         self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = "DMA RTC timestamp trigger"]
+    #[inline(always)]
+    pub fn rtc_timestamp(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::RTC_TIMESTAMP)
+    }
+    #[doc = "DMAC ID for DCC0 register"]
+    #[inline(always)]
+    pub fn dsu_dcc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC0)
+    }
+    #[doc = "DMAC ID for DCC1 register"]
+    #[inline(always)]
+    pub fn dsu_dcc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC1)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom0_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom0_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom1_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom1_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom2_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom2_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom3_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom3_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom4_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom4_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom5_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom5_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom6_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom6_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom7_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom7_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_TX)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can0_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN0_DEBUG)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can1_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN1_DEBUG)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_3)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_4(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_4)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_5(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_5)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_3)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_2)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_1)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc5_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc6_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc7_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_1)
+    }
+    #[doc = "index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc0_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc0_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_SEQ)
+    }
+    #[doc = "Index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc1_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc1_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_SEQ)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_0)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_1)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_0)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_1)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_0)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_1)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_0)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_1)
+    }
+    #[doc = "Indexes of PCC RX trigger"]
+    #[inline(always)]
+    pub fn pcc_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::PCC_RX)
+    }
+    #[doc = "DMA DATA Write trigger"]
+    #[inline(always)]
+    pub fn aes_wr(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_WR)
+    }
+    #[doc = "DMA DATA Read trigger"]
+    #[inline(always)]
+    pub fn aes_rd(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_RD)
+    }
+    #[doc = "Indexes of QSPI RX trigger"]
+    #[inline(always)]
+    pub fn qspi_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_RX)
+    }
+    #[doc = "Indexes of QSPI TX trigger"]
+    #[inline(always)]
+    pub fn qspi_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_TX)
     }
     #[doc = r"Writes raw bits to the field"]
     #[inline(always)]

--- a/pac/atsamd51j/src/dmac/channel/chctrla.rs
+++ b/pac/atsamd51j/src/dmac/channel/chctrla.rs
@@ -88,6 +88,174 @@ impl<'a> RUNSTDBY_W<'a> {
 pub enum TRIGSRC_A {
     #[doc = "0: Only software/event triggers"]
     DISABLE = 0,
+    #[doc = "1: DMA RTC timestamp trigger"]
+    RTC_TIMESTAMP = 1,
+    #[doc = "2: DMAC ID for DCC0 register"]
+    DSU_DCC0 = 2,
+    #[doc = "3: DMAC ID for DCC1 register"]
+    DSU_DCC1 = 3,
+    #[doc = "4: Index of DMA RX trigger"]
+    SERCOM0_RX = 4,
+    #[doc = "5: Index of DMA TX trigger"]
+    SERCOM0_TX = 5,
+    #[doc = "6: Index of DMA RX trigger"]
+    SERCOM1_RX = 6,
+    #[doc = "7: Index of DMA TX trigger"]
+    SERCOM1_TX = 7,
+    #[doc = "8: Index of DMA RX trigger"]
+    SERCOM2_RX = 8,
+    #[doc = "9: Index of DMA TX trigger"]
+    SERCOM2_TX = 9,
+    #[doc = "10: Index of DMA RX trigger"]
+    SERCOM3_RX = 10,
+    #[doc = "11: Index of DMA TX trigger"]
+    SERCOM3_TX = 11,
+    #[doc = "12: Index of DMA RX trigger"]
+    SERCOM4_RX = 12,
+    #[doc = "13: Index of DMA TX trigger"]
+    SERCOM4_TX = 13,
+    #[doc = "14: Index of DMA RX trigger"]
+    SERCOM5_RX = 14,
+    #[doc = "15: Index of DMA TX trigger"]
+    SERCOM5_TX = 15,
+    #[doc = "16: Index of DMA RX trigger"]
+    SERCOM6_RX = 16,
+    #[doc = "17: Index of DMA TX trigger"]
+    SERCOM6_TX = 17,
+    #[doc = "18: Index of DMA RX trigger"]
+    SERCOM7_RX = 18,
+    #[doc = "19: Index of DMA TX trigger"]
+    SERCOM7_TX = 19,
+    #[doc = "20: DMA CAN Debug Req"]
+    CAN0_DEBUG = 20,
+    #[doc = "21: DMA CAN Debug Req"]
+    CAN1_DEBUG = 21,
+    #[doc = "22: DMA overflow/underflow/retrigger trigger"]
+    TCC0_OVF = 22,
+    #[doc = "23: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_0 = 23,
+    #[doc = "24: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_1 = 24,
+    #[doc = "25: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_2 = 25,
+    #[doc = "26: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_3 = 26,
+    #[doc = "27: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_4 = 27,
+    #[doc = "28: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_5 = 28,
+    #[doc = "29: DMA overflow/underflow/retrigger trigger"]
+    TCC1_OVF = 29,
+    #[doc = "30: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_0 = 30,
+    #[doc = "31: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_1 = 31,
+    #[doc = "32: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_2 = 32,
+    #[doc = "33: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_3 = 33,
+    #[doc = "34: DMA overflow/underflow/retrigger trigger"]
+    TCC2_OVF = 34,
+    #[doc = "35: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_0 = 35,
+    #[doc = "36: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_1 = 36,
+    #[doc = "37: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_2 = 37,
+    #[doc = "38: DMA overflow/underflow/retrigger trigger"]
+    TCC3_OVF = 38,
+    #[doc = "39: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_0 = 39,
+    #[doc = "40: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_1 = 40,
+    #[doc = "41: DMA overflow/underflow/retrigger trigger"]
+    TCC4_OVF = 41,
+    #[doc = "42: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_0 = 42,
+    #[doc = "43: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_1 = 43,
+    #[doc = "44: Indexes of DMA Overflow trigger"]
+    TC0_OVF = 44,
+    #[doc = "45: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_0 = 45,
+    #[doc = "46: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_1 = 46,
+    #[doc = "47: Indexes of DMA Overflow trigger"]
+    TC1_OVF = 47,
+    #[doc = "48: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_0 = 48,
+    #[doc = "49: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_1 = 49,
+    #[doc = "50: Indexes of DMA Overflow trigger"]
+    TC2_OVF = 50,
+    #[doc = "51: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_0 = 51,
+    #[doc = "52: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_1 = 52,
+    #[doc = "53: Indexes of DMA Overflow trigger"]
+    TC3_OVF = 53,
+    #[doc = "54: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_0 = 54,
+    #[doc = "55: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_1 = 55,
+    #[doc = "56: Indexes of DMA Overflow trigger"]
+    TC4_OVF = 56,
+    #[doc = "57: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_0 = 57,
+    #[doc = "58: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_1 = 58,
+    #[doc = "59: Indexes of DMA Overflow trigger"]
+    TC5_OVF = 59,
+    #[doc = "60: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_0 = 60,
+    #[doc = "61: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_1 = 61,
+    #[doc = "62: Indexes of DMA Overflow trigger"]
+    TC6_OVF = 62,
+    #[doc = "63: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_0 = 63,
+    #[doc = "64: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_1 = 64,
+    #[doc = "65: Indexes of DMA Overflow trigger"]
+    TC7_OVF = 65,
+    #[doc = "66: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_0 = 66,
+    #[doc = "67: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_1 = 67,
+    #[doc = "68: index of DMA RESRDY trigger"]
+    ADC0_RESRDY = 68,
+    #[doc = "69: Index of DMA SEQ trigger"]
+    ADC0_SEQ = 69,
+    #[doc = "70: Index of DMA RESRDY trigger"]
+    ADC1_RESRDY = 70,
+    #[doc = "71: Index of DMA SEQ trigger"]
+    ADC1_SEQ = 71,
+    #[doc = "72: DMA DAC Empty Req"]
+    DAC_EMPTY_0 = 72,
+    #[doc = "73: DMA DAC Empty Req"]
+    DAC_EMPTY_1 = 73,
+    #[doc = "74: DMA DAC Result Ready Req"]
+    DAC_RESRDY_0 = 74,
+    #[doc = "75: DMA DAC Result Ready Req"]
+    DAC_RESRDY_1 = 75,
+    #[doc = "76: Indexes of DMA RX triggers"]
+    I2S_RX_0 = 76,
+    #[doc = "77: Indexes of DMA RX triggers"]
+    I2S_RX_1 = 77,
+    #[doc = "78: Indexes of DMA TX triggers"]
+    I2S_TX_0 = 78,
+    #[doc = "79: Indexes of DMA TX triggers"]
+    I2S_TX_1 = 79,
+    #[doc = "80: Indexes of PCC RX trigger"]
+    PCC_RX = 80,
+    #[doc = "81: DMA DATA Write trigger"]
+    AES_WR = 81,
+    #[doc = "82: DMA DATA Read trigger"]
+    AES_RD = 82,
+    #[doc = "83: Indexes of QSPI RX trigger"]
+    QSPI_RX = 83,
+    #[doc = "84: Indexes of QSPI TX trigger"]
+    QSPI_TX = 84,
 }
 impl From<TRIGSRC_A> for u8 {
     #[inline(always)]
@@ -104,6 +272,90 @@ impl TRIGSRC_R {
         use crate::Variant::*;
         match self.bits {
             0 => Val(TRIGSRC_A::DISABLE),
+            1 => Val(TRIGSRC_A::RTC_TIMESTAMP),
+            2 => Val(TRIGSRC_A::DSU_DCC0),
+            3 => Val(TRIGSRC_A::DSU_DCC1),
+            4 => Val(TRIGSRC_A::SERCOM0_RX),
+            5 => Val(TRIGSRC_A::SERCOM0_TX),
+            6 => Val(TRIGSRC_A::SERCOM1_RX),
+            7 => Val(TRIGSRC_A::SERCOM1_TX),
+            8 => Val(TRIGSRC_A::SERCOM2_RX),
+            9 => Val(TRIGSRC_A::SERCOM2_TX),
+            10 => Val(TRIGSRC_A::SERCOM3_RX),
+            11 => Val(TRIGSRC_A::SERCOM3_TX),
+            12 => Val(TRIGSRC_A::SERCOM4_RX),
+            13 => Val(TRIGSRC_A::SERCOM4_TX),
+            14 => Val(TRIGSRC_A::SERCOM5_RX),
+            15 => Val(TRIGSRC_A::SERCOM5_TX),
+            16 => Val(TRIGSRC_A::SERCOM6_RX),
+            17 => Val(TRIGSRC_A::SERCOM6_TX),
+            18 => Val(TRIGSRC_A::SERCOM7_RX),
+            19 => Val(TRIGSRC_A::SERCOM7_TX),
+            20 => Val(TRIGSRC_A::CAN0_DEBUG),
+            21 => Val(TRIGSRC_A::CAN1_DEBUG),
+            22 => Val(TRIGSRC_A::TCC0_OVF),
+            23 => Val(TRIGSRC_A::TCC0_MC_0),
+            24 => Val(TRIGSRC_A::TCC0_MC_1),
+            25 => Val(TRIGSRC_A::TCC0_MC_2),
+            26 => Val(TRIGSRC_A::TCC0_MC_3),
+            27 => Val(TRIGSRC_A::TCC0_MC_4),
+            28 => Val(TRIGSRC_A::TCC0_MC_5),
+            29 => Val(TRIGSRC_A::TCC1_OVF),
+            30 => Val(TRIGSRC_A::TCC1_MC_0),
+            31 => Val(TRIGSRC_A::TCC1_MC_1),
+            32 => Val(TRIGSRC_A::TCC1_MC_2),
+            33 => Val(TRIGSRC_A::TCC1_MC_3),
+            34 => Val(TRIGSRC_A::TCC2_OVF),
+            35 => Val(TRIGSRC_A::TCC2_MC_0),
+            36 => Val(TRIGSRC_A::TCC2_MC_1),
+            37 => Val(TRIGSRC_A::TCC2_MC_2),
+            38 => Val(TRIGSRC_A::TCC3_OVF),
+            39 => Val(TRIGSRC_A::TCC3_MC_0),
+            40 => Val(TRIGSRC_A::TCC3_MC_1),
+            41 => Val(TRIGSRC_A::TCC4_OVF),
+            42 => Val(TRIGSRC_A::TCC4_MC_0),
+            43 => Val(TRIGSRC_A::TCC4_MC_1),
+            44 => Val(TRIGSRC_A::TC0_OVF),
+            45 => Val(TRIGSRC_A::TC0_MC_0),
+            46 => Val(TRIGSRC_A::TC0_MC_1),
+            47 => Val(TRIGSRC_A::TC1_OVF),
+            48 => Val(TRIGSRC_A::TC1_MC_0),
+            49 => Val(TRIGSRC_A::TC1_MC_1),
+            50 => Val(TRIGSRC_A::TC2_OVF),
+            51 => Val(TRIGSRC_A::TC2_MC_0),
+            52 => Val(TRIGSRC_A::TC2_MC_1),
+            53 => Val(TRIGSRC_A::TC3_OVF),
+            54 => Val(TRIGSRC_A::TC3_MC_0),
+            55 => Val(TRIGSRC_A::TC3_MC_1),
+            56 => Val(TRIGSRC_A::TC4_OVF),
+            57 => Val(TRIGSRC_A::TC4_MC_0),
+            58 => Val(TRIGSRC_A::TC4_MC_1),
+            59 => Val(TRIGSRC_A::TC5_OVF),
+            60 => Val(TRIGSRC_A::TC5_MC_0),
+            61 => Val(TRIGSRC_A::TC5_MC_1),
+            62 => Val(TRIGSRC_A::TC6_OVF),
+            63 => Val(TRIGSRC_A::TC6_MC_0),
+            64 => Val(TRIGSRC_A::TC6_MC_1),
+            65 => Val(TRIGSRC_A::TC7_OVF),
+            66 => Val(TRIGSRC_A::TC7_MC_0),
+            67 => Val(TRIGSRC_A::TC7_MC_1),
+            68 => Val(TRIGSRC_A::ADC0_RESRDY),
+            69 => Val(TRIGSRC_A::ADC0_SEQ),
+            70 => Val(TRIGSRC_A::ADC1_RESRDY),
+            71 => Val(TRIGSRC_A::ADC1_SEQ),
+            72 => Val(TRIGSRC_A::DAC_EMPTY_0),
+            73 => Val(TRIGSRC_A::DAC_EMPTY_1),
+            74 => Val(TRIGSRC_A::DAC_RESRDY_0),
+            75 => Val(TRIGSRC_A::DAC_RESRDY_1),
+            76 => Val(TRIGSRC_A::I2S_RX_0),
+            77 => Val(TRIGSRC_A::I2S_RX_1),
+            78 => Val(TRIGSRC_A::I2S_TX_0),
+            79 => Val(TRIGSRC_A::I2S_TX_1),
+            80 => Val(TRIGSRC_A::PCC_RX),
+            81 => Val(TRIGSRC_A::AES_WR),
+            82 => Val(TRIGSRC_A::AES_RD),
+            83 => Val(TRIGSRC_A::QSPI_RX),
+            84 => Val(TRIGSRC_A::QSPI_TX),
             i => Res(i),
         }
     }
@@ -111,6 +363,426 @@ impl TRIGSRC_R {
     #[inline(always)]
     pub fn is_disable(&self) -> bool {
         *self == TRIGSRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `RTC_TIMESTAMP`"]
+    #[inline(always)]
+    pub fn is_rtc_timestamp(&self) -> bool {
+        *self == TRIGSRC_A::RTC_TIMESTAMP
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC0`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc0(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC0
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC1`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc1(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC1
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_RX`"]
+    #[inline(always)]
+    pub fn is_sercom0_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_TX`"]
+    #[inline(always)]
+    pub fn is_sercom0_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_RX`"]
+    #[inline(always)]
+    pub fn is_sercom1_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_TX`"]
+    #[inline(always)]
+    pub fn is_sercom1_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_RX`"]
+    #[inline(always)]
+    pub fn is_sercom2_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_TX`"]
+    #[inline(always)]
+    pub fn is_sercom2_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_RX`"]
+    #[inline(always)]
+    pub fn is_sercom3_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_TX`"]
+    #[inline(always)]
+    pub fn is_sercom3_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_RX`"]
+    #[inline(always)]
+    pub fn is_sercom4_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_TX`"]
+    #[inline(always)]
+    pub fn is_sercom4_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_RX`"]
+    #[inline(always)]
+    pub fn is_sercom5_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_TX`"]
+    #[inline(always)]
+    pub fn is_sercom5_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_RX`"]
+    #[inline(always)]
+    pub fn is_sercom6_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_TX`"]
+    #[inline(always)]
+    pub fn is_sercom6_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_RX`"]
+    #[inline(always)]
+    pub fn is_sercom7_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_TX`"]
+    #[inline(always)]
+    pub fn is_sercom7_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_TX
+    }
+    #[doc = "Checks if the value of the field is `CAN0_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can0_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN0_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `CAN1_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can1_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN1_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `TCC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_4`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_4(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_4
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_5`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_5(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_5
+    }
+    #[doc = "Checks if the value of the field is `TCC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC5_OVF`"]
+    #[inline(always)]
+    pub fn is_tc5_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC5_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC6_OVF`"]
+    #[inline(always)]
+    pub fn is_tc6_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC6_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC7_OVF`"]
+    #[inline(always)]
+    pub fn is_tc7_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC7_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_1
+    }
+    #[doc = "Checks if the value of the field is `ADC0_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc0_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC0_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc0_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_SEQ
+    }
+    #[doc = "Checks if the value of the field is `ADC1_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc1_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC1_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc1_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_SEQ
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_0`"]
+    #[inline(always)]
+    pub fn is_dac_empty_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_1`"]
+    #[inline(always)]
+    pub fn is_dac_empty_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_1
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_0`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_1`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_1
+    }
+    #[doc = "Checks if the value of the field is `PCC_RX`"]
+    #[inline(always)]
+    pub fn is_pcc_rx(&self) -> bool {
+        *self == TRIGSRC_A::PCC_RX
+    }
+    #[doc = "Checks if the value of the field is `AES_WR`"]
+    #[inline(always)]
+    pub fn is_aes_wr(&self) -> bool {
+        *self == TRIGSRC_A::AES_WR
+    }
+    #[doc = "Checks if the value of the field is `AES_RD`"]
+    #[inline(always)]
+    pub fn is_aes_rd(&self) -> bool {
+        *self == TRIGSRC_A::AES_RD
+    }
+    #[doc = "Checks if the value of the field is `QSPI_RX`"]
+    #[inline(always)]
+    pub fn is_qspi_rx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_RX
+    }
+    #[doc = "Checks if the value of the field is `QSPI_TX`"]
+    #[inline(always)]
+    pub fn is_qspi_tx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_TX
     }
 }
 #[doc = "Write proxy for field `TRIGSRC`"]
@@ -127,6 +799,426 @@ impl<'a> TRIGSRC_W<'a> {
     #[inline(always)]
     pub fn disable(self) -> &'a mut W {
         self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = "DMA RTC timestamp trigger"]
+    #[inline(always)]
+    pub fn rtc_timestamp(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::RTC_TIMESTAMP)
+    }
+    #[doc = "DMAC ID for DCC0 register"]
+    #[inline(always)]
+    pub fn dsu_dcc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC0)
+    }
+    #[doc = "DMAC ID for DCC1 register"]
+    #[inline(always)]
+    pub fn dsu_dcc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC1)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom0_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom0_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom1_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom1_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom2_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom2_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom3_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom3_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom4_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom4_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom5_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom5_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom6_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom6_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom7_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom7_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_TX)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can0_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN0_DEBUG)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can1_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN1_DEBUG)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_3)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_4(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_4)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_5(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_5)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_3)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_2)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_1)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc5_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc6_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc7_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_1)
+    }
+    #[doc = "index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc0_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc0_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_SEQ)
+    }
+    #[doc = "Index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc1_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc1_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_SEQ)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_0)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_1)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_0)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_1)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_0)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_1)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_0)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_1)
+    }
+    #[doc = "Indexes of PCC RX trigger"]
+    #[inline(always)]
+    pub fn pcc_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::PCC_RX)
+    }
+    #[doc = "DMA DATA Write trigger"]
+    #[inline(always)]
+    pub fn aes_wr(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_WR)
+    }
+    #[doc = "DMA DATA Read trigger"]
+    #[inline(always)]
+    pub fn aes_rd(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_RD)
+    }
+    #[doc = "Indexes of QSPI RX trigger"]
+    #[inline(always)]
+    pub fn qspi_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_RX)
+    }
+    #[doc = "Indexes of QSPI TX trigger"]
+    #[inline(always)]
+    pub fn qspi_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_TX)
     }
     #[doc = r"Writes raw bits to the field"]
     #[inline(always)]

--- a/pac/atsamd51n/src/dmac/channel/chctrla.rs
+++ b/pac/atsamd51n/src/dmac/channel/chctrla.rs
@@ -88,6 +88,174 @@ impl<'a> RUNSTDBY_W<'a> {
 pub enum TRIGSRC_A {
     #[doc = "0: Only software/event triggers"]
     DISABLE = 0,
+    #[doc = "1: DMA RTC timestamp trigger"]
+    RTC_TIMESTAMP = 1,
+    #[doc = "2: DMAC ID for DCC0 register"]
+    DSU_DCC0 = 2,
+    #[doc = "3: DMAC ID for DCC1 register"]
+    DSU_DCC1 = 3,
+    #[doc = "4: Index of DMA RX trigger"]
+    SERCOM0_RX = 4,
+    #[doc = "5: Index of DMA TX trigger"]
+    SERCOM0_TX = 5,
+    #[doc = "6: Index of DMA RX trigger"]
+    SERCOM1_RX = 6,
+    #[doc = "7: Index of DMA TX trigger"]
+    SERCOM1_TX = 7,
+    #[doc = "8: Index of DMA RX trigger"]
+    SERCOM2_RX = 8,
+    #[doc = "9: Index of DMA TX trigger"]
+    SERCOM2_TX = 9,
+    #[doc = "10: Index of DMA RX trigger"]
+    SERCOM3_RX = 10,
+    #[doc = "11: Index of DMA TX trigger"]
+    SERCOM3_TX = 11,
+    #[doc = "12: Index of DMA RX trigger"]
+    SERCOM4_RX = 12,
+    #[doc = "13: Index of DMA TX trigger"]
+    SERCOM4_TX = 13,
+    #[doc = "14: Index of DMA RX trigger"]
+    SERCOM5_RX = 14,
+    #[doc = "15: Index of DMA TX trigger"]
+    SERCOM5_TX = 15,
+    #[doc = "16: Index of DMA RX trigger"]
+    SERCOM6_RX = 16,
+    #[doc = "17: Index of DMA TX trigger"]
+    SERCOM6_TX = 17,
+    #[doc = "18: Index of DMA RX trigger"]
+    SERCOM7_RX = 18,
+    #[doc = "19: Index of DMA TX trigger"]
+    SERCOM7_TX = 19,
+    #[doc = "20: DMA CAN Debug Req"]
+    CAN0_DEBUG = 20,
+    #[doc = "21: DMA CAN Debug Req"]
+    CAN1_DEBUG = 21,
+    #[doc = "22: DMA overflow/underflow/retrigger trigger"]
+    TCC0_OVF = 22,
+    #[doc = "23: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_0 = 23,
+    #[doc = "24: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_1 = 24,
+    #[doc = "25: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_2 = 25,
+    #[doc = "26: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_3 = 26,
+    #[doc = "27: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_4 = 27,
+    #[doc = "28: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_5 = 28,
+    #[doc = "29: DMA overflow/underflow/retrigger trigger"]
+    TCC1_OVF = 29,
+    #[doc = "30: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_0 = 30,
+    #[doc = "31: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_1 = 31,
+    #[doc = "32: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_2 = 32,
+    #[doc = "33: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_3 = 33,
+    #[doc = "34: DMA overflow/underflow/retrigger trigger"]
+    TCC2_OVF = 34,
+    #[doc = "35: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_0 = 35,
+    #[doc = "36: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_1 = 36,
+    #[doc = "37: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_2 = 37,
+    #[doc = "38: DMA overflow/underflow/retrigger trigger"]
+    TCC3_OVF = 38,
+    #[doc = "39: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_0 = 39,
+    #[doc = "40: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_1 = 40,
+    #[doc = "41: DMA overflow/underflow/retrigger trigger"]
+    TCC4_OVF = 41,
+    #[doc = "42: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_0 = 42,
+    #[doc = "43: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_1 = 43,
+    #[doc = "44: Indexes of DMA Overflow trigger"]
+    TC0_OVF = 44,
+    #[doc = "45: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_0 = 45,
+    #[doc = "46: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_1 = 46,
+    #[doc = "47: Indexes of DMA Overflow trigger"]
+    TC1_OVF = 47,
+    #[doc = "48: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_0 = 48,
+    #[doc = "49: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_1 = 49,
+    #[doc = "50: Indexes of DMA Overflow trigger"]
+    TC2_OVF = 50,
+    #[doc = "51: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_0 = 51,
+    #[doc = "52: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_1 = 52,
+    #[doc = "53: Indexes of DMA Overflow trigger"]
+    TC3_OVF = 53,
+    #[doc = "54: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_0 = 54,
+    #[doc = "55: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_1 = 55,
+    #[doc = "56: Indexes of DMA Overflow trigger"]
+    TC4_OVF = 56,
+    #[doc = "57: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_0 = 57,
+    #[doc = "58: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_1 = 58,
+    #[doc = "59: Indexes of DMA Overflow trigger"]
+    TC5_OVF = 59,
+    #[doc = "60: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_0 = 60,
+    #[doc = "61: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_1 = 61,
+    #[doc = "62: Indexes of DMA Overflow trigger"]
+    TC6_OVF = 62,
+    #[doc = "63: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_0 = 63,
+    #[doc = "64: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_1 = 64,
+    #[doc = "65: Indexes of DMA Overflow trigger"]
+    TC7_OVF = 65,
+    #[doc = "66: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_0 = 66,
+    #[doc = "67: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_1 = 67,
+    #[doc = "68: index of DMA RESRDY trigger"]
+    ADC0_RESRDY = 68,
+    #[doc = "69: Index of DMA SEQ trigger"]
+    ADC0_SEQ = 69,
+    #[doc = "70: Index of DMA RESRDY trigger"]
+    ADC1_RESRDY = 70,
+    #[doc = "71: Index of DMA SEQ trigger"]
+    ADC1_SEQ = 71,
+    #[doc = "72: DMA DAC Empty Req"]
+    DAC_EMPTY_0 = 72,
+    #[doc = "73: DMA DAC Empty Req"]
+    DAC_EMPTY_1 = 73,
+    #[doc = "74: DMA DAC Result Ready Req"]
+    DAC_RESRDY_0 = 74,
+    #[doc = "75: DMA DAC Result Ready Req"]
+    DAC_RESRDY_1 = 75,
+    #[doc = "76: Indexes of DMA RX triggers"]
+    I2S_RX_0 = 76,
+    #[doc = "77: Indexes of DMA RX triggers"]
+    I2S_RX_1 = 77,
+    #[doc = "78: Indexes of DMA TX triggers"]
+    I2S_TX_0 = 78,
+    #[doc = "79: Indexes of DMA TX triggers"]
+    I2S_TX_1 = 79,
+    #[doc = "80: Indexes of PCC RX trigger"]
+    PCC_RX = 80,
+    #[doc = "81: DMA DATA Write trigger"]
+    AES_WR = 81,
+    #[doc = "82: DMA DATA Read trigger"]
+    AES_RD = 82,
+    #[doc = "83: Indexes of QSPI RX trigger"]
+    QSPI_RX = 83,
+    #[doc = "84: Indexes of QSPI TX trigger"]
+    QSPI_TX = 84,
 }
 impl From<TRIGSRC_A> for u8 {
     #[inline(always)]
@@ -104,6 +272,90 @@ impl TRIGSRC_R {
         use crate::Variant::*;
         match self.bits {
             0 => Val(TRIGSRC_A::DISABLE),
+            1 => Val(TRIGSRC_A::RTC_TIMESTAMP),
+            2 => Val(TRIGSRC_A::DSU_DCC0),
+            3 => Val(TRIGSRC_A::DSU_DCC1),
+            4 => Val(TRIGSRC_A::SERCOM0_RX),
+            5 => Val(TRIGSRC_A::SERCOM0_TX),
+            6 => Val(TRIGSRC_A::SERCOM1_RX),
+            7 => Val(TRIGSRC_A::SERCOM1_TX),
+            8 => Val(TRIGSRC_A::SERCOM2_RX),
+            9 => Val(TRIGSRC_A::SERCOM2_TX),
+            10 => Val(TRIGSRC_A::SERCOM3_RX),
+            11 => Val(TRIGSRC_A::SERCOM3_TX),
+            12 => Val(TRIGSRC_A::SERCOM4_RX),
+            13 => Val(TRIGSRC_A::SERCOM4_TX),
+            14 => Val(TRIGSRC_A::SERCOM5_RX),
+            15 => Val(TRIGSRC_A::SERCOM5_TX),
+            16 => Val(TRIGSRC_A::SERCOM6_RX),
+            17 => Val(TRIGSRC_A::SERCOM6_TX),
+            18 => Val(TRIGSRC_A::SERCOM7_RX),
+            19 => Val(TRIGSRC_A::SERCOM7_TX),
+            20 => Val(TRIGSRC_A::CAN0_DEBUG),
+            21 => Val(TRIGSRC_A::CAN1_DEBUG),
+            22 => Val(TRIGSRC_A::TCC0_OVF),
+            23 => Val(TRIGSRC_A::TCC0_MC_0),
+            24 => Val(TRIGSRC_A::TCC0_MC_1),
+            25 => Val(TRIGSRC_A::TCC0_MC_2),
+            26 => Val(TRIGSRC_A::TCC0_MC_3),
+            27 => Val(TRIGSRC_A::TCC0_MC_4),
+            28 => Val(TRIGSRC_A::TCC0_MC_5),
+            29 => Val(TRIGSRC_A::TCC1_OVF),
+            30 => Val(TRIGSRC_A::TCC1_MC_0),
+            31 => Val(TRIGSRC_A::TCC1_MC_1),
+            32 => Val(TRIGSRC_A::TCC1_MC_2),
+            33 => Val(TRIGSRC_A::TCC1_MC_3),
+            34 => Val(TRIGSRC_A::TCC2_OVF),
+            35 => Val(TRIGSRC_A::TCC2_MC_0),
+            36 => Val(TRIGSRC_A::TCC2_MC_1),
+            37 => Val(TRIGSRC_A::TCC2_MC_2),
+            38 => Val(TRIGSRC_A::TCC3_OVF),
+            39 => Val(TRIGSRC_A::TCC3_MC_0),
+            40 => Val(TRIGSRC_A::TCC3_MC_1),
+            41 => Val(TRIGSRC_A::TCC4_OVF),
+            42 => Val(TRIGSRC_A::TCC4_MC_0),
+            43 => Val(TRIGSRC_A::TCC4_MC_1),
+            44 => Val(TRIGSRC_A::TC0_OVF),
+            45 => Val(TRIGSRC_A::TC0_MC_0),
+            46 => Val(TRIGSRC_A::TC0_MC_1),
+            47 => Val(TRIGSRC_A::TC1_OVF),
+            48 => Val(TRIGSRC_A::TC1_MC_0),
+            49 => Val(TRIGSRC_A::TC1_MC_1),
+            50 => Val(TRIGSRC_A::TC2_OVF),
+            51 => Val(TRIGSRC_A::TC2_MC_0),
+            52 => Val(TRIGSRC_A::TC2_MC_1),
+            53 => Val(TRIGSRC_A::TC3_OVF),
+            54 => Val(TRIGSRC_A::TC3_MC_0),
+            55 => Val(TRIGSRC_A::TC3_MC_1),
+            56 => Val(TRIGSRC_A::TC4_OVF),
+            57 => Val(TRIGSRC_A::TC4_MC_0),
+            58 => Val(TRIGSRC_A::TC4_MC_1),
+            59 => Val(TRIGSRC_A::TC5_OVF),
+            60 => Val(TRIGSRC_A::TC5_MC_0),
+            61 => Val(TRIGSRC_A::TC5_MC_1),
+            62 => Val(TRIGSRC_A::TC6_OVF),
+            63 => Val(TRIGSRC_A::TC6_MC_0),
+            64 => Val(TRIGSRC_A::TC6_MC_1),
+            65 => Val(TRIGSRC_A::TC7_OVF),
+            66 => Val(TRIGSRC_A::TC7_MC_0),
+            67 => Val(TRIGSRC_A::TC7_MC_1),
+            68 => Val(TRIGSRC_A::ADC0_RESRDY),
+            69 => Val(TRIGSRC_A::ADC0_SEQ),
+            70 => Val(TRIGSRC_A::ADC1_RESRDY),
+            71 => Val(TRIGSRC_A::ADC1_SEQ),
+            72 => Val(TRIGSRC_A::DAC_EMPTY_0),
+            73 => Val(TRIGSRC_A::DAC_EMPTY_1),
+            74 => Val(TRIGSRC_A::DAC_RESRDY_0),
+            75 => Val(TRIGSRC_A::DAC_RESRDY_1),
+            76 => Val(TRIGSRC_A::I2S_RX_0),
+            77 => Val(TRIGSRC_A::I2S_RX_1),
+            78 => Val(TRIGSRC_A::I2S_TX_0),
+            79 => Val(TRIGSRC_A::I2S_TX_1),
+            80 => Val(TRIGSRC_A::PCC_RX),
+            81 => Val(TRIGSRC_A::AES_WR),
+            82 => Val(TRIGSRC_A::AES_RD),
+            83 => Val(TRIGSRC_A::QSPI_RX),
+            84 => Val(TRIGSRC_A::QSPI_TX),
             i => Res(i),
         }
     }
@@ -111,6 +363,426 @@ impl TRIGSRC_R {
     #[inline(always)]
     pub fn is_disable(&self) -> bool {
         *self == TRIGSRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `RTC_TIMESTAMP`"]
+    #[inline(always)]
+    pub fn is_rtc_timestamp(&self) -> bool {
+        *self == TRIGSRC_A::RTC_TIMESTAMP
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC0`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc0(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC0
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC1`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc1(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC1
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_RX`"]
+    #[inline(always)]
+    pub fn is_sercom0_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_TX`"]
+    #[inline(always)]
+    pub fn is_sercom0_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_RX`"]
+    #[inline(always)]
+    pub fn is_sercom1_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_TX`"]
+    #[inline(always)]
+    pub fn is_sercom1_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_RX`"]
+    #[inline(always)]
+    pub fn is_sercom2_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_TX`"]
+    #[inline(always)]
+    pub fn is_sercom2_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_RX`"]
+    #[inline(always)]
+    pub fn is_sercom3_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_TX`"]
+    #[inline(always)]
+    pub fn is_sercom3_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_RX`"]
+    #[inline(always)]
+    pub fn is_sercom4_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_TX`"]
+    #[inline(always)]
+    pub fn is_sercom4_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_RX`"]
+    #[inline(always)]
+    pub fn is_sercom5_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_TX`"]
+    #[inline(always)]
+    pub fn is_sercom5_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_RX`"]
+    #[inline(always)]
+    pub fn is_sercom6_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_TX`"]
+    #[inline(always)]
+    pub fn is_sercom6_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_RX`"]
+    #[inline(always)]
+    pub fn is_sercom7_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_TX`"]
+    #[inline(always)]
+    pub fn is_sercom7_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_TX
+    }
+    #[doc = "Checks if the value of the field is `CAN0_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can0_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN0_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `CAN1_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can1_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN1_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `TCC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_4`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_4(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_4
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_5`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_5(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_5
+    }
+    #[doc = "Checks if the value of the field is `TCC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC5_OVF`"]
+    #[inline(always)]
+    pub fn is_tc5_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC5_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC6_OVF`"]
+    #[inline(always)]
+    pub fn is_tc6_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC6_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC7_OVF`"]
+    #[inline(always)]
+    pub fn is_tc7_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC7_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_1
+    }
+    #[doc = "Checks if the value of the field is `ADC0_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc0_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC0_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc0_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_SEQ
+    }
+    #[doc = "Checks if the value of the field is `ADC1_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc1_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC1_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc1_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_SEQ
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_0`"]
+    #[inline(always)]
+    pub fn is_dac_empty_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_1`"]
+    #[inline(always)]
+    pub fn is_dac_empty_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_1
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_0`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_1`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_1
+    }
+    #[doc = "Checks if the value of the field is `PCC_RX`"]
+    #[inline(always)]
+    pub fn is_pcc_rx(&self) -> bool {
+        *self == TRIGSRC_A::PCC_RX
+    }
+    #[doc = "Checks if the value of the field is `AES_WR`"]
+    #[inline(always)]
+    pub fn is_aes_wr(&self) -> bool {
+        *self == TRIGSRC_A::AES_WR
+    }
+    #[doc = "Checks if the value of the field is `AES_RD`"]
+    #[inline(always)]
+    pub fn is_aes_rd(&self) -> bool {
+        *self == TRIGSRC_A::AES_RD
+    }
+    #[doc = "Checks if the value of the field is `QSPI_RX`"]
+    #[inline(always)]
+    pub fn is_qspi_rx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_RX
+    }
+    #[doc = "Checks if the value of the field is `QSPI_TX`"]
+    #[inline(always)]
+    pub fn is_qspi_tx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_TX
     }
 }
 #[doc = "Write proxy for field `TRIGSRC`"]
@@ -127,6 +799,426 @@ impl<'a> TRIGSRC_W<'a> {
     #[inline(always)]
     pub fn disable(self) -> &'a mut W {
         self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = "DMA RTC timestamp trigger"]
+    #[inline(always)]
+    pub fn rtc_timestamp(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::RTC_TIMESTAMP)
+    }
+    #[doc = "DMAC ID for DCC0 register"]
+    #[inline(always)]
+    pub fn dsu_dcc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC0)
+    }
+    #[doc = "DMAC ID for DCC1 register"]
+    #[inline(always)]
+    pub fn dsu_dcc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC1)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom0_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom0_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom1_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom1_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom2_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom2_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom3_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom3_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom4_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom4_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom5_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom5_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom6_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom6_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom7_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom7_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_TX)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can0_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN0_DEBUG)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can1_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN1_DEBUG)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_3)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_4(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_4)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_5(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_5)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_3)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_2)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_1)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc5_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc6_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc7_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_1)
+    }
+    #[doc = "index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc0_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc0_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_SEQ)
+    }
+    #[doc = "Index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc1_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc1_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_SEQ)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_0)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_1)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_0)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_1)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_0)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_1)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_0)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_1)
+    }
+    #[doc = "Indexes of PCC RX trigger"]
+    #[inline(always)]
+    pub fn pcc_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::PCC_RX)
+    }
+    #[doc = "DMA DATA Write trigger"]
+    #[inline(always)]
+    pub fn aes_wr(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_WR)
+    }
+    #[doc = "DMA DATA Read trigger"]
+    #[inline(always)]
+    pub fn aes_rd(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_RD)
+    }
+    #[doc = "Indexes of QSPI RX trigger"]
+    #[inline(always)]
+    pub fn qspi_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_RX)
+    }
+    #[doc = "Indexes of QSPI TX trigger"]
+    #[inline(always)]
+    pub fn qspi_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_TX)
     }
     #[doc = r"Writes raw bits to the field"]
     #[inline(always)]

--- a/pac/atsamd51p/src/dmac/channel/chctrla.rs
+++ b/pac/atsamd51p/src/dmac/channel/chctrla.rs
@@ -88,6 +88,174 @@ impl<'a> RUNSTDBY_W<'a> {
 pub enum TRIGSRC_A {
     #[doc = "0: Only software/event triggers"]
     DISABLE = 0,
+    #[doc = "1: DMA RTC timestamp trigger"]
+    RTC_TIMESTAMP = 1,
+    #[doc = "2: DMAC ID for DCC0 register"]
+    DSU_DCC0 = 2,
+    #[doc = "3: DMAC ID for DCC1 register"]
+    DSU_DCC1 = 3,
+    #[doc = "4: Index of DMA RX trigger"]
+    SERCOM0_RX = 4,
+    #[doc = "5: Index of DMA TX trigger"]
+    SERCOM0_TX = 5,
+    #[doc = "6: Index of DMA RX trigger"]
+    SERCOM1_RX = 6,
+    #[doc = "7: Index of DMA TX trigger"]
+    SERCOM1_TX = 7,
+    #[doc = "8: Index of DMA RX trigger"]
+    SERCOM2_RX = 8,
+    #[doc = "9: Index of DMA TX trigger"]
+    SERCOM2_TX = 9,
+    #[doc = "10: Index of DMA RX trigger"]
+    SERCOM3_RX = 10,
+    #[doc = "11: Index of DMA TX trigger"]
+    SERCOM3_TX = 11,
+    #[doc = "12: Index of DMA RX trigger"]
+    SERCOM4_RX = 12,
+    #[doc = "13: Index of DMA TX trigger"]
+    SERCOM4_TX = 13,
+    #[doc = "14: Index of DMA RX trigger"]
+    SERCOM5_RX = 14,
+    #[doc = "15: Index of DMA TX trigger"]
+    SERCOM5_TX = 15,
+    #[doc = "16: Index of DMA RX trigger"]
+    SERCOM6_RX = 16,
+    #[doc = "17: Index of DMA TX trigger"]
+    SERCOM6_TX = 17,
+    #[doc = "18: Index of DMA RX trigger"]
+    SERCOM7_RX = 18,
+    #[doc = "19: Index of DMA TX trigger"]
+    SERCOM7_TX = 19,
+    #[doc = "20: DMA CAN Debug Req"]
+    CAN0_DEBUG = 20,
+    #[doc = "21: DMA CAN Debug Req"]
+    CAN1_DEBUG = 21,
+    #[doc = "22: DMA overflow/underflow/retrigger trigger"]
+    TCC0_OVF = 22,
+    #[doc = "23: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_0 = 23,
+    #[doc = "24: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_1 = 24,
+    #[doc = "25: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_2 = 25,
+    #[doc = "26: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_3 = 26,
+    #[doc = "27: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_4 = 27,
+    #[doc = "28: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_5 = 28,
+    #[doc = "29: DMA overflow/underflow/retrigger trigger"]
+    TCC1_OVF = 29,
+    #[doc = "30: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_0 = 30,
+    #[doc = "31: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_1 = 31,
+    #[doc = "32: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_2 = 32,
+    #[doc = "33: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_3 = 33,
+    #[doc = "34: DMA overflow/underflow/retrigger trigger"]
+    TCC2_OVF = 34,
+    #[doc = "35: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_0 = 35,
+    #[doc = "36: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_1 = 36,
+    #[doc = "37: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_2 = 37,
+    #[doc = "38: DMA overflow/underflow/retrigger trigger"]
+    TCC3_OVF = 38,
+    #[doc = "39: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_0 = 39,
+    #[doc = "40: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_1 = 40,
+    #[doc = "41: DMA overflow/underflow/retrigger trigger"]
+    TCC4_OVF = 41,
+    #[doc = "42: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_0 = 42,
+    #[doc = "43: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_1 = 43,
+    #[doc = "44: Indexes of DMA Overflow trigger"]
+    TC0_OVF = 44,
+    #[doc = "45: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_0 = 45,
+    #[doc = "46: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_1 = 46,
+    #[doc = "47: Indexes of DMA Overflow trigger"]
+    TC1_OVF = 47,
+    #[doc = "48: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_0 = 48,
+    #[doc = "49: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_1 = 49,
+    #[doc = "50: Indexes of DMA Overflow trigger"]
+    TC2_OVF = 50,
+    #[doc = "51: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_0 = 51,
+    #[doc = "52: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_1 = 52,
+    #[doc = "53: Indexes of DMA Overflow trigger"]
+    TC3_OVF = 53,
+    #[doc = "54: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_0 = 54,
+    #[doc = "55: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_1 = 55,
+    #[doc = "56: Indexes of DMA Overflow trigger"]
+    TC4_OVF = 56,
+    #[doc = "57: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_0 = 57,
+    #[doc = "58: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_1 = 58,
+    #[doc = "59: Indexes of DMA Overflow trigger"]
+    TC5_OVF = 59,
+    #[doc = "60: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_0 = 60,
+    #[doc = "61: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_1 = 61,
+    #[doc = "62: Indexes of DMA Overflow trigger"]
+    TC6_OVF = 62,
+    #[doc = "63: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_0 = 63,
+    #[doc = "64: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_1 = 64,
+    #[doc = "65: Indexes of DMA Overflow trigger"]
+    TC7_OVF = 65,
+    #[doc = "66: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_0 = 66,
+    #[doc = "67: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_1 = 67,
+    #[doc = "68: index of DMA RESRDY trigger"]
+    ADC0_RESRDY = 68,
+    #[doc = "69: Index of DMA SEQ trigger"]
+    ADC0_SEQ = 69,
+    #[doc = "70: Index of DMA RESRDY trigger"]
+    ADC1_RESRDY = 70,
+    #[doc = "71: Index of DMA SEQ trigger"]
+    ADC1_SEQ = 71,
+    #[doc = "72: DMA DAC Empty Req"]
+    DAC_EMPTY_0 = 72,
+    #[doc = "73: DMA DAC Empty Req"]
+    DAC_EMPTY_1 = 73,
+    #[doc = "74: DMA DAC Result Ready Req"]
+    DAC_RESRDY_0 = 74,
+    #[doc = "75: DMA DAC Result Ready Req"]
+    DAC_RESRDY_1 = 75,
+    #[doc = "76: Indexes of DMA RX triggers"]
+    I2S_RX_0 = 76,
+    #[doc = "77: Indexes of DMA RX triggers"]
+    I2S_RX_1 = 77,
+    #[doc = "78: Indexes of DMA TX triggers"]
+    I2S_TX_0 = 78,
+    #[doc = "79: Indexes of DMA TX triggers"]
+    I2S_TX_1 = 79,
+    #[doc = "80: Indexes of PCC RX trigger"]
+    PCC_RX = 80,
+    #[doc = "81: DMA DATA Write trigger"]
+    AES_WR = 81,
+    #[doc = "82: DMA DATA Read trigger"]
+    AES_RD = 82,
+    #[doc = "83: Indexes of QSPI RX trigger"]
+    QSPI_RX = 83,
+    #[doc = "84: Indexes of QSPI TX trigger"]
+    QSPI_TX = 84,
 }
 impl From<TRIGSRC_A> for u8 {
     #[inline(always)]
@@ -104,6 +272,90 @@ impl TRIGSRC_R {
         use crate::Variant::*;
         match self.bits {
             0 => Val(TRIGSRC_A::DISABLE),
+            1 => Val(TRIGSRC_A::RTC_TIMESTAMP),
+            2 => Val(TRIGSRC_A::DSU_DCC0),
+            3 => Val(TRIGSRC_A::DSU_DCC1),
+            4 => Val(TRIGSRC_A::SERCOM0_RX),
+            5 => Val(TRIGSRC_A::SERCOM0_TX),
+            6 => Val(TRIGSRC_A::SERCOM1_RX),
+            7 => Val(TRIGSRC_A::SERCOM1_TX),
+            8 => Val(TRIGSRC_A::SERCOM2_RX),
+            9 => Val(TRIGSRC_A::SERCOM2_TX),
+            10 => Val(TRIGSRC_A::SERCOM3_RX),
+            11 => Val(TRIGSRC_A::SERCOM3_TX),
+            12 => Val(TRIGSRC_A::SERCOM4_RX),
+            13 => Val(TRIGSRC_A::SERCOM4_TX),
+            14 => Val(TRIGSRC_A::SERCOM5_RX),
+            15 => Val(TRIGSRC_A::SERCOM5_TX),
+            16 => Val(TRIGSRC_A::SERCOM6_RX),
+            17 => Val(TRIGSRC_A::SERCOM6_TX),
+            18 => Val(TRIGSRC_A::SERCOM7_RX),
+            19 => Val(TRIGSRC_A::SERCOM7_TX),
+            20 => Val(TRIGSRC_A::CAN0_DEBUG),
+            21 => Val(TRIGSRC_A::CAN1_DEBUG),
+            22 => Val(TRIGSRC_A::TCC0_OVF),
+            23 => Val(TRIGSRC_A::TCC0_MC_0),
+            24 => Val(TRIGSRC_A::TCC0_MC_1),
+            25 => Val(TRIGSRC_A::TCC0_MC_2),
+            26 => Val(TRIGSRC_A::TCC0_MC_3),
+            27 => Val(TRIGSRC_A::TCC0_MC_4),
+            28 => Val(TRIGSRC_A::TCC0_MC_5),
+            29 => Val(TRIGSRC_A::TCC1_OVF),
+            30 => Val(TRIGSRC_A::TCC1_MC_0),
+            31 => Val(TRIGSRC_A::TCC1_MC_1),
+            32 => Val(TRIGSRC_A::TCC1_MC_2),
+            33 => Val(TRIGSRC_A::TCC1_MC_3),
+            34 => Val(TRIGSRC_A::TCC2_OVF),
+            35 => Val(TRIGSRC_A::TCC2_MC_0),
+            36 => Val(TRIGSRC_A::TCC2_MC_1),
+            37 => Val(TRIGSRC_A::TCC2_MC_2),
+            38 => Val(TRIGSRC_A::TCC3_OVF),
+            39 => Val(TRIGSRC_A::TCC3_MC_0),
+            40 => Val(TRIGSRC_A::TCC3_MC_1),
+            41 => Val(TRIGSRC_A::TCC4_OVF),
+            42 => Val(TRIGSRC_A::TCC4_MC_0),
+            43 => Val(TRIGSRC_A::TCC4_MC_1),
+            44 => Val(TRIGSRC_A::TC0_OVF),
+            45 => Val(TRIGSRC_A::TC0_MC_0),
+            46 => Val(TRIGSRC_A::TC0_MC_1),
+            47 => Val(TRIGSRC_A::TC1_OVF),
+            48 => Val(TRIGSRC_A::TC1_MC_0),
+            49 => Val(TRIGSRC_A::TC1_MC_1),
+            50 => Val(TRIGSRC_A::TC2_OVF),
+            51 => Val(TRIGSRC_A::TC2_MC_0),
+            52 => Val(TRIGSRC_A::TC2_MC_1),
+            53 => Val(TRIGSRC_A::TC3_OVF),
+            54 => Val(TRIGSRC_A::TC3_MC_0),
+            55 => Val(TRIGSRC_A::TC3_MC_1),
+            56 => Val(TRIGSRC_A::TC4_OVF),
+            57 => Val(TRIGSRC_A::TC4_MC_0),
+            58 => Val(TRIGSRC_A::TC4_MC_1),
+            59 => Val(TRIGSRC_A::TC5_OVF),
+            60 => Val(TRIGSRC_A::TC5_MC_0),
+            61 => Val(TRIGSRC_A::TC5_MC_1),
+            62 => Val(TRIGSRC_A::TC6_OVF),
+            63 => Val(TRIGSRC_A::TC6_MC_0),
+            64 => Val(TRIGSRC_A::TC6_MC_1),
+            65 => Val(TRIGSRC_A::TC7_OVF),
+            66 => Val(TRIGSRC_A::TC7_MC_0),
+            67 => Val(TRIGSRC_A::TC7_MC_1),
+            68 => Val(TRIGSRC_A::ADC0_RESRDY),
+            69 => Val(TRIGSRC_A::ADC0_SEQ),
+            70 => Val(TRIGSRC_A::ADC1_RESRDY),
+            71 => Val(TRIGSRC_A::ADC1_SEQ),
+            72 => Val(TRIGSRC_A::DAC_EMPTY_0),
+            73 => Val(TRIGSRC_A::DAC_EMPTY_1),
+            74 => Val(TRIGSRC_A::DAC_RESRDY_0),
+            75 => Val(TRIGSRC_A::DAC_RESRDY_1),
+            76 => Val(TRIGSRC_A::I2S_RX_0),
+            77 => Val(TRIGSRC_A::I2S_RX_1),
+            78 => Val(TRIGSRC_A::I2S_TX_0),
+            79 => Val(TRIGSRC_A::I2S_TX_1),
+            80 => Val(TRIGSRC_A::PCC_RX),
+            81 => Val(TRIGSRC_A::AES_WR),
+            82 => Val(TRIGSRC_A::AES_RD),
+            83 => Val(TRIGSRC_A::QSPI_RX),
+            84 => Val(TRIGSRC_A::QSPI_TX),
             i => Res(i),
         }
     }
@@ -111,6 +363,426 @@ impl TRIGSRC_R {
     #[inline(always)]
     pub fn is_disable(&self) -> bool {
         *self == TRIGSRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `RTC_TIMESTAMP`"]
+    #[inline(always)]
+    pub fn is_rtc_timestamp(&self) -> bool {
+        *self == TRIGSRC_A::RTC_TIMESTAMP
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC0`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc0(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC0
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC1`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc1(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC1
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_RX`"]
+    #[inline(always)]
+    pub fn is_sercom0_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_TX`"]
+    #[inline(always)]
+    pub fn is_sercom0_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_RX`"]
+    #[inline(always)]
+    pub fn is_sercom1_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_TX`"]
+    #[inline(always)]
+    pub fn is_sercom1_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_RX`"]
+    #[inline(always)]
+    pub fn is_sercom2_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_TX`"]
+    #[inline(always)]
+    pub fn is_sercom2_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_RX`"]
+    #[inline(always)]
+    pub fn is_sercom3_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_TX`"]
+    #[inline(always)]
+    pub fn is_sercom3_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_RX`"]
+    #[inline(always)]
+    pub fn is_sercom4_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_TX`"]
+    #[inline(always)]
+    pub fn is_sercom4_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_RX`"]
+    #[inline(always)]
+    pub fn is_sercom5_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_TX`"]
+    #[inline(always)]
+    pub fn is_sercom5_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_RX`"]
+    #[inline(always)]
+    pub fn is_sercom6_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_TX`"]
+    #[inline(always)]
+    pub fn is_sercom6_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_RX`"]
+    #[inline(always)]
+    pub fn is_sercom7_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_TX`"]
+    #[inline(always)]
+    pub fn is_sercom7_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_TX
+    }
+    #[doc = "Checks if the value of the field is `CAN0_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can0_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN0_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `CAN1_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can1_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN1_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `TCC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_4`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_4(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_4
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_5`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_5(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_5
+    }
+    #[doc = "Checks if the value of the field is `TCC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC5_OVF`"]
+    #[inline(always)]
+    pub fn is_tc5_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC5_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC6_OVF`"]
+    #[inline(always)]
+    pub fn is_tc6_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC6_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC7_OVF`"]
+    #[inline(always)]
+    pub fn is_tc7_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC7_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_1
+    }
+    #[doc = "Checks if the value of the field is `ADC0_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc0_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC0_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc0_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_SEQ
+    }
+    #[doc = "Checks if the value of the field is `ADC1_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc1_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC1_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc1_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_SEQ
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_0`"]
+    #[inline(always)]
+    pub fn is_dac_empty_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_1`"]
+    #[inline(always)]
+    pub fn is_dac_empty_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_1
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_0`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_1`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_1
+    }
+    #[doc = "Checks if the value of the field is `PCC_RX`"]
+    #[inline(always)]
+    pub fn is_pcc_rx(&self) -> bool {
+        *self == TRIGSRC_A::PCC_RX
+    }
+    #[doc = "Checks if the value of the field is `AES_WR`"]
+    #[inline(always)]
+    pub fn is_aes_wr(&self) -> bool {
+        *self == TRIGSRC_A::AES_WR
+    }
+    #[doc = "Checks if the value of the field is `AES_RD`"]
+    #[inline(always)]
+    pub fn is_aes_rd(&self) -> bool {
+        *self == TRIGSRC_A::AES_RD
+    }
+    #[doc = "Checks if the value of the field is `QSPI_RX`"]
+    #[inline(always)]
+    pub fn is_qspi_rx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_RX
+    }
+    #[doc = "Checks if the value of the field is `QSPI_TX`"]
+    #[inline(always)]
+    pub fn is_qspi_tx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_TX
     }
 }
 #[doc = "Write proxy for field `TRIGSRC`"]
@@ -127,6 +799,426 @@ impl<'a> TRIGSRC_W<'a> {
     #[inline(always)]
     pub fn disable(self) -> &'a mut W {
         self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = "DMA RTC timestamp trigger"]
+    #[inline(always)]
+    pub fn rtc_timestamp(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::RTC_TIMESTAMP)
+    }
+    #[doc = "DMAC ID for DCC0 register"]
+    #[inline(always)]
+    pub fn dsu_dcc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC0)
+    }
+    #[doc = "DMAC ID for DCC1 register"]
+    #[inline(always)]
+    pub fn dsu_dcc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC1)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom0_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom0_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom1_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom1_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom2_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom2_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom3_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom3_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom4_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom4_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom5_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom5_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom6_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom6_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom7_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom7_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_TX)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can0_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN0_DEBUG)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can1_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN1_DEBUG)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_3)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_4(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_4)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_5(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_5)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_3)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_2)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_1)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc5_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc6_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc7_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_1)
+    }
+    #[doc = "index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc0_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc0_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_SEQ)
+    }
+    #[doc = "Index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc1_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc1_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_SEQ)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_0)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_1)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_0)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_1)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_0)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_1)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_0)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_1)
+    }
+    #[doc = "Indexes of PCC RX trigger"]
+    #[inline(always)]
+    pub fn pcc_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::PCC_RX)
+    }
+    #[doc = "DMA DATA Write trigger"]
+    #[inline(always)]
+    pub fn aes_wr(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_WR)
+    }
+    #[doc = "DMA DATA Read trigger"]
+    #[inline(always)]
+    pub fn aes_rd(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_RD)
+    }
+    #[doc = "Indexes of QSPI RX trigger"]
+    #[inline(always)]
+    pub fn qspi_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_RX)
+    }
+    #[doc = "Indexes of QSPI TX trigger"]
+    #[inline(always)]
+    pub fn qspi_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_TX)
     }
     #[doc = r"Writes raw bits to the field"]
     #[inline(always)]

--- a/pac/atsame51g/src/dmac/channel/chctrla.rs
+++ b/pac/atsame51g/src/dmac/channel/chctrla.rs
@@ -88,6 +88,174 @@ impl<'a> RUNSTDBY_W<'a> {
 pub enum TRIGSRC_A {
     #[doc = "0: Only software/event triggers"]
     DISABLE = 0,
+    #[doc = "1: DMA RTC timestamp trigger"]
+    RTC_TIMESTAMP = 1,
+    #[doc = "2: DMAC ID for DCC0 register"]
+    DSU_DCC0 = 2,
+    #[doc = "3: DMAC ID for DCC1 register"]
+    DSU_DCC1 = 3,
+    #[doc = "4: Index of DMA RX trigger"]
+    SERCOM0_RX = 4,
+    #[doc = "5: Index of DMA TX trigger"]
+    SERCOM0_TX = 5,
+    #[doc = "6: Index of DMA RX trigger"]
+    SERCOM1_RX = 6,
+    #[doc = "7: Index of DMA TX trigger"]
+    SERCOM1_TX = 7,
+    #[doc = "8: Index of DMA RX trigger"]
+    SERCOM2_RX = 8,
+    #[doc = "9: Index of DMA TX trigger"]
+    SERCOM2_TX = 9,
+    #[doc = "10: Index of DMA RX trigger"]
+    SERCOM3_RX = 10,
+    #[doc = "11: Index of DMA TX trigger"]
+    SERCOM3_TX = 11,
+    #[doc = "12: Index of DMA RX trigger"]
+    SERCOM4_RX = 12,
+    #[doc = "13: Index of DMA TX trigger"]
+    SERCOM4_TX = 13,
+    #[doc = "14: Index of DMA RX trigger"]
+    SERCOM5_RX = 14,
+    #[doc = "15: Index of DMA TX trigger"]
+    SERCOM5_TX = 15,
+    #[doc = "16: Index of DMA RX trigger"]
+    SERCOM6_RX = 16,
+    #[doc = "17: Index of DMA TX trigger"]
+    SERCOM6_TX = 17,
+    #[doc = "18: Index of DMA RX trigger"]
+    SERCOM7_RX = 18,
+    #[doc = "19: Index of DMA TX trigger"]
+    SERCOM7_TX = 19,
+    #[doc = "20: DMA CAN Debug Req"]
+    CAN0_DEBUG = 20,
+    #[doc = "21: DMA CAN Debug Req"]
+    CAN1_DEBUG = 21,
+    #[doc = "22: DMA overflow/underflow/retrigger trigger"]
+    TCC0_OVF = 22,
+    #[doc = "23: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_0 = 23,
+    #[doc = "24: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_1 = 24,
+    #[doc = "25: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_2 = 25,
+    #[doc = "26: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_3 = 26,
+    #[doc = "27: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_4 = 27,
+    #[doc = "28: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_5 = 28,
+    #[doc = "29: DMA overflow/underflow/retrigger trigger"]
+    TCC1_OVF = 29,
+    #[doc = "30: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_0 = 30,
+    #[doc = "31: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_1 = 31,
+    #[doc = "32: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_2 = 32,
+    #[doc = "33: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_3 = 33,
+    #[doc = "34: DMA overflow/underflow/retrigger trigger"]
+    TCC2_OVF = 34,
+    #[doc = "35: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_0 = 35,
+    #[doc = "36: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_1 = 36,
+    #[doc = "37: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_2 = 37,
+    #[doc = "38: DMA overflow/underflow/retrigger trigger"]
+    TCC3_OVF = 38,
+    #[doc = "39: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_0 = 39,
+    #[doc = "40: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_1 = 40,
+    #[doc = "41: DMA overflow/underflow/retrigger trigger"]
+    TCC4_OVF = 41,
+    #[doc = "42: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_0 = 42,
+    #[doc = "43: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_1 = 43,
+    #[doc = "44: Indexes of DMA Overflow trigger"]
+    TC0_OVF = 44,
+    #[doc = "45: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_0 = 45,
+    #[doc = "46: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_1 = 46,
+    #[doc = "47: Indexes of DMA Overflow trigger"]
+    TC1_OVF = 47,
+    #[doc = "48: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_0 = 48,
+    #[doc = "49: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_1 = 49,
+    #[doc = "50: Indexes of DMA Overflow trigger"]
+    TC2_OVF = 50,
+    #[doc = "51: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_0 = 51,
+    #[doc = "52: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_1 = 52,
+    #[doc = "53: Indexes of DMA Overflow trigger"]
+    TC3_OVF = 53,
+    #[doc = "54: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_0 = 54,
+    #[doc = "55: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_1 = 55,
+    #[doc = "56: Indexes of DMA Overflow trigger"]
+    TC4_OVF = 56,
+    #[doc = "57: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_0 = 57,
+    #[doc = "58: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_1 = 58,
+    #[doc = "59: Indexes of DMA Overflow trigger"]
+    TC5_OVF = 59,
+    #[doc = "60: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_0 = 60,
+    #[doc = "61: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_1 = 61,
+    #[doc = "62: Indexes of DMA Overflow trigger"]
+    TC6_OVF = 62,
+    #[doc = "63: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_0 = 63,
+    #[doc = "64: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_1 = 64,
+    #[doc = "65: Indexes of DMA Overflow trigger"]
+    TC7_OVF = 65,
+    #[doc = "66: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_0 = 66,
+    #[doc = "67: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_1 = 67,
+    #[doc = "68: index of DMA RESRDY trigger"]
+    ADC0_RESRDY = 68,
+    #[doc = "69: Index of DMA SEQ trigger"]
+    ADC0_SEQ = 69,
+    #[doc = "70: Index of DMA RESRDY trigger"]
+    ADC1_RESRDY = 70,
+    #[doc = "71: Index of DMA SEQ trigger"]
+    ADC1_SEQ = 71,
+    #[doc = "72: DMA DAC Empty Req"]
+    DAC_EMPTY_0 = 72,
+    #[doc = "73: DMA DAC Empty Req"]
+    DAC_EMPTY_1 = 73,
+    #[doc = "74: DMA DAC Result Ready Req"]
+    DAC_RESRDY_0 = 74,
+    #[doc = "75: DMA DAC Result Ready Req"]
+    DAC_RESRDY_1 = 75,
+    #[doc = "76: Indexes of DMA RX triggers"]
+    I2S_RX_0 = 76,
+    #[doc = "77: Indexes of DMA RX triggers"]
+    I2S_RX_1 = 77,
+    #[doc = "78: Indexes of DMA TX triggers"]
+    I2S_TX_0 = 78,
+    #[doc = "79: Indexes of DMA TX triggers"]
+    I2S_TX_1 = 79,
+    #[doc = "80: Indexes of PCC RX trigger"]
+    PCC_RX = 80,
+    #[doc = "81: DMA DATA Write trigger"]
+    AES_WR = 81,
+    #[doc = "82: DMA DATA Read trigger"]
+    AES_RD = 82,
+    #[doc = "83: Indexes of QSPI RX trigger"]
+    QSPI_RX = 83,
+    #[doc = "84: Indexes of QSPI TX trigger"]
+    QSPI_TX = 84,
 }
 impl From<TRIGSRC_A> for u8 {
     #[inline(always)]
@@ -104,6 +272,90 @@ impl TRIGSRC_R {
         use crate::Variant::*;
         match self.bits {
             0 => Val(TRIGSRC_A::DISABLE),
+            1 => Val(TRIGSRC_A::RTC_TIMESTAMP),
+            2 => Val(TRIGSRC_A::DSU_DCC0),
+            3 => Val(TRIGSRC_A::DSU_DCC1),
+            4 => Val(TRIGSRC_A::SERCOM0_RX),
+            5 => Val(TRIGSRC_A::SERCOM0_TX),
+            6 => Val(TRIGSRC_A::SERCOM1_RX),
+            7 => Val(TRIGSRC_A::SERCOM1_TX),
+            8 => Val(TRIGSRC_A::SERCOM2_RX),
+            9 => Val(TRIGSRC_A::SERCOM2_TX),
+            10 => Val(TRIGSRC_A::SERCOM3_RX),
+            11 => Val(TRIGSRC_A::SERCOM3_TX),
+            12 => Val(TRIGSRC_A::SERCOM4_RX),
+            13 => Val(TRIGSRC_A::SERCOM4_TX),
+            14 => Val(TRIGSRC_A::SERCOM5_RX),
+            15 => Val(TRIGSRC_A::SERCOM5_TX),
+            16 => Val(TRIGSRC_A::SERCOM6_RX),
+            17 => Val(TRIGSRC_A::SERCOM6_TX),
+            18 => Val(TRIGSRC_A::SERCOM7_RX),
+            19 => Val(TRIGSRC_A::SERCOM7_TX),
+            20 => Val(TRIGSRC_A::CAN0_DEBUG),
+            21 => Val(TRIGSRC_A::CAN1_DEBUG),
+            22 => Val(TRIGSRC_A::TCC0_OVF),
+            23 => Val(TRIGSRC_A::TCC0_MC_0),
+            24 => Val(TRIGSRC_A::TCC0_MC_1),
+            25 => Val(TRIGSRC_A::TCC0_MC_2),
+            26 => Val(TRIGSRC_A::TCC0_MC_3),
+            27 => Val(TRIGSRC_A::TCC0_MC_4),
+            28 => Val(TRIGSRC_A::TCC0_MC_5),
+            29 => Val(TRIGSRC_A::TCC1_OVF),
+            30 => Val(TRIGSRC_A::TCC1_MC_0),
+            31 => Val(TRIGSRC_A::TCC1_MC_1),
+            32 => Val(TRIGSRC_A::TCC1_MC_2),
+            33 => Val(TRIGSRC_A::TCC1_MC_3),
+            34 => Val(TRIGSRC_A::TCC2_OVF),
+            35 => Val(TRIGSRC_A::TCC2_MC_0),
+            36 => Val(TRIGSRC_A::TCC2_MC_1),
+            37 => Val(TRIGSRC_A::TCC2_MC_2),
+            38 => Val(TRIGSRC_A::TCC3_OVF),
+            39 => Val(TRIGSRC_A::TCC3_MC_0),
+            40 => Val(TRIGSRC_A::TCC3_MC_1),
+            41 => Val(TRIGSRC_A::TCC4_OVF),
+            42 => Val(TRIGSRC_A::TCC4_MC_0),
+            43 => Val(TRIGSRC_A::TCC4_MC_1),
+            44 => Val(TRIGSRC_A::TC0_OVF),
+            45 => Val(TRIGSRC_A::TC0_MC_0),
+            46 => Val(TRIGSRC_A::TC0_MC_1),
+            47 => Val(TRIGSRC_A::TC1_OVF),
+            48 => Val(TRIGSRC_A::TC1_MC_0),
+            49 => Val(TRIGSRC_A::TC1_MC_1),
+            50 => Val(TRIGSRC_A::TC2_OVF),
+            51 => Val(TRIGSRC_A::TC2_MC_0),
+            52 => Val(TRIGSRC_A::TC2_MC_1),
+            53 => Val(TRIGSRC_A::TC3_OVF),
+            54 => Val(TRIGSRC_A::TC3_MC_0),
+            55 => Val(TRIGSRC_A::TC3_MC_1),
+            56 => Val(TRIGSRC_A::TC4_OVF),
+            57 => Val(TRIGSRC_A::TC4_MC_0),
+            58 => Val(TRIGSRC_A::TC4_MC_1),
+            59 => Val(TRIGSRC_A::TC5_OVF),
+            60 => Val(TRIGSRC_A::TC5_MC_0),
+            61 => Val(TRIGSRC_A::TC5_MC_1),
+            62 => Val(TRIGSRC_A::TC6_OVF),
+            63 => Val(TRIGSRC_A::TC6_MC_0),
+            64 => Val(TRIGSRC_A::TC6_MC_1),
+            65 => Val(TRIGSRC_A::TC7_OVF),
+            66 => Val(TRIGSRC_A::TC7_MC_0),
+            67 => Val(TRIGSRC_A::TC7_MC_1),
+            68 => Val(TRIGSRC_A::ADC0_RESRDY),
+            69 => Val(TRIGSRC_A::ADC0_SEQ),
+            70 => Val(TRIGSRC_A::ADC1_RESRDY),
+            71 => Val(TRIGSRC_A::ADC1_SEQ),
+            72 => Val(TRIGSRC_A::DAC_EMPTY_0),
+            73 => Val(TRIGSRC_A::DAC_EMPTY_1),
+            74 => Val(TRIGSRC_A::DAC_RESRDY_0),
+            75 => Val(TRIGSRC_A::DAC_RESRDY_1),
+            76 => Val(TRIGSRC_A::I2S_RX_0),
+            77 => Val(TRIGSRC_A::I2S_RX_1),
+            78 => Val(TRIGSRC_A::I2S_TX_0),
+            79 => Val(TRIGSRC_A::I2S_TX_1),
+            80 => Val(TRIGSRC_A::PCC_RX),
+            81 => Val(TRIGSRC_A::AES_WR),
+            82 => Val(TRIGSRC_A::AES_RD),
+            83 => Val(TRIGSRC_A::QSPI_RX),
+            84 => Val(TRIGSRC_A::QSPI_TX),
             i => Res(i),
         }
     }
@@ -111,6 +363,426 @@ impl TRIGSRC_R {
     #[inline(always)]
     pub fn is_disable(&self) -> bool {
         *self == TRIGSRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `RTC_TIMESTAMP`"]
+    #[inline(always)]
+    pub fn is_rtc_timestamp(&self) -> bool {
+        *self == TRIGSRC_A::RTC_TIMESTAMP
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC0`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc0(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC0
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC1`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc1(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC1
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_RX`"]
+    #[inline(always)]
+    pub fn is_sercom0_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_TX`"]
+    #[inline(always)]
+    pub fn is_sercom0_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_RX`"]
+    #[inline(always)]
+    pub fn is_sercom1_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_TX`"]
+    #[inline(always)]
+    pub fn is_sercom1_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_RX`"]
+    #[inline(always)]
+    pub fn is_sercom2_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_TX`"]
+    #[inline(always)]
+    pub fn is_sercom2_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_RX`"]
+    #[inline(always)]
+    pub fn is_sercom3_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_TX`"]
+    #[inline(always)]
+    pub fn is_sercom3_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_RX`"]
+    #[inline(always)]
+    pub fn is_sercom4_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_TX`"]
+    #[inline(always)]
+    pub fn is_sercom4_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_RX`"]
+    #[inline(always)]
+    pub fn is_sercom5_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_TX`"]
+    #[inline(always)]
+    pub fn is_sercom5_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_RX`"]
+    #[inline(always)]
+    pub fn is_sercom6_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_TX`"]
+    #[inline(always)]
+    pub fn is_sercom6_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_RX`"]
+    #[inline(always)]
+    pub fn is_sercom7_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_TX`"]
+    #[inline(always)]
+    pub fn is_sercom7_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_TX
+    }
+    #[doc = "Checks if the value of the field is `CAN0_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can0_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN0_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `CAN1_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can1_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN1_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `TCC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_4`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_4(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_4
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_5`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_5(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_5
+    }
+    #[doc = "Checks if the value of the field is `TCC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC5_OVF`"]
+    #[inline(always)]
+    pub fn is_tc5_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC5_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC6_OVF`"]
+    #[inline(always)]
+    pub fn is_tc6_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC6_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC7_OVF`"]
+    #[inline(always)]
+    pub fn is_tc7_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC7_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_1
+    }
+    #[doc = "Checks if the value of the field is `ADC0_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc0_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC0_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc0_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_SEQ
+    }
+    #[doc = "Checks if the value of the field is `ADC1_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc1_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC1_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc1_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_SEQ
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_0`"]
+    #[inline(always)]
+    pub fn is_dac_empty_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_1`"]
+    #[inline(always)]
+    pub fn is_dac_empty_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_1
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_0`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_1`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_1
+    }
+    #[doc = "Checks if the value of the field is `PCC_RX`"]
+    #[inline(always)]
+    pub fn is_pcc_rx(&self) -> bool {
+        *self == TRIGSRC_A::PCC_RX
+    }
+    #[doc = "Checks if the value of the field is `AES_WR`"]
+    #[inline(always)]
+    pub fn is_aes_wr(&self) -> bool {
+        *self == TRIGSRC_A::AES_WR
+    }
+    #[doc = "Checks if the value of the field is `AES_RD`"]
+    #[inline(always)]
+    pub fn is_aes_rd(&self) -> bool {
+        *self == TRIGSRC_A::AES_RD
+    }
+    #[doc = "Checks if the value of the field is `QSPI_RX`"]
+    #[inline(always)]
+    pub fn is_qspi_rx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_RX
+    }
+    #[doc = "Checks if the value of the field is `QSPI_TX`"]
+    #[inline(always)]
+    pub fn is_qspi_tx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_TX
     }
 }
 #[doc = "Write proxy for field `TRIGSRC`"]
@@ -127,6 +799,426 @@ impl<'a> TRIGSRC_W<'a> {
     #[inline(always)]
     pub fn disable(self) -> &'a mut W {
         self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = "DMA RTC timestamp trigger"]
+    #[inline(always)]
+    pub fn rtc_timestamp(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::RTC_TIMESTAMP)
+    }
+    #[doc = "DMAC ID for DCC0 register"]
+    #[inline(always)]
+    pub fn dsu_dcc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC0)
+    }
+    #[doc = "DMAC ID for DCC1 register"]
+    #[inline(always)]
+    pub fn dsu_dcc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC1)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom0_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom0_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom1_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom1_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom2_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom2_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom3_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom3_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom4_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom4_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom5_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom5_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom6_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom6_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom7_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom7_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_TX)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can0_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN0_DEBUG)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can1_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN1_DEBUG)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_3)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_4(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_4)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_5(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_5)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_3)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_2)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_1)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc5_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc6_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc7_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_1)
+    }
+    #[doc = "index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc0_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc0_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_SEQ)
+    }
+    #[doc = "Index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc1_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc1_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_SEQ)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_0)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_1)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_0)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_1)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_0)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_1)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_0)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_1)
+    }
+    #[doc = "Indexes of PCC RX trigger"]
+    #[inline(always)]
+    pub fn pcc_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::PCC_RX)
+    }
+    #[doc = "DMA DATA Write trigger"]
+    #[inline(always)]
+    pub fn aes_wr(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_WR)
+    }
+    #[doc = "DMA DATA Read trigger"]
+    #[inline(always)]
+    pub fn aes_rd(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_RD)
+    }
+    #[doc = "Indexes of QSPI RX trigger"]
+    #[inline(always)]
+    pub fn qspi_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_RX)
+    }
+    #[doc = "Indexes of QSPI TX trigger"]
+    #[inline(always)]
+    pub fn qspi_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_TX)
     }
     #[doc = r"Writes raw bits to the field"]
     #[inline(always)]

--- a/pac/atsame51j/src/dmac/channel/chctrla.rs
+++ b/pac/atsame51j/src/dmac/channel/chctrla.rs
@@ -88,6 +88,174 @@ impl<'a> RUNSTDBY_W<'a> {
 pub enum TRIGSRC_A {
     #[doc = "0: Only software/event triggers"]
     DISABLE = 0,
+    #[doc = "1: DMA RTC timestamp trigger"]
+    RTC_TIMESTAMP = 1,
+    #[doc = "2: DMAC ID for DCC0 register"]
+    DSU_DCC0 = 2,
+    #[doc = "3: DMAC ID for DCC1 register"]
+    DSU_DCC1 = 3,
+    #[doc = "4: Index of DMA RX trigger"]
+    SERCOM0_RX = 4,
+    #[doc = "5: Index of DMA TX trigger"]
+    SERCOM0_TX = 5,
+    #[doc = "6: Index of DMA RX trigger"]
+    SERCOM1_RX = 6,
+    #[doc = "7: Index of DMA TX trigger"]
+    SERCOM1_TX = 7,
+    #[doc = "8: Index of DMA RX trigger"]
+    SERCOM2_RX = 8,
+    #[doc = "9: Index of DMA TX trigger"]
+    SERCOM2_TX = 9,
+    #[doc = "10: Index of DMA RX trigger"]
+    SERCOM3_RX = 10,
+    #[doc = "11: Index of DMA TX trigger"]
+    SERCOM3_TX = 11,
+    #[doc = "12: Index of DMA RX trigger"]
+    SERCOM4_RX = 12,
+    #[doc = "13: Index of DMA TX trigger"]
+    SERCOM4_TX = 13,
+    #[doc = "14: Index of DMA RX trigger"]
+    SERCOM5_RX = 14,
+    #[doc = "15: Index of DMA TX trigger"]
+    SERCOM5_TX = 15,
+    #[doc = "16: Index of DMA RX trigger"]
+    SERCOM6_RX = 16,
+    #[doc = "17: Index of DMA TX trigger"]
+    SERCOM6_TX = 17,
+    #[doc = "18: Index of DMA RX trigger"]
+    SERCOM7_RX = 18,
+    #[doc = "19: Index of DMA TX trigger"]
+    SERCOM7_TX = 19,
+    #[doc = "20: DMA CAN Debug Req"]
+    CAN0_DEBUG = 20,
+    #[doc = "21: DMA CAN Debug Req"]
+    CAN1_DEBUG = 21,
+    #[doc = "22: DMA overflow/underflow/retrigger trigger"]
+    TCC0_OVF = 22,
+    #[doc = "23: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_0 = 23,
+    #[doc = "24: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_1 = 24,
+    #[doc = "25: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_2 = 25,
+    #[doc = "26: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_3 = 26,
+    #[doc = "27: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_4 = 27,
+    #[doc = "28: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_5 = 28,
+    #[doc = "29: DMA overflow/underflow/retrigger trigger"]
+    TCC1_OVF = 29,
+    #[doc = "30: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_0 = 30,
+    #[doc = "31: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_1 = 31,
+    #[doc = "32: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_2 = 32,
+    #[doc = "33: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_3 = 33,
+    #[doc = "34: DMA overflow/underflow/retrigger trigger"]
+    TCC2_OVF = 34,
+    #[doc = "35: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_0 = 35,
+    #[doc = "36: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_1 = 36,
+    #[doc = "37: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_2 = 37,
+    #[doc = "38: DMA overflow/underflow/retrigger trigger"]
+    TCC3_OVF = 38,
+    #[doc = "39: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_0 = 39,
+    #[doc = "40: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_1 = 40,
+    #[doc = "41: DMA overflow/underflow/retrigger trigger"]
+    TCC4_OVF = 41,
+    #[doc = "42: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_0 = 42,
+    #[doc = "43: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_1 = 43,
+    #[doc = "44: Indexes of DMA Overflow trigger"]
+    TC0_OVF = 44,
+    #[doc = "45: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_0 = 45,
+    #[doc = "46: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_1 = 46,
+    #[doc = "47: Indexes of DMA Overflow trigger"]
+    TC1_OVF = 47,
+    #[doc = "48: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_0 = 48,
+    #[doc = "49: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_1 = 49,
+    #[doc = "50: Indexes of DMA Overflow trigger"]
+    TC2_OVF = 50,
+    #[doc = "51: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_0 = 51,
+    #[doc = "52: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_1 = 52,
+    #[doc = "53: Indexes of DMA Overflow trigger"]
+    TC3_OVF = 53,
+    #[doc = "54: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_0 = 54,
+    #[doc = "55: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_1 = 55,
+    #[doc = "56: Indexes of DMA Overflow trigger"]
+    TC4_OVF = 56,
+    #[doc = "57: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_0 = 57,
+    #[doc = "58: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_1 = 58,
+    #[doc = "59: Indexes of DMA Overflow trigger"]
+    TC5_OVF = 59,
+    #[doc = "60: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_0 = 60,
+    #[doc = "61: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_1 = 61,
+    #[doc = "62: Indexes of DMA Overflow trigger"]
+    TC6_OVF = 62,
+    #[doc = "63: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_0 = 63,
+    #[doc = "64: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_1 = 64,
+    #[doc = "65: Indexes of DMA Overflow trigger"]
+    TC7_OVF = 65,
+    #[doc = "66: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_0 = 66,
+    #[doc = "67: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_1 = 67,
+    #[doc = "68: index of DMA RESRDY trigger"]
+    ADC0_RESRDY = 68,
+    #[doc = "69: Index of DMA SEQ trigger"]
+    ADC0_SEQ = 69,
+    #[doc = "70: Index of DMA RESRDY trigger"]
+    ADC1_RESRDY = 70,
+    #[doc = "71: Index of DMA SEQ trigger"]
+    ADC1_SEQ = 71,
+    #[doc = "72: DMA DAC Empty Req"]
+    DAC_EMPTY_0 = 72,
+    #[doc = "73: DMA DAC Empty Req"]
+    DAC_EMPTY_1 = 73,
+    #[doc = "74: DMA DAC Result Ready Req"]
+    DAC_RESRDY_0 = 74,
+    #[doc = "75: DMA DAC Result Ready Req"]
+    DAC_RESRDY_1 = 75,
+    #[doc = "76: Indexes of DMA RX triggers"]
+    I2S_RX_0 = 76,
+    #[doc = "77: Indexes of DMA RX triggers"]
+    I2S_RX_1 = 77,
+    #[doc = "78: Indexes of DMA TX triggers"]
+    I2S_TX_0 = 78,
+    #[doc = "79: Indexes of DMA TX triggers"]
+    I2S_TX_1 = 79,
+    #[doc = "80: Indexes of PCC RX trigger"]
+    PCC_RX = 80,
+    #[doc = "81: DMA DATA Write trigger"]
+    AES_WR = 81,
+    #[doc = "82: DMA DATA Read trigger"]
+    AES_RD = 82,
+    #[doc = "83: Indexes of QSPI RX trigger"]
+    QSPI_RX = 83,
+    #[doc = "84: Indexes of QSPI TX trigger"]
+    QSPI_TX = 84,
 }
 impl From<TRIGSRC_A> for u8 {
     #[inline(always)]
@@ -104,6 +272,90 @@ impl TRIGSRC_R {
         use crate::Variant::*;
         match self.bits {
             0 => Val(TRIGSRC_A::DISABLE),
+            1 => Val(TRIGSRC_A::RTC_TIMESTAMP),
+            2 => Val(TRIGSRC_A::DSU_DCC0),
+            3 => Val(TRIGSRC_A::DSU_DCC1),
+            4 => Val(TRIGSRC_A::SERCOM0_RX),
+            5 => Val(TRIGSRC_A::SERCOM0_TX),
+            6 => Val(TRIGSRC_A::SERCOM1_RX),
+            7 => Val(TRIGSRC_A::SERCOM1_TX),
+            8 => Val(TRIGSRC_A::SERCOM2_RX),
+            9 => Val(TRIGSRC_A::SERCOM2_TX),
+            10 => Val(TRIGSRC_A::SERCOM3_RX),
+            11 => Val(TRIGSRC_A::SERCOM3_TX),
+            12 => Val(TRIGSRC_A::SERCOM4_RX),
+            13 => Val(TRIGSRC_A::SERCOM4_TX),
+            14 => Val(TRIGSRC_A::SERCOM5_RX),
+            15 => Val(TRIGSRC_A::SERCOM5_TX),
+            16 => Val(TRIGSRC_A::SERCOM6_RX),
+            17 => Val(TRIGSRC_A::SERCOM6_TX),
+            18 => Val(TRIGSRC_A::SERCOM7_RX),
+            19 => Val(TRIGSRC_A::SERCOM7_TX),
+            20 => Val(TRIGSRC_A::CAN0_DEBUG),
+            21 => Val(TRIGSRC_A::CAN1_DEBUG),
+            22 => Val(TRIGSRC_A::TCC0_OVF),
+            23 => Val(TRIGSRC_A::TCC0_MC_0),
+            24 => Val(TRIGSRC_A::TCC0_MC_1),
+            25 => Val(TRIGSRC_A::TCC0_MC_2),
+            26 => Val(TRIGSRC_A::TCC0_MC_3),
+            27 => Val(TRIGSRC_A::TCC0_MC_4),
+            28 => Val(TRIGSRC_A::TCC0_MC_5),
+            29 => Val(TRIGSRC_A::TCC1_OVF),
+            30 => Val(TRIGSRC_A::TCC1_MC_0),
+            31 => Val(TRIGSRC_A::TCC1_MC_1),
+            32 => Val(TRIGSRC_A::TCC1_MC_2),
+            33 => Val(TRIGSRC_A::TCC1_MC_3),
+            34 => Val(TRIGSRC_A::TCC2_OVF),
+            35 => Val(TRIGSRC_A::TCC2_MC_0),
+            36 => Val(TRIGSRC_A::TCC2_MC_1),
+            37 => Val(TRIGSRC_A::TCC2_MC_2),
+            38 => Val(TRIGSRC_A::TCC3_OVF),
+            39 => Val(TRIGSRC_A::TCC3_MC_0),
+            40 => Val(TRIGSRC_A::TCC3_MC_1),
+            41 => Val(TRIGSRC_A::TCC4_OVF),
+            42 => Val(TRIGSRC_A::TCC4_MC_0),
+            43 => Val(TRIGSRC_A::TCC4_MC_1),
+            44 => Val(TRIGSRC_A::TC0_OVF),
+            45 => Val(TRIGSRC_A::TC0_MC_0),
+            46 => Val(TRIGSRC_A::TC0_MC_1),
+            47 => Val(TRIGSRC_A::TC1_OVF),
+            48 => Val(TRIGSRC_A::TC1_MC_0),
+            49 => Val(TRIGSRC_A::TC1_MC_1),
+            50 => Val(TRIGSRC_A::TC2_OVF),
+            51 => Val(TRIGSRC_A::TC2_MC_0),
+            52 => Val(TRIGSRC_A::TC2_MC_1),
+            53 => Val(TRIGSRC_A::TC3_OVF),
+            54 => Val(TRIGSRC_A::TC3_MC_0),
+            55 => Val(TRIGSRC_A::TC3_MC_1),
+            56 => Val(TRIGSRC_A::TC4_OVF),
+            57 => Val(TRIGSRC_A::TC4_MC_0),
+            58 => Val(TRIGSRC_A::TC4_MC_1),
+            59 => Val(TRIGSRC_A::TC5_OVF),
+            60 => Val(TRIGSRC_A::TC5_MC_0),
+            61 => Val(TRIGSRC_A::TC5_MC_1),
+            62 => Val(TRIGSRC_A::TC6_OVF),
+            63 => Val(TRIGSRC_A::TC6_MC_0),
+            64 => Val(TRIGSRC_A::TC6_MC_1),
+            65 => Val(TRIGSRC_A::TC7_OVF),
+            66 => Val(TRIGSRC_A::TC7_MC_0),
+            67 => Val(TRIGSRC_A::TC7_MC_1),
+            68 => Val(TRIGSRC_A::ADC0_RESRDY),
+            69 => Val(TRIGSRC_A::ADC0_SEQ),
+            70 => Val(TRIGSRC_A::ADC1_RESRDY),
+            71 => Val(TRIGSRC_A::ADC1_SEQ),
+            72 => Val(TRIGSRC_A::DAC_EMPTY_0),
+            73 => Val(TRIGSRC_A::DAC_EMPTY_1),
+            74 => Val(TRIGSRC_A::DAC_RESRDY_0),
+            75 => Val(TRIGSRC_A::DAC_RESRDY_1),
+            76 => Val(TRIGSRC_A::I2S_RX_0),
+            77 => Val(TRIGSRC_A::I2S_RX_1),
+            78 => Val(TRIGSRC_A::I2S_TX_0),
+            79 => Val(TRIGSRC_A::I2S_TX_1),
+            80 => Val(TRIGSRC_A::PCC_RX),
+            81 => Val(TRIGSRC_A::AES_WR),
+            82 => Val(TRIGSRC_A::AES_RD),
+            83 => Val(TRIGSRC_A::QSPI_RX),
+            84 => Val(TRIGSRC_A::QSPI_TX),
             i => Res(i),
         }
     }
@@ -111,6 +363,426 @@ impl TRIGSRC_R {
     #[inline(always)]
     pub fn is_disable(&self) -> bool {
         *self == TRIGSRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `RTC_TIMESTAMP`"]
+    #[inline(always)]
+    pub fn is_rtc_timestamp(&self) -> bool {
+        *self == TRIGSRC_A::RTC_TIMESTAMP
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC0`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc0(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC0
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC1`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc1(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC1
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_RX`"]
+    #[inline(always)]
+    pub fn is_sercom0_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_TX`"]
+    #[inline(always)]
+    pub fn is_sercom0_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_RX`"]
+    #[inline(always)]
+    pub fn is_sercom1_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_TX`"]
+    #[inline(always)]
+    pub fn is_sercom1_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_RX`"]
+    #[inline(always)]
+    pub fn is_sercom2_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_TX`"]
+    #[inline(always)]
+    pub fn is_sercom2_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_RX`"]
+    #[inline(always)]
+    pub fn is_sercom3_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_TX`"]
+    #[inline(always)]
+    pub fn is_sercom3_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_RX`"]
+    #[inline(always)]
+    pub fn is_sercom4_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_TX`"]
+    #[inline(always)]
+    pub fn is_sercom4_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_RX`"]
+    #[inline(always)]
+    pub fn is_sercom5_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_TX`"]
+    #[inline(always)]
+    pub fn is_sercom5_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_RX`"]
+    #[inline(always)]
+    pub fn is_sercom6_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_TX`"]
+    #[inline(always)]
+    pub fn is_sercom6_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_RX`"]
+    #[inline(always)]
+    pub fn is_sercom7_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_TX`"]
+    #[inline(always)]
+    pub fn is_sercom7_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_TX
+    }
+    #[doc = "Checks if the value of the field is `CAN0_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can0_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN0_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `CAN1_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can1_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN1_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `TCC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_4`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_4(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_4
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_5`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_5(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_5
+    }
+    #[doc = "Checks if the value of the field is `TCC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC5_OVF`"]
+    #[inline(always)]
+    pub fn is_tc5_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC5_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC6_OVF`"]
+    #[inline(always)]
+    pub fn is_tc6_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC6_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC7_OVF`"]
+    #[inline(always)]
+    pub fn is_tc7_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC7_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_1
+    }
+    #[doc = "Checks if the value of the field is `ADC0_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc0_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC0_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc0_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_SEQ
+    }
+    #[doc = "Checks if the value of the field is `ADC1_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc1_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC1_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc1_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_SEQ
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_0`"]
+    #[inline(always)]
+    pub fn is_dac_empty_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_1`"]
+    #[inline(always)]
+    pub fn is_dac_empty_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_1
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_0`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_1`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_1
+    }
+    #[doc = "Checks if the value of the field is `PCC_RX`"]
+    #[inline(always)]
+    pub fn is_pcc_rx(&self) -> bool {
+        *self == TRIGSRC_A::PCC_RX
+    }
+    #[doc = "Checks if the value of the field is `AES_WR`"]
+    #[inline(always)]
+    pub fn is_aes_wr(&self) -> bool {
+        *self == TRIGSRC_A::AES_WR
+    }
+    #[doc = "Checks if the value of the field is `AES_RD`"]
+    #[inline(always)]
+    pub fn is_aes_rd(&self) -> bool {
+        *self == TRIGSRC_A::AES_RD
+    }
+    #[doc = "Checks if the value of the field is `QSPI_RX`"]
+    #[inline(always)]
+    pub fn is_qspi_rx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_RX
+    }
+    #[doc = "Checks if the value of the field is `QSPI_TX`"]
+    #[inline(always)]
+    pub fn is_qspi_tx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_TX
     }
 }
 #[doc = "Write proxy for field `TRIGSRC`"]
@@ -127,6 +799,426 @@ impl<'a> TRIGSRC_W<'a> {
     #[inline(always)]
     pub fn disable(self) -> &'a mut W {
         self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = "DMA RTC timestamp trigger"]
+    #[inline(always)]
+    pub fn rtc_timestamp(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::RTC_TIMESTAMP)
+    }
+    #[doc = "DMAC ID for DCC0 register"]
+    #[inline(always)]
+    pub fn dsu_dcc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC0)
+    }
+    #[doc = "DMAC ID for DCC1 register"]
+    #[inline(always)]
+    pub fn dsu_dcc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC1)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom0_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom0_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom1_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom1_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom2_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom2_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom3_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom3_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom4_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom4_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom5_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom5_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom6_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom6_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom7_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom7_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_TX)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can0_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN0_DEBUG)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can1_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN1_DEBUG)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_3)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_4(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_4)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_5(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_5)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_3)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_2)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_1)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc5_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc6_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc7_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_1)
+    }
+    #[doc = "index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc0_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc0_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_SEQ)
+    }
+    #[doc = "Index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc1_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc1_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_SEQ)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_0)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_1)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_0)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_1)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_0)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_1)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_0)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_1)
+    }
+    #[doc = "Indexes of PCC RX trigger"]
+    #[inline(always)]
+    pub fn pcc_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::PCC_RX)
+    }
+    #[doc = "DMA DATA Write trigger"]
+    #[inline(always)]
+    pub fn aes_wr(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_WR)
+    }
+    #[doc = "DMA DATA Read trigger"]
+    #[inline(always)]
+    pub fn aes_rd(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_RD)
+    }
+    #[doc = "Indexes of QSPI RX trigger"]
+    #[inline(always)]
+    pub fn qspi_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_RX)
+    }
+    #[doc = "Indexes of QSPI TX trigger"]
+    #[inline(always)]
+    pub fn qspi_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_TX)
     }
     #[doc = r"Writes raw bits to the field"]
     #[inline(always)]

--- a/pac/atsame51n/src/dmac/channel/chctrla.rs
+++ b/pac/atsame51n/src/dmac/channel/chctrla.rs
@@ -88,6 +88,174 @@ impl<'a> RUNSTDBY_W<'a> {
 pub enum TRIGSRC_A {
     #[doc = "0: Only software/event triggers"]
     DISABLE = 0,
+    #[doc = "1: DMA RTC timestamp trigger"]
+    RTC_TIMESTAMP = 1,
+    #[doc = "2: DMAC ID for DCC0 register"]
+    DSU_DCC0 = 2,
+    #[doc = "3: DMAC ID for DCC1 register"]
+    DSU_DCC1 = 3,
+    #[doc = "4: Index of DMA RX trigger"]
+    SERCOM0_RX = 4,
+    #[doc = "5: Index of DMA TX trigger"]
+    SERCOM0_TX = 5,
+    #[doc = "6: Index of DMA RX trigger"]
+    SERCOM1_RX = 6,
+    #[doc = "7: Index of DMA TX trigger"]
+    SERCOM1_TX = 7,
+    #[doc = "8: Index of DMA RX trigger"]
+    SERCOM2_RX = 8,
+    #[doc = "9: Index of DMA TX trigger"]
+    SERCOM2_TX = 9,
+    #[doc = "10: Index of DMA RX trigger"]
+    SERCOM3_RX = 10,
+    #[doc = "11: Index of DMA TX trigger"]
+    SERCOM3_TX = 11,
+    #[doc = "12: Index of DMA RX trigger"]
+    SERCOM4_RX = 12,
+    #[doc = "13: Index of DMA TX trigger"]
+    SERCOM4_TX = 13,
+    #[doc = "14: Index of DMA RX trigger"]
+    SERCOM5_RX = 14,
+    #[doc = "15: Index of DMA TX trigger"]
+    SERCOM5_TX = 15,
+    #[doc = "16: Index of DMA RX trigger"]
+    SERCOM6_RX = 16,
+    #[doc = "17: Index of DMA TX trigger"]
+    SERCOM6_TX = 17,
+    #[doc = "18: Index of DMA RX trigger"]
+    SERCOM7_RX = 18,
+    #[doc = "19: Index of DMA TX trigger"]
+    SERCOM7_TX = 19,
+    #[doc = "20: DMA CAN Debug Req"]
+    CAN0_DEBUG = 20,
+    #[doc = "21: DMA CAN Debug Req"]
+    CAN1_DEBUG = 21,
+    #[doc = "22: DMA overflow/underflow/retrigger trigger"]
+    TCC0_OVF = 22,
+    #[doc = "23: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_0 = 23,
+    #[doc = "24: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_1 = 24,
+    #[doc = "25: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_2 = 25,
+    #[doc = "26: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_3 = 26,
+    #[doc = "27: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_4 = 27,
+    #[doc = "28: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_5 = 28,
+    #[doc = "29: DMA overflow/underflow/retrigger trigger"]
+    TCC1_OVF = 29,
+    #[doc = "30: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_0 = 30,
+    #[doc = "31: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_1 = 31,
+    #[doc = "32: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_2 = 32,
+    #[doc = "33: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_3 = 33,
+    #[doc = "34: DMA overflow/underflow/retrigger trigger"]
+    TCC2_OVF = 34,
+    #[doc = "35: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_0 = 35,
+    #[doc = "36: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_1 = 36,
+    #[doc = "37: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_2 = 37,
+    #[doc = "38: DMA overflow/underflow/retrigger trigger"]
+    TCC3_OVF = 38,
+    #[doc = "39: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_0 = 39,
+    #[doc = "40: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_1 = 40,
+    #[doc = "41: DMA overflow/underflow/retrigger trigger"]
+    TCC4_OVF = 41,
+    #[doc = "42: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_0 = 42,
+    #[doc = "43: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_1 = 43,
+    #[doc = "44: Indexes of DMA Overflow trigger"]
+    TC0_OVF = 44,
+    #[doc = "45: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_0 = 45,
+    #[doc = "46: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_1 = 46,
+    #[doc = "47: Indexes of DMA Overflow trigger"]
+    TC1_OVF = 47,
+    #[doc = "48: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_0 = 48,
+    #[doc = "49: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_1 = 49,
+    #[doc = "50: Indexes of DMA Overflow trigger"]
+    TC2_OVF = 50,
+    #[doc = "51: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_0 = 51,
+    #[doc = "52: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_1 = 52,
+    #[doc = "53: Indexes of DMA Overflow trigger"]
+    TC3_OVF = 53,
+    #[doc = "54: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_0 = 54,
+    #[doc = "55: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_1 = 55,
+    #[doc = "56: Indexes of DMA Overflow trigger"]
+    TC4_OVF = 56,
+    #[doc = "57: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_0 = 57,
+    #[doc = "58: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_1 = 58,
+    #[doc = "59: Indexes of DMA Overflow trigger"]
+    TC5_OVF = 59,
+    #[doc = "60: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_0 = 60,
+    #[doc = "61: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_1 = 61,
+    #[doc = "62: Indexes of DMA Overflow trigger"]
+    TC6_OVF = 62,
+    #[doc = "63: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_0 = 63,
+    #[doc = "64: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_1 = 64,
+    #[doc = "65: Indexes of DMA Overflow trigger"]
+    TC7_OVF = 65,
+    #[doc = "66: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_0 = 66,
+    #[doc = "67: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_1 = 67,
+    #[doc = "68: index of DMA RESRDY trigger"]
+    ADC0_RESRDY = 68,
+    #[doc = "69: Index of DMA SEQ trigger"]
+    ADC0_SEQ = 69,
+    #[doc = "70: Index of DMA RESRDY trigger"]
+    ADC1_RESRDY = 70,
+    #[doc = "71: Index of DMA SEQ trigger"]
+    ADC1_SEQ = 71,
+    #[doc = "72: DMA DAC Empty Req"]
+    DAC_EMPTY_0 = 72,
+    #[doc = "73: DMA DAC Empty Req"]
+    DAC_EMPTY_1 = 73,
+    #[doc = "74: DMA DAC Result Ready Req"]
+    DAC_RESRDY_0 = 74,
+    #[doc = "75: DMA DAC Result Ready Req"]
+    DAC_RESRDY_1 = 75,
+    #[doc = "76: Indexes of DMA RX triggers"]
+    I2S_RX_0 = 76,
+    #[doc = "77: Indexes of DMA RX triggers"]
+    I2S_RX_1 = 77,
+    #[doc = "78: Indexes of DMA TX triggers"]
+    I2S_TX_0 = 78,
+    #[doc = "79: Indexes of DMA TX triggers"]
+    I2S_TX_1 = 79,
+    #[doc = "80: Indexes of PCC RX trigger"]
+    PCC_RX = 80,
+    #[doc = "81: DMA DATA Write trigger"]
+    AES_WR = 81,
+    #[doc = "82: DMA DATA Read trigger"]
+    AES_RD = 82,
+    #[doc = "83: Indexes of QSPI RX trigger"]
+    QSPI_RX = 83,
+    #[doc = "84: Indexes of QSPI TX trigger"]
+    QSPI_TX = 84,
 }
 impl From<TRIGSRC_A> for u8 {
     #[inline(always)]
@@ -104,6 +272,90 @@ impl TRIGSRC_R {
         use crate::Variant::*;
         match self.bits {
             0 => Val(TRIGSRC_A::DISABLE),
+            1 => Val(TRIGSRC_A::RTC_TIMESTAMP),
+            2 => Val(TRIGSRC_A::DSU_DCC0),
+            3 => Val(TRIGSRC_A::DSU_DCC1),
+            4 => Val(TRIGSRC_A::SERCOM0_RX),
+            5 => Val(TRIGSRC_A::SERCOM0_TX),
+            6 => Val(TRIGSRC_A::SERCOM1_RX),
+            7 => Val(TRIGSRC_A::SERCOM1_TX),
+            8 => Val(TRIGSRC_A::SERCOM2_RX),
+            9 => Val(TRIGSRC_A::SERCOM2_TX),
+            10 => Val(TRIGSRC_A::SERCOM3_RX),
+            11 => Val(TRIGSRC_A::SERCOM3_TX),
+            12 => Val(TRIGSRC_A::SERCOM4_RX),
+            13 => Val(TRIGSRC_A::SERCOM4_TX),
+            14 => Val(TRIGSRC_A::SERCOM5_RX),
+            15 => Val(TRIGSRC_A::SERCOM5_TX),
+            16 => Val(TRIGSRC_A::SERCOM6_RX),
+            17 => Val(TRIGSRC_A::SERCOM6_TX),
+            18 => Val(TRIGSRC_A::SERCOM7_RX),
+            19 => Val(TRIGSRC_A::SERCOM7_TX),
+            20 => Val(TRIGSRC_A::CAN0_DEBUG),
+            21 => Val(TRIGSRC_A::CAN1_DEBUG),
+            22 => Val(TRIGSRC_A::TCC0_OVF),
+            23 => Val(TRIGSRC_A::TCC0_MC_0),
+            24 => Val(TRIGSRC_A::TCC0_MC_1),
+            25 => Val(TRIGSRC_A::TCC0_MC_2),
+            26 => Val(TRIGSRC_A::TCC0_MC_3),
+            27 => Val(TRIGSRC_A::TCC0_MC_4),
+            28 => Val(TRIGSRC_A::TCC0_MC_5),
+            29 => Val(TRIGSRC_A::TCC1_OVF),
+            30 => Val(TRIGSRC_A::TCC1_MC_0),
+            31 => Val(TRIGSRC_A::TCC1_MC_1),
+            32 => Val(TRIGSRC_A::TCC1_MC_2),
+            33 => Val(TRIGSRC_A::TCC1_MC_3),
+            34 => Val(TRIGSRC_A::TCC2_OVF),
+            35 => Val(TRIGSRC_A::TCC2_MC_0),
+            36 => Val(TRIGSRC_A::TCC2_MC_1),
+            37 => Val(TRIGSRC_A::TCC2_MC_2),
+            38 => Val(TRIGSRC_A::TCC3_OVF),
+            39 => Val(TRIGSRC_A::TCC3_MC_0),
+            40 => Val(TRIGSRC_A::TCC3_MC_1),
+            41 => Val(TRIGSRC_A::TCC4_OVF),
+            42 => Val(TRIGSRC_A::TCC4_MC_0),
+            43 => Val(TRIGSRC_A::TCC4_MC_1),
+            44 => Val(TRIGSRC_A::TC0_OVF),
+            45 => Val(TRIGSRC_A::TC0_MC_0),
+            46 => Val(TRIGSRC_A::TC0_MC_1),
+            47 => Val(TRIGSRC_A::TC1_OVF),
+            48 => Val(TRIGSRC_A::TC1_MC_0),
+            49 => Val(TRIGSRC_A::TC1_MC_1),
+            50 => Val(TRIGSRC_A::TC2_OVF),
+            51 => Val(TRIGSRC_A::TC2_MC_0),
+            52 => Val(TRIGSRC_A::TC2_MC_1),
+            53 => Val(TRIGSRC_A::TC3_OVF),
+            54 => Val(TRIGSRC_A::TC3_MC_0),
+            55 => Val(TRIGSRC_A::TC3_MC_1),
+            56 => Val(TRIGSRC_A::TC4_OVF),
+            57 => Val(TRIGSRC_A::TC4_MC_0),
+            58 => Val(TRIGSRC_A::TC4_MC_1),
+            59 => Val(TRIGSRC_A::TC5_OVF),
+            60 => Val(TRIGSRC_A::TC5_MC_0),
+            61 => Val(TRIGSRC_A::TC5_MC_1),
+            62 => Val(TRIGSRC_A::TC6_OVF),
+            63 => Val(TRIGSRC_A::TC6_MC_0),
+            64 => Val(TRIGSRC_A::TC6_MC_1),
+            65 => Val(TRIGSRC_A::TC7_OVF),
+            66 => Val(TRIGSRC_A::TC7_MC_0),
+            67 => Val(TRIGSRC_A::TC7_MC_1),
+            68 => Val(TRIGSRC_A::ADC0_RESRDY),
+            69 => Val(TRIGSRC_A::ADC0_SEQ),
+            70 => Val(TRIGSRC_A::ADC1_RESRDY),
+            71 => Val(TRIGSRC_A::ADC1_SEQ),
+            72 => Val(TRIGSRC_A::DAC_EMPTY_0),
+            73 => Val(TRIGSRC_A::DAC_EMPTY_1),
+            74 => Val(TRIGSRC_A::DAC_RESRDY_0),
+            75 => Val(TRIGSRC_A::DAC_RESRDY_1),
+            76 => Val(TRIGSRC_A::I2S_RX_0),
+            77 => Val(TRIGSRC_A::I2S_RX_1),
+            78 => Val(TRIGSRC_A::I2S_TX_0),
+            79 => Val(TRIGSRC_A::I2S_TX_1),
+            80 => Val(TRIGSRC_A::PCC_RX),
+            81 => Val(TRIGSRC_A::AES_WR),
+            82 => Val(TRIGSRC_A::AES_RD),
+            83 => Val(TRIGSRC_A::QSPI_RX),
+            84 => Val(TRIGSRC_A::QSPI_TX),
             i => Res(i),
         }
     }
@@ -111,6 +363,426 @@ impl TRIGSRC_R {
     #[inline(always)]
     pub fn is_disable(&self) -> bool {
         *self == TRIGSRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `RTC_TIMESTAMP`"]
+    #[inline(always)]
+    pub fn is_rtc_timestamp(&self) -> bool {
+        *self == TRIGSRC_A::RTC_TIMESTAMP
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC0`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc0(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC0
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC1`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc1(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC1
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_RX`"]
+    #[inline(always)]
+    pub fn is_sercom0_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_TX`"]
+    #[inline(always)]
+    pub fn is_sercom0_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_RX`"]
+    #[inline(always)]
+    pub fn is_sercom1_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_TX`"]
+    #[inline(always)]
+    pub fn is_sercom1_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_RX`"]
+    #[inline(always)]
+    pub fn is_sercom2_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_TX`"]
+    #[inline(always)]
+    pub fn is_sercom2_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_RX`"]
+    #[inline(always)]
+    pub fn is_sercom3_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_TX`"]
+    #[inline(always)]
+    pub fn is_sercom3_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_RX`"]
+    #[inline(always)]
+    pub fn is_sercom4_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_TX`"]
+    #[inline(always)]
+    pub fn is_sercom4_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_RX`"]
+    #[inline(always)]
+    pub fn is_sercom5_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_TX`"]
+    #[inline(always)]
+    pub fn is_sercom5_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_RX`"]
+    #[inline(always)]
+    pub fn is_sercom6_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_TX`"]
+    #[inline(always)]
+    pub fn is_sercom6_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_RX`"]
+    #[inline(always)]
+    pub fn is_sercom7_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_TX`"]
+    #[inline(always)]
+    pub fn is_sercom7_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_TX
+    }
+    #[doc = "Checks if the value of the field is `CAN0_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can0_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN0_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `CAN1_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can1_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN1_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `TCC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_4`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_4(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_4
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_5`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_5(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_5
+    }
+    #[doc = "Checks if the value of the field is `TCC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC5_OVF`"]
+    #[inline(always)]
+    pub fn is_tc5_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC5_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC6_OVF`"]
+    #[inline(always)]
+    pub fn is_tc6_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC6_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC7_OVF`"]
+    #[inline(always)]
+    pub fn is_tc7_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC7_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_1
+    }
+    #[doc = "Checks if the value of the field is `ADC0_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc0_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC0_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc0_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_SEQ
+    }
+    #[doc = "Checks if the value of the field is `ADC1_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc1_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC1_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc1_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_SEQ
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_0`"]
+    #[inline(always)]
+    pub fn is_dac_empty_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_1`"]
+    #[inline(always)]
+    pub fn is_dac_empty_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_1
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_0`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_1`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_1
+    }
+    #[doc = "Checks if the value of the field is `PCC_RX`"]
+    #[inline(always)]
+    pub fn is_pcc_rx(&self) -> bool {
+        *self == TRIGSRC_A::PCC_RX
+    }
+    #[doc = "Checks if the value of the field is `AES_WR`"]
+    #[inline(always)]
+    pub fn is_aes_wr(&self) -> bool {
+        *self == TRIGSRC_A::AES_WR
+    }
+    #[doc = "Checks if the value of the field is `AES_RD`"]
+    #[inline(always)]
+    pub fn is_aes_rd(&self) -> bool {
+        *self == TRIGSRC_A::AES_RD
+    }
+    #[doc = "Checks if the value of the field is `QSPI_RX`"]
+    #[inline(always)]
+    pub fn is_qspi_rx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_RX
+    }
+    #[doc = "Checks if the value of the field is `QSPI_TX`"]
+    #[inline(always)]
+    pub fn is_qspi_tx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_TX
     }
 }
 #[doc = "Write proxy for field `TRIGSRC`"]
@@ -127,6 +799,426 @@ impl<'a> TRIGSRC_W<'a> {
     #[inline(always)]
     pub fn disable(self) -> &'a mut W {
         self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = "DMA RTC timestamp trigger"]
+    #[inline(always)]
+    pub fn rtc_timestamp(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::RTC_TIMESTAMP)
+    }
+    #[doc = "DMAC ID for DCC0 register"]
+    #[inline(always)]
+    pub fn dsu_dcc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC0)
+    }
+    #[doc = "DMAC ID for DCC1 register"]
+    #[inline(always)]
+    pub fn dsu_dcc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC1)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom0_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom0_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom1_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom1_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom2_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom2_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom3_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom3_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom4_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom4_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom5_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom5_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom6_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom6_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom7_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom7_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_TX)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can0_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN0_DEBUG)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can1_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN1_DEBUG)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_3)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_4(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_4)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_5(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_5)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_3)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_2)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_1)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc5_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc6_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc7_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_1)
+    }
+    #[doc = "index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc0_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc0_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_SEQ)
+    }
+    #[doc = "Index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc1_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc1_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_SEQ)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_0)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_1)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_0)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_1)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_0)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_1)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_0)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_1)
+    }
+    #[doc = "Indexes of PCC RX trigger"]
+    #[inline(always)]
+    pub fn pcc_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::PCC_RX)
+    }
+    #[doc = "DMA DATA Write trigger"]
+    #[inline(always)]
+    pub fn aes_wr(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_WR)
+    }
+    #[doc = "DMA DATA Read trigger"]
+    #[inline(always)]
+    pub fn aes_rd(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_RD)
+    }
+    #[doc = "Indexes of QSPI RX trigger"]
+    #[inline(always)]
+    pub fn qspi_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_RX)
+    }
+    #[doc = "Indexes of QSPI TX trigger"]
+    #[inline(always)]
+    pub fn qspi_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_TX)
     }
     #[doc = r"Writes raw bits to the field"]
     #[inline(always)]

--- a/pac/atsame53j/src/dmac/channel/chctrla.rs
+++ b/pac/atsame53j/src/dmac/channel/chctrla.rs
@@ -88,6 +88,174 @@ impl<'a> RUNSTDBY_W<'a> {
 pub enum TRIGSRC_A {
     #[doc = "0: Only software/event triggers"]
     DISABLE = 0,
+    #[doc = "1: DMA RTC timestamp trigger"]
+    RTC_TIMESTAMP = 1,
+    #[doc = "2: DMAC ID for DCC0 register"]
+    DSU_DCC0 = 2,
+    #[doc = "3: DMAC ID for DCC1 register"]
+    DSU_DCC1 = 3,
+    #[doc = "4: Index of DMA RX trigger"]
+    SERCOM0_RX = 4,
+    #[doc = "5: Index of DMA TX trigger"]
+    SERCOM0_TX = 5,
+    #[doc = "6: Index of DMA RX trigger"]
+    SERCOM1_RX = 6,
+    #[doc = "7: Index of DMA TX trigger"]
+    SERCOM1_TX = 7,
+    #[doc = "8: Index of DMA RX trigger"]
+    SERCOM2_RX = 8,
+    #[doc = "9: Index of DMA TX trigger"]
+    SERCOM2_TX = 9,
+    #[doc = "10: Index of DMA RX trigger"]
+    SERCOM3_RX = 10,
+    #[doc = "11: Index of DMA TX trigger"]
+    SERCOM3_TX = 11,
+    #[doc = "12: Index of DMA RX trigger"]
+    SERCOM4_RX = 12,
+    #[doc = "13: Index of DMA TX trigger"]
+    SERCOM4_TX = 13,
+    #[doc = "14: Index of DMA RX trigger"]
+    SERCOM5_RX = 14,
+    #[doc = "15: Index of DMA TX trigger"]
+    SERCOM5_TX = 15,
+    #[doc = "16: Index of DMA RX trigger"]
+    SERCOM6_RX = 16,
+    #[doc = "17: Index of DMA TX trigger"]
+    SERCOM6_TX = 17,
+    #[doc = "18: Index of DMA RX trigger"]
+    SERCOM7_RX = 18,
+    #[doc = "19: Index of DMA TX trigger"]
+    SERCOM7_TX = 19,
+    #[doc = "20: DMA CAN Debug Req"]
+    CAN0_DEBUG = 20,
+    #[doc = "21: DMA CAN Debug Req"]
+    CAN1_DEBUG = 21,
+    #[doc = "22: DMA overflow/underflow/retrigger trigger"]
+    TCC0_OVF = 22,
+    #[doc = "23: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_0 = 23,
+    #[doc = "24: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_1 = 24,
+    #[doc = "25: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_2 = 25,
+    #[doc = "26: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_3 = 26,
+    #[doc = "27: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_4 = 27,
+    #[doc = "28: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_5 = 28,
+    #[doc = "29: DMA overflow/underflow/retrigger trigger"]
+    TCC1_OVF = 29,
+    #[doc = "30: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_0 = 30,
+    #[doc = "31: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_1 = 31,
+    #[doc = "32: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_2 = 32,
+    #[doc = "33: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_3 = 33,
+    #[doc = "34: DMA overflow/underflow/retrigger trigger"]
+    TCC2_OVF = 34,
+    #[doc = "35: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_0 = 35,
+    #[doc = "36: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_1 = 36,
+    #[doc = "37: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_2 = 37,
+    #[doc = "38: DMA overflow/underflow/retrigger trigger"]
+    TCC3_OVF = 38,
+    #[doc = "39: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_0 = 39,
+    #[doc = "40: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_1 = 40,
+    #[doc = "41: DMA overflow/underflow/retrigger trigger"]
+    TCC4_OVF = 41,
+    #[doc = "42: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_0 = 42,
+    #[doc = "43: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_1 = 43,
+    #[doc = "44: Indexes of DMA Overflow trigger"]
+    TC0_OVF = 44,
+    #[doc = "45: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_0 = 45,
+    #[doc = "46: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_1 = 46,
+    #[doc = "47: Indexes of DMA Overflow trigger"]
+    TC1_OVF = 47,
+    #[doc = "48: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_0 = 48,
+    #[doc = "49: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_1 = 49,
+    #[doc = "50: Indexes of DMA Overflow trigger"]
+    TC2_OVF = 50,
+    #[doc = "51: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_0 = 51,
+    #[doc = "52: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_1 = 52,
+    #[doc = "53: Indexes of DMA Overflow trigger"]
+    TC3_OVF = 53,
+    #[doc = "54: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_0 = 54,
+    #[doc = "55: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_1 = 55,
+    #[doc = "56: Indexes of DMA Overflow trigger"]
+    TC4_OVF = 56,
+    #[doc = "57: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_0 = 57,
+    #[doc = "58: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_1 = 58,
+    #[doc = "59: Indexes of DMA Overflow trigger"]
+    TC5_OVF = 59,
+    #[doc = "60: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_0 = 60,
+    #[doc = "61: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_1 = 61,
+    #[doc = "62: Indexes of DMA Overflow trigger"]
+    TC6_OVF = 62,
+    #[doc = "63: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_0 = 63,
+    #[doc = "64: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_1 = 64,
+    #[doc = "65: Indexes of DMA Overflow trigger"]
+    TC7_OVF = 65,
+    #[doc = "66: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_0 = 66,
+    #[doc = "67: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_1 = 67,
+    #[doc = "68: index of DMA RESRDY trigger"]
+    ADC0_RESRDY = 68,
+    #[doc = "69: Index of DMA SEQ trigger"]
+    ADC0_SEQ = 69,
+    #[doc = "70: Index of DMA RESRDY trigger"]
+    ADC1_RESRDY = 70,
+    #[doc = "71: Index of DMA SEQ trigger"]
+    ADC1_SEQ = 71,
+    #[doc = "72: DMA DAC Empty Req"]
+    DAC_EMPTY_0 = 72,
+    #[doc = "73: DMA DAC Empty Req"]
+    DAC_EMPTY_1 = 73,
+    #[doc = "74: DMA DAC Result Ready Req"]
+    DAC_RESRDY_0 = 74,
+    #[doc = "75: DMA DAC Result Ready Req"]
+    DAC_RESRDY_1 = 75,
+    #[doc = "76: Indexes of DMA RX triggers"]
+    I2S_RX_0 = 76,
+    #[doc = "77: Indexes of DMA RX triggers"]
+    I2S_RX_1 = 77,
+    #[doc = "78: Indexes of DMA TX triggers"]
+    I2S_TX_0 = 78,
+    #[doc = "79: Indexes of DMA TX triggers"]
+    I2S_TX_1 = 79,
+    #[doc = "80: Indexes of PCC RX trigger"]
+    PCC_RX = 80,
+    #[doc = "81: DMA DATA Write trigger"]
+    AES_WR = 81,
+    #[doc = "82: DMA DATA Read trigger"]
+    AES_RD = 82,
+    #[doc = "83: Indexes of QSPI RX trigger"]
+    QSPI_RX = 83,
+    #[doc = "84: Indexes of QSPI TX trigger"]
+    QSPI_TX = 84,
 }
 impl From<TRIGSRC_A> for u8 {
     #[inline(always)]
@@ -104,6 +272,90 @@ impl TRIGSRC_R {
         use crate::Variant::*;
         match self.bits {
             0 => Val(TRIGSRC_A::DISABLE),
+            1 => Val(TRIGSRC_A::RTC_TIMESTAMP),
+            2 => Val(TRIGSRC_A::DSU_DCC0),
+            3 => Val(TRIGSRC_A::DSU_DCC1),
+            4 => Val(TRIGSRC_A::SERCOM0_RX),
+            5 => Val(TRIGSRC_A::SERCOM0_TX),
+            6 => Val(TRIGSRC_A::SERCOM1_RX),
+            7 => Val(TRIGSRC_A::SERCOM1_TX),
+            8 => Val(TRIGSRC_A::SERCOM2_RX),
+            9 => Val(TRIGSRC_A::SERCOM2_TX),
+            10 => Val(TRIGSRC_A::SERCOM3_RX),
+            11 => Val(TRIGSRC_A::SERCOM3_TX),
+            12 => Val(TRIGSRC_A::SERCOM4_RX),
+            13 => Val(TRIGSRC_A::SERCOM4_TX),
+            14 => Val(TRIGSRC_A::SERCOM5_RX),
+            15 => Val(TRIGSRC_A::SERCOM5_TX),
+            16 => Val(TRIGSRC_A::SERCOM6_RX),
+            17 => Val(TRIGSRC_A::SERCOM6_TX),
+            18 => Val(TRIGSRC_A::SERCOM7_RX),
+            19 => Val(TRIGSRC_A::SERCOM7_TX),
+            20 => Val(TRIGSRC_A::CAN0_DEBUG),
+            21 => Val(TRIGSRC_A::CAN1_DEBUG),
+            22 => Val(TRIGSRC_A::TCC0_OVF),
+            23 => Val(TRIGSRC_A::TCC0_MC_0),
+            24 => Val(TRIGSRC_A::TCC0_MC_1),
+            25 => Val(TRIGSRC_A::TCC0_MC_2),
+            26 => Val(TRIGSRC_A::TCC0_MC_3),
+            27 => Val(TRIGSRC_A::TCC0_MC_4),
+            28 => Val(TRIGSRC_A::TCC0_MC_5),
+            29 => Val(TRIGSRC_A::TCC1_OVF),
+            30 => Val(TRIGSRC_A::TCC1_MC_0),
+            31 => Val(TRIGSRC_A::TCC1_MC_1),
+            32 => Val(TRIGSRC_A::TCC1_MC_2),
+            33 => Val(TRIGSRC_A::TCC1_MC_3),
+            34 => Val(TRIGSRC_A::TCC2_OVF),
+            35 => Val(TRIGSRC_A::TCC2_MC_0),
+            36 => Val(TRIGSRC_A::TCC2_MC_1),
+            37 => Val(TRIGSRC_A::TCC2_MC_2),
+            38 => Val(TRIGSRC_A::TCC3_OVF),
+            39 => Val(TRIGSRC_A::TCC3_MC_0),
+            40 => Val(TRIGSRC_A::TCC3_MC_1),
+            41 => Val(TRIGSRC_A::TCC4_OVF),
+            42 => Val(TRIGSRC_A::TCC4_MC_0),
+            43 => Val(TRIGSRC_A::TCC4_MC_1),
+            44 => Val(TRIGSRC_A::TC0_OVF),
+            45 => Val(TRIGSRC_A::TC0_MC_0),
+            46 => Val(TRIGSRC_A::TC0_MC_1),
+            47 => Val(TRIGSRC_A::TC1_OVF),
+            48 => Val(TRIGSRC_A::TC1_MC_0),
+            49 => Val(TRIGSRC_A::TC1_MC_1),
+            50 => Val(TRIGSRC_A::TC2_OVF),
+            51 => Val(TRIGSRC_A::TC2_MC_0),
+            52 => Val(TRIGSRC_A::TC2_MC_1),
+            53 => Val(TRIGSRC_A::TC3_OVF),
+            54 => Val(TRIGSRC_A::TC3_MC_0),
+            55 => Val(TRIGSRC_A::TC3_MC_1),
+            56 => Val(TRIGSRC_A::TC4_OVF),
+            57 => Val(TRIGSRC_A::TC4_MC_0),
+            58 => Val(TRIGSRC_A::TC4_MC_1),
+            59 => Val(TRIGSRC_A::TC5_OVF),
+            60 => Val(TRIGSRC_A::TC5_MC_0),
+            61 => Val(TRIGSRC_A::TC5_MC_1),
+            62 => Val(TRIGSRC_A::TC6_OVF),
+            63 => Val(TRIGSRC_A::TC6_MC_0),
+            64 => Val(TRIGSRC_A::TC6_MC_1),
+            65 => Val(TRIGSRC_A::TC7_OVF),
+            66 => Val(TRIGSRC_A::TC7_MC_0),
+            67 => Val(TRIGSRC_A::TC7_MC_1),
+            68 => Val(TRIGSRC_A::ADC0_RESRDY),
+            69 => Val(TRIGSRC_A::ADC0_SEQ),
+            70 => Val(TRIGSRC_A::ADC1_RESRDY),
+            71 => Val(TRIGSRC_A::ADC1_SEQ),
+            72 => Val(TRIGSRC_A::DAC_EMPTY_0),
+            73 => Val(TRIGSRC_A::DAC_EMPTY_1),
+            74 => Val(TRIGSRC_A::DAC_RESRDY_0),
+            75 => Val(TRIGSRC_A::DAC_RESRDY_1),
+            76 => Val(TRIGSRC_A::I2S_RX_0),
+            77 => Val(TRIGSRC_A::I2S_RX_1),
+            78 => Val(TRIGSRC_A::I2S_TX_0),
+            79 => Val(TRIGSRC_A::I2S_TX_1),
+            80 => Val(TRIGSRC_A::PCC_RX),
+            81 => Val(TRIGSRC_A::AES_WR),
+            82 => Val(TRIGSRC_A::AES_RD),
+            83 => Val(TRIGSRC_A::QSPI_RX),
+            84 => Val(TRIGSRC_A::QSPI_TX),
             i => Res(i),
         }
     }
@@ -111,6 +363,426 @@ impl TRIGSRC_R {
     #[inline(always)]
     pub fn is_disable(&self) -> bool {
         *self == TRIGSRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `RTC_TIMESTAMP`"]
+    #[inline(always)]
+    pub fn is_rtc_timestamp(&self) -> bool {
+        *self == TRIGSRC_A::RTC_TIMESTAMP
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC0`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc0(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC0
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC1`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc1(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC1
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_RX`"]
+    #[inline(always)]
+    pub fn is_sercom0_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_TX`"]
+    #[inline(always)]
+    pub fn is_sercom0_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_RX`"]
+    #[inline(always)]
+    pub fn is_sercom1_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_TX`"]
+    #[inline(always)]
+    pub fn is_sercom1_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_RX`"]
+    #[inline(always)]
+    pub fn is_sercom2_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_TX`"]
+    #[inline(always)]
+    pub fn is_sercom2_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_RX`"]
+    #[inline(always)]
+    pub fn is_sercom3_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_TX`"]
+    #[inline(always)]
+    pub fn is_sercom3_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_RX`"]
+    #[inline(always)]
+    pub fn is_sercom4_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_TX`"]
+    #[inline(always)]
+    pub fn is_sercom4_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_RX`"]
+    #[inline(always)]
+    pub fn is_sercom5_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_TX`"]
+    #[inline(always)]
+    pub fn is_sercom5_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_RX`"]
+    #[inline(always)]
+    pub fn is_sercom6_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_TX`"]
+    #[inline(always)]
+    pub fn is_sercom6_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_RX`"]
+    #[inline(always)]
+    pub fn is_sercom7_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_TX`"]
+    #[inline(always)]
+    pub fn is_sercom7_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_TX
+    }
+    #[doc = "Checks if the value of the field is `CAN0_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can0_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN0_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `CAN1_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can1_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN1_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `TCC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_4`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_4(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_4
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_5`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_5(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_5
+    }
+    #[doc = "Checks if the value of the field is `TCC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC5_OVF`"]
+    #[inline(always)]
+    pub fn is_tc5_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC5_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC6_OVF`"]
+    #[inline(always)]
+    pub fn is_tc6_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC6_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC7_OVF`"]
+    #[inline(always)]
+    pub fn is_tc7_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC7_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_1
+    }
+    #[doc = "Checks if the value of the field is `ADC0_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc0_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC0_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc0_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_SEQ
+    }
+    #[doc = "Checks if the value of the field is `ADC1_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc1_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC1_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc1_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_SEQ
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_0`"]
+    #[inline(always)]
+    pub fn is_dac_empty_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_1`"]
+    #[inline(always)]
+    pub fn is_dac_empty_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_1
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_0`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_1`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_1
+    }
+    #[doc = "Checks if the value of the field is `PCC_RX`"]
+    #[inline(always)]
+    pub fn is_pcc_rx(&self) -> bool {
+        *self == TRIGSRC_A::PCC_RX
+    }
+    #[doc = "Checks if the value of the field is `AES_WR`"]
+    #[inline(always)]
+    pub fn is_aes_wr(&self) -> bool {
+        *self == TRIGSRC_A::AES_WR
+    }
+    #[doc = "Checks if the value of the field is `AES_RD`"]
+    #[inline(always)]
+    pub fn is_aes_rd(&self) -> bool {
+        *self == TRIGSRC_A::AES_RD
+    }
+    #[doc = "Checks if the value of the field is `QSPI_RX`"]
+    #[inline(always)]
+    pub fn is_qspi_rx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_RX
+    }
+    #[doc = "Checks if the value of the field is `QSPI_TX`"]
+    #[inline(always)]
+    pub fn is_qspi_tx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_TX
     }
 }
 #[doc = "Write proxy for field `TRIGSRC`"]
@@ -127,6 +799,426 @@ impl<'a> TRIGSRC_W<'a> {
     #[inline(always)]
     pub fn disable(self) -> &'a mut W {
         self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = "DMA RTC timestamp trigger"]
+    #[inline(always)]
+    pub fn rtc_timestamp(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::RTC_TIMESTAMP)
+    }
+    #[doc = "DMAC ID for DCC0 register"]
+    #[inline(always)]
+    pub fn dsu_dcc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC0)
+    }
+    #[doc = "DMAC ID for DCC1 register"]
+    #[inline(always)]
+    pub fn dsu_dcc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC1)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom0_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom0_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom1_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom1_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom2_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom2_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom3_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom3_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom4_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom4_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom5_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom5_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom6_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom6_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom7_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom7_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_TX)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can0_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN0_DEBUG)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can1_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN1_DEBUG)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_3)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_4(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_4)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_5(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_5)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_3)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_2)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_1)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc5_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc6_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc7_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_1)
+    }
+    #[doc = "index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc0_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc0_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_SEQ)
+    }
+    #[doc = "Index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc1_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc1_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_SEQ)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_0)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_1)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_0)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_1)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_0)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_1)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_0)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_1)
+    }
+    #[doc = "Indexes of PCC RX trigger"]
+    #[inline(always)]
+    pub fn pcc_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::PCC_RX)
+    }
+    #[doc = "DMA DATA Write trigger"]
+    #[inline(always)]
+    pub fn aes_wr(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_WR)
+    }
+    #[doc = "DMA DATA Read trigger"]
+    #[inline(always)]
+    pub fn aes_rd(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_RD)
+    }
+    #[doc = "Indexes of QSPI RX trigger"]
+    #[inline(always)]
+    pub fn qspi_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_RX)
+    }
+    #[doc = "Indexes of QSPI TX trigger"]
+    #[inline(always)]
+    pub fn qspi_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_TX)
     }
     #[doc = r"Writes raw bits to the field"]
     #[inline(always)]

--- a/pac/atsame53n/src/dmac/channel/chctrla.rs
+++ b/pac/atsame53n/src/dmac/channel/chctrla.rs
@@ -88,6 +88,174 @@ impl<'a> RUNSTDBY_W<'a> {
 pub enum TRIGSRC_A {
     #[doc = "0: Only software/event triggers"]
     DISABLE = 0,
+    #[doc = "1: DMA RTC timestamp trigger"]
+    RTC_TIMESTAMP = 1,
+    #[doc = "2: DMAC ID for DCC0 register"]
+    DSU_DCC0 = 2,
+    #[doc = "3: DMAC ID for DCC1 register"]
+    DSU_DCC1 = 3,
+    #[doc = "4: Index of DMA RX trigger"]
+    SERCOM0_RX = 4,
+    #[doc = "5: Index of DMA TX trigger"]
+    SERCOM0_TX = 5,
+    #[doc = "6: Index of DMA RX trigger"]
+    SERCOM1_RX = 6,
+    #[doc = "7: Index of DMA TX trigger"]
+    SERCOM1_TX = 7,
+    #[doc = "8: Index of DMA RX trigger"]
+    SERCOM2_RX = 8,
+    #[doc = "9: Index of DMA TX trigger"]
+    SERCOM2_TX = 9,
+    #[doc = "10: Index of DMA RX trigger"]
+    SERCOM3_RX = 10,
+    #[doc = "11: Index of DMA TX trigger"]
+    SERCOM3_TX = 11,
+    #[doc = "12: Index of DMA RX trigger"]
+    SERCOM4_RX = 12,
+    #[doc = "13: Index of DMA TX trigger"]
+    SERCOM4_TX = 13,
+    #[doc = "14: Index of DMA RX trigger"]
+    SERCOM5_RX = 14,
+    #[doc = "15: Index of DMA TX trigger"]
+    SERCOM5_TX = 15,
+    #[doc = "16: Index of DMA RX trigger"]
+    SERCOM6_RX = 16,
+    #[doc = "17: Index of DMA TX trigger"]
+    SERCOM6_TX = 17,
+    #[doc = "18: Index of DMA RX trigger"]
+    SERCOM7_RX = 18,
+    #[doc = "19: Index of DMA TX trigger"]
+    SERCOM7_TX = 19,
+    #[doc = "20: DMA CAN Debug Req"]
+    CAN0_DEBUG = 20,
+    #[doc = "21: DMA CAN Debug Req"]
+    CAN1_DEBUG = 21,
+    #[doc = "22: DMA overflow/underflow/retrigger trigger"]
+    TCC0_OVF = 22,
+    #[doc = "23: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_0 = 23,
+    #[doc = "24: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_1 = 24,
+    #[doc = "25: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_2 = 25,
+    #[doc = "26: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_3 = 26,
+    #[doc = "27: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_4 = 27,
+    #[doc = "28: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_5 = 28,
+    #[doc = "29: DMA overflow/underflow/retrigger trigger"]
+    TCC1_OVF = 29,
+    #[doc = "30: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_0 = 30,
+    #[doc = "31: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_1 = 31,
+    #[doc = "32: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_2 = 32,
+    #[doc = "33: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_3 = 33,
+    #[doc = "34: DMA overflow/underflow/retrigger trigger"]
+    TCC2_OVF = 34,
+    #[doc = "35: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_0 = 35,
+    #[doc = "36: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_1 = 36,
+    #[doc = "37: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_2 = 37,
+    #[doc = "38: DMA overflow/underflow/retrigger trigger"]
+    TCC3_OVF = 38,
+    #[doc = "39: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_0 = 39,
+    #[doc = "40: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_1 = 40,
+    #[doc = "41: DMA overflow/underflow/retrigger trigger"]
+    TCC4_OVF = 41,
+    #[doc = "42: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_0 = 42,
+    #[doc = "43: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_1 = 43,
+    #[doc = "44: Indexes of DMA Overflow trigger"]
+    TC0_OVF = 44,
+    #[doc = "45: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_0 = 45,
+    #[doc = "46: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_1 = 46,
+    #[doc = "47: Indexes of DMA Overflow trigger"]
+    TC1_OVF = 47,
+    #[doc = "48: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_0 = 48,
+    #[doc = "49: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_1 = 49,
+    #[doc = "50: Indexes of DMA Overflow trigger"]
+    TC2_OVF = 50,
+    #[doc = "51: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_0 = 51,
+    #[doc = "52: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_1 = 52,
+    #[doc = "53: Indexes of DMA Overflow trigger"]
+    TC3_OVF = 53,
+    #[doc = "54: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_0 = 54,
+    #[doc = "55: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_1 = 55,
+    #[doc = "56: Indexes of DMA Overflow trigger"]
+    TC4_OVF = 56,
+    #[doc = "57: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_0 = 57,
+    #[doc = "58: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_1 = 58,
+    #[doc = "59: Indexes of DMA Overflow trigger"]
+    TC5_OVF = 59,
+    #[doc = "60: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_0 = 60,
+    #[doc = "61: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_1 = 61,
+    #[doc = "62: Indexes of DMA Overflow trigger"]
+    TC6_OVF = 62,
+    #[doc = "63: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_0 = 63,
+    #[doc = "64: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_1 = 64,
+    #[doc = "65: Indexes of DMA Overflow trigger"]
+    TC7_OVF = 65,
+    #[doc = "66: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_0 = 66,
+    #[doc = "67: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_1 = 67,
+    #[doc = "68: index of DMA RESRDY trigger"]
+    ADC0_RESRDY = 68,
+    #[doc = "69: Index of DMA SEQ trigger"]
+    ADC0_SEQ = 69,
+    #[doc = "70: Index of DMA RESRDY trigger"]
+    ADC1_RESRDY = 70,
+    #[doc = "71: Index of DMA SEQ trigger"]
+    ADC1_SEQ = 71,
+    #[doc = "72: DMA DAC Empty Req"]
+    DAC_EMPTY_0 = 72,
+    #[doc = "73: DMA DAC Empty Req"]
+    DAC_EMPTY_1 = 73,
+    #[doc = "74: DMA DAC Result Ready Req"]
+    DAC_RESRDY_0 = 74,
+    #[doc = "75: DMA DAC Result Ready Req"]
+    DAC_RESRDY_1 = 75,
+    #[doc = "76: Indexes of DMA RX triggers"]
+    I2S_RX_0 = 76,
+    #[doc = "77: Indexes of DMA RX triggers"]
+    I2S_RX_1 = 77,
+    #[doc = "78: Indexes of DMA TX triggers"]
+    I2S_TX_0 = 78,
+    #[doc = "79: Indexes of DMA TX triggers"]
+    I2S_TX_1 = 79,
+    #[doc = "80: Indexes of PCC RX trigger"]
+    PCC_RX = 80,
+    #[doc = "81: DMA DATA Write trigger"]
+    AES_WR = 81,
+    #[doc = "82: DMA DATA Read trigger"]
+    AES_RD = 82,
+    #[doc = "83: Indexes of QSPI RX trigger"]
+    QSPI_RX = 83,
+    #[doc = "84: Indexes of QSPI TX trigger"]
+    QSPI_TX = 84,
 }
 impl From<TRIGSRC_A> for u8 {
     #[inline(always)]
@@ -104,6 +272,90 @@ impl TRIGSRC_R {
         use crate::Variant::*;
         match self.bits {
             0 => Val(TRIGSRC_A::DISABLE),
+            1 => Val(TRIGSRC_A::RTC_TIMESTAMP),
+            2 => Val(TRIGSRC_A::DSU_DCC0),
+            3 => Val(TRIGSRC_A::DSU_DCC1),
+            4 => Val(TRIGSRC_A::SERCOM0_RX),
+            5 => Val(TRIGSRC_A::SERCOM0_TX),
+            6 => Val(TRIGSRC_A::SERCOM1_RX),
+            7 => Val(TRIGSRC_A::SERCOM1_TX),
+            8 => Val(TRIGSRC_A::SERCOM2_RX),
+            9 => Val(TRIGSRC_A::SERCOM2_TX),
+            10 => Val(TRIGSRC_A::SERCOM3_RX),
+            11 => Val(TRIGSRC_A::SERCOM3_TX),
+            12 => Val(TRIGSRC_A::SERCOM4_RX),
+            13 => Val(TRIGSRC_A::SERCOM4_TX),
+            14 => Val(TRIGSRC_A::SERCOM5_RX),
+            15 => Val(TRIGSRC_A::SERCOM5_TX),
+            16 => Val(TRIGSRC_A::SERCOM6_RX),
+            17 => Val(TRIGSRC_A::SERCOM6_TX),
+            18 => Val(TRIGSRC_A::SERCOM7_RX),
+            19 => Val(TRIGSRC_A::SERCOM7_TX),
+            20 => Val(TRIGSRC_A::CAN0_DEBUG),
+            21 => Val(TRIGSRC_A::CAN1_DEBUG),
+            22 => Val(TRIGSRC_A::TCC0_OVF),
+            23 => Val(TRIGSRC_A::TCC0_MC_0),
+            24 => Val(TRIGSRC_A::TCC0_MC_1),
+            25 => Val(TRIGSRC_A::TCC0_MC_2),
+            26 => Val(TRIGSRC_A::TCC0_MC_3),
+            27 => Val(TRIGSRC_A::TCC0_MC_4),
+            28 => Val(TRIGSRC_A::TCC0_MC_5),
+            29 => Val(TRIGSRC_A::TCC1_OVF),
+            30 => Val(TRIGSRC_A::TCC1_MC_0),
+            31 => Val(TRIGSRC_A::TCC1_MC_1),
+            32 => Val(TRIGSRC_A::TCC1_MC_2),
+            33 => Val(TRIGSRC_A::TCC1_MC_3),
+            34 => Val(TRIGSRC_A::TCC2_OVF),
+            35 => Val(TRIGSRC_A::TCC2_MC_0),
+            36 => Val(TRIGSRC_A::TCC2_MC_1),
+            37 => Val(TRIGSRC_A::TCC2_MC_2),
+            38 => Val(TRIGSRC_A::TCC3_OVF),
+            39 => Val(TRIGSRC_A::TCC3_MC_0),
+            40 => Val(TRIGSRC_A::TCC3_MC_1),
+            41 => Val(TRIGSRC_A::TCC4_OVF),
+            42 => Val(TRIGSRC_A::TCC4_MC_0),
+            43 => Val(TRIGSRC_A::TCC4_MC_1),
+            44 => Val(TRIGSRC_A::TC0_OVF),
+            45 => Val(TRIGSRC_A::TC0_MC_0),
+            46 => Val(TRIGSRC_A::TC0_MC_1),
+            47 => Val(TRIGSRC_A::TC1_OVF),
+            48 => Val(TRIGSRC_A::TC1_MC_0),
+            49 => Val(TRIGSRC_A::TC1_MC_1),
+            50 => Val(TRIGSRC_A::TC2_OVF),
+            51 => Val(TRIGSRC_A::TC2_MC_0),
+            52 => Val(TRIGSRC_A::TC2_MC_1),
+            53 => Val(TRIGSRC_A::TC3_OVF),
+            54 => Val(TRIGSRC_A::TC3_MC_0),
+            55 => Val(TRIGSRC_A::TC3_MC_1),
+            56 => Val(TRIGSRC_A::TC4_OVF),
+            57 => Val(TRIGSRC_A::TC4_MC_0),
+            58 => Val(TRIGSRC_A::TC4_MC_1),
+            59 => Val(TRIGSRC_A::TC5_OVF),
+            60 => Val(TRIGSRC_A::TC5_MC_0),
+            61 => Val(TRIGSRC_A::TC5_MC_1),
+            62 => Val(TRIGSRC_A::TC6_OVF),
+            63 => Val(TRIGSRC_A::TC6_MC_0),
+            64 => Val(TRIGSRC_A::TC6_MC_1),
+            65 => Val(TRIGSRC_A::TC7_OVF),
+            66 => Val(TRIGSRC_A::TC7_MC_0),
+            67 => Val(TRIGSRC_A::TC7_MC_1),
+            68 => Val(TRIGSRC_A::ADC0_RESRDY),
+            69 => Val(TRIGSRC_A::ADC0_SEQ),
+            70 => Val(TRIGSRC_A::ADC1_RESRDY),
+            71 => Val(TRIGSRC_A::ADC1_SEQ),
+            72 => Val(TRIGSRC_A::DAC_EMPTY_0),
+            73 => Val(TRIGSRC_A::DAC_EMPTY_1),
+            74 => Val(TRIGSRC_A::DAC_RESRDY_0),
+            75 => Val(TRIGSRC_A::DAC_RESRDY_1),
+            76 => Val(TRIGSRC_A::I2S_RX_0),
+            77 => Val(TRIGSRC_A::I2S_RX_1),
+            78 => Val(TRIGSRC_A::I2S_TX_0),
+            79 => Val(TRIGSRC_A::I2S_TX_1),
+            80 => Val(TRIGSRC_A::PCC_RX),
+            81 => Val(TRIGSRC_A::AES_WR),
+            82 => Val(TRIGSRC_A::AES_RD),
+            83 => Val(TRIGSRC_A::QSPI_RX),
+            84 => Val(TRIGSRC_A::QSPI_TX),
             i => Res(i),
         }
     }
@@ -111,6 +363,426 @@ impl TRIGSRC_R {
     #[inline(always)]
     pub fn is_disable(&self) -> bool {
         *self == TRIGSRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `RTC_TIMESTAMP`"]
+    #[inline(always)]
+    pub fn is_rtc_timestamp(&self) -> bool {
+        *self == TRIGSRC_A::RTC_TIMESTAMP
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC0`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc0(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC0
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC1`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc1(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC1
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_RX`"]
+    #[inline(always)]
+    pub fn is_sercom0_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_TX`"]
+    #[inline(always)]
+    pub fn is_sercom0_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_RX`"]
+    #[inline(always)]
+    pub fn is_sercom1_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_TX`"]
+    #[inline(always)]
+    pub fn is_sercom1_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_RX`"]
+    #[inline(always)]
+    pub fn is_sercom2_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_TX`"]
+    #[inline(always)]
+    pub fn is_sercom2_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_RX`"]
+    #[inline(always)]
+    pub fn is_sercom3_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_TX`"]
+    #[inline(always)]
+    pub fn is_sercom3_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_RX`"]
+    #[inline(always)]
+    pub fn is_sercom4_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_TX`"]
+    #[inline(always)]
+    pub fn is_sercom4_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_RX`"]
+    #[inline(always)]
+    pub fn is_sercom5_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_TX`"]
+    #[inline(always)]
+    pub fn is_sercom5_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_RX`"]
+    #[inline(always)]
+    pub fn is_sercom6_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_TX`"]
+    #[inline(always)]
+    pub fn is_sercom6_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_RX`"]
+    #[inline(always)]
+    pub fn is_sercom7_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_TX`"]
+    #[inline(always)]
+    pub fn is_sercom7_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_TX
+    }
+    #[doc = "Checks if the value of the field is `CAN0_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can0_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN0_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `CAN1_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can1_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN1_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `TCC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_4`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_4(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_4
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_5`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_5(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_5
+    }
+    #[doc = "Checks if the value of the field is `TCC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC5_OVF`"]
+    #[inline(always)]
+    pub fn is_tc5_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC5_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC6_OVF`"]
+    #[inline(always)]
+    pub fn is_tc6_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC6_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC7_OVF`"]
+    #[inline(always)]
+    pub fn is_tc7_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC7_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_1
+    }
+    #[doc = "Checks if the value of the field is `ADC0_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc0_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC0_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc0_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_SEQ
+    }
+    #[doc = "Checks if the value of the field is `ADC1_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc1_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC1_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc1_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_SEQ
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_0`"]
+    #[inline(always)]
+    pub fn is_dac_empty_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_1`"]
+    #[inline(always)]
+    pub fn is_dac_empty_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_1
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_0`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_1`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_1
+    }
+    #[doc = "Checks if the value of the field is `PCC_RX`"]
+    #[inline(always)]
+    pub fn is_pcc_rx(&self) -> bool {
+        *self == TRIGSRC_A::PCC_RX
+    }
+    #[doc = "Checks if the value of the field is `AES_WR`"]
+    #[inline(always)]
+    pub fn is_aes_wr(&self) -> bool {
+        *self == TRIGSRC_A::AES_WR
+    }
+    #[doc = "Checks if the value of the field is `AES_RD`"]
+    #[inline(always)]
+    pub fn is_aes_rd(&self) -> bool {
+        *self == TRIGSRC_A::AES_RD
+    }
+    #[doc = "Checks if the value of the field is `QSPI_RX`"]
+    #[inline(always)]
+    pub fn is_qspi_rx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_RX
+    }
+    #[doc = "Checks if the value of the field is `QSPI_TX`"]
+    #[inline(always)]
+    pub fn is_qspi_tx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_TX
     }
 }
 #[doc = "Write proxy for field `TRIGSRC`"]
@@ -127,6 +799,426 @@ impl<'a> TRIGSRC_W<'a> {
     #[inline(always)]
     pub fn disable(self) -> &'a mut W {
         self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = "DMA RTC timestamp trigger"]
+    #[inline(always)]
+    pub fn rtc_timestamp(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::RTC_TIMESTAMP)
+    }
+    #[doc = "DMAC ID for DCC0 register"]
+    #[inline(always)]
+    pub fn dsu_dcc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC0)
+    }
+    #[doc = "DMAC ID for DCC1 register"]
+    #[inline(always)]
+    pub fn dsu_dcc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC1)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom0_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom0_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom1_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom1_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom2_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom2_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom3_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom3_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom4_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom4_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom5_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom5_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom6_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom6_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom7_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom7_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_TX)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can0_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN0_DEBUG)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can1_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN1_DEBUG)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_3)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_4(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_4)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_5(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_5)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_3)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_2)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_1)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc5_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc6_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc7_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_1)
+    }
+    #[doc = "index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc0_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc0_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_SEQ)
+    }
+    #[doc = "Index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc1_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc1_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_SEQ)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_0)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_1)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_0)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_1)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_0)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_1)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_0)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_1)
+    }
+    #[doc = "Indexes of PCC RX trigger"]
+    #[inline(always)]
+    pub fn pcc_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::PCC_RX)
+    }
+    #[doc = "DMA DATA Write trigger"]
+    #[inline(always)]
+    pub fn aes_wr(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_WR)
+    }
+    #[doc = "DMA DATA Read trigger"]
+    #[inline(always)]
+    pub fn aes_rd(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_RD)
+    }
+    #[doc = "Indexes of QSPI RX trigger"]
+    #[inline(always)]
+    pub fn qspi_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_RX)
+    }
+    #[doc = "Indexes of QSPI TX trigger"]
+    #[inline(always)]
+    pub fn qspi_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_TX)
     }
     #[doc = r"Writes raw bits to the field"]
     #[inline(always)]

--- a/pac/atsame54n/src/dmac/channel/chctrla.rs
+++ b/pac/atsame54n/src/dmac/channel/chctrla.rs
@@ -88,6 +88,174 @@ impl<'a> RUNSTDBY_W<'a> {
 pub enum TRIGSRC_A {
     #[doc = "0: Only software/event triggers"]
     DISABLE = 0,
+    #[doc = "1: DMA RTC timestamp trigger"]
+    RTC_TIMESTAMP = 1,
+    #[doc = "2: DMAC ID for DCC0 register"]
+    DSU_DCC0 = 2,
+    #[doc = "3: DMAC ID for DCC1 register"]
+    DSU_DCC1 = 3,
+    #[doc = "4: Index of DMA RX trigger"]
+    SERCOM0_RX = 4,
+    #[doc = "5: Index of DMA TX trigger"]
+    SERCOM0_TX = 5,
+    #[doc = "6: Index of DMA RX trigger"]
+    SERCOM1_RX = 6,
+    #[doc = "7: Index of DMA TX trigger"]
+    SERCOM1_TX = 7,
+    #[doc = "8: Index of DMA RX trigger"]
+    SERCOM2_RX = 8,
+    #[doc = "9: Index of DMA TX trigger"]
+    SERCOM2_TX = 9,
+    #[doc = "10: Index of DMA RX trigger"]
+    SERCOM3_RX = 10,
+    #[doc = "11: Index of DMA TX trigger"]
+    SERCOM3_TX = 11,
+    #[doc = "12: Index of DMA RX trigger"]
+    SERCOM4_RX = 12,
+    #[doc = "13: Index of DMA TX trigger"]
+    SERCOM4_TX = 13,
+    #[doc = "14: Index of DMA RX trigger"]
+    SERCOM5_RX = 14,
+    #[doc = "15: Index of DMA TX trigger"]
+    SERCOM5_TX = 15,
+    #[doc = "16: Index of DMA RX trigger"]
+    SERCOM6_RX = 16,
+    #[doc = "17: Index of DMA TX trigger"]
+    SERCOM6_TX = 17,
+    #[doc = "18: Index of DMA RX trigger"]
+    SERCOM7_RX = 18,
+    #[doc = "19: Index of DMA TX trigger"]
+    SERCOM7_TX = 19,
+    #[doc = "20: DMA CAN Debug Req"]
+    CAN0_DEBUG = 20,
+    #[doc = "21: DMA CAN Debug Req"]
+    CAN1_DEBUG = 21,
+    #[doc = "22: DMA overflow/underflow/retrigger trigger"]
+    TCC0_OVF = 22,
+    #[doc = "23: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_0 = 23,
+    #[doc = "24: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_1 = 24,
+    #[doc = "25: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_2 = 25,
+    #[doc = "26: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_3 = 26,
+    #[doc = "27: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_4 = 27,
+    #[doc = "28: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_5 = 28,
+    #[doc = "29: DMA overflow/underflow/retrigger trigger"]
+    TCC1_OVF = 29,
+    #[doc = "30: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_0 = 30,
+    #[doc = "31: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_1 = 31,
+    #[doc = "32: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_2 = 32,
+    #[doc = "33: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_3 = 33,
+    #[doc = "34: DMA overflow/underflow/retrigger trigger"]
+    TCC2_OVF = 34,
+    #[doc = "35: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_0 = 35,
+    #[doc = "36: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_1 = 36,
+    #[doc = "37: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_2 = 37,
+    #[doc = "38: DMA overflow/underflow/retrigger trigger"]
+    TCC3_OVF = 38,
+    #[doc = "39: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_0 = 39,
+    #[doc = "40: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_1 = 40,
+    #[doc = "41: DMA overflow/underflow/retrigger trigger"]
+    TCC4_OVF = 41,
+    #[doc = "42: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_0 = 42,
+    #[doc = "43: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_1 = 43,
+    #[doc = "44: Indexes of DMA Overflow trigger"]
+    TC0_OVF = 44,
+    #[doc = "45: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_0 = 45,
+    #[doc = "46: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_1 = 46,
+    #[doc = "47: Indexes of DMA Overflow trigger"]
+    TC1_OVF = 47,
+    #[doc = "48: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_0 = 48,
+    #[doc = "49: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_1 = 49,
+    #[doc = "50: Indexes of DMA Overflow trigger"]
+    TC2_OVF = 50,
+    #[doc = "51: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_0 = 51,
+    #[doc = "52: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_1 = 52,
+    #[doc = "53: Indexes of DMA Overflow trigger"]
+    TC3_OVF = 53,
+    #[doc = "54: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_0 = 54,
+    #[doc = "55: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_1 = 55,
+    #[doc = "56: Indexes of DMA Overflow trigger"]
+    TC4_OVF = 56,
+    #[doc = "57: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_0 = 57,
+    #[doc = "58: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_1 = 58,
+    #[doc = "59: Indexes of DMA Overflow trigger"]
+    TC5_OVF = 59,
+    #[doc = "60: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_0 = 60,
+    #[doc = "61: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_1 = 61,
+    #[doc = "62: Indexes of DMA Overflow trigger"]
+    TC6_OVF = 62,
+    #[doc = "63: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_0 = 63,
+    #[doc = "64: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_1 = 64,
+    #[doc = "65: Indexes of DMA Overflow trigger"]
+    TC7_OVF = 65,
+    #[doc = "66: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_0 = 66,
+    #[doc = "67: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_1 = 67,
+    #[doc = "68: index of DMA RESRDY trigger"]
+    ADC0_RESRDY = 68,
+    #[doc = "69: Index of DMA SEQ trigger"]
+    ADC0_SEQ = 69,
+    #[doc = "70: Index of DMA RESRDY trigger"]
+    ADC1_RESRDY = 70,
+    #[doc = "71: Index of DMA SEQ trigger"]
+    ADC1_SEQ = 71,
+    #[doc = "72: DMA DAC Empty Req"]
+    DAC_EMPTY_0 = 72,
+    #[doc = "73: DMA DAC Empty Req"]
+    DAC_EMPTY_1 = 73,
+    #[doc = "74: DMA DAC Result Ready Req"]
+    DAC_RESRDY_0 = 74,
+    #[doc = "75: DMA DAC Result Ready Req"]
+    DAC_RESRDY_1 = 75,
+    #[doc = "76: Indexes of DMA RX triggers"]
+    I2S_RX_0 = 76,
+    #[doc = "77: Indexes of DMA RX triggers"]
+    I2S_RX_1 = 77,
+    #[doc = "78: Indexes of DMA TX triggers"]
+    I2S_TX_0 = 78,
+    #[doc = "79: Indexes of DMA TX triggers"]
+    I2S_TX_1 = 79,
+    #[doc = "80: Indexes of PCC RX trigger"]
+    PCC_RX = 80,
+    #[doc = "81: DMA DATA Write trigger"]
+    AES_WR = 81,
+    #[doc = "82: DMA DATA Read trigger"]
+    AES_RD = 82,
+    #[doc = "83: Indexes of QSPI RX trigger"]
+    QSPI_RX = 83,
+    #[doc = "84: Indexes of QSPI TX trigger"]
+    QSPI_TX = 84,
 }
 impl From<TRIGSRC_A> for u8 {
     #[inline(always)]
@@ -104,6 +272,90 @@ impl TRIGSRC_R {
         use crate::Variant::*;
         match self.bits {
             0 => Val(TRIGSRC_A::DISABLE),
+            1 => Val(TRIGSRC_A::RTC_TIMESTAMP),
+            2 => Val(TRIGSRC_A::DSU_DCC0),
+            3 => Val(TRIGSRC_A::DSU_DCC1),
+            4 => Val(TRIGSRC_A::SERCOM0_RX),
+            5 => Val(TRIGSRC_A::SERCOM0_TX),
+            6 => Val(TRIGSRC_A::SERCOM1_RX),
+            7 => Val(TRIGSRC_A::SERCOM1_TX),
+            8 => Val(TRIGSRC_A::SERCOM2_RX),
+            9 => Val(TRIGSRC_A::SERCOM2_TX),
+            10 => Val(TRIGSRC_A::SERCOM3_RX),
+            11 => Val(TRIGSRC_A::SERCOM3_TX),
+            12 => Val(TRIGSRC_A::SERCOM4_RX),
+            13 => Val(TRIGSRC_A::SERCOM4_TX),
+            14 => Val(TRIGSRC_A::SERCOM5_RX),
+            15 => Val(TRIGSRC_A::SERCOM5_TX),
+            16 => Val(TRIGSRC_A::SERCOM6_RX),
+            17 => Val(TRIGSRC_A::SERCOM6_TX),
+            18 => Val(TRIGSRC_A::SERCOM7_RX),
+            19 => Val(TRIGSRC_A::SERCOM7_TX),
+            20 => Val(TRIGSRC_A::CAN0_DEBUG),
+            21 => Val(TRIGSRC_A::CAN1_DEBUG),
+            22 => Val(TRIGSRC_A::TCC0_OVF),
+            23 => Val(TRIGSRC_A::TCC0_MC_0),
+            24 => Val(TRIGSRC_A::TCC0_MC_1),
+            25 => Val(TRIGSRC_A::TCC0_MC_2),
+            26 => Val(TRIGSRC_A::TCC0_MC_3),
+            27 => Val(TRIGSRC_A::TCC0_MC_4),
+            28 => Val(TRIGSRC_A::TCC0_MC_5),
+            29 => Val(TRIGSRC_A::TCC1_OVF),
+            30 => Val(TRIGSRC_A::TCC1_MC_0),
+            31 => Val(TRIGSRC_A::TCC1_MC_1),
+            32 => Val(TRIGSRC_A::TCC1_MC_2),
+            33 => Val(TRIGSRC_A::TCC1_MC_3),
+            34 => Val(TRIGSRC_A::TCC2_OVF),
+            35 => Val(TRIGSRC_A::TCC2_MC_0),
+            36 => Val(TRIGSRC_A::TCC2_MC_1),
+            37 => Val(TRIGSRC_A::TCC2_MC_2),
+            38 => Val(TRIGSRC_A::TCC3_OVF),
+            39 => Val(TRIGSRC_A::TCC3_MC_0),
+            40 => Val(TRIGSRC_A::TCC3_MC_1),
+            41 => Val(TRIGSRC_A::TCC4_OVF),
+            42 => Val(TRIGSRC_A::TCC4_MC_0),
+            43 => Val(TRIGSRC_A::TCC4_MC_1),
+            44 => Val(TRIGSRC_A::TC0_OVF),
+            45 => Val(TRIGSRC_A::TC0_MC_0),
+            46 => Val(TRIGSRC_A::TC0_MC_1),
+            47 => Val(TRIGSRC_A::TC1_OVF),
+            48 => Val(TRIGSRC_A::TC1_MC_0),
+            49 => Val(TRIGSRC_A::TC1_MC_1),
+            50 => Val(TRIGSRC_A::TC2_OVF),
+            51 => Val(TRIGSRC_A::TC2_MC_0),
+            52 => Val(TRIGSRC_A::TC2_MC_1),
+            53 => Val(TRIGSRC_A::TC3_OVF),
+            54 => Val(TRIGSRC_A::TC3_MC_0),
+            55 => Val(TRIGSRC_A::TC3_MC_1),
+            56 => Val(TRIGSRC_A::TC4_OVF),
+            57 => Val(TRIGSRC_A::TC4_MC_0),
+            58 => Val(TRIGSRC_A::TC4_MC_1),
+            59 => Val(TRIGSRC_A::TC5_OVF),
+            60 => Val(TRIGSRC_A::TC5_MC_0),
+            61 => Val(TRIGSRC_A::TC5_MC_1),
+            62 => Val(TRIGSRC_A::TC6_OVF),
+            63 => Val(TRIGSRC_A::TC6_MC_0),
+            64 => Val(TRIGSRC_A::TC6_MC_1),
+            65 => Val(TRIGSRC_A::TC7_OVF),
+            66 => Val(TRIGSRC_A::TC7_MC_0),
+            67 => Val(TRIGSRC_A::TC7_MC_1),
+            68 => Val(TRIGSRC_A::ADC0_RESRDY),
+            69 => Val(TRIGSRC_A::ADC0_SEQ),
+            70 => Val(TRIGSRC_A::ADC1_RESRDY),
+            71 => Val(TRIGSRC_A::ADC1_SEQ),
+            72 => Val(TRIGSRC_A::DAC_EMPTY_0),
+            73 => Val(TRIGSRC_A::DAC_EMPTY_1),
+            74 => Val(TRIGSRC_A::DAC_RESRDY_0),
+            75 => Val(TRIGSRC_A::DAC_RESRDY_1),
+            76 => Val(TRIGSRC_A::I2S_RX_0),
+            77 => Val(TRIGSRC_A::I2S_RX_1),
+            78 => Val(TRIGSRC_A::I2S_TX_0),
+            79 => Val(TRIGSRC_A::I2S_TX_1),
+            80 => Val(TRIGSRC_A::PCC_RX),
+            81 => Val(TRIGSRC_A::AES_WR),
+            82 => Val(TRIGSRC_A::AES_RD),
+            83 => Val(TRIGSRC_A::QSPI_RX),
+            84 => Val(TRIGSRC_A::QSPI_TX),
             i => Res(i),
         }
     }
@@ -111,6 +363,426 @@ impl TRIGSRC_R {
     #[inline(always)]
     pub fn is_disable(&self) -> bool {
         *self == TRIGSRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `RTC_TIMESTAMP`"]
+    #[inline(always)]
+    pub fn is_rtc_timestamp(&self) -> bool {
+        *self == TRIGSRC_A::RTC_TIMESTAMP
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC0`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc0(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC0
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC1`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc1(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC1
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_RX`"]
+    #[inline(always)]
+    pub fn is_sercom0_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_TX`"]
+    #[inline(always)]
+    pub fn is_sercom0_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_RX`"]
+    #[inline(always)]
+    pub fn is_sercom1_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_TX`"]
+    #[inline(always)]
+    pub fn is_sercom1_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_RX`"]
+    #[inline(always)]
+    pub fn is_sercom2_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_TX`"]
+    #[inline(always)]
+    pub fn is_sercom2_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_RX`"]
+    #[inline(always)]
+    pub fn is_sercom3_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_TX`"]
+    #[inline(always)]
+    pub fn is_sercom3_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_RX`"]
+    #[inline(always)]
+    pub fn is_sercom4_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_TX`"]
+    #[inline(always)]
+    pub fn is_sercom4_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_RX`"]
+    #[inline(always)]
+    pub fn is_sercom5_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_TX`"]
+    #[inline(always)]
+    pub fn is_sercom5_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_RX`"]
+    #[inline(always)]
+    pub fn is_sercom6_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_TX`"]
+    #[inline(always)]
+    pub fn is_sercom6_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_RX`"]
+    #[inline(always)]
+    pub fn is_sercom7_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_TX`"]
+    #[inline(always)]
+    pub fn is_sercom7_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_TX
+    }
+    #[doc = "Checks if the value of the field is `CAN0_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can0_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN0_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `CAN1_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can1_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN1_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `TCC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_4`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_4(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_4
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_5`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_5(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_5
+    }
+    #[doc = "Checks if the value of the field is `TCC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC5_OVF`"]
+    #[inline(always)]
+    pub fn is_tc5_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC5_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC6_OVF`"]
+    #[inline(always)]
+    pub fn is_tc6_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC6_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC7_OVF`"]
+    #[inline(always)]
+    pub fn is_tc7_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC7_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_1
+    }
+    #[doc = "Checks if the value of the field is `ADC0_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc0_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC0_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc0_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_SEQ
+    }
+    #[doc = "Checks if the value of the field is `ADC1_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc1_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC1_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc1_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_SEQ
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_0`"]
+    #[inline(always)]
+    pub fn is_dac_empty_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_1`"]
+    #[inline(always)]
+    pub fn is_dac_empty_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_1
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_0`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_1`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_1
+    }
+    #[doc = "Checks if the value of the field is `PCC_RX`"]
+    #[inline(always)]
+    pub fn is_pcc_rx(&self) -> bool {
+        *self == TRIGSRC_A::PCC_RX
+    }
+    #[doc = "Checks if the value of the field is `AES_WR`"]
+    #[inline(always)]
+    pub fn is_aes_wr(&self) -> bool {
+        *self == TRIGSRC_A::AES_WR
+    }
+    #[doc = "Checks if the value of the field is `AES_RD`"]
+    #[inline(always)]
+    pub fn is_aes_rd(&self) -> bool {
+        *self == TRIGSRC_A::AES_RD
+    }
+    #[doc = "Checks if the value of the field is `QSPI_RX`"]
+    #[inline(always)]
+    pub fn is_qspi_rx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_RX
+    }
+    #[doc = "Checks if the value of the field is `QSPI_TX`"]
+    #[inline(always)]
+    pub fn is_qspi_tx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_TX
     }
 }
 #[doc = "Write proxy for field `TRIGSRC`"]
@@ -127,6 +799,426 @@ impl<'a> TRIGSRC_W<'a> {
     #[inline(always)]
     pub fn disable(self) -> &'a mut W {
         self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = "DMA RTC timestamp trigger"]
+    #[inline(always)]
+    pub fn rtc_timestamp(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::RTC_TIMESTAMP)
+    }
+    #[doc = "DMAC ID for DCC0 register"]
+    #[inline(always)]
+    pub fn dsu_dcc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC0)
+    }
+    #[doc = "DMAC ID for DCC1 register"]
+    #[inline(always)]
+    pub fn dsu_dcc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC1)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom0_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom0_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom1_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom1_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom2_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom2_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom3_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom3_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom4_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom4_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom5_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom5_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom6_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom6_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom7_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom7_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_TX)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can0_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN0_DEBUG)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can1_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN1_DEBUG)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_3)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_4(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_4)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_5(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_5)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_3)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_2)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_1)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc5_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc6_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc7_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_1)
+    }
+    #[doc = "index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc0_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc0_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_SEQ)
+    }
+    #[doc = "Index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc1_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc1_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_SEQ)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_0)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_1)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_0)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_1)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_0)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_1)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_0)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_1)
+    }
+    #[doc = "Indexes of PCC RX trigger"]
+    #[inline(always)]
+    pub fn pcc_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::PCC_RX)
+    }
+    #[doc = "DMA DATA Write trigger"]
+    #[inline(always)]
+    pub fn aes_wr(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_WR)
+    }
+    #[doc = "DMA DATA Read trigger"]
+    #[inline(always)]
+    pub fn aes_rd(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_RD)
+    }
+    #[doc = "Indexes of QSPI RX trigger"]
+    #[inline(always)]
+    pub fn qspi_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_RX)
+    }
+    #[doc = "Indexes of QSPI TX trigger"]
+    #[inline(always)]
+    pub fn qspi_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_TX)
     }
     #[doc = r"Writes raw bits to the field"]
     #[inline(always)]

--- a/pac/atsame54p/src/dmac/channel/chctrla.rs
+++ b/pac/atsame54p/src/dmac/channel/chctrla.rs
@@ -88,6 +88,174 @@ impl<'a> RUNSTDBY_W<'a> {
 pub enum TRIGSRC_A {
     #[doc = "0: Only software/event triggers"]
     DISABLE = 0,
+    #[doc = "1: DMA RTC timestamp trigger"]
+    RTC_TIMESTAMP = 1,
+    #[doc = "2: DMAC ID for DCC0 register"]
+    DSU_DCC0 = 2,
+    #[doc = "3: DMAC ID for DCC1 register"]
+    DSU_DCC1 = 3,
+    #[doc = "4: Index of DMA RX trigger"]
+    SERCOM0_RX = 4,
+    #[doc = "5: Index of DMA TX trigger"]
+    SERCOM0_TX = 5,
+    #[doc = "6: Index of DMA RX trigger"]
+    SERCOM1_RX = 6,
+    #[doc = "7: Index of DMA TX trigger"]
+    SERCOM1_TX = 7,
+    #[doc = "8: Index of DMA RX trigger"]
+    SERCOM2_RX = 8,
+    #[doc = "9: Index of DMA TX trigger"]
+    SERCOM2_TX = 9,
+    #[doc = "10: Index of DMA RX trigger"]
+    SERCOM3_RX = 10,
+    #[doc = "11: Index of DMA TX trigger"]
+    SERCOM3_TX = 11,
+    #[doc = "12: Index of DMA RX trigger"]
+    SERCOM4_RX = 12,
+    #[doc = "13: Index of DMA TX trigger"]
+    SERCOM4_TX = 13,
+    #[doc = "14: Index of DMA RX trigger"]
+    SERCOM5_RX = 14,
+    #[doc = "15: Index of DMA TX trigger"]
+    SERCOM5_TX = 15,
+    #[doc = "16: Index of DMA RX trigger"]
+    SERCOM6_RX = 16,
+    #[doc = "17: Index of DMA TX trigger"]
+    SERCOM6_TX = 17,
+    #[doc = "18: Index of DMA RX trigger"]
+    SERCOM7_RX = 18,
+    #[doc = "19: Index of DMA TX trigger"]
+    SERCOM7_TX = 19,
+    #[doc = "20: DMA CAN Debug Req"]
+    CAN0_DEBUG = 20,
+    #[doc = "21: DMA CAN Debug Req"]
+    CAN1_DEBUG = 21,
+    #[doc = "22: DMA overflow/underflow/retrigger trigger"]
+    TCC0_OVF = 22,
+    #[doc = "23: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_0 = 23,
+    #[doc = "24: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_1 = 24,
+    #[doc = "25: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_2 = 25,
+    #[doc = "26: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_3 = 26,
+    #[doc = "27: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_4 = 27,
+    #[doc = "28: Indexes of DMA Match/Compare triggers"]
+    TCC0_MC_5 = 28,
+    #[doc = "29: DMA overflow/underflow/retrigger trigger"]
+    TCC1_OVF = 29,
+    #[doc = "30: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_0 = 30,
+    #[doc = "31: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_1 = 31,
+    #[doc = "32: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_2 = 32,
+    #[doc = "33: Indexes of DMA Match/Compare triggers"]
+    TCC1_MC_3 = 33,
+    #[doc = "34: DMA overflow/underflow/retrigger trigger"]
+    TCC2_OVF = 34,
+    #[doc = "35: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_0 = 35,
+    #[doc = "36: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_1 = 36,
+    #[doc = "37: Indexes of DMA Match/Compare triggers"]
+    TCC2_MC_2 = 37,
+    #[doc = "38: DMA overflow/underflow/retrigger trigger"]
+    TCC3_OVF = 38,
+    #[doc = "39: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_0 = 39,
+    #[doc = "40: Indexes of DMA Match/Compare triggers"]
+    TCC3_MC_1 = 40,
+    #[doc = "41: DMA overflow/underflow/retrigger trigger"]
+    TCC4_OVF = 41,
+    #[doc = "42: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_0 = 42,
+    #[doc = "43: Indexes of DMA Match/Compare triggers"]
+    TCC4_MC_1 = 43,
+    #[doc = "44: Indexes of DMA Overflow trigger"]
+    TC0_OVF = 44,
+    #[doc = "45: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_0 = 45,
+    #[doc = "46: Indexes of DMA Match/Compare triggers"]
+    TC0_MC_1 = 46,
+    #[doc = "47: Indexes of DMA Overflow trigger"]
+    TC1_OVF = 47,
+    #[doc = "48: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_0 = 48,
+    #[doc = "49: Indexes of DMA Match/Compare triggers"]
+    TC1_MC_1 = 49,
+    #[doc = "50: Indexes of DMA Overflow trigger"]
+    TC2_OVF = 50,
+    #[doc = "51: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_0 = 51,
+    #[doc = "52: Indexes of DMA Match/Compare triggers"]
+    TC2_MC_1 = 52,
+    #[doc = "53: Indexes of DMA Overflow trigger"]
+    TC3_OVF = 53,
+    #[doc = "54: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_0 = 54,
+    #[doc = "55: Indexes of DMA Match/Compare triggers"]
+    TC3_MC_1 = 55,
+    #[doc = "56: Indexes of DMA Overflow trigger"]
+    TC4_OVF = 56,
+    #[doc = "57: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_0 = 57,
+    #[doc = "58: Indexes of DMA Match/Compare triggers"]
+    TC4_MC_1 = 58,
+    #[doc = "59: Indexes of DMA Overflow trigger"]
+    TC5_OVF = 59,
+    #[doc = "60: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_0 = 60,
+    #[doc = "61: Indexes of DMA Match/Compare triggers"]
+    TC5_MC_1 = 61,
+    #[doc = "62: Indexes of DMA Overflow trigger"]
+    TC6_OVF = 62,
+    #[doc = "63: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_0 = 63,
+    #[doc = "64: Indexes of DMA Match/Compare triggers"]
+    TC6_MC_1 = 64,
+    #[doc = "65: Indexes of DMA Overflow trigger"]
+    TC7_OVF = 65,
+    #[doc = "66: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_0 = 66,
+    #[doc = "67: Indexes of DMA Match/Compare triggers"]
+    TC7_MC_1 = 67,
+    #[doc = "68: index of DMA RESRDY trigger"]
+    ADC0_RESRDY = 68,
+    #[doc = "69: Index of DMA SEQ trigger"]
+    ADC0_SEQ = 69,
+    #[doc = "70: Index of DMA RESRDY trigger"]
+    ADC1_RESRDY = 70,
+    #[doc = "71: Index of DMA SEQ trigger"]
+    ADC1_SEQ = 71,
+    #[doc = "72: DMA DAC Empty Req"]
+    DAC_EMPTY_0 = 72,
+    #[doc = "73: DMA DAC Empty Req"]
+    DAC_EMPTY_1 = 73,
+    #[doc = "74: DMA DAC Result Ready Req"]
+    DAC_RESRDY_0 = 74,
+    #[doc = "75: DMA DAC Result Ready Req"]
+    DAC_RESRDY_1 = 75,
+    #[doc = "76: Indexes of DMA RX triggers"]
+    I2S_RX_0 = 76,
+    #[doc = "77: Indexes of DMA RX triggers"]
+    I2S_RX_1 = 77,
+    #[doc = "78: Indexes of DMA TX triggers"]
+    I2S_TX_0 = 78,
+    #[doc = "79: Indexes of DMA TX triggers"]
+    I2S_TX_1 = 79,
+    #[doc = "80: Indexes of PCC RX trigger"]
+    PCC_RX = 80,
+    #[doc = "81: DMA DATA Write trigger"]
+    AES_WR = 81,
+    #[doc = "82: DMA DATA Read trigger"]
+    AES_RD = 82,
+    #[doc = "83: Indexes of QSPI RX trigger"]
+    QSPI_RX = 83,
+    #[doc = "84: Indexes of QSPI TX trigger"]
+    QSPI_TX = 84,
 }
 impl From<TRIGSRC_A> for u8 {
     #[inline(always)]
@@ -104,6 +272,90 @@ impl TRIGSRC_R {
         use crate::Variant::*;
         match self.bits {
             0 => Val(TRIGSRC_A::DISABLE),
+            1 => Val(TRIGSRC_A::RTC_TIMESTAMP),
+            2 => Val(TRIGSRC_A::DSU_DCC0),
+            3 => Val(TRIGSRC_A::DSU_DCC1),
+            4 => Val(TRIGSRC_A::SERCOM0_RX),
+            5 => Val(TRIGSRC_A::SERCOM0_TX),
+            6 => Val(TRIGSRC_A::SERCOM1_RX),
+            7 => Val(TRIGSRC_A::SERCOM1_TX),
+            8 => Val(TRIGSRC_A::SERCOM2_RX),
+            9 => Val(TRIGSRC_A::SERCOM2_TX),
+            10 => Val(TRIGSRC_A::SERCOM3_RX),
+            11 => Val(TRIGSRC_A::SERCOM3_TX),
+            12 => Val(TRIGSRC_A::SERCOM4_RX),
+            13 => Val(TRIGSRC_A::SERCOM4_TX),
+            14 => Val(TRIGSRC_A::SERCOM5_RX),
+            15 => Val(TRIGSRC_A::SERCOM5_TX),
+            16 => Val(TRIGSRC_A::SERCOM6_RX),
+            17 => Val(TRIGSRC_A::SERCOM6_TX),
+            18 => Val(TRIGSRC_A::SERCOM7_RX),
+            19 => Val(TRIGSRC_A::SERCOM7_TX),
+            20 => Val(TRIGSRC_A::CAN0_DEBUG),
+            21 => Val(TRIGSRC_A::CAN1_DEBUG),
+            22 => Val(TRIGSRC_A::TCC0_OVF),
+            23 => Val(TRIGSRC_A::TCC0_MC_0),
+            24 => Val(TRIGSRC_A::TCC0_MC_1),
+            25 => Val(TRIGSRC_A::TCC0_MC_2),
+            26 => Val(TRIGSRC_A::TCC0_MC_3),
+            27 => Val(TRIGSRC_A::TCC0_MC_4),
+            28 => Val(TRIGSRC_A::TCC0_MC_5),
+            29 => Val(TRIGSRC_A::TCC1_OVF),
+            30 => Val(TRIGSRC_A::TCC1_MC_0),
+            31 => Val(TRIGSRC_A::TCC1_MC_1),
+            32 => Val(TRIGSRC_A::TCC1_MC_2),
+            33 => Val(TRIGSRC_A::TCC1_MC_3),
+            34 => Val(TRIGSRC_A::TCC2_OVF),
+            35 => Val(TRIGSRC_A::TCC2_MC_0),
+            36 => Val(TRIGSRC_A::TCC2_MC_1),
+            37 => Val(TRIGSRC_A::TCC2_MC_2),
+            38 => Val(TRIGSRC_A::TCC3_OVF),
+            39 => Val(TRIGSRC_A::TCC3_MC_0),
+            40 => Val(TRIGSRC_A::TCC3_MC_1),
+            41 => Val(TRIGSRC_A::TCC4_OVF),
+            42 => Val(TRIGSRC_A::TCC4_MC_0),
+            43 => Val(TRIGSRC_A::TCC4_MC_1),
+            44 => Val(TRIGSRC_A::TC0_OVF),
+            45 => Val(TRIGSRC_A::TC0_MC_0),
+            46 => Val(TRIGSRC_A::TC0_MC_1),
+            47 => Val(TRIGSRC_A::TC1_OVF),
+            48 => Val(TRIGSRC_A::TC1_MC_0),
+            49 => Val(TRIGSRC_A::TC1_MC_1),
+            50 => Val(TRIGSRC_A::TC2_OVF),
+            51 => Val(TRIGSRC_A::TC2_MC_0),
+            52 => Val(TRIGSRC_A::TC2_MC_1),
+            53 => Val(TRIGSRC_A::TC3_OVF),
+            54 => Val(TRIGSRC_A::TC3_MC_0),
+            55 => Val(TRIGSRC_A::TC3_MC_1),
+            56 => Val(TRIGSRC_A::TC4_OVF),
+            57 => Val(TRIGSRC_A::TC4_MC_0),
+            58 => Val(TRIGSRC_A::TC4_MC_1),
+            59 => Val(TRIGSRC_A::TC5_OVF),
+            60 => Val(TRIGSRC_A::TC5_MC_0),
+            61 => Val(TRIGSRC_A::TC5_MC_1),
+            62 => Val(TRIGSRC_A::TC6_OVF),
+            63 => Val(TRIGSRC_A::TC6_MC_0),
+            64 => Val(TRIGSRC_A::TC6_MC_1),
+            65 => Val(TRIGSRC_A::TC7_OVF),
+            66 => Val(TRIGSRC_A::TC7_MC_0),
+            67 => Val(TRIGSRC_A::TC7_MC_1),
+            68 => Val(TRIGSRC_A::ADC0_RESRDY),
+            69 => Val(TRIGSRC_A::ADC0_SEQ),
+            70 => Val(TRIGSRC_A::ADC1_RESRDY),
+            71 => Val(TRIGSRC_A::ADC1_SEQ),
+            72 => Val(TRIGSRC_A::DAC_EMPTY_0),
+            73 => Val(TRIGSRC_A::DAC_EMPTY_1),
+            74 => Val(TRIGSRC_A::DAC_RESRDY_0),
+            75 => Val(TRIGSRC_A::DAC_RESRDY_1),
+            76 => Val(TRIGSRC_A::I2S_RX_0),
+            77 => Val(TRIGSRC_A::I2S_RX_1),
+            78 => Val(TRIGSRC_A::I2S_TX_0),
+            79 => Val(TRIGSRC_A::I2S_TX_1),
+            80 => Val(TRIGSRC_A::PCC_RX),
+            81 => Val(TRIGSRC_A::AES_WR),
+            82 => Val(TRIGSRC_A::AES_RD),
+            83 => Val(TRIGSRC_A::QSPI_RX),
+            84 => Val(TRIGSRC_A::QSPI_TX),
             i => Res(i),
         }
     }
@@ -111,6 +363,426 @@ impl TRIGSRC_R {
     #[inline(always)]
     pub fn is_disable(&self) -> bool {
         *self == TRIGSRC_A::DISABLE
+    }
+    #[doc = "Checks if the value of the field is `RTC_TIMESTAMP`"]
+    #[inline(always)]
+    pub fn is_rtc_timestamp(&self) -> bool {
+        *self == TRIGSRC_A::RTC_TIMESTAMP
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC0`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc0(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC0
+    }
+    #[doc = "Checks if the value of the field is `DSU_DCC1`"]
+    #[inline(always)]
+    pub fn is_dsu_dcc1(&self) -> bool {
+        *self == TRIGSRC_A::DSU_DCC1
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_RX`"]
+    #[inline(always)]
+    pub fn is_sercom0_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM0_TX`"]
+    #[inline(always)]
+    pub fn is_sercom0_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM0_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_RX`"]
+    #[inline(always)]
+    pub fn is_sercom1_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM1_TX`"]
+    #[inline(always)]
+    pub fn is_sercom1_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM1_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_RX`"]
+    #[inline(always)]
+    pub fn is_sercom2_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM2_TX`"]
+    #[inline(always)]
+    pub fn is_sercom2_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM2_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_RX`"]
+    #[inline(always)]
+    pub fn is_sercom3_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM3_TX`"]
+    #[inline(always)]
+    pub fn is_sercom3_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM3_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_RX`"]
+    #[inline(always)]
+    pub fn is_sercom4_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM4_TX`"]
+    #[inline(always)]
+    pub fn is_sercom4_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM4_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_RX`"]
+    #[inline(always)]
+    pub fn is_sercom5_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM5_TX`"]
+    #[inline(always)]
+    pub fn is_sercom5_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM5_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_RX`"]
+    #[inline(always)]
+    pub fn is_sercom6_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM6_TX`"]
+    #[inline(always)]
+    pub fn is_sercom6_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM6_TX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_RX`"]
+    #[inline(always)]
+    pub fn is_sercom7_rx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_RX
+    }
+    #[doc = "Checks if the value of the field is `SERCOM7_TX`"]
+    #[inline(always)]
+    pub fn is_sercom7_tx(&self) -> bool {
+        *self == TRIGSRC_A::SERCOM7_TX
+    }
+    #[doc = "Checks if the value of the field is `CAN0_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can0_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN0_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `CAN1_DEBUG`"]
+    #[inline(always)]
+    pub fn is_can1_debug(&self) -> bool {
+        *self == TRIGSRC_A::CAN1_DEBUG
+    }
+    #[doc = "Checks if the value of the field is `TCC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_4`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_4(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_4
+    }
+    #[doc = "Checks if the value of the field is `TCC0_MC_5`"]
+    #[inline(always)]
+    pub fn is_tcc0_mc_5(&self) -> bool {
+        *self == TRIGSRC_A::TCC0_MC_5
+    }
+    #[doc = "Checks if the value of the field is `TCC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC1_MC_3`"]
+    #[inline(always)]
+    pub fn is_tcc1_mc_3(&self) -> bool {
+        *self == TRIGSRC_A::TCC1_MC_3
+    }
+    #[doc = "Checks if the value of the field is `TCC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC2_MC_2`"]
+    #[inline(always)]
+    pub fn is_tcc2_mc_2(&self) -> bool {
+        *self == TRIGSRC_A::TCC2_MC_2
+    }
+    #[doc = "Checks if the value of the field is `TCC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TCC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tcc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TCC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tcc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TCC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC0_OVF`"]
+    #[inline(always)]
+    pub fn is_tc0_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC0_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC0_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc0_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC0_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC1_OVF`"]
+    #[inline(always)]
+    pub fn is_tc1_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC1_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC1_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc1_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC1_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC2_OVF`"]
+    #[inline(always)]
+    pub fn is_tc2_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC2_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC2_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc2_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC2_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC3_OVF`"]
+    #[inline(always)]
+    pub fn is_tc3_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC3_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC3_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc3_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC3_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC4_OVF`"]
+    #[inline(always)]
+    pub fn is_tc4_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC4_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC4_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc4_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC4_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC5_OVF`"]
+    #[inline(always)]
+    pub fn is_tc5_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC5_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC5_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc5_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC5_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC6_OVF`"]
+    #[inline(always)]
+    pub fn is_tc6_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC6_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC6_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc6_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC6_MC_1
+    }
+    #[doc = "Checks if the value of the field is `TC7_OVF`"]
+    #[inline(always)]
+    pub fn is_tc7_ovf(&self) -> bool {
+        *self == TRIGSRC_A::TC7_OVF
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_0`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_0(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_0
+    }
+    #[doc = "Checks if the value of the field is `TC7_MC_1`"]
+    #[inline(always)]
+    pub fn is_tc7_mc_1(&self) -> bool {
+        *self == TRIGSRC_A::TC7_MC_1
+    }
+    #[doc = "Checks if the value of the field is `ADC0_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc0_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC0_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc0_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC0_SEQ
+    }
+    #[doc = "Checks if the value of the field is `ADC1_RESRDY`"]
+    #[inline(always)]
+    pub fn is_adc1_resrdy(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_RESRDY
+    }
+    #[doc = "Checks if the value of the field is `ADC1_SEQ`"]
+    #[inline(always)]
+    pub fn is_adc1_seq(&self) -> bool {
+        *self == TRIGSRC_A::ADC1_SEQ
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_0`"]
+    #[inline(always)]
+    pub fn is_dac_empty_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_EMPTY_1`"]
+    #[inline(always)]
+    pub fn is_dac_empty_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_EMPTY_1
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_0`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_0(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_0
+    }
+    #[doc = "Checks if the value of the field is `DAC_RESRDY_1`"]
+    #[inline(always)]
+    pub fn is_dac_resrdy_1(&self) -> bool {
+        *self == TRIGSRC_A::DAC_RESRDY_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_RX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_rx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_RX_1
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_0`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_0(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_0
+    }
+    #[doc = "Checks if the value of the field is `I2S_TX_1`"]
+    #[inline(always)]
+    pub fn is_i2s_tx_1(&self) -> bool {
+        *self == TRIGSRC_A::I2S_TX_1
+    }
+    #[doc = "Checks if the value of the field is `PCC_RX`"]
+    #[inline(always)]
+    pub fn is_pcc_rx(&self) -> bool {
+        *self == TRIGSRC_A::PCC_RX
+    }
+    #[doc = "Checks if the value of the field is `AES_WR`"]
+    #[inline(always)]
+    pub fn is_aes_wr(&self) -> bool {
+        *self == TRIGSRC_A::AES_WR
+    }
+    #[doc = "Checks if the value of the field is `AES_RD`"]
+    #[inline(always)]
+    pub fn is_aes_rd(&self) -> bool {
+        *self == TRIGSRC_A::AES_RD
+    }
+    #[doc = "Checks if the value of the field is `QSPI_RX`"]
+    #[inline(always)]
+    pub fn is_qspi_rx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_RX
+    }
+    #[doc = "Checks if the value of the field is `QSPI_TX`"]
+    #[inline(always)]
+    pub fn is_qspi_tx(&self) -> bool {
+        *self == TRIGSRC_A::QSPI_TX
     }
 }
 #[doc = "Write proxy for field `TRIGSRC`"]
@@ -127,6 +799,426 @@ impl<'a> TRIGSRC_W<'a> {
     #[inline(always)]
     pub fn disable(self) -> &'a mut W {
         self.variant(TRIGSRC_A::DISABLE)
+    }
+    #[doc = "DMA RTC timestamp trigger"]
+    #[inline(always)]
+    pub fn rtc_timestamp(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::RTC_TIMESTAMP)
+    }
+    #[doc = "DMAC ID for DCC0 register"]
+    #[inline(always)]
+    pub fn dsu_dcc0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC0)
+    }
+    #[doc = "DMAC ID for DCC1 register"]
+    #[inline(always)]
+    pub fn dsu_dcc1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DSU_DCC1)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom0_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom0_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM0_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom1_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom1_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM1_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom2_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom2_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM2_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom3_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom3_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM3_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom4_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom4_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM4_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom5_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom5_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM5_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom6_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom6_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM6_TX)
+    }
+    #[doc = "Index of DMA RX trigger"]
+    #[inline(always)]
+    pub fn sercom7_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_RX)
+    }
+    #[doc = "Index of DMA TX trigger"]
+    #[inline(always)]
+    pub fn sercom7_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::SERCOM7_TX)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can0_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN0_DEBUG)
+    }
+    #[doc = "DMA CAN Debug Req"]
+    #[inline(always)]
+    pub fn can1_debug(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::CAN1_DEBUG)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_3)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_4(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_4)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc0_mc_5(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC0_MC_5)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_2)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc1_mc_3(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC1_MC_3)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc2_mc_2(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC2_MC_2)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC3_MC_1)
+    }
+    #[doc = "DMA overflow/underflow/retrigger trigger"]
+    #[inline(always)]
+    pub fn tcc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tcc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TCC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc0_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc0_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC0_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc1_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc1_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC1_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc2_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc2_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC2_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc3_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc3_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC3_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc4_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc4_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC4_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc5_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc5_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC5_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc6_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc6_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC6_MC_1)
+    }
+    #[doc = "Indexes of DMA Overflow trigger"]
+    #[inline(always)]
+    pub fn tc7_ovf(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_OVF)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_0)
+    }
+    #[doc = "Indexes of DMA Match/Compare triggers"]
+    #[inline(always)]
+    pub fn tc7_mc_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::TC7_MC_1)
+    }
+    #[doc = "index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc0_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc0_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC0_SEQ)
+    }
+    #[doc = "Index of DMA RESRDY trigger"]
+    #[inline(always)]
+    pub fn adc1_resrdy(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_RESRDY)
+    }
+    #[doc = "Index of DMA SEQ trigger"]
+    #[inline(always)]
+    pub fn adc1_seq(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::ADC1_SEQ)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_0)
+    }
+    #[doc = "DMA DAC Empty Req"]
+    #[inline(always)]
+    pub fn dac_empty_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_EMPTY_1)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_0)
+    }
+    #[doc = "DMA DAC Result Ready Req"]
+    #[inline(always)]
+    pub fn dac_resrdy_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::DAC_RESRDY_1)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_0)
+    }
+    #[doc = "Indexes of DMA RX triggers"]
+    #[inline(always)]
+    pub fn i2s_rx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_RX_1)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_0(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_0)
+    }
+    #[doc = "Indexes of DMA TX triggers"]
+    #[inline(always)]
+    pub fn i2s_tx_1(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::I2S_TX_1)
+    }
+    #[doc = "Indexes of PCC RX trigger"]
+    #[inline(always)]
+    pub fn pcc_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::PCC_RX)
+    }
+    #[doc = "DMA DATA Write trigger"]
+    #[inline(always)]
+    pub fn aes_wr(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_WR)
+    }
+    #[doc = "DMA DATA Read trigger"]
+    #[inline(always)]
+    pub fn aes_rd(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::AES_RD)
+    }
+    #[doc = "Indexes of QSPI RX trigger"]
+    #[inline(always)]
+    pub fn qspi_rx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_RX)
+    }
+    #[doc = "Indexes of QSPI TX trigger"]
+    #[inline(always)]
+    pub fn qspi_tx(self) -> &'a mut W {
+        self.variant(TRIGSRC_A::QSPI_TX)
     }
     #[doc = r"Writes raw bits to the field"]
     #[inline(always)]

--- a/svd/devices/atsamd11c14a.xsl
+++ b/svd/devices/atsamd11c14a.xsl
@@ -5,4 +5,108 @@
   <xsl:template match="/device/peripherals/peripheral[name='USB']/registers/cluster[name='DEVICE']/register[name='FSMSTATUS']/fields/field[name='FSMSTATE']/bitWidth">
     <bitWidth>7</bitWidth>
   </xsl:template>
+
+  <!-- The DMAC trigger sources in the original SVD only have the 0=disabled
+  enumeration value -->
+  <xsl:template match="/device/peripherals/peripheral[name='DMAC']/registers/register[name='CHCTRLB']/fields/field[name='TRIGSRC']/enumeratedValues">
+    <enumeratedValues>
+      <xsl:copy-of select="./name"/>
+      <xsl:copy-of select="./enumeratedValue"/>
+      <enumeratedValue>
+        <name>SERCOM0_RX</name>
+        <description>SERCOM0 RX Trigger</description>
+        <value>0x01</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM0_TX</name>
+        <description>SERCOM0 TX Trigger</description>
+        <value>0x02</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM1_RX</name>
+        <description>SERCOM1 RX Trigger</description>
+        <value>0x03</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM1_TX</name>
+        <description>SERCOM1 TX Trigger</description>
+        <value>0x04</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM2_RX</name>
+        <description>SERCOM2 RX Trigger</description>
+        <value>0x05</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM2_TX</name>
+        <description>SERCOM2 TX Trigger</description>
+        <value>0x06</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_OVF</name>
+        <description>TCC0 Overflow Trigger</description>
+        <value>0x07</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_MC0</name>
+        <description>TCC0 Match/Compare 0 Trigger</description>
+        <value>0x08</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_MC1</name>
+        <description>TCC0 Match/Compare 1 Trigger</description>
+        <value>0x09</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_MC2</name>
+        <description>TCC0 Match/Compare 2 Trigger</description>
+        <value>0x0A</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_MC3</name>
+        <description>TCC0 Match/Compare 3 Trigger</description>
+        <value>0x0B</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC1_OVF</name>
+        <description>TC1 Overflow Trigger</description>
+        <value>0x0C</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC1_MC0</name>
+        <description>TC1 Match/Compare 0 Trigger</description>
+        <value>0x0D</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC1_MC1</name>
+        <description>TC1 Match/Compare 1 Trigger</description>
+        <value>0x0E</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC2_OVF</name>
+        <description>TC2 Overflow Trigger</description>
+        <value>0x0F</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC2_MC0</name>
+        <description>TC2 Match/Compare 0 Trigger</description>
+        <value>0x10</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC2_MC1</name>
+        <description>TC2 Match/Compare 1 Trigger</description>
+        <value>0x11</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>ADC_RESRDY</name>
+        <description>ADC Result Ready Trigger</description>
+        <value>0x12</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>DAC_EMPTY</name>
+        <description>DAC Empty Trigger</description>
+        <value>0x13</value>
+      </enumeratedValue>
+    </enumeratedValues>
+  </xsl:template>
 </xsl:stylesheet>

--- a/svd/devices/atsamd21e18a.xsl
+++ b/svd/devices/atsamd21e18a.xsl
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:include href="include/common.xsl"/>
+  <xsl:include href="include/atsamd21.xsl"/>
 </xsl:stylesheet>

--- a/svd/devices/atsamd21g18a.xsl
+++ b/svd/devices/atsamd21g18a.xsl
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:include href="include/common.xsl"/>
+  <xsl:include href="include/atsamd21.xsl"/>
 </xsl:stylesheet>

--- a/svd/devices/atsamd21j18a.xsl
+++ b/svd/devices/atsamd21j18a.xsl
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:include href="include/common.xsl"/>
+  <xsl:include href="include/atsamd21.xsl"/>
 </xsl:stylesheet>

--- a/svd/devices/include/atsamd21.xsl
+++ b/svd/devices/include/atsamd21.xsl
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <!-- The DMAC trigger sources in the original SVD only have the 0=disabled
+  enumeration value -->
+  <xsl:template match="/device/peripherals/peripheral[name='DMAC']/registers/register[name='CHCTRLB']/fields/field[name='TRIGSRC']/enumeratedValues">
+    <enumeratedValues>
+      <xsl:copy-of select="./name"/>
+      <xsl:copy-of select="./enumeratedValue"/>
+      <enumeratedValue>
+        <name>SERCOM0_RX</name>
+        <description>SERCOM0 RX Trigger</description>
+        <value>0x01</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM0_TX</name>
+        <description>SERCOM0 TX Trigger</description>
+        <value>0x02</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM1_RX</name>
+        <description>SERCOM1 RX Trigger</description>
+        <value>0x03</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM1_TX</name>
+        <description>SERCOM1 TX Trigger</description>
+        <value>0x04</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM2_RX</name>
+        <description>SERCOM2 RX Trigger</description>
+        <value>0x05</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM2_TX</name>
+        <description>SERCOM2 TX Trigger</description>
+        <value>0x06</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM3_RX</name>
+        <description>SERCOM3 RX Trigger</description>
+        <value>0x07</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM3_TX</name>
+        <description>SERCOM3 TX Trigger</description>
+        <value>0x08</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM4_RX</name>
+        <description>SERCOM4 RX Trigger</description>
+        <value>0x09</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM4_TX</name>
+        <description>SERCOM4 TX Trigger</description>
+        <value>0x0A</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM5_RX</name>
+        <description>SERCOM5 RX Trigger</description>
+        <value>0x0B</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM5_TX</name>
+        <description>SERCOM5 TX Trigger</description>
+        <value>0x0C</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_OVF</name>
+        <description>TCC0 Overflow Trigger</description>
+        <value>0x0D</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_MC0</name>
+        <description>TCC0 Match/Compare 0 Trigger</description>
+        <value>0x0E</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_MC1</name>
+        <description>TCC0 Match/Compare 1 Trigger</description>
+        <value>0x0F</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_MC2</name>
+        <description>TCC0 Match/Compare 2 Trigger</description>
+        <value>0x10</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_MC3</name>
+        <description>TCC0 Match/Compare 3 Trigger</description>
+        <value>0x11</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC1_OVF</name>
+        <description>TCC1 Overflow Trigger</description>
+        <value>0x12</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC1_MC0</name>
+        <description>TCC1 Match/Compare 0 Trigger</description>
+        <value>0x13</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC1_MC1</name>
+        <description>TCC1 Match/Compare 1 Trigger</description>
+        <value>0x14</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC2_OVF</name>
+        <description>TCC2 Overflow Trigger</description>
+        <value>0x15</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC2_MC0</name>
+        <description>TCC2 Match/Compare 0 Trigger</description>
+        <value>0x16</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC2_MC1</name>
+        <description>TCC2 Match/Compare 1 Trigger</description>
+        <value>0x17</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC3_OVF</name>
+        <description>TC3 Overflow Trigger</description>
+        <value>0x18</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC3_MC0</name>
+        <description>TC3 Match/Compare 0 Trigger</description>
+        <value>0x19</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC3_MC1</name>
+        <description>TC3 Match/Compare 1 Trigger</description>
+        <value>0x1A</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC4_OVF</name>
+        <description>TC4 Overflow Trigger</description>
+        <value>0x1B</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC4_MC0</name>
+        <description>TC4 Match/Compare 0 Trigger</description>
+        <value>0x1C</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC4_MC1</name>
+        <description>TC4 Match/Compare 1 Trigger</description>
+        <value>0x1D</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC5_OVF</name>
+        <description>TC5 Overflow Trigger</description>
+        <value>0x1E</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC5_MC0</name>
+        <description>TC5 Match/Compare 0 Trigger</description>
+        <value>0x1F</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC5_MC1</name>
+        <description>TC5 Match/Compare 1 Trigger</description>
+        <value>0x20</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC6_OVF</name>
+        <description>TC6 Overflow Trigger</description>
+        <value>0x21</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC6_MC0</name>
+        <description>TC6 Match/Compare 0 Trigger</description>
+        <value>0x22</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC6_MC1</name>
+        <description>TC6 Match/Compare 1 Trigger</description>
+        <value>0x23</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC7_OVF</name>
+        <description>TC7 Overflow Trigger</description>
+        <value>0x24</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC7_MC0</name>
+        <description>TC7 Match/Compare 0 Trigger</description>
+        <value>0x25</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC7_MC1</name>
+        <description>TC7 Match/Compare 1 Trigger</description>
+        <value>0x26</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>ADC_RESRDY</name>
+        <description>ADC Result Ready Trigger</description>
+        <value>0x27</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>DAC_EMPTY</name>
+        <description>DAC Empty Trigger</description>
+        <value>0x28</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>I2S_RX_0</name>
+        <description>I2S RX 0 Trigger</description>
+        <value>0x29</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>I2S_RX_1</name>
+        <description>I2S RX 1 Trigger</description>
+        <value>0x2A</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>I2S_TX_0</name>
+        <description>I2S TX 0 Trigger</description>
+        <value>0x2B</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>I2S_TX_1</name>
+        <description>I2S TX 1 Trigger</description>
+        <value>0x2C</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC3_OVF</name>
+        <description>TCC3 Overflow Trigger</description>
+        <value>0x2D</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC3_MC0</name>
+        <description>TCC3 Match/Compare 0 Trigger</description>
+        <value>0x2E</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC3_MC1</name>
+        <description>TCC3 Match/Compare 1 Trigger</description>
+        <value>0x2F</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC3_MC2</name>
+        <description>Match/Compare 2 Trigger</description>
+        <value>0x30</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC3_MC3</name>
+        <description>Match/Compare 3 Trigger</description>
+        <value>0x31</value>
+      </enumeratedValue>
+    </enumeratedValues>
+  </xsl:template>
+</xsl:stylesheet>

--- a/svd/devices/include/atsamd5x.xsl
+++ b/svd/devices/include/atsamd5x.xsl
@@ -31,4 +31,433 @@
       </field>
     </fields>
   </xsl:template>
+
+  <!-- The DMAC trigger sources in the original SVD only have the 0=disabled
+  enumeration value -->
+  <xsl:template match="/device/peripherals/peripheral[name='DMAC']/registers/cluster/register[name='CHCTRLA']/fields/field[name='TRIGSRC']/enumeratedValues">
+    <enumeratedValues>
+      <xsl:copy-of select="./name"/>
+      <xsl:copy-of select="./enumeratedValue"/>
+      <enumeratedValue>
+        <name>RTC_TIMESTAMP</name>
+        <description>DMA RTC timestamp trigger</description>
+        <value>0x01</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>DSU_DCC0</name>
+        <description>DMAC ID for DCC0 register</description>
+        <value>0x02</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>DSU_DCC1</name>
+        <description>DMAC ID for DCC1 register</description>
+        <value>0x03</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM0_RX</name>
+        <description>Index of DMA RX trigger</description>
+        <value>0x04</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM0_TX</name>
+        <description>Index of DMA TX trigger</description>
+        <value>0x05</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM1_RX</name>
+        <description>Index of DMA RX trigger</description>
+        <value>0x06</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM1_TX</name>
+        <description>Index of DMA TX trigger</description>
+        <value>0x07</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM2_RX</name>
+        <description>Index of DMA RX trigger</description>
+        <value>0x08</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM2_TX</name>
+        <description>Index of DMA TX trigger</description>
+        <value>0x09</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM3_RX</name>
+        <description>Index of DMA RX trigger</description>
+        <value>0x0A</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM3_TX</name>
+        <description>Index of DMA TX trigger</description>
+        <value>0x0B</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM4_RX</name>
+        <description>Index of DMA RX trigger</description>
+        <value>0x0C</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM4_TX</name>
+        <description>Index of DMA TX trigger</description>
+        <value>0x0D</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM5_RX</name>
+        <description>Index of DMA RX trigger</description>
+        <value>0x0E</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM5_TX</name>
+        <description>Index of DMA TX trigger</description>
+        <value>0x0F</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM6_RX</name>
+        <description>Index of DMA RX trigger</description>
+        <value>0x10</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM6_TX</name>
+        <description>Index of DMA TX trigger</description>
+        <value>0x11</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM7_RX</name>
+        <description>Index of DMA RX trigger</description>
+        <value>0x12</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>SERCOM7_TX</name>
+        <description>Index of DMA TX trigger</description>
+        <value>0x13</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>CAN0_DEBUG</name>
+        <description>DMA CAN Debug Req</description>
+        <value>0x14</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>CAN1_DEBUG</name>
+        <description>DMA CAN Debug Req</description>
+        <value>0x15</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_OVF</name>
+        <description>DMA overflow/underflow/retrigger trigger</description>
+        <value>0x16</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_MC_0</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x17</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_MC_1</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x18</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_MC_2</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x19</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_MC_3</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x1A</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_MC_4</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x1B</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC0_MC_5</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x1C</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC1_OVF</name>
+        <description>DMA overflow/underflow/retrigger trigger</description>
+        <value>0x1D</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC1_MC_0</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x1E</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC1_MC_1</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x1F</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC1_MC_2</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x20</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC1_MC_3</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x21</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC2_OVF</name>
+        <description>DMA overflow/underflow/retrigger trigger</description>
+        <value>0x22</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC2_MC_0</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x23</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC2_MC_1</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x24</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC2_MC_2</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x25</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC3_OVF</name>
+        <description>DMA overflow/underflow/retrigger trigger</description>
+        <value>0x26</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC3_MC_0</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x27</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC3_MC_1</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x28</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC4_OVF</name>
+        <description>DMA overflow/underflow/retrigger trigger</description>
+        <value>0x29</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC4_MC_0</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x2A</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TCC4_MC_1</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x2B</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC0_OVF</name>
+        <description>Indexes of DMA Overflow trigger</description>
+        <value>0x2C</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC0_MC_0</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x2D</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC0_MC_1</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x2E</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC1_OVF</name>
+        <description>Indexes of DMA Overflow trigger</description>
+        <value>0x2F</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC1_MC_0</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x30</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC1_MC_1</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x31</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC2_OVF</name>
+        <description>Indexes of DMA Overflow trigger</description>
+        <value>0x32</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC2_MC_0</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x33</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC2_MC_1</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x34</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC3_OVF</name>
+        <description>Indexes of DMA Overflow trigger</description>
+        <value>0x35</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC3_MC_0</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x36</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC3_MC_1</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x37</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC4_OVF</name>
+        <description>Indexes of DMA Overflow trigger</description>
+        <value>0x38</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC4_MC_0</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x39</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC4_MC_1</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x3A</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC5_OVF</name>
+        <description>Indexes of DMA Overflow trigger</description>
+        <value>0x3B</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC5_MC_0</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x3C</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC5_MC_1</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x3D</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC6_OVF</name>
+        <description>Indexes of DMA Overflow trigger</description>
+        <value>0x3E</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC6_MC_0</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x3F</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC6_MC_1</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x40</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC7_OVF</name>
+        <description>Indexes of DMA Overflow trigger</description>
+        <value>0x41</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC7_MC_0</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x42</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>TC7_MC_1</name>
+        <description>Indexes of DMA Match/Compare triggers</description>
+        <value>0x43</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>ADC0_RESRDY</name>
+        <description>index of DMA RESRDY trigger</description>
+        <value>0x44</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>ADC0_SEQ</name>
+        <description>Index of DMA SEQ trigger</description>
+        <value>0x45</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>ADC1_RESRDY</name>
+        <description>Index of DMA RESRDY trigger</description>
+        <value>0x46</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>ADC1_SEQ</name>
+        <description>Index of DMA SEQ trigger</description>
+        <value>0x47</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>DAC_EMPTY_0</name>
+        <description>DMA DAC Empty Req</description>
+        <value>0x48</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>DAC_EMPTY_1</name>
+        <description>DMA DAC Empty Req</description>
+        <value>0x49</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>DAC_RESRDY_0</name>
+        <description>DMA DAC Result Ready Req</description>
+        <value>0x4A</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>DAC_RESRDY_1</name>
+        <description>DMA DAC Result Ready Req</description>
+        <value>0x4B</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>I2S_RX_0</name>
+        <description>Indexes of DMA RX triggers</description>
+        <value>0x4C</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>I2S_RX_1</name>
+        <description>Indexes of DMA RX triggers</description>
+        <value>0x4D</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>I2S_TX_0</name>
+        <description>Indexes of DMA TX triggers</description>
+        <value>0x4E</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>I2S_TX_1</name>
+        <description>Indexes of DMA TX triggers</description>
+        <value>0x4F</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>PCC_RX</name>
+        <description>Indexes of PCC RX trigger</description>
+        <value>0x50</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>AES_WR</name>
+        <description>DMA DATA Write trigger</description>
+        <value>0x51</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>AES_RD</name>
+        <description>DMA DATA Read trigger</description>
+        <value>0x52</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>QSPI_RX</name>
+        <description>Indexes of QSPI RX trigger</description>
+        <value>0x53</value>
+      </enumeratedValue>
+      <enumeratedValue>
+        <name>QSPI_TX</name>
+        <description>Indexes of QSPI TX trigger</description>
+        <value>0x54</value>
+      </enumeratedValue>
+    </enumeratedValues>
+  </xsl:template>
 </xsl:stylesheet>

--- a/update.sh
+++ b/update.sh
@@ -11,13 +11,15 @@ cargo install --force --version 0.7.0 form
 # PATCH SVD FILES AND GENERATE CRATES
 
 TOP="${PWD}"
-SED="${TOP}/sed"
+
+# Use sed from a supplied SED environment variable, or /bin/sed if unset
+SED=${SED:-/bin/sed}
 
 for xsl in svd/devices/*\.xsl; do
   chip=$(basename "${xsl}" .xsl)
   CHIP=$(echo "${chip}" | tr '[:lower:]' '[:upper:]')
   svd=svd/${CHIP:0:9}.svd
-  cp svd/${CHIP}.svd $svd
+  cp "svd/${CHIP}.svd" "$svd"
   
   # remove last characters, because they just represent the memory size
   pushd "${TOP}/pac/${chip:0:9}"
@@ -28,7 +30,7 @@ for xsl in svd/devices/*\.xsl; do
   rm -rf src/
   form -i lib.rs -o src
   rm lib.rs
-  SED -i "s/${CHIP}/${CHIP:0:9}/g" src/lib.rs
+  ${SED} -i "s/${CHIP}/${CHIP:0:9}/g" src/lib.rs
   cargo +nightly fmt
   rustfmt +nightly build.rs
 


### PR DESCRIPTION
This is intended to fix #321.  The SAMD11 and SAMD21 values are straight out of their datasheets.  SAMD5x changes required a little bit of interpretation of the datasheet, and I apologise for not making up some better docstrings than what are in the datasheet.