### PR TITLE
Allow SAMD11 and SAMD21 to read DRVSTR bit in PORT

### DIFF
--- a/pac/atsamd11c/src/port/pincfg0_.rs
+++ b/pac/atsamd11c/src/port/pincfg0_.rs
@@ -82,6 +82,8 @@ impl<'a> PULLEN_W<'a> {
         self.w
     }
 }
+#[doc = "Reader of field `DRVSTR`"]
+pub type DRVSTR_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `DRVSTR`"]
 pub struct DRVSTR_W<'a> {
     w: &'a mut W,
@@ -119,6 +121,11 @@ impl R {
     #[inline(always)]
     pub fn pullen(&self) -> PULLEN_R {
         PULLEN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Output Driver Strength Selection"]
+    #[inline(always)]
+    pub fn drvstr(&self) -> DRVSTR_R {
+        DRVSTR_R::new(((self.bits >> 6) & 0x01) != 0)
     }
 }
 impl W {

--- a/pac/atsamd21e/src/port/pincfg0_.rs
+++ b/pac/atsamd21e/src/port/pincfg0_.rs
@@ -82,6 +82,8 @@ impl<'a> PULLEN_W<'a> {
         self.w
     }
 }
+#[doc = "Reader of field `DRVSTR`"]
+pub type DRVSTR_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `DRVSTR`"]
 pub struct DRVSTR_W<'a> {
     w: &'a mut W,
@@ -119,6 +121,11 @@ impl R {
     #[inline(always)]
     pub fn pullen(&self) -> PULLEN_R {
         PULLEN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Output Driver Strength Selection"]
+    #[inline(always)]
+    pub fn drvstr(&self) -> DRVSTR_R {
+        DRVSTR_R::new(((self.bits >> 6) & 0x01) != 0)
     }
 }
 impl W {

--- a/pac/atsamd21g/src/port/pincfg0_.rs
+++ b/pac/atsamd21g/src/port/pincfg0_.rs
@@ -82,6 +82,8 @@ impl<'a> PULLEN_W<'a> {
         self.w
     }
 }
+#[doc = "Reader of field `DRVSTR`"]
+pub type DRVSTR_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `DRVSTR`"]
 pub struct DRVSTR_W<'a> {
     w: &'a mut W,
@@ -119,6 +121,11 @@ impl R {
     #[inline(always)]
     pub fn pullen(&self) -> PULLEN_R {
         PULLEN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Output Driver Strength Selection"]
+    #[inline(always)]
+    pub fn drvstr(&self) -> DRVSTR_R {
+        DRVSTR_R::new(((self.bits >> 6) & 0x01) != 0)
     }
 }
 impl W {

--- a/pac/atsamd21g/src/port/pincfg1_.rs
+++ b/pac/atsamd21g/src/port/pincfg1_.rs
@@ -82,6 +82,8 @@ impl<'a> PULLEN_W<'a> {
         self.w
     }
 }
+#[doc = "Reader of field `DRVSTR`"]
+pub type DRVSTR_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `DRVSTR`"]
 pub struct DRVSTR_W<'a> {
     w: &'a mut W,
@@ -119,6 +121,11 @@ impl R {
     #[inline(always)]
     pub fn pullen(&self) -> PULLEN_R {
         PULLEN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Output Driver Strength Selection"]
+    #[inline(always)]
+    pub fn drvstr(&self) -> DRVSTR_R {
+        DRVSTR_R::new(((self.bits >> 6) & 0x01) != 0)
     }
 }
 impl W {

--- a/pac/atsamd21j/src/port/pincfg0_.rs
+++ b/pac/atsamd21j/src/port/pincfg0_.rs
@@ -82,6 +82,8 @@ impl<'a> PULLEN_W<'a> {
         self.w
     }
 }
+#[doc = "Reader of field `DRVSTR`"]
+pub type DRVSTR_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `DRVSTR`"]
 pub struct DRVSTR_W<'a> {
     w: &'a mut W,
@@ -119,6 +121,11 @@ impl R {
     #[inline(always)]
     pub fn pullen(&self) -> PULLEN_R {
         PULLEN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Output Driver Strength Selection"]
+    #[inline(always)]
+    pub fn drvstr(&self) -> DRVSTR_R {
+        DRVSTR_R::new(((self.bits >> 6) & 0x01) != 0)
     }
 }
 impl W {

--- a/pac/atsamd21j/src/port/pincfg1_.rs
+++ b/pac/atsamd21j/src/port/pincfg1_.rs
@@ -82,6 +82,8 @@ impl<'a> PULLEN_W<'a> {
         self.w
     }
 }
+#[doc = "Reader of field `DRVSTR`"]
+pub type DRVSTR_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `DRVSTR`"]
 pub struct DRVSTR_W<'a> {
     w: &'a mut W,
@@ -119,6 +121,11 @@ impl R {
     #[inline(always)]
     pub fn pullen(&self) -> PULLEN_R {
         PULLEN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - Output Driver Strength Selection"]
+    #[inline(always)]
+    pub fn drvstr(&self) -> DRVSTR_R {
+        DRVSTR_R::new(((self.bits >> 6) & 0x01) != 0)
     }
 }
 impl W {

--- a/svd/devices/atsamd11c14a.xsl
+++ b/svd/devices/atsamd11c14a.xsl
@@ -109,4 +109,9 @@
       </enumeratedValue>
     </enumeratedValues>
   </xsl:template>
+
+  <!-- The drive strength bit is erroneously write-only in the
+  original SVD, remove the accesss field that marks it as such -->
+  <xsl:template match="/device/peripherals/peripheral[name='PORT']/registers/register[name='PINCFG0_%s']/fields/field[name='DRVSTR']/access">
+  </xsl:template>
 </xsl:stylesheet>

--- a/svd/devices/include/atsamd21.xsl
+++ b/svd/devices/include/atsamd21.xsl
@@ -253,4 +253,10 @@
       </enumeratedValue>
     </enumeratedValues>
   </xsl:template>
+
+  <!-- The drive strength bit is erroneously write-only in the
+  original SVD, remove the accesss field that marks it as such -->
+  <xsl:template match="/device/peripherals/peripheral[name='PORT']/registers/register[name='PINCFG0_%s']/fields/field[name='DRVSTR']/access">
+  </xsl:template>
+ 
 </xsl:stylesheet>


### PR DESCRIPTION
Per suggestion in matrix from @bradleyharden .  The SAMD21 change agrees with newer versions of the datasheet, the newest SAMD11 datasheet is quite old and lists that bit as write-only, but a quick test on actual hardware indicates that the bit is indeed readable.