### PR TITLE
bump-pacs workflow: Update deps in HAL.

### DIFF
--- a/.github/actions/sync-pac-versions/action.yml
+++ b/.github/actions/sync-pac-versions/action.yml
@@ -1,0 +1,9 @@
+name: 'Sync HAL to PAC versions'
+description: 'Updates HAL file with latest PAC versions'
+runs:
+  using: "composite"
+  steps:
+    - run: sudo apt install python3-toml
+      shell: bash
+    - run: python3 ${{ github.action_path }}/update-from-pac.py
+      shell: bash

--- a/.github/actions/sync-pac-versions/update-from-pac.py
+++ b/.github/actions/sync-pac-versions/update-from-pac.py
@@ -1,0 +1,61 @@
+#!/bin/python3
+
+import os
+import re
+import sys
+import toml
+
+class PacDep(object):
+    def __init__(self, name, hal_info, pac_info):
+        self._name = name
+        self._hal_version = hal_info['version'][:3]
+        self._pac_version = pac_info['package']['version'][:3]
+        self._line = None
+
+    @property
+    def hal_version(self):
+        return self._hal_version
+
+    @property
+    def pac_version(self):
+        return self._pac_version
+
+    @property
+    def line(self):
+        return self._line
+
+    @line.setter
+    def line(self, value):
+        self._line = value
+
+# Populate a dictionary containing the different PACs and their version.
+pacs = dict()
+h = toml.load("hal/Cargo.toml")
+for dep, info in h['dependencies'].items():
+    is_pac = os.path.isdir("pac/" + dep)
+    if is_pac:
+        pacs[dep] = PacDep(dep, info, toml.load("pac/" + dep + "/Cargo.toml"))
+
+# Collect version and line information for each PAC.
+with open('hal/Cargo.toml', 'r') as f:
+    lines = f.read().splitlines()
+    for i, l in enumerate(lines):
+        l = l.strip()
+        if l.startswith('[dependencies.') and l.endswith(']'):
+            crate = re.search(r'(\[dependencies)\.(.+)]', l).group(2)
+            if crate in pacs:
+                pacs[crate].line = i
+
+# Update our line array
+for crate, p in pacs.items():
+    if p.hal_version != p.pac_version:
+        assert lines[p.line+2].startswith('version = "')
+        lines[p.line+2] = "version = \"%s\"" % p.pac_version
+        print("HAL dependency on %s upgraded from %s to %s." %
+                (crate, p.hal_version, p.pac_version),
+                file=sys.stderr)
+    else:
+        print("HAL dependency on %s is up-to-date." % crate, file=sys.stderr)
+
+with open('hal/Cargo.toml', 'w') as f:
+    f.write('\n'.join(lines) + '\n')

--- a/.github/workflows/bump-pac.yml
+++ b/.github/workflows/bump-pac.yml
@@ -6,6 +6,10 @@ on:
         description: 'Version bump (patch/minor/major)'
         required: true
         default: 'minor'
+      sync_hal:
+        description: 'Update PAC deps in HAL (yes/no)'
+        required: true
+        default: 'yes'
 
 jobs:
   bump-pac-versions:
@@ -35,6 +39,10 @@ jobs:
 
           rm Cargo.toml
           git diff > bump.patch
+
+      - name: Update HAL deps
+        if: github.event.inputs.sync_hal == 'yes'
+        uses: ./.github/actions/sync-pac-versions
 
       - name: Upload diff
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
This PR adds a new option to automatically update the PAC versions in `hal/Cargo.toml` to reference the bumped version.