### PR TITLE
Fix publish of hal crate, correct bump workflow filename

### DIFF
--- a/.github/workflows/bump-crates.yml
+++ b/.github/workflows/bump-crates.yml
@@ -136,7 +136,7 @@ jobs:
           body: |
             Automated bump of crate versions.
             - Workflow launched by `${{ github.actor }}`
-            - Workflow: [bump-pac.yml][1]
+            - Workflow: [bump-crates.yml][1]
             - PAC bump = `${{ github.event.inputs.pac_bump }}`
             - HAL bump = `${{ github.event.inputs.hal_bump }}`
             - BSP bump = `${{ github.event.inputs.bsp_bump }}`

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: |
           set -ex
-          cd "hal" && cargo publish
+          cd "hal" && cargo publish --no-verify
 
 
       - name: Release BSP crates


### PR DESCRIPTION
 - Run publish command for HAL crate using `--no-verify`, due to its dependence on chip-specific feature flags
 - Rename `bump-pac.yml` to `bump-crates.yml` to reflect that the workflow can bump any combination of the crate types