### PR TITLE
Bring in probe-rs ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,11 @@ The `cargo-hf2` crate replaces the `cargo build` command to include flashing ove
 
 ```bash
 $ cargo install cargo-hf2
-$ cargo hf2 --manifest-path metro_m0/Cargo.toml \
-    --example blinky_basic --features unproven --release
+```
+
+and from a bsp directory
+```
+$ cargo hf2 --example blinky_basic --features unproven --release
 ```
 
 For more information, refer to the `README` files for each crate:
@@ -204,6 +207,81 @@ $ ~/.arduino15/packages/arduino/tools/bossac/1.7.0/bossac -i -d \
 ```
 
 This same technique should work for all of the Adafruit M0/M4 boards, as they all ship with a bossac compatible  bootloader. Note that M0 devices may need `-o 0x2000` and M4 devices may need `-o 0x4000` added to the `bossac`  parameter lists.
+
+## Getting code onto the device with debugger: cargo-flash
+
+This is the preferred pure rust ecosystem method for flashing with debugger.
+
+[cargo flash](https://github.com/probe-rs/cargo-flash) replaces the `cargo build` command to include flashing over debugger using probe-rs and libusb.
+
+```bash
+$ cargo install cargo-flash
+```
+We need to know the specific id of your device's chip. Luckily adafruit lists ATSAMD21G18 for metro_m0
+```bash
+$ cargo flash --list-chips | grep ATSAMD21G18
+        ATSAMD21G18A
+        ATSAMD21G18AU
+```
+
+You can stash this chip in the cargo toml so you never have to pass it as an argument, which we recommend.
+```
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21G18A"
+```
+
+And cargo flash simply replaces your cargo build command!
+```bash
+$ cargo flash --example blinky_basic --features unproven --release
+```
+
+Or you can provide it via the chip command line argument
+```bash
+$ cargo flash --example blinky_basic --features unproven --release --chip ATSAMD21G18A
+```
+
+## Debugging: probe-run
+
+This is the preferred pure rust ecosystem method for debugging. It requires no external gdb server, nor C or Python tooling like openocd.
+
+[probe-run](https://github.com/probe-rs/cargo-flash) attemps to bring the hosted cargo run print line debugging experience to embedded. It also has advanced logging features to vastly reduce format size under the [defmt](https://github.com/knurling-rs/defmt) project which is not covered here.
+
+`probe-run` needs to be set as your `runner` in the `.cargo/config` along with the id of your chip. Also debug symbols need to be enabled for any profile you're building for. In your application you'll want to use a `probe-run` compatible panic crate like `panic-probe` and an rtt debug logging crate like `rtt-target`. Also don't forget to init your rtt machinery.
+
+`probe-run` will then be called after a successful build to flash the code directly to the target via debugger and will then wait to receive any rtt prints from your target. Finally if a panic occurs or you ever call `cortex_m::asm::bkpt()` `probe-run` will detect, print a stack trace, and exit. You can exit `probe-run` on the host side with ctrl-c.
+
+```bash
+$ cargo install probe-run
+```
+
+Then simply use your ide's run or play button, or run:
+```bash
+$ cargo run --release --example adc --features=unproven
+    Finished release [optimized + debuginfo] target(s) in 1.10s
+     Running `probe-run --chip ATSAMD11C14A target/thumbv6m-none-eabi/release/examples/adc`
+  (HOST) INFO  flashing program (35.17 KiB)
+  (HOST) INFO  success!
+────────────────────────────────────────────────────────────────────────────────
+4129
+4074
+4177
+^Cstack backtrace:
+   0: <atsamd_hal::common::delay::Delay as embedded_hal::blocking::delay::DelayUs<u32>>::delay_us
+        at /home/atsamd/hal/src/common/delay.rs:72
+   1: <atsamd_hal::common::delay::Delay as embedded_hal::blocking::delay::DelayMs<u32>>::delay_ms
+        at /home/atsamd/hal/src/common/delay.rs:35
+   2: <atsamd_hal::common::delay::Delay as embedded_hal::blocking::delay::DelayMs<u16>>::delay_ms
+        at /home/atsamd/hal/src/common/delay.rs:41
+   3: neopixel_adc_battery::__cortex_m_rt_main
+        at examples/neopixel_adc_battery.rs:50
+   4: main
+        at examples/neopixel_adc_battery.rs:23
+   5: ResetTrampoline
+        at /home/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.13/src/lib.rs:547
+   6: Reset
+        at /home/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.13/src/lib.rs:550
+```
 
 ## Debugging: JLink
 

--- a/boards/arduino_mkr1000/.cargo/config
+++ b/boards/arduino_mkr1000/.cargo/config
@@ -5,6 +5,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD21G18A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/arduino_mkr1000/Cargo.toml
+++ b/boards/arduino_mkr1000/Cargo.toml
@@ -40,3 +40,7 @@ rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
 usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
+
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21G18A"

--- a/boards/arduino_mkrvidor4000/.cargo/config
+++ b/boards/arduino_mkrvidor4000/.cargo/config
@@ -5,6 +5,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD21G18A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/arduino_mkrvidor4000/Cargo.toml
+++ b/boards/arduino_mkrvidor4000/Cargo.toml
@@ -34,3 +34,7 @@ panic_halt = ["panic-halt"]
 unproven = ["atsamd-hal/unproven"]
 usb = ["atsamd-hal/usb"]
 use_semihosting = []
+
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21G18A"

--- a/boards/arduino_mkrzero/.cargo/config
+++ b/boards/arduino_mkrzero/.cargo/config
@@ -5,6 +5,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD21G18A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/arduino_mkrzero/Cargo.toml
+++ b/boards/arduino_mkrzero/Cargo.toml
@@ -43,6 +43,10 @@ panic_halt = ["panic-halt"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21G18A"
+
 [[example]]
 name = "blinky_basic"
 

--- a/boards/arduino_nano33iot/.cargo/config
+++ b/boards/arduino_nano33iot/.cargo/config
@@ -5,6 +5,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD21G18A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/arduino_nano33iot/Cargo.toml
+++ b/boards/arduino_nano33iot/Cargo.toml
@@ -54,6 +54,10 @@ panic_halt = ["panic-halt"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21G18A"
+
 [[example]]
 name = "blinky_basic"
 

--- a/boards/circuit_playground_express/.cargo/config
+++ b/boards/circuit_playground_express/.cargo/config
@@ -5,6 +5,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD21G18A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -28,3 +28,7 @@ default = ["rt", "atsamd-hal/samd21g"]
 rt = ["atsamd-hal/samd21g-rt"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
+
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21G18A"

--- a/boards/edgebadge/.cargo/config
+++ b/boards/edgebadge/.cargo/config
@@ -1,6 +1,6 @@
 # vim:ft=toml:
 [target.thumbv7em-none-eabihf]
-runner = 'arm-none-eabi-gdb'
+runner = "hf2 elf"
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/boards/edgebadge/.cargo/config
+++ b/boards/edgebadge/.cargo/config
@@ -1,6 +1,7 @@
 # vim:ft=toml:
 [target.thumbv7em-none-eabihf]
 runner = "hf2 elf"
+#runner = 'probe-run --chip ATSAMD51J19A'
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -66,6 +66,10 @@ debug = true
 lto = "fat"
 opt-level = 's'
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD51J19A"
+
 [[example]]
 name = "usb_serial"
 required-features = ["usb"]

--- a/boards/edgebadge/README.md
+++ b/boards/edgebadge/README.md
@@ -3,41 +3,39 @@
 This crate provides a type-safe API for working with the [Adafruit EdgeBadge
 board](https://www.adafruit.com/product/4400).
 
+Check out the repository for examples:
+https://github.com/atsamd-rs/atsamd/tree/master/boards/edgebadge/examples
+
 ## Prerequisites
 * Install the cross compile toolchain `rustup target add thumbv7em-none-eabihf`
-* Install [cargo-hf2 the hf2 bootloader flasher tool](https://crates.io/crates/cargo-hf2) however your platform requires
-
-## Uploading an example
-Check out the repository for examples:
-
-https://github.com/atsamd-rs/atsamd/tree/master/boards/edgebadge/examples
+* Install [hf2-cli] the uf2 bootloader flasher tool(https://crates.io/crates/hf2-cli) however your platform requires
 
 * Be in this directory `cd boards/edgebadge`
 * Put your device in bootloader mode usually by hitting the reset button twice.
-* Build and upload in one step
-```
-$ cargo hf2 --release --example blinky_basic
-    Finished release [optimized + debuginfo] target(s) in 0.19s
-    Searching for a connected device with known vid/pid pair.
-    Trying  Ok(Some("Adafruit Industries")) Ok(Some("PyBadge"))
-    Flashing "/Users/User/atsamd/boards/edgebadge/target/thumbv7em-none-eabihf/release/examples/blinky_basic"
-    Finished in 0.079s
-$
+
+### Uploading an example: cargo run
+
+The `.cargo/config` in this bsp is preset with `hf2-cli` as a `runner`. This means you can use cargo run to both cargo build and attempt to upload:
+```bash
+$ cargo run --release --example blinky_basic
 ```
 
+Or even better just your ide's "run" button or hotkey and cargo run will build and upload.
+
+## troubleshooting
 Note some examples will tell you they need more features enabled
 ```
-$ cargo hf2 --release --example neopixel_button
-error: target `neopixel_button` in package `edgebadge` requires the features: `unproven`
-Consider enabling them by passing, e.g., `--features="unproven"`
+$ cargo run --release --example neopixel_easing
+error: target `neopixel_easing` in package `edgebadge` requires the features: `math`
+Consider enabling them by passing, e.g., `--features="math"`
 ```
 Just follow the instructions to add --features like
 ```
-cargo hf2 --release --example neopixel_button --features="unproven"
+cargo run --release --example neopixel_easing --features="math"
     Finished release [optimized + debuginfo] target(s) in 0.09s
     Searching for a connected device with known vid/pid pair.
     Trying  Ok(Some("Adafruit Industries")) Ok(Some("PyBadge"))
-    Flashing "/Users/User/atsamd/boards/edgebadge/target/thumbv7em-none-eabihf/release/examples/neopixel_button"
+    Flashing "/Users/User/atsamd/boards/edgebadge/target/thumbv7em-none-eabihf/release/examples/neopixel_easing"
     Finished in 0.167s
 $
 ```

--- a/boards/edgebadge/README.md
+++ b/boards/edgebadge/README.md
@@ -8,7 +8,7 @@ https://github.com/atsamd-rs/atsamd/tree/master/boards/edgebadge/examples
 
 ## Prerequisites
 * Install the cross compile toolchain `rustup target add thumbv7em-none-eabihf`
-* Install [hf2-cli] the uf2 bootloader flasher tool(https://crates.io/crates/hf2-cli) however your platform requires
+* Install [hf2-cli](https://crates.io/crates/hf2-cli) the uf2 bootloader flasher tool however your platform requires
 
 * Be in this directory `cd boards/edgebadge`
 * Put your device in bootloader mode usually by hitting the reset button twice.

--- a/boards/feather_m0/.cargo/config
+++ b/boards/feather_m0/.cargo/config
@@ -5,6 +5,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD21G18A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -99,6 +99,10 @@ debug = true
 lto = true
 opt-level = "s"
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21G18A"
+
 [[example]]
 name = "blinky_basic"
 

--- a/boards/feather_m4/.cargo/config
+++ b/boards/feather_m4/.cargo/config
@@ -1,6 +1,7 @@
 # vim:ft=toml:
 [target.thumbv7em-none-eabihf]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD51J19A'
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -60,6 +60,10 @@ debug = true
 lto = true
 opt-level = "s"
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD51J19A"
+
 [[example]]
 name = "pwm"
 required-features = ["unproven"]

--- a/boards/gemma_m0/.cargo/config
+++ b/boards/gemma_m0/.cargo/config
@@ -5,6 +5,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD21E18A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/gemma_m0/Cargo.toml
+++ b/boards/gemma_m0/Cargo.toml
@@ -32,3 +32,7 @@ default = ["rt", "atsamd-hal/samd21e"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21e-rt"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
+
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21E18A"

--- a/boards/grand_central_m4/.cargo/config
+++ b/boards/grand_central_m4/.cargo/config
@@ -1,6 +1,7 @@
 # vim:ft=toml:
 [target.thumbv7em-none-eabihf]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD51P20A'
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -58,6 +58,10 @@ lto = true
 lto = true
 opt-level = "s"
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD51P20A"
+
 [[example]]
 name = "blinky_basic"
 

--- a/boards/itsybitsy_m0/.cargo/config
+++ b/boards/itsybitsy_m0/.cargo/config
@@ -5,6 +5,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD21G18A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -51,6 +51,10 @@ usb = ["atsamd-hal/usb", "usb-device", "usbd-serial", "usbd-hid"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21G18A"
+
 [[example]]
 name = "blinky_basic"
 

--- a/boards/itsybitsy_m4/.cargo/config
+++ b/boards/itsybitsy_m4/.cargo/config
@@ -1,6 +1,7 @@
 # vim:ft=toml:
 [target.thumbv7em-none-eabihf]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD51G19A'
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/boards/itsybitsy_m4/Cargo.toml
+++ b/boards/itsybitsy_m4/Cargo.toml
@@ -63,6 +63,9 @@ debug = true
 lto = true
 opt-level = "s"
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD51G19A"
 
 [[example]]
 name = "blinky_basic"

--- a/boards/metro_m0/.cargo/config
+++ b/boards/metro_m0/.cargo/config
@@ -5,6 +5,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD21G18A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -64,6 +64,10 @@ debug = true
 lto = true
 opt-level = "s"
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21G18A"
+
 [[example]]
 name = "usb_echo"
 required-features = ["usb", "unproven"]

--- a/boards/metro_m4/.cargo/config
+++ b/boards/metro_m4/.cargo/config
@@ -1,6 +1,6 @@
 # vim:ft=toml:
 [target.thumbv7em-none-eabihf]
-runner = 'arm-none-eabi-gdb'
+runner = 'probe-run --chip ATSAMD51J19A'
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/boards/metro_m4/.embed.toml
+++ b/boards/metro_m4/.embed.toml
@@ -1,0 +1,8 @@
+[default.probe]
+protocol = "Swd"
+
+[default.general]
+chip = "ATSAMD51J19A"
+
+[default.rtt]
+enabled = true

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -10,12 +10,12 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.6"
+cortex-m = "0.6.3"
 embedded-hal = "0.2.3"
 nb = "0.1"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.6.13"
 optional = true
 
 [dependencies.atsamd-hal]
@@ -32,10 +32,12 @@ version = "0.1"
 optional = true
 
 [dev-dependencies]
+panic-probe = "0.1.0"
 panic-halt = "0.2"
 panic-semihosting = "0.5"
-panic_rtt = "0.2"
+panic-rtt-target = { version = "0.1.1", features = ["cortex-m"] }
 cortex-m-semihosting = "0.3"
+rtt-target = { version = "0.3.0", features = ["cortex-m"] }
 cortex-m-rtic = "0.5.1"
 smart-leds = "0.3"
 
@@ -56,6 +58,7 @@ debug = true
 lto = true
 
 [profile.release]
+debug = true
 lto = true
 opt-level = 3
 

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -59,6 +59,10 @@ lto = true
 lto = true
 opt-level = 3
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD51J19A"
+
 [[example]]
 name = "blinky_basic"
 

--- a/boards/metro_m4/examples/hello.rs
+++ b/boards/metro_m4/examples/hello.rs
@@ -1,0 +1,36 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate metro_m4 as hal;
+
+use panic_probe as _; //for probe-run
+use rtt_target::{rprintln, rtt_init_print};
+//use panic_rtt as _; //for cargo embed
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+
+#[entry]
+fn main() -> ! {
+    rtt_init_print!();
+
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.MCLK,
+        &mut peripherals.OSC32KCTRL,
+        &mut peripherals.OSCCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+    loop {
+        // panic!('goodbye');
+        rprintln!("hellooooo");
+        cortex_m::asm::bkpt();
+    }
+}

--- a/boards/pfza_proto1/.cargo/config
+++ b/boards/pfza_proto1/.cargo/config
@@ -1,6 +1,7 @@
 # vim:ft=toml:
 [target.thumbv7em-none-eabihf]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAME54P20A'
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/boards/pfza_proto1/Cargo.toml
+++ b/boards/pfza_proto1/Cargo.toml
@@ -42,3 +42,7 @@ lto = true
 [profile.release]
 lto = true
 opt-level = "s"
+
+# for cargo flash
+[package.metadata]
+chip = "ATSAME54P20A"

--- a/boards/pygamer/.cargo/config
+++ b/boards/pygamer/.cargo/config
@@ -1,6 +1,6 @@
 # vim:ft=toml:
 [target.thumbv7em-none-eabihf]
-runner = 'arm-none-eabi-gdb'
+runner = "hf2 elf"
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/boards/pygamer/.cargo/config
+++ b/boards/pygamer/.cargo/config
@@ -1,6 +1,7 @@
 # vim:ft=toml:
 [target.thumbv7em-none-eabihf]
 runner = "hf2 elf"
+#runner = 'probe-run --chip ATSAMD51J19A'
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -74,6 +74,10 @@ lto = "thin" # thin for debug speed
 lto = "fat"
 opt-level = 's'
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD51J19A"
+
 [[example]]
 name = "usb_serial"
 required-features = ["usb"]

--- a/boards/pygamer/README.md
+++ b/boards/pygamer/README.md
@@ -3,41 +3,39 @@
 This crate provides a type-safe API for working with the [Adafruit PyGamer
 board](https://www.adafruit.com/product/4242).
 
-## Prerequisites
-* Add the cross compile toolchain `rustup target add thumbv7em-none-eabihf`
-* Install [cargo-hf2 the hf2 bootloader flasher tool](https://crates.io/crates/cargo-hf2) however your platform requires
-
-## Uploading an example
 Check out the repository for examples:
-
 https://github.com/atsamd-rs/atsamd/tree/master/boards/pygamer/examples
 
+
+## Prerequisites
+* Install the cross compile toolchain `rustup target add thumbv7em-none-eabihf`
+* Install [hf2-cli] the uf2 bootloader flasher tool(https://crates.io/crates/hf2-cli) however your platform requires
 * Be in this directory `cd boards/pygamer`
 * Put your device in bootloader mode usually by hitting the reset button twice.
-* Build and upload in one step
-```
-$ cargo hf2 --release --example blinky_basic
-    Finished release [optimized + debuginfo] target(s) in 0.19s
-    Searching for a connected device with known vid/pid pair.
-    Trying  Ok(Some("Adafruit Industries")) Ok(Some("PyGamer"))
-    Flashing "/Users/User/atsamd/boards/pygamer/target/thumbv7em-none-eabihf/release/examples/blinky_basic"
-    Finished in 0.079s
-$
+
+### Uploading an example: cargo run
+
+The `.cargo/config` in this bsp is preset with `hf2-cli` as a `runner`. This means you can use cargo run to both cargo build and attempt to upload:
+```bash
+$ cargo run --release --example blinky_basic
 ```
 
+Or even better just your ide's "run" button or hotkey and cargo run will build and upload.
+
+## troubleshooting
 Note some examples will tell you they need more features enabled
 ```
-$ cargo hf2 --release --example neopixel_button
-error: target `neopixel_button` in package `pygamer` requires the features: `unproven`
-Consider enabling them by passing, e.g., `--features="unproven"`
+$ cargo run --release --example neopixel_easing
+error: target `neopixel_easing` in package `pygamer` requires the features: `math`
+Consider enabling them by passing, e.g., `--features="math"`
 ```
 Just follow the instructions to add --features like
 ```
-cargo hf2 --release --example neopixel_button --features="unproven"
+cargo run --release --example neopixel_easing --features="math"
     Finished release [optimized + debuginfo] target(s) in 0.09s
     Searching for a connected device with known vid/pid pair.
     Trying  Ok(Some("Adafruit Industries")) Ok(Some("PyGamer"))
-    Flashing "/Users/User/atsamd/boards/pygamer/target/thumbv7em-none-eabihf/release/examples/neopixel_button"
+    Flashing "/Users/User/atsamd/boards/pygamer/target/thumbv7em-none-eabihf/release/examples/neopixel_easing"
     Finished in 0.167s
 $
 ```

--- a/boards/pygamer/README.md
+++ b/boards/pygamer/README.md
@@ -9,7 +9,7 @@ https://github.com/atsamd-rs/atsamd/tree/master/boards/pygamer/examples
 
 ## Prerequisites
 * Install the cross compile toolchain `rustup target add thumbv7em-none-eabihf`
-* Install [hf2-cli] the uf2 bootloader flasher tool(https://crates.io/crates/hf2-cli) however your platform requires
+* Install [hf2-cli](https://crates.io/crates/hf2-cli) the uf2 bootloader flasher tool however your platform requires
 * Be in this directory `cd boards/pygamer`
 * Put your device in bootloader mode usually by hitting the reset button twice.
 

--- a/boards/pyportal/.cargo/config
+++ b/boards/pyportal/.cargo/config
@@ -1,6 +1,6 @@
 # vim:ft=toml:
 [target.thumbv7em-none-eabihf]
-runner = 'arm-none-eabi-gdb'
+runner = "hf2 elf"
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/boards/pyportal/.cargo/config
+++ b/boards/pyportal/.cargo/config
@@ -1,6 +1,7 @@
 # vim:ft=toml:
 [target.thumbv7em-none-eabihf]
 runner = "hf2 elf"
+#runner = 'probe-run --chip ATSAMD51J20A'
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/boards/pyportal/Cargo.toml
+++ b/boards/pyportal/Cargo.toml
@@ -53,3 +53,7 @@ lto = true
 [profile.release]
 lto = true
 opt-level = "s"
+
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD51J20A"

--- a/boards/pyportal/README.md
+++ b/boards/pyportal/README.md
@@ -3,24 +3,21 @@
 This crate provides a type-safe API for working with the [Adafruit PyPortal
 board](https://www.adafruit.com/product/4116).
 
+Check out the repository for examples:
+https://github.com/atsamd-rs/atsamd/tree/master/boards/pyportal/examples
+
 ## Prerequisites
 * Install the cross compile toolchain `rustup target add thumbv7em-none-eabihf`
-* Install [cargo-hf2 the hf2 bootloader flasher tool](https://crates.io/crates/cargo-hf2) however your platform requires
-
-## Uploading an example
-Check out the repository for examples:
-
-https://github.com/atsamd-rs/atsamd/tree/master/boards/pyportal/examples
+* Install [hf2-cli] the uf2 bootloader flasher tool(https://crates.io/crates/hf2-cli) however your platform requires
 
 * Be in this directory `cd boards/pyportal`
 * Put your device in bootloader mode usually by hitting the reset button twice.
-* Build and upload in one step
+
+### Uploading an example: cargo run
+
+The `.cargo/config` in this bsp is preset with `hf2-cli` as a `runner`. This means you can use cargo run to both cargo build and attempt to upload:
+```bash
+$ cargo run --release --example blinky_basic
 ```
-$ cargo hf2 --release --example blinky_basic
-    Finished release [optimized + debuginfo] target(s) in 0.19s
-    Searching for a connected device with known vid/pid pair.
-    Trying  Ok(Some("Adafruit Industries")) Ok(Some("PyBadge"))
-    Flashing "/Users/User/atsamd/boards/pyportal/target/thumbv7em-none-eabihf/release/examples/blinky_basic"
-    Finished in 0.079s
-$
-```
+
+Or even better just your ide's "run" button or hotkey and cargo run will build and upload.

--- a/boards/pyportal/README.md
+++ b/boards/pyportal/README.md
@@ -8,7 +8,7 @@ https://github.com/atsamd-rs/atsamd/tree/master/boards/pyportal/examples
 
 ## Prerequisites
 * Install the cross compile toolchain `rustup target add thumbv7em-none-eabihf`
-* Install [hf2-cli] the uf2 bootloader flasher tool(https://crates.io/crates/hf2-cli) however your platform requires
+* Install [hf2-cli](https://crates.io/crates/hf2-cli) the uf2 bootloader flasher tool however your platform requires
 
 * Be in this directory `cd boards/pyportal`
 * Put your device in bootloader mode usually by hitting the reset button twice.

--- a/boards/samd11_bare/.cargo/config
+++ b/boards/samd11_bare/.cargo/config
@@ -4,7 +4,7 @@
 target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
-runner = 'arm-none-eabi-gdb'
+runner = 'probe-run --chip ATSAMD11C14A'
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -34,6 +34,10 @@ rt = ["cortex-m-rt", "atsamd-hal/samd11c-rt"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD11C14A"
+
 [[example]]
 name = "adc"
 required-features = ["unproven"]

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -10,12 +10,12 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.6"
+cortex-m = "0.6.4"
 embedded-hal = "0.2.3"
 nb = "0.1"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.6.13"
 optional = true
 
 [dependencies.atsamd-hal]
@@ -24,8 +24,9 @@ version = "0.12"
 default-features = false
 
 [dev-dependencies]
-cortex-m-semihosting = "0.3.5"
 panic-halt = "0.2"
+panic-probe = "0.1.0"
+rtt-target = { version = "0.3.0", features = ["cortex-m"] }
 
 [features]
 # ask the HAL to enable atsamd11c support
@@ -34,13 +35,16 @@ rt = ["cortex-m-rt", "atsamd-hal/samd11c-rt"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
 
+[profile.release]
+debug = true
+
 # for cargo flash
 [package.metadata]
 chip = "ATSAMD11C14A"
 
 [[example]]
 name = "adc"
-required-features = ["unproven"]
+required-features = ["unproven", "rt"]
 
 [[example]]
 name = "blinky_basic"

--- a/boards/samd11_bare/README.md
+++ b/boards/samd11_bare/README.md
@@ -7,3 +7,65 @@ This crate provides a type-safe API for working with the [ATSAMD11C](https://www
 Check out the repository for examples:
 
 https://github.com/atsamd-rs/atsamd/tree/master/boards/samd11_bare/examples
+
+
+## Getting code onto the device with debugger: cargo-flash
+
+This is the preferred pure rust ecosystem method for flashing with debugger.
+
+[cargo flash](https://github.com/probe-rs/cargo-flash) replaces the `cargo build` command to include flashing over debugger using probe-rs and libusb.
+
+```bash
+$ cargo install cargo-flash
+```
+
+Cargo flash needs to know the specific id of your chip, but its included in the package.metadata field of the Cargo.toml so you can omit it.
+
+Then cargo flash simply replaces your cargo build command!
+```bash
+$ cargo flash --example blinky_basic --features unproven --release
+```
+
+## Debugging: probe-run
+
+This is the preferred pure rust ecosystem method for debugging. It requires no external gdb server, nor C or Python tooling like openocd.
+
+[probe-run](https://github.com/probe-rs/cargo-flash) attemps to bring the hosted cargo run print line debugging experience to embedded. It also has advanced logging features to vastly reduce format size under the [defmt](https://github.com/knurling-rs/defmt) project which is not covered here.
+
+`probe-run` needs to be set as your `runner` in the `.cargo/config` along with the id of your chip. Also debug symbols need to be enabled for any profile you're building for. In your application you'll want to use a `probe-run` compatible panic crate like `panic-probe` and an rtt debug logging crate like `rtt-target`. Also don't forget to init your rtt machinery.
+
+`probe-run` will then be called after a successful build to flash the code directly to the target via debugger and will then wait to receive any rtt prints from your target. Finally if a panic occurs or you ever call `cortex_m::asm::bkpt()` `probe-run` will detect, print a stack trace, and exit. You can exit `probe-run` on the host side with ctrl-c.
+
+```bash
+$ cargo install probe-run
+```
+
+Then simply use your ide's run or play button, or run:
+```bash
+$ cargo run --release --example adc --features=unproven
+    Finished release [optimized + debuginfo] target(s) in 0.99s
+     Running `probe-run --chip ATSAMD11C14A target\thumbv6m-none-eabi\release\examples\adc`
+  (HOST) INFO  flashing program (7.18 KiB)
+  (HOST) INFO  success!
+────────────────────────────────────────────────────────────────────────────────
+3828
+3829
+414
+413
+419
+^Cstack backtrace:
+   0: <atsamd_hal::common::delay::Delay as embedded_hal::blocking::delay::DelayUs<u32>>::delay_us
+        at /home/atsamd/hal/src/common/delay.rs:72
+   1: <atsamd_hal::common::delay::Delay as embedded_hal::blocking::delay::DelayMs<u32>>::delay_ms
+        at /home/atsamd/hal/src/common/delay.rs:35
+   2: <atsamd_hal::common::delay::Delay as embedded_hal::blocking::delay::DelayMs<u16>>::delay_ms
+        at /home/atsamd/hal/src/common/delay.rs:41
+   3: neopixel_adc_battery::__cortex_m_rt_main
+        at examples/neopixel_adc_battery.rs:50
+   4: main
+        at examples/neopixel_adc_battery.rs:23
+   5: ResetTrampoline
+        at /home/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.13/src/lib.rs:547
+   6: Reset
+        at /home/.cargo/registry/src/github.com-1ecc6299db9ec823/cortex-m-rt-0.6.13/src/lib.rs:550
+```

--- a/boards/samd11_bare/examples/adc.rs
+++ b/boards/samd11_bare/examples/adc.rs
@@ -1,25 +1,35 @@
+//! Reads the adc and prints to rtt every second.
+//!
+//! Requires `cargo install probe-run`
+//!
+//! probe-run builds, uploads, and runs your code on device and in combination
+//! with rtt-target and panic-probe prints debug and panic information to your
+//! console. Its used for short running sessions like seeing the results of a
+//! calculation or a measurement, a panic message or backtrace of an error right
+//! on your command line. You can also force an exit with a
+//! cortex_m::asm::bkpt()
+//!
+//! `cargo run --release --example adc --features=unproven`
+
 #![no_std]
 #![no_main]
 
 extern crate cortex_m;
-extern crate cortex_m_semihosting;
 extern crate embedded_hal;
 extern crate samd11_bare as hal;
 
-#[cfg(not(feature = "use_semihosting"))]
-extern crate panic_halt;
-#[cfg(feature = "use_semihosting")]
-extern crate panic_semihosting;
-
-use cortex_m_semihosting::hprintln;
 use hal::adc::Adc;
 use hal::clock::GenericClockController;
 use hal::entry;
 use hal::pac::{CorePeripherals, Peripherals};
 use hal::prelude::*;
+use panic_probe as _;
+use rtt_target::{rprintln, rtt_init_print};
 
 #[entry]
 fn main() -> ! {
+    rtt_init_print!();
+
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
 
@@ -37,7 +47,7 @@ fn main() -> ! {
 
     loop {
         let data: u16 = adc.read(&mut a0).unwrap();
-        hprintln!("{}", data).ok();
+        rprintln!("{}", data);
         delay.delay_ms(1000u16);
     }
 }

--- a/boards/samd11_bare/examples/serial.rs
+++ b/boards/samd11_bare/examples/serial.rs
@@ -2,13 +2,8 @@
 #![no_main]
 
 extern crate cortex_m;
-extern crate cortex_m_semihosting;
-extern crate samd11_bare as hal;
-
-#[cfg(not(feature = "use_semihosting"))]
 extern crate panic_halt;
-#[cfg(feature = "use_semihosting")]
-extern crate panic_semihosting;
+extern crate samd11_bare as hal;
 
 #[macro_use(block)]
 extern crate nb;

--- a/boards/samd21_mini/.cargo/config
+++ b/boards/samd21_mini/.cargo/config
@@ -5,6 +5,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD21G18A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/samd21_mini/Cargo.toml
+++ b/boards/samd21_mini/Cargo.toml
@@ -35,3 +35,7 @@ default = ["rt", "atsamd-hal/samd21g"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
+
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21G18A"

--- a/boards/serpente/.cargo/config
+++ b/boards/serpente/.cargo/config
@@ -5,6 +5,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD21E18A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/serpente/Cargo.toml
+++ b/boards/serpente/Cargo.toml
@@ -32,6 +32,10 @@ rt = ["cortex-m-rt", "atsamd-hal/samd21e-rt"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21E18A"
+
 [[example]]
 name = "blinky_basic"
 

--- a/boards/sodaq_one/.cargo/config
+++ b/boards/sodaq_one/.cargo/config
@@ -5,6 +5,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD21G18A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/sodaq_one/Cargo.toml
+++ b/boards/sodaq_one/Cargo.toml
@@ -37,6 +37,9 @@ use_rtt = ["atsamd-hal/use_rtt"]
 #usb = ["atsamd-hal/usb"]
 use_semihosting = []
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21G18A"
 
 [profile.dev]
 incremental = false

--- a/boards/sodaq_sara_aff/.cargo/config
+++ b/boards/sodaq_sara_aff/.cargo/config
@@ -5,6 +5,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD21J18A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/sodaq_sara_aff/Cargo.toml
+++ b/boards/sodaq_sara_aff/Cargo.toml
@@ -32,3 +32,7 @@ default = ["rt", "atsamd-hal/samd21j"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21j-rt"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
+
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21J18A"

--- a/boards/trellis_m4/.cargo/config
+++ b/boards/trellis_m4/.cargo/config
@@ -1,6 +1,7 @@
 # vim:ft=toml:
 [target.thumbv7em-none-eabihf]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD51G19A'
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -66,6 +66,10 @@ lto = true
 lto = true
 opt-level = "s"
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD51G19A"
+
 [[example]]
 name = "neopixel_accel"
 required-features = ["adxl343"]

--- a/boards/trinket_m0/.cargo/config
+++ b/boards/trinket_m0/.cargo/config
@@ -5,6 +5,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD21E18A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/trinket_m0/Cargo.toml
+++ b/boards/trinket_m0/Cargo.toml
@@ -45,6 +45,10 @@ unproven = ["atsamd-hal/unproven"]
 usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
 use_semihosting = []
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21E18A"
+
 [[example]]
 name = "blinky_basic"
 

--- a/boards/wio_lite_mg126/.cargo/config
+++ b/boards/wio_lite_mg126/.cargo/config
@@ -5,6 +5,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD21G18A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/wio_lite_mg126/Cargo.toml
+++ b/boards/wio_lite_mg126/Cargo.toml
@@ -66,6 +66,10 @@ panic_halt = ["panic-halt"]
 panic_abort = ["panic-abort"]
 panic_semihosting = ["panic-semihosting"]
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD21G18A"
+
 [[example]]
 name = "pwm"
 required-features = ["unproven"]

--- a/boards/wio_terminal/.cargo/config
+++ b/boards/wio_terminal/.cargo/config
@@ -1,5 +1,6 @@
 [target.thumbv7em-none-eabihf]
 runner = "arm-none-eabi-gdb"
+#runner = 'probe-run --chip ATSAMD51P19A'
 
 [build]
 target = "thumbv7em-none-eabihf"

--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -70,6 +70,10 @@ lto = true
 lto = true
 opt-level = "s"
 
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD51P19A"
+
 [[example]]
 name = "blinky"
 

--- a/boards/xiao_m0/.cargo/config
+++ b/boards/xiao_m0/.cargo/config
@@ -3,6 +3,8 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = 'arm-none-eabi-gdb'
+#runner = 'probe-run --chip ATSAMD51P19A'
+
 rustflags = [
 
   # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x

--- a/boards/xiao_m0/Cargo.toml
+++ b/boards/xiao_m0/Cargo.toml
@@ -50,3 +50,7 @@ required-features = ["usb"]
 [profile.release]
 lto = true
 opt-level = "s"
+
+# for cargo flash
+[package.metadata]
+chip = "ATSAMD51P19A"


### PR DESCRIPTION
So far just cargo flash in the main readme

Eventually need cargo-embed and or probe-run as well. Can merge now or wait.

For bare boards and any devices that have a debugger (it seems like explained boards and arduino zero mainly) I would probably like to check in full probe-run and or cargo embed setups. Though I dont know if edbg is actually supported currently. Its supposedly a cmsis dap (or compatible?) but theres an open PR https://github.com/probe-rs/probe-rs/pull/308 so Im not sure if it needs more massaging 

Further we should dump all the semihosting across the board and add back probe run and or cargo embed in a few select places. 




