### PR TITLE
Add additional BSP peripheral helper functions

### DIFF
--- a/boards/metro_m0/src/lib.rs
+++ b/boards/metro_m0/src/lib.rs
@@ -256,7 +256,7 @@ pub fn usb_allocator(
 #[cfg(feature = "usb")]
 #[deprecated(
     since = "0.8.0",
-    note = "Please use the usb_allocator function instead",
+    note = "Please use the usb_allocator function instead"
 )]
 pub fn usb_bus(
     usb: pac::USB,

--- a/boards/metro_m0/src/lib.rs
+++ b/boards/metro_m0/src/lib.rs
@@ -12,10 +12,9 @@ pub use hal::common::*;
 pub use hal::samd21::*;
 pub use hal::target_device as pac;
 
+use gpio::{self, *};
+
 use hal::clock::GenericClockController;
-#[cfg(feature = "usb")]
-use hal::gpio::IntoFunction;
-use hal::gpio::{Floating, Input, PfC, Port};
 use hal::sercom::{I2CMaster3, PadPin, SPIMaster4, SPIMaster5, UART0};
 use hal::time::Hertz;
 
@@ -234,7 +233,7 @@ pub fn uart<F: Into<Hertz>>(
 }
 
 #[cfg(feature = "usb")]
-pub fn usb_bus(
+pub fn usb_allocator(
     usb: pac::USB,
     clocks: &mut GenericClockController,
     pm: &mut pac::PM,
@@ -243,9 +242,8 @@ pub fn usb_bus(
     port: &mut Port,
 ) -> UsbBusAllocator<UsbBus> {
     let gclk0 = clocks.gclk0();
-    // dbgprint!("making usb clock");
     let usb_clock = &clocks.usb(&gclk0).unwrap();
-    // dbgprint!("got clock");
+
     UsbBusAllocator::new(UsbBus::new(
         usb_clock,
         pm,
@@ -253,4 +251,20 @@ pub fn usb_bus(
         dp.into_function(port),
         usb,
     ))
+}
+
+#[cfg(feature = "usb")]
+#[deprecated(
+    since = "0.8.0",
+    note = "Please use the usb_allocator function instead",
+)]
+pub fn usb_bus(
+    usb: pac::USB,
+    clocks: &mut GenericClockController,
+    pm: &mut pac::PM,
+    dm: gpio::Pa24<Input<Floating>>,
+    dp: gpio::Pa25<Input<Floating>>,
+    port: &mut Port,
+) -> UsbBusAllocator<UsbBus> {
+    usb_allocator(usb, clocks, pm, dm, dp, port)
 }

--- a/boards/metro_m0/src/lib.rs
+++ b/boards/metro_m0/src/lib.rs
@@ -12,9 +12,10 @@ pub use hal::common::*;
 pub use hal::samd21::*;
 pub use hal::target_device as pac;
 
-use gpio::{self, *};
-
 use hal::clock::GenericClockController;
+#[cfg(feature = "usb")]
+use hal::gpio::IntoFunction;
+use hal::gpio::{Floating, Input, PfC, Port};
 use hal::sercom::{I2CMaster3, PadPin, SPIMaster4, SPIMaster5, UART0};
 use hal::time::Hertz;
 

--- a/boards/wio_lite_mg126/src/lib.rs
+++ b/boards/wio_lite_mg126/src/lib.rs
@@ -95,7 +95,7 @@ define_pins!(
     /// Digital 1: TX
     pin tx = a27,
 
-    /// USB Data MInus
+    /// USB Data Minus
     pin usb_dm = a24,
 
     /// USB Data Plus


### PR DESCRIPTION
Just starting to pick away at #254 a bit.

- Added `spi_master` to the Trinket M0 ([reference](https://learn.adafruit.com/adafruit-trinket-m0-circuitpython-arduino/pinouts#unique-pad-capabilities-2910532-4))
- Renamed `usb_bus` to `usb_allocator` for Metro M0, added deprecation notice and compatibility shim for `usb_bus`
- Added `spi_master` and `uart` to the Wio Lite MG126 ([reference](https://wiki.seeedstudio.com/Wio-Lite-MG126/))