### PR TITLE
Fix release crates workflow (install both thumb targets)

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -21,6 +21,21 @@ jobs:
       - name: Set up Rust
         uses: hecrj/setup-rust-action@v1
       - uses: actions/checkout@v2
+      - name: Install thumbv6m
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+          toolchain: stable
+          target: thumbv6m-none-eabi
+      - name: Install thumbv7em
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+          toolchain: stable
+          target: thumbv7em-none-eabihf
+
 
       - name: Login
         run: cargo login ${CRATES_IO_TOKEN}


### PR DESCRIPTION
Previously the workflow was crashing out because when building (as part of pre-publish verification), the target in question was not present.

This PR add steps to install both the thumb toolchains.