### PR TITLE
Added missing TIDM::ENIDn fields to PACs

### DIFF
--- a/pac/atsame53j/src/gmac/tidm.rs
+++ b/pac/atsame53j/src/gmac/tidm.rs
@@ -25,11 +25,40 @@ impl<'a> TID_W<'a> {
         self.w
     }
 }
+#[doc = "Reader of field `ENID`"]
+pub type ENID_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENID`"]
+pub struct ENID_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENID_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 31)) | (((value as u32) & 0x01) << 31);
+        self.w
+    }
+}
 impl R {
     #[doc = "Bits 0:15 - Type ID Match 1"]
     #[inline(always)]
     pub fn tid(&self) -> TID_R {
         TID_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bit 31 - Enable Copying of TID Matched Frames"]
+    #[inline(always)]
+    pub fn enid(&self) -> ENID_R {
+        ENID_R::new(((self.bits >> 31) & 0x01) != 0)
     }
 }
 impl W {
@@ -37,5 +66,10 @@ impl W {
     #[inline(always)]
     pub fn tid(&mut self) -> TID_W {
         TID_W { w: self }
+    }
+    #[doc = "Bit 31 - Enable Copying of TID Matched Frames"]
+    #[inline(always)]
+    pub fn enid(&mut self) -> ENID_W {
+        ENID_W { w: self }
     }
 }

--- a/pac/atsame53n/src/gmac/tidm.rs
+++ b/pac/atsame53n/src/gmac/tidm.rs
@@ -25,11 +25,40 @@ impl<'a> TID_W<'a> {
         self.w
     }
 }
+#[doc = "Reader of field `ENID`"]
+pub type ENID_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENID`"]
+pub struct ENID_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENID_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 31)) | (((value as u32) & 0x01) << 31);
+        self.w
+    }
+}
 impl R {
     #[doc = "Bits 0:15 - Type ID Match 1"]
     #[inline(always)]
     pub fn tid(&self) -> TID_R {
         TID_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bit 31 - Enable Copying of TID Matched Frames"]
+    #[inline(always)]
+    pub fn enid(&self) -> ENID_R {
+        ENID_R::new(((self.bits >> 31) & 0x01) != 0)
     }
 }
 impl W {
@@ -37,5 +66,10 @@ impl W {
     #[inline(always)]
     pub fn tid(&mut self) -> TID_W {
         TID_W { w: self }
+    }
+    #[doc = "Bit 31 - Enable Copying of TID Matched Frames"]
+    #[inline(always)]
+    pub fn enid(&mut self) -> ENID_W {
+        ENID_W { w: self }
     }
 }

--- a/pac/atsame54n/src/gmac/tidm.rs
+++ b/pac/atsame54n/src/gmac/tidm.rs
@@ -25,11 +25,40 @@ impl<'a> TID_W<'a> {
         self.w
     }
 }
+#[doc = "Reader of field `ENID`"]
+pub type ENID_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENID`"]
+pub struct ENID_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENID_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 31)) | (((value as u32) & 0x01) << 31);
+        self.w
+    }
+}
 impl R {
     #[doc = "Bits 0:15 - Type ID Match 1"]
     #[inline(always)]
     pub fn tid(&self) -> TID_R {
         TID_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bit 31 - Enable Copying of TID Matched Frames"]
+    #[inline(always)]
+    pub fn enid(&self) -> ENID_R {
+        ENID_R::new(((self.bits >> 31) & 0x01) != 0)
     }
 }
 impl W {
@@ -37,5 +66,10 @@ impl W {
     #[inline(always)]
     pub fn tid(&mut self) -> TID_W {
         TID_W { w: self }
+    }
+    #[doc = "Bit 31 - Enable Copying of TID Matched Frames"]
+    #[inline(always)]
+    pub fn enid(&mut self) -> ENID_W {
+        ENID_W { w: self }
     }
 }

--- a/pac/atsame54p/src/gmac/tidm.rs
+++ b/pac/atsame54p/src/gmac/tidm.rs
@@ -25,11 +25,40 @@ impl<'a> TID_W<'a> {
         self.w
     }
 }
+#[doc = "Reader of field `ENID`"]
+pub type ENID_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENID`"]
+pub struct ENID_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENID_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 31)) | (((value as u32) & 0x01) << 31);
+        self.w
+    }
+}
 impl R {
     #[doc = "Bits 0:15 - Type ID Match 1"]
     #[inline(always)]
     pub fn tid(&self) -> TID_R {
         TID_R::new((self.bits & 0xffff) as u16)
+    }
+    #[doc = "Bit 31 - Enable Copying of TID Matched Frames"]
+    #[inline(always)]
+    pub fn enid(&self) -> ENID_R {
+        ENID_R::new(((self.bits >> 31) & 0x01) != 0)
     }
 }
 impl W {
@@ -37,5 +66,10 @@ impl W {
     #[inline(always)]
     pub fn tid(&mut self) -> TID_W {
         TID_W { w: self }
+    }
+    #[doc = "Bit 31 - Enable Copying of TID Matched Frames"]
+    #[inline(always)]
+    pub fn enid(&mut self) -> ENID_W {
+        ENID_W { w: self }
     }
 }

--- a/svd/devices/include/atsamd5x.xsl
+++ b/svd/devices/include/atsamd5x.xsl
@@ -32,6 +32,19 @@
     </fields>
   </xsl:template>
 
+  <!-- The GMAC::TIDM::ENIDn fields are all missing. -->
+  <xsl:template match="/device/peripherals/peripheral[name='GMAC']/registers/register[name='TIDM[%s]']/fields">
+    <fields>
+      <xsl:copy-of select="./field"/>
+      <field>
+        <name>ENID</name>
+        <description>Enable Copying of TID Matched Frames</description>
+        <bitOffset>31</bitOffset>
+        <bitWidth>1</bitWidth>
+      </field>
+    </fields>
+  </xsl:template>
+
   <!-- The DMAC trigger sources in the original SVD only have the 0=disabled
   enumeration value -->
   <xsl:template match="/device/peripherals/peripheral[name='DMAC']/registers/cluster/register[name='CHCTRLA']/fields/field[name='TRIGSRC']/enumeratedValues">


### PR DESCRIPTION
The SVD files do not contain the TIDM::ENIDn fields for the GMAC peripheral.
See page 505 Chapter `24.9.24 GMAC Type ID Match n Register` in the data sheet.