### PR TITLE
unify the identical copies of TimerParams

### DIFF
--- a/hal/src/common/mod.rs
+++ b/hal/src/common/mod.rs
@@ -5,6 +5,7 @@ pub mod sercom;
 pub mod sleeping_delay;
 pub mod spi_common;
 pub mod time;
+pub mod timer_params;
 pub mod timer_traits;
 
 #[cfg(any(feature = "samd11", feature = "samd21"))]

--- a/hal/src/common/thumbv6m/pwm.rs
+++ b/hal/src/common/thumbv6m/pwm.rs
@@ -1,7 +1,7 @@
 use crate::clock;
 use crate::hal::{Pwm, PwmPin};
 use crate::time::Hertz;
-use crate::timer::TimerParams;
+use crate::timer_params::TimerParams;
 
 use crate::target_device::{PM, TCC0};
 #[cfg(feature = "samd11")]

--- a/hal/src/common/thumbv7em/pwm.rs
+++ b/hal/src/common/thumbv7em/pwm.rs
@@ -2,7 +2,7 @@ use crate::clock;
 use crate::gpio::*;
 use crate::hal::{Pwm, PwmPin};
 use crate::time::Hertz;
-use crate::timer::TimerParams;
+use crate::timer_params::TimerParams;
 
 use crate::target_device::{MCLK, TC0, TC1, TC2, TC3, TCC0, TCC1, TCC2};
 #[cfg(feature = "min-samd51j")]

--- a/hal/src/common/thumbv7em/timer.rs
+++ b/hal/src/common/thumbv7em/timer.rs
@@ -3,6 +3,7 @@ use crate::hal::timer::{CountDown, Periodic};
 use crate::target_device::tc0::COUNT16;
 #[allow(unused)]
 use crate::target_device::{MCLK, TC2, TC3};
+use crate::timer_params::TimerParams;
 // Only the G variants are missing these timers
 #[cfg(feature = "min-samd51j")]
 use crate::target_device::{TC4, TC5};
@@ -168,59 +169,6 @@ impl TimerCounter<$TC>
     }
 }
         )+
-    }
-}
-
-/// Helper type for computing cycles and divider given frequency
-#[derive(Debug, Clone, Copy)]
-pub struct TimerParams {
-    pub divider: u16,
-    pub cycles: u32,
-}
-
-impl TimerParams {
-    pub fn new<T>(timeout: T, src_freq: u32) -> Self
-    where
-        T: Into<Hertz>,
-    {
-        let timeout = timeout.into();
-        let ticks: u32 = src_freq / timeout.0.max(1);
-        Self::new_from_ticks(ticks)
-    }
-
-    pub fn new_us<T>(timeout: T, src_freq: u32) -> Self
-    where
-        T: Into<Nanoseconds>,
-    {
-        let timeout = timeout.into();
-        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_000_u64) as u32;
-        Self::new_from_ticks(ticks)
-    }
-
-    fn new_from_ticks(ticks: u32) -> Self {
-        let divider = ((ticks >> 16) + 1).next_power_of_two();
-        let divider = match divider {
-            1 | 2 | 4 | 8 | 16 | 64 | 256 | 1024 => divider,
-            // There are a couple of gaps, so we round up to the next largest
-            // divider; we'll need to count twice as many but it will work.
-            32 => 64,
-            128 => 256,
-            512 => 1024,
-            // Catch all case; this is lame.  Would be great to detect this
-            // and fail at compile time.
-            _ => 1024,
-        };
-
-        let cycles: u32 = ticks / divider as u32;
-
-        if cycles > u16::max_value() as u32 {
-            panic!("cycles {} is out of range for a 16 bit counter", cycles);
-        }
-
-        TimerParams {
-            divider: divider as u16,
-            cycles,
-        }
     }
 }
 

--- a/hal/src/common/timer_params.rs
+++ b/hal/src/common/timer_params.rs
@@ -1,0 +1,83 @@
+//! helper struct to calculate divider & cycles settings for timers.
+use crate::time::{Hertz, Nanoseconds};
+
+/// Helper type for computing cycles and divider given frequency
+#[derive(Debug, Clone, Copy)]
+pub struct TimerParams {
+    pub divider: u16,
+    pub cycles: u32,
+}
+
+impl TimerParams {
+    /// calculates TimerParams from a given frequency based timeout.
+    pub fn new<T>(timeout: T, src_freq: u32) -> Self
+    where
+        T: Into<Hertz>,
+    {
+        let timeout = timeout.into();
+        let ticks: u32 = src_freq / timeout.0.max(1);
+        Self::new_from_ticks(ticks)
+    }
+
+    /// calculates TimerParams from a given period based timeout.
+    pub fn new_us<T>(timeout: T, src_freq: u32) -> Self
+    where
+        T: Into<Nanoseconds>,
+    {
+        let timeout = timeout.into();
+        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_000_u64) as u32;
+        Self::new_from_ticks(ticks)
+    }
+
+    fn new_from_ticks(ticks: u32) -> Self {
+        let divider = ((ticks >> 16) + 1).next_power_of_two();
+        let divider = match divider {
+            1 | 2 | 4 | 8 | 16 | 64 | 256 | 1024 => divider,
+            // There are a couple of gaps, so we round up to the next largest
+            // divider; we'll need to count twice as many but it will work.
+            32 => 64,
+            128 => 256,
+            512 => 1024,
+            // Catch all case; this is lame.  Would be great to detect this
+            // and fail at compile time.
+            _ => 1024,
+        };
+
+        let cycles: u32 = ticks / divider as u32;
+
+        if cycles > u16::max_value() as u32 {
+            panic!("cycles {} is out of range for a 16 bit counter", cycles);
+        }
+
+        TimerParams {
+            divider: divider as u16,
+            cycles,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::time::U32Ext;
+    use crate::timer_params::TimerParams;
+
+    #[test]
+    fn timer_params_hz_and_us_same_1hz() {
+        let tp_from_hz = TimerParams::new(1_u32.hz(), 48_000_000_u32);
+        let tp_from_us = TimerParams::new_us(1_000_000_u32.us(), 48_000_000_u32);
+
+        assert_eq!(tp_from_hz.divider, tp_from_us.divider);
+        assert_eq!(tp_from_hz.cycles, tp_from_us.cycles);
+    }
+
+    #[test]
+    fn timer_params_hz_and_us_same_3hz() {
+        let tp_from_hz = TimerParams::new(3_u32.hz(), 48_000_000_u32);
+        let tp_from_us = TimerParams::new_us(333_333_u32.us(), 48_000_000_u32);
+
+        // There's some rounding error here, but it is extremely small (1 cycle
+        // difference)
+        assert_eq!(tp_from_hz.divider, tp_from_us.divider);
+        assert!((tp_from_hz.cycles as i32 - tp_from_us.cycles as i32).abs() <= 1);
+    }
+}

--- a/hal/src/samd11/timer.rs
+++ b/hal/src/samd11/timer.rs
@@ -2,6 +2,7 @@
 use crate::target_device::tc1::COUNT16;
 #[allow(unused)]
 use crate::target_device::{PM, TC1};
+use crate::timer_params::TimerParams;
 use crate::timer_traits::InterruptDrivenTimer;
 use hal::timer::{CountDown, Periodic};
 
@@ -158,59 +159,6 @@ impl TimerCounter<$TC>
     }
 }
         )+
-    }
-}
-
-/// Helper type for computing cycles and divider given frequency
-#[derive(Debug, Clone, Copy)]
-pub struct TimerParams {
-    pub divider: u16,
-    pub cycles: u32,
-}
-
-impl TimerParams {
-    pub fn new<T>(timeout: T, src_freq: u32) -> Self
-    where
-        T: Into<Hertz>,
-    {
-        let timeout = timeout.into();
-        let ticks: u32 = src_freq / timeout.0.max(1);
-        Self::new_from_ticks(ticks)
-    }
-
-    pub fn new_us<T>(timeout: T, src_freq: u32) -> Self
-    where
-        T: Into<Nanoseconds>,
-    {
-        let timeout = timeout.into();
-        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_000_u64) as u32;
-        Self::new_from_ticks(ticks)
-    }
-
-    fn new_from_ticks(ticks: u32) -> Self {
-        let divider = ((ticks >> 16) + 1).next_power_of_two();
-        let divider = match divider {
-            1 | 2 | 4 | 8 | 16 | 64 | 256 | 1024 => divider,
-            // There are a couple of gaps, so we round up to the next largest
-            // divider; we'll need to count twice as many but it will work.
-            32 => 64,
-            128 => 256,
-            512 => 1024,
-            // Catch all case; this is lame.  Would be great to detect this
-            // and fail at compile time.
-            _ => 1024,
-        };
-
-        let cycles: u32 = ticks / divider as u32;
-
-        if cycles > u16::max_value() as u32 {
-            panic!("cycles {} is out of range for a 16 bit counter", cycles,);
-        }
-
-        TimerParams {
-            divider: divider as u16,
-            cycles,
-        }
     }
 }
 

--- a/hal/src/samd21/timer.rs
+++ b/hal/src/samd21/timer.rs
@@ -2,6 +2,7 @@
 use crate::target_device::tc3::COUNT16;
 #[allow(unused)]
 use crate::target_device::{PM, TC3, TC4, TC5};
+use crate::timer_params::TimerParams;
 use hal::timer::{CountDown, Periodic};
 
 use crate::clock;
@@ -167,89 +168,10 @@ impl TimerCounter<$TC>
     }
 }
 
-/// Helper type for computing cycles and divider given frequency
-#[derive(Debug, Clone, Copy)]
-pub struct TimerParams {
-    pub divider: u16,
-    pub cycles: u32,
-}
-
-impl TimerParams {
-    pub fn new<T>(timeout: T, src_freq: u32) -> Self
-    where
-        T: Into<Hertz>,
-    {
-        let timeout = timeout.into();
-        let ticks: u32 = src_freq / timeout.0.max(1);
-        TimerParams::new_from_ticks(ticks)
-    }
-
-    pub fn new_us<T>(timeout: T, src_freq: u32) -> Self
-    where
-        T: Into<Nanoseconds>,
-    {
-        let timeout = timeout.into();
-        let ticks: u32 = (timeout.0 as u64 * src_freq as u64 / 1_000_000_000_u64) as u32;
-        Self::new_from_ticks(ticks)
-    }
-
-    fn new_from_ticks(ticks: u32) -> Self {
-        let divider = ((ticks >> 16) + 1).next_power_of_two();
-        let divider = match divider {
-            1 | 2 | 4 | 8 | 16 | 64 | 256 | 1024 => divider,
-            // There are a couple of gaps, so we round up to the next largest
-            // divider; we'll need to count twice as many but it will work.
-            32 => 64,
-            128 => 256,
-            512 => 1024,
-            // Catch all case; this is lame.  Would be great to detect this
-            // and fail at compile time.
-            _ => 1024,
-        };
-
-        let cycles: u32 = ticks / divider as u32;
-
-        if cycles > u16::max_value() as u32 {
-            panic!("cycles {} is out of range for a 16 bit counter", cycles);
-        }
-
-        TimerParams {
-            divider: divider as u16,
-            cycles,
-        }
-    }
-}
-
 tc! {
     TimerCounter3: (TC3, tc3_, Tcc2Tc3Clock),
     TimerCounter4: (TC4, tc4_, Tc4Tc5Clock),
     TimerCounter5: (TC5, tc5_, Tc4Tc5Clock),
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::samd21::timer::TimerParams;
-    use crate::time::U32Ext;
-
-    #[test]
-    fn timer_params_hz_and_us_same_1hz() {
-        let tp_from_hz = TimerParams::new(1_u32.hz(), 48_000_000_u32);
-        let tp_from_us = TimerParams::new_us(1_000_000_u32.us(), 48_000_000_u32);
-
-        assert_eq!(tp_from_hz.divider, tp_from_us.divider);
-        assert_eq!(tp_from_hz.cycles, tp_from_us.cycles);
-    }
-
-    #[test]
-    fn timer_params_hz_and_us_same_3hz() {
-        let tp_from_hz = TimerParams::new(3_u32.hz(), 48_000_000_u32);
-        let tp_from_us = TimerParams::new_us(333_333_u32.us(), 48_000_000_u32);
-
-        // There's some rounding error here, but it is extremely small (1 cycle
-        // difference)
-        assert_eq!(tp_from_hz.divider, tp_from_us.divider);
-        assert!((tp_from_hz.cycles as i32 - tp_from_us.cycles as i32).abs() <= 1);
-    }
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
the SAMD11, SAMD21, and thumbv7em copies of `TimerParams` are identical. This unifies them into one common place.