### PR TITLE
Use vcell v0.1.2

### DIFF
--- a/pac/atsamd11c/Cargo.toml
+++ b/pac/atsamd11c/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
 [dependencies]
-bare-metal = "~0.2"
-cortex-m = "~0.6"
-vcell = "~0.1.2"
+bare-metal = "0.2"
+cortex-m = "0.6"
+vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.6.12"
 optional = true
 
 [features]

--- a/pac/atsamd11c/Cargo.toml
+++ b/pac/atsamd11c/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 bare-metal = "~0.2"
 cortex-m = "~0.6"
-vcell = "~0.1"
+vcell = "~0.1.2"
 
 [dependencies.cortex-m-rt]
 version = "~0.6.12"

--- a/pac/atsamd21e/Cargo.toml
+++ b/pac/atsamd21e/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
 [dependencies]
-bare-metal = "~0.2"
-cortex-m = "~0.6"
-vcell = "~0.1.2"
+bare-metal = "0.2"
+cortex-m = "0.6"
+vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.6.12"
 optional = true
 
 [features]

--- a/pac/atsamd21e/Cargo.toml
+++ b/pac/atsamd21e/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 bare-metal = "~0.2"
 cortex-m = "~0.6"
-vcell = "~0.1"
+vcell = "~0.1.2"
 
 [dependencies.cortex-m-rt]
 version = "~0.6.12"

--- a/pac/atsamd21g/Cargo.toml
+++ b/pac/atsamd21g/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
 [dependencies]
-bare-metal = "~0.2"
-cortex-m = "~0.6"
-vcell = "~0.1.2"
+bare-metal = "0.2"
+cortex-m = "0.6"
+vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.6.12"
 optional = true
 
 [features]

--- a/pac/atsamd21g/Cargo.toml
+++ b/pac/atsamd21g/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 bare-metal = "~0.2"
 cortex-m = "~0.6"
-vcell = "~0.1"
+vcell = "~0.1.2"
 
 [dependencies.cortex-m-rt]
 version = "~0.6.12"

--- a/pac/atsamd21j/Cargo.toml
+++ b/pac/atsamd21j/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
 [dependencies]
-bare-metal = "~0.2"
-cortex-m = "~0.6"
-vcell = "~0.1.2"
+bare-metal = "0.2"
+cortex-m = "0.6"
+vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.6.12"
 optional = true
 
 [features]

--- a/pac/atsamd21j/Cargo.toml
+++ b/pac/atsamd21j/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 bare-metal = "~0.2"
 cortex-m = "~0.6"
-vcell = "~0.1"
+vcell = "~0.1.2"
 
 [dependencies.cortex-m-rt]
 version = "~0.6.12"

--- a/pac/atsamd51g/Cargo.toml
+++ b/pac/atsamd51g/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
 [dependencies]
-bare-metal = "~0.2"
-cortex-m = "~0.6"
-vcell = "~0.1.2"
+bare-metal = "0.2"
+cortex-m = "0.6"
+vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.6.12"
 optional = true
 
 [features]

--- a/pac/atsamd51g/Cargo.toml
+++ b/pac/atsamd51g/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 bare-metal = "~0.2"
 cortex-m = "~0.6"
-vcell = "~0.1"
+vcell = "~0.1.2"
 
 [dependencies.cortex-m-rt]
 version = "~0.6.12"

--- a/pac/atsamd51j/Cargo.toml
+++ b/pac/atsamd51j/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
 [dependencies]
-bare-metal = "~0.2"
-cortex-m = "~0.6"
-vcell = "~0.1.2"
+bare-metal = "0.2"
+cortex-m = "0.6"
+vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.6.12"
 optional = true
 
 [features]

--- a/pac/atsamd51j/Cargo.toml
+++ b/pac/atsamd51j/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 bare-metal = "~0.2"
 cortex-m = "~0.6"
-vcell = "~0.1"
+vcell = "~0.1.2"
 
 [dependencies.cortex-m-rt]
 version = "~0.6.12"

--- a/pac/atsamd51n/Cargo.toml
+++ b/pac/atsamd51n/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 [dependencies]
 bare-metal = "~0.2"
 cortex-m = "~0.6"
-vcell = "~0.1"
+vcell = "~0.1.2"
 
 [dependencies.cortex-m-rt]
 version = "~0.6.12"

--- a/pac/atsamd51n/Cargo.toml
+++ b/pac/atsamd51n/Cargo.toml
@@ -13,12 +13,12 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
 [dependencies]
-bare-metal = "~0.2"
-cortex-m = "~0.6"
-vcell = "~0.1.2"
+bare-metal = "0.2"
+cortex-m = "0.6"
+vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.6.12"
 optional = true
 
 [features]

--- a/pac/atsamd51p/Cargo.toml
+++ b/pac/atsamd51p/Cargo.toml
@@ -10,12 +10,12 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-bare-metal = "~0.2"
-cortex-m = "~0.6"
-vcell = "~0.1.2"
+bare-metal = "0.2"
+cortex-m = "0.6"
+vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.6.12"
 optional = true
 
 [features]

--- a/pac/atsamd51p/Cargo.toml
+++ b/pac/atsamd51p/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 bare-metal = "~0.2"
 cortex-m = "~0.6"
-vcell = "~0.1"
+vcell = "~0.1.2"
 
 [dependencies.cortex-m-rt]
 version = "~0.6.12"

--- a/pac/atsame51g/Cargo.toml
+++ b/pac/atsame51g/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
 [dependencies]
-bare-metal = "~0.2"
-cortex-m = "~0.6"
-vcell = "~0.1.2"
+bare-metal = "0.2"
+cortex-m = "0.6"
+vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.6.12"
 optional = true
 
 [features]

--- a/pac/atsame51g/Cargo.toml
+++ b/pac/atsame51g/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 bare-metal = "~0.2"
 cortex-m = "~0.6"
-vcell = "~0.1"
+vcell = "~0.1.2"
 
 [dependencies.cortex-m-rt]
 version = "~0.6.12"

--- a/pac/atsame51j/Cargo.toml
+++ b/pac/atsame51j/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
 [dependencies]
-bare-metal = "~0.2"
-cortex-m = "~0.6"
-vcell = "~0.1.2"
+bare-metal = "0.2"
+cortex-m = "0.6"
+vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.6.12"
 optional = true
 
 [features]

--- a/pac/atsame51j/Cargo.toml
+++ b/pac/atsame51j/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 bare-metal = "~0.2"
 cortex-m = "~0.6"
-vcell = "~0.1"
+vcell = "~0.1.2"
 
 [dependencies.cortex-m-rt]
 version = "~0.6.12"

--- a/pac/atsame51n/Cargo.toml
+++ b/pac/atsame51n/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
 [dependencies]
-bare-metal = "~0.2"
-cortex-m = "~0.6"
-vcell = "~0.1.2"
+bare-metal = "0.2"
+cortex-m = "0.6"
+vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.6.12"
 optional = true
 
 [features]

--- a/pac/atsame51n/Cargo.toml
+++ b/pac/atsame51n/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 bare-metal = "~0.2"
 cortex-m = "~0.6"
-vcell = "~0.1"
+vcell = "~0.1.2"
 
 [dependencies.cortex-m-rt]
 version = "~0.6.12"

--- a/pac/atsame53j/Cargo.toml
+++ b/pac/atsame53j/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
 [dependencies]
-bare-metal = "~0.2"
-cortex-m = "~0.6"
-vcell = "~0.1.2"
+bare-metal = "0.2"
+cortex-m = "0.6"
+vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.6.12"
 optional = true
 
 [features]

--- a/pac/atsame53j/Cargo.toml
+++ b/pac/atsame53j/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 bare-metal = "~0.2"
 cortex-m = "~0.6"
-vcell = "~0.1"
+vcell = "~0.1.2"
 
 [dependencies.cortex-m-rt]
 version = "~0.6.12"

--- a/pac/atsame53n/Cargo.toml
+++ b/pac/atsame53n/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
 [dependencies]
-bare-metal = "~0.2"
-cortex-m = "~0.6"
-vcell = "~0.1.2"
+bare-metal = "0.2"
+cortex-m = "0.6"
+vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.6.12"
 optional = true
 
 [features]

--- a/pac/atsame53n/Cargo.toml
+++ b/pac/atsame53n/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 bare-metal = "~0.2"
 cortex-m = "~0.6"
-vcell = "~0.1"
+vcell = "~0.1.2"
 
 [dependencies.cortex-m-rt]
 version = "~0.6.12"

--- a/pac/atsame54n/Cargo.toml
+++ b/pac/atsame54n/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
 [dependencies]
-bare-metal = "~0.2"
-cortex-m = "~0.6"
-vcell = "~0.1.2"
+bare-metal = "0.2"
+cortex-m = "0.6"
+vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.6.12"
 optional = true
 
 [features]

--- a/pac/atsame54n/Cargo.toml
+++ b/pac/atsame54n/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 bare-metal = "~0.2"
 cortex-m = "~0.6"
-vcell = "~0.1"
+vcell = "~0.1.2"
 
 [dependencies.cortex-m-rt]
 version = "~0.6.12"

--- a/pac/atsame54p/Cargo.toml
+++ b/pac/atsame54p/Cargo.toml
@@ -14,12 +14,12 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
 [dependencies]
-bare-metal = "~0.2"
-cortex-m = "~0.6"
-vcell = "~0.1.2"
+bare-metal = "0.2"
+cortex-m = "0.6"
+vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.6.12"
 optional = true
 
 [features]

--- a/pac/atsame54p/Cargo.toml
+++ b/pac/atsame54p/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 [dependencies]
 bare-metal = "~0.2"
 cortex-m = "~0.6"
-vcell = "~0.1"
+vcell = "~0.1.2"
 
 [dependencies.cortex-m-rt]
 version = "~0.6.12"


### PR DESCRIPTION
The `register.rs` file included in the output of svd2rust uses
`as_ptr()`, which was only added in vcell v0.1.1 (now yanked).

See https://github.com/rust-embedded/svd2rust/pull/484 (maybe wait until it's looked at/merged)

This was found while doing #355 with a very old existing clone & running into weird compile errors:
```
error[E0599]: no method named `as_ptr` found for struct `VolatileCell<U>` in the current scope
  --> /[..]/atsamd/pac/atsamd21e/src/generic.rs:39:23
   |
39 |         self.register.as_ptr()
   |                       ^^^^^^ method not found in `VolatileCell<U>`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0599`.
error: could not compile `atsamd21e`

To learn more, run the command again with --verbose.
```