### PR TITLE
swap USB pads to use gpio v2 objects

### DIFF
--- a/hal/src/common/thumbv7em/usb/mod.rs
+++ b/hal/src/common/thumbv7em/usb/mod.rs
@@ -10,11 +10,14 @@ pub use self::bus::UsbBus;
 mod devicedesc;
 use self::devicedesc::Descriptors;
 
+
+use gpio::v2::*;
+
 /// Emit SOF at 1Khz on this pin when configured as function H
-pub type SofPad = gpio::Pa23<gpio::PfH>;
+pub type SofPad = Pin<PA23, AlternateH>;
 
 /// USB D- is connected here
-pub type DmPad = gpio::Pa24<gpio::PfH>;
+pub type DmPad = Pin<PA24, AlternateH>;
 
 /// USB D+ is connected here
-pub type DpPad = gpio::Pa25<gpio::PfH>;
+pub type DpPad = Pin<PA25, AlternateH>;


### PR DESCRIPTION
Swaps USB pads to `hal::common::gpio::v2` objects﻿ to work where one is using the V2 types. This is probably going to set of a whoole chain of build failures in other modules I guess.

Not sure whether it's useful to merge this as it's breaking, I guess it could be hidden behind features if y'all wanted to support both?