### PR TITLE
Upgrade deps to fix UB caused by generic-array 0.13.0

### DIFF
--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -39,8 +39,8 @@ usbd-serial = { version = "0.1", optional = true }
 bbqueue = { version = "^0.4.11", optional = true }
 nb = { version = "0.1", optional = true }
 nom = { version = "^6.0", default-features = false, optional = true }
-generic-array = { version = "0.13", optional = true }
-seeed-erpc = { version = "0.1.0", optional = true }
+generic-array = { version = "0.14", optional = true }
+seeed-erpc = { version = "0.1.1", optional = true }
 
 [dependencies.atsamd-hal]
 path = "../../hal"


### PR DESCRIPTION
Fixes crashing wifi-scan example, caused by https://github.com/fizyk20/generic-array/issues/97