### PR TITLE
Force refresh of crates.io index when publishing

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -78,5 +78,15 @@ jobs:
           sudo apt-get install -y jq
           for bsp in $(cat crates.json | jq -Mr -c '.boards | keys[]');
           do
-            (cd "boards/${bsp}" && cargo publish );
+            (
+              cd "boards/${bsp}"
+              PUBLISH_ERR=$(cargo publish 2>&1 >/dev/null)
+              if [[ "$PUBLISH_ERR" == *" is already uploaded"* ]]; then
+                exit 0
+              fi
+              if [[ "$PUBLISH_ERR" == *"error: "* ]]; then
+                echo "$PUBLISH_ERR"
+                exit 1
+              fi
+            )
           done

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -59,6 +59,10 @@ jobs:
         shell: bash
         run: |
           set -ex
+
+          # Install random crate to force update of the registry
+          cargo install lazy_static || true
+
           cd "hal" && cargo publish --no-verify
 
 
@@ -67,6 +71,10 @@ jobs:
         shell: bash
         run: |
           set -ex
+
+          # Install random crate to force update of the registry
+          cargo install lazy_static || true
+
           sudo apt-get install -y jq
           for bsp in $(cat crates.json | jq -Mr -c '.boards | keys[]');
           do


### PR DESCRIPTION
Cargo doesnt actually support refreshing the index so we have to do it as a side effect of `cargo install` - `cargo install lazy_static` is also what crater does.