### PR TITLE
Fix erroneous exclusion of examples directory, which breaks publishing

### DIFF
--- a/.github/workflows/build-bsp.yml
+++ b/.github/workflows/build-bsp.yml
@@ -42,3 +42,4 @@ jobs:
         set -ex
         cd boards/${{ matrix.bsp }}
         $(${build_invocation})
+        cargo publish --dry-run

--- a/boards/arduino_nano33iot/Cargo.toml
+++ b/boards/arduino_nano33iot/Cargo.toml
@@ -9,8 +9,6 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 edition = "2018"
 
-exclude = ["examples"]
-
 [dependencies]
 cortex-m = "0.6"
 embedded-hal = "0.2.3"

--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 edition = "2018"
-exclude = ["assets", "examples"]
+exclude = ["assets"]
 
 [dependencies]
 cortex-m = "0.6"

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 edition = "2018"
-exclude = ["assets", "examples"]
+exclude = ["assets"]
 
 [dependencies]
 cortex-m = "0.6"

--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -23,7 +23,7 @@ categories = [
     "no-std",
 ]
 
-exclude = ["assets", "examples"]
+exclude = ["assets"]
 
 [dependencies]
 bitfield = "0.13"


### PR DESCRIPTION
Fixes the following BSPs:

 - arduino_nano33iot
 - edgebadge
 - pygamer
 - wio_terminal
 
 And adds `cargo publish --dry-run` to CI to detect this in the future.