### PR TITLE
Add underscore on unused `adc` parameter

### DIFF
--- a/hal/src/common/thumbv7em/adc.rs
+++ b/hal/src/common/thumbv7em/adc.rs
@@ -166,13 +166,13 @@ impl Adc<$ADC> {
 }
 
 impl ConversionMode<$ADC> for SingleConversion  {
-    fn on_start(adc: &mut Adc<$ADC>) {
+    fn on_start(_adc: &mut Adc<$ADC>) {
     }
     fn on_complete(adc: &mut Adc<$ADC>) {
         adc.disable_interrupts();
         adc.power_down();
     }
-    fn on_stop(adc: &mut Adc<$ADC>) {
+    fn on_stop(_adc: &mut Adc<$ADC>) {
     }
 }
 
@@ -180,7 +180,7 @@ impl ConversionMode<$ADC> for FreeRunning {
     fn on_start(adc: &mut Adc<$ADC>) {
         adc.enable_freerunning();
     }
-    fn on_complete(adc: &mut Adc<$ADC>) {
+    fn on_complete(_adc: &mut Adc<$ADC>) {
     }
     fn on_stop(adc: &mut Adc<$ADC>) {
         adc.disable_interrupts();


### PR DESCRIPTION
These are generating the following compiler warnings.

``` log
warning: unused variable: `adc`
   --> deps/atsamd/hal/src/common/thumbv7em/adc.rs:169:17
    |
44  | / macro_rules! adc_hal {
45  | |     ($($ADC:ident: ($init:ident, $mclk:ident, $apmask:ident, $compcal:ident, $refcal:ident, $r2rcal:ident),)+) => {
46  | |         $(
47  | | impl Adc<$ADC> {
...   |
169 | |     fn on_start(adc: &mut Adc<$ADC>) {
    | |                 ^^^ help: if this is intentional, prefix it with an underscore: `_adc`
...   |
245 | |     }
246 | | }
    | |_- in this expansion of `adc_hal!`
...
260 | / adc_hal! {
261 | |     ADC0: (adc0, apbdmask, adc0_, adc0_biascomp_scale_cal, adc0_biasref_scale_cal, adc0_biasr2r_scale_cal),
262 | |     ADC1: (adc1, apbdmask, adc1_, adc1_biascomp_scale_cal, adc1_biasref_scale_cal, adc1_biasr2r_scale_cal),
263 | | }
    | |_- in this macro invocation
    |
    = note: `#[warn(unused_variables)]` on by default
```