### PR TITLE
Patch SVD for SWRST register in RTC

### DIFF
--- a/hal/src/common/rtc.rs
+++ b/hal/src/common/rtc.rs
@@ -203,9 +203,7 @@ impl CountDown for Rtc {
         // can ask it to perform a reset.
         self.reset();
 
-        // the SVD erroneously marks swrst as write-only, so we
-        // need to manually read the bit here
-        while self.mode0_ctrla().read().bits() & 1 != 0 {}
+        while self.mode0_ctrla().read().swrst().bit_is_set() {}
 
         // set cycles to compare to...
         self.mode0().comp[0].write(|w| unsafe { w.comp().bits(cycles) });

--- a/pac/atsamd11c/src/rtc/mode0/ctrl.rs
+++ b/pac/atsamd11c/src/rtc/mode0/ctrl.rs
@@ -10,6 +10,8 @@ impl crate::ResetValue for super::CTRL {
         0
     }
 }
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `SWRST`"]
 pub struct SWRST_W<'a> {
     w: &'a mut W,
@@ -343,6 +345,11 @@ impl<'a> PRESCALER_W<'a> {
     }
 }
 impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
     #[doc = "Bit 1 - Enable"]
     #[inline(always)]
     pub fn enable(&self) -> ENABLE_R {

--- a/pac/atsamd11c/src/rtc/mode1/ctrl.rs
+++ b/pac/atsamd11c/src/rtc/mode1/ctrl.rs
@@ -10,6 +10,8 @@ impl crate::ResetValue for super::CTRL {
         0
     }
 }
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `SWRST`"]
 pub struct SWRST_W<'a> {
     w: &'a mut W,
@@ -319,6 +321,11 @@ impl<'a> PRESCALER_W<'a> {
     }
 }
 impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
     #[doc = "Bit 1 - Enable"]
     #[inline(always)]
     pub fn enable(&self) -> ENABLE_R {

--- a/pac/atsamd11c/src/rtc/mode2/ctrl.rs
+++ b/pac/atsamd11c/src/rtc/mode2/ctrl.rs
@@ -10,6 +10,8 @@ impl crate::ResetValue for super::CTRL {
         0
     }
 }
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `SWRST`"]
 pub struct SWRST_W<'a> {
     w: &'a mut W,
@@ -367,6 +369,11 @@ impl<'a> PRESCALER_W<'a> {
     }
 }
 impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
     #[doc = "Bit 1 - Enable"]
     #[inline(always)]
     pub fn enable(&self) -> ENABLE_R {

--- a/pac/atsamd21e/src/rtc/mode0/ctrl.rs
+++ b/pac/atsamd21e/src/rtc/mode0/ctrl.rs
@@ -10,6 +10,8 @@ impl crate::ResetValue for super::CTRL {
         0
     }
 }
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `SWRST`"]
 pub struct SWRST_W<'a> {
     w: &'a mut W,
@@ -343,6 +345,11 @@ impl<'a> PRESCALER_W<'a> {
     }
 }
 impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
     #[doc = "Bit 1 - Enable"]
     #[inline(always)]
     pub fn enable(&self) -> ENABLE_R {

--- a/pac/atsamd21e/src/rtc/mode1/ctrl.rs
+++ b/pac/atsamd21e/src/rtc/mode1/ctrl.rs
@@ -10,6 +10,8 @@ impl crate::ResetValue for super::CTRL {
         0
     }
 }
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `SWRST`"]
 pub struct SWRST_W<'a> {
     w: &'a mut W,
@@ -319,6 +321,11 @@ impl<'a> PRESCALER_W<'a> {
     }
 }
 impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
     #[doc = "Bit 1 - Enable"]
     #[inline(always)]
     pub fn enable(&self) -> ENABLE_R {

--- a/pac/atsamd21e/src/rtc/mode2/ctrl.rs
+++ b/pac/atsamd21e/src/rtc/mode2/ctrl.rs
@@ -10,6 +10,8 @@ impl crate::ResetValue for super::CTRL {
         0
     }
 }
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `SWRST`"]
 pub struct SWRST_W<'a> {
     w: &'a mut W,
@@ -367,6 +369,11 @@ impl<'a> PRESCALER_W<'a> {
     }
 }
 impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
     #[doc = "Bit 1 - Enable"]
     #[inline(always)]
     pub fn enable(&self) -> ENABLE_R {

--- a/pac/atsamd21g/src/rtc/mode0/ctrl.rs
+++ b/pac/atsamd21g/src/rtc/mode0/ctrl.rs
@@ -10,6 +10,8 @@ impl crate::ResetValue for super::CTRL {
         0
     }
 }
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `SWRST`"]
 pub struct SWRST_W<'a> {
     w: &'a mut W,
@@ -343,6 +345,11 @@ impl<'a> PRESCALER_W<'a> {
     }
 }
 impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
     #[doc = "Bit 1 - Enable"]
     #[inline(always)]
     pub fn enable(&self) -> ENABLE_R {

--- a/pac/atsamd21g/src/rtc/mode1/ctrl.rs
+++ b/pac/atsamd21g/src/rtc/mode1/ctrl.rs
@@ -10,6 +10,8 @@ impl crate::ResetValue for super::CTRL {
         0
     }
 }
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `SWRST`"]
 pub struct SWRST_W<'a> {
     w: &'a mut W,
@@ -319,6 +321,11 @@ impl<'a> PRESCALER_W<'a> {
     }
 }
 impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
     #[doc = "Bit 1 - Enable"]
     #[inline(always)]
     pub fn enable(&self) -> ENABLE_R {

--- a/pac/atsamd21g/src/rtc/mode2/ctrl.rs
+++ b/pac/atsamd21g/src/rtc/mode2/ctrl.rs
@@ -10,6 +10,8 @@ impl crate::ResetValue for super::CTRL {
         0
     }
 }
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `SWRST`"]
 pub struct SWRST_W<'a> {
     w: &'a mut W,
@@ -367,6 +369,11 @@ impl<'a> PRESCALER_W<'a> {
     }
 }
 impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
     #[doc = "Bit 1 - Enable"]
     #[inline(always)]
     pub fn enable(&self) -> ENABLE_R {

--- a/pac/atsamd21j/src/rtc/mode0/ctrl.rs
+++ b/pac/atsamd21j/src/rtc/mode0/ctrl.rs
@@ -10,6 +10,8 @@ impl crate::ResetValue for super::CTRL {
         0
     }
 }
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `SWRST`"]
 pub struct SWRST_W<'a> {
     w: &'a mut W,
@@ -343,6 +345,11 @@ impl<'a> PRESCALER_W<'a> {
     }
 }
 impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
     #[doc = "Bit 1 - Enable"]
     #[inline(always)]
     pub fn enable(&self) -> ENABLE_R {

--- a/pac/atsamd21j/src/rtc/mode1/ctrl.rs
+++ b/pac/atsamd21j/src/rtc/mode1/ctrl.rs
@@ -10,6 +10,8 @@ impl crate::ResetValue for super::CTRL {
         0
     }
 }
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `SWRST`"]
 pub struct SWRST_W<'a> {
     w: &'a mut W,
@@ -319,6 +321,11 @@ impl<'a> PRESCALER_W<'a> {
     }
 }
 impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
     #[doc = "Bit 1 - Enable"]
     #[inline(always)]
     pub fn enable(&self) -> ENABLE_R {

--- a/pac/atsamd21j/src/rtc/mode2/ctrl.rs
+++ b/pac/atsamd21j/src/rtc/mode2/ctrl.rs
@@ -10,6 +10,8 @@ impl crate::ResetValue for super::CTRL {
         0
     }
 }
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
 #[doc = "Write proxy for field `SWRST`"]
 pub struct SWRST_W<'a> {
     w: &'a mut W,
@@ -367,6 +369,11 @@ impl<'a> PRESCALER_W<'a> {
     }
 }
 impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
     #[doc = "Bit 1 - Enable"]
     #[inline(always)]
     pub fn enable(&self) -> ENABLE_R {

--- a/svd/devices/atsamd11c14a.xsl
+++ b/svd/devices/atsamd11c14a.xsl
@@ -110,8 +110,9 @@
     </enumeratedValues>
   </xsl:template>
 
-  <!-- The drive strength bit is erroneously write-only in the
-  original SVD, remove the accesss field that marks it as such -->
-  <xsl:template match="/device/peripherals/peripheral[name='PORT']/registers/register[name='PINCFG0_%s']/fields/field[name='DRVSTR']/access">
-  </xsl:template>
+  <!-- Some register bits are erroneously write-only in the
+  original SVD, remove the access field that marks it as such -->
+  <xsl:template match="/device/peripherals/peripheral[name='PORT']/registers/register[name='PINCFG0_%s']/fields/field[name='DRVSTR']/access" />
+  <xsl:template match="/device/peripherals/peripheral[name='RTC']/registers/cluster/register[name='CTRL']/fields/field[name='SWRST']/access" />
+
 </xsl:stylesheet>

--- a/svd/devices/include/atsamd21.xsl
+++ b/svd/devices/include/atsamd21.xsl
@@ -254,9 +254,9 @@
     </enumeratedValues>
   </xsl:template>
 
-  <!-- The drive strength bit is erroneously write-only in the
-  original SVD, remove the accesss field that marks it as such -->
-  <xsl:template match="/device/peripherals/peripheral[name='PORT']/registers/register[name='PINCFG0_%s']/fields/field[name='DRVSTR']/access">
-  </xsl:template>
- 
+  <!-- Some register bits are erroneously write-only in the
+  original SVD, remove the access field that marks it as such -->
+  <xsl:template match="/device/peripherals/peripheral[name='PORT']/registers/register[name='PINCFG0_%s']/fields/field[name='DRVSTR']/access" />
+  <xsl:template match="/device/peripherals/peripheral[name='RTC']/registers/cluster/register[name='CTRL']/fields/field[name='SWRST']/access" />
+
 </xsl:stylesheet>


### PR DESCRIPTION
Add SVD patch to remove `access` field on SWRST for all RTC modes.