### PR TITLE
Fix usb clippy warnings

### DIFF
--- a/hal/src/common/thumbv7em/usb/bus.rs
+++ b/hal/src/common/thumbv7em/usb/bus.rs
@@ -159,7 +159,7 @@ fn buffer() -> &'static mut [u8; BUFFER_SIZE] {
 }
 
 struct BufferAllocator {
-    buffers: &'static mut [u8; BUFFER_SIZE],
+    buffers: &'static mut [MaybeUninit<u8>; BUFFER_SIZE],
     next_buf: u16,
 }
 
@@ -174,7 +174,7 @@ impl BufferAllocator {
     fn allocate_buffer(&mut self, size: u16) -> UsbResult<*mut u8> {
         debug_assert!(size & 1 == 0);
 
-        let start_addr = &mut self.buffers[self.next_buf as usize] as *mut u8;
+        let start_addr = &mut self.buffers[self.next_buf as usize].as_mut_ptr();
         let buf_end = unsafe { start_addr.offset(BUFFER_SIZE as isize) };
 
         // The address must be 32-bit aligned, so allow for that here

--- a/hal/src/common/thumbv7em/usb/bus.rs
+++ b/hal/src/common/thumbv7em/usb/bus.rs
@@ -17,7 +17,6 @@ use core::marker::PhantomData;
 use core::mem;
 use cortex_m::interrupt::{free as disable_interrupts, Mutex};
 use cortex_m::singleton;
-use usb_device;
 use usb_device::bus::PollResult;
 use usb_device::endpoint::{EndpointAddress, EndpointType};
 use usb_device::{Result as UsbResult, UsbDirection, UsbError};
@@ -128,6 +127,7 @@ impl AllEndpoints {
         Err(UsbError::EndpointOverflow)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn allocate_endpoint(
         &mut self,
         dir: UsbDirection,
@@ -312,7 +312,7 @@ impl<'a> Bank<'a, InBank> {
 
     /// Writes out endpoint configuration to its in-memory descriptor.
     fn flush_config(&mut self) {
-        let config = self.config().clone();
+        let config = *self.config();
         {
             let desc = self.desc_bank();
             desc.set_address(config.addr as *mut u8);
@@ -418,7 +418,7 @@ impl<'a> Bank<'a, OutBank> {
 
     /// Writes out endpoint configuration to its in-memory descriptor.
     fn flush_config(&mut self) {
-        let config = self.config().clone();
+        let config = *self.config();
         {
             let desc = self.desc_bank();
             desc.set_address(config.addr as *mut u8);
@@ -485,7 +485,7 @@ impl Inner {
     ep!(epstatus, EPSTATUS);
     ep!(epintflag, EPINTFLAG);
 
-    fn bank0<'a>(&'a self, ep: EndpointAddress) -> UsbResult<Bank<'a, OutBank>> {
+    fn bank0(&'_ self, ep: EndpointAddress) -> UsbResult<Bank<'_, OutBank>> {
         if ep.is_in() {
             return Err(UsbError::InvalidEndpoint);
         }
@@ -503,7 +503,7 @@ impl Inner {
         })
     }
 
-    fn bank1<'a>(&'a self, ep: EndpointAddress) -> UsbResult<Bank<'a, InBank>> {
+    fn bank1(&'_ self, ep: EndpointAddress) -> UsbResult<Bank<'_, InBank>> {
         if ep.is_out() {
             return Err(UsbError::InvalidEndpoint);
         }
@@ -723,10 +723,8 @@ impl Inner {
             if let Ok(mut bank) = self.bank0(ep_addr) {
                 bank.setup_ep_interrupts();
             }
-        } else {
-            if let Ok(mut bank) = self.bank1(ep_addr) {
-                bank.setup_ep_interrupts();
-            }
+        } else if let Ok(mut bank) = self.bank1(ep_addr) {
+            bank.setup_ep_interrupts();
         }
     }
 
@@ -769,7 +767,7 @@ impl Inner {
 
         let idx = match addr {
             None => endpoints.find_free_endpoint(dir)?,
-            Some(addr) => EndpointAddress::from(addr).index(),
+            Some(addr) => addr.index(),
         };
 
         let addr = endpoints.allocate_endpoint(
@@ -784,7 +782,7 @@ impl Inner {
 
         dbgprint!("alloc_ep -> {:?}\n", addr);
 
-        Ok(addr.into())
+        Ok(addr)
     }
 
     fn set_device_address(&self, addr: u8) {
@@ -868,7 +866,7 @@ impl Inner {
     }
 
     fn write(&self, ep: EndpointAddress, buf: &[u8]) -> UsbResult<usize> {
-        let mut bank = self.bank1(ep.into())?;
+        let mut bank = self.bank1(ep)?;
 
         if bank.is_ready() {
             // Waiting for the host to pick up the existing data
@@ -899,7 +897,7 @@ impl Inner {
     }
 
     fn read(&self, ep: EndpointAddress, buf: &mut [u8]) -> UsbResult<usize> {
-        let mut bank = self.bank0(ep.into())?;
+        let mut bank = self.bank0(ep)?;
         let rxstp = bank.received_setup_interrupt();
 
         if bank.is_ready() || rxstp {
@@ -940,9 +938,9 @@ impl Inner {
 
     fn is_stalled(&self, ep: EndpointAddress) -> bool {
         if ep.is_out() {
-            self.bank0(ep.into()).unwrap().is_stalled()
+            self.bank0(ep).unwrap().is_stalled()
         } else {
-            self.bank1(ep.into()).unwrap().is_stalled()
+            self.bank1(ep).unwrap().is_stalled()
         }
     }
 

--- a/hal/src/common/thumbv7em/usb/bus.rs
+++ b/hal/src/common/thumbv7em/usb/bus.rs
@@ -159,7 +159,7 @@ fn buffer() -> &'static mut [u8; BUFFER_SIZE] {
 }
 
 struct BufferAllocator {
-    buffers: &'static mut [MaybeUninit<u8>; BUFFER_SIZE],
+    buffers: &'static mut [u8; BUFFER_SIZE],
     next_buf: u16,
 }
 
@@ -174,7 +174,7 @@ impl BufferAllocator {
     fn allocate_buffer(&mut self, size: u16) -> UsbResult<*mut u8> {
         debug_assert!(size & 1 == 0);
 
-        let start_addr = &mut self.buffers[self.next_buf as usize].as_mut_ptr();
+        let start_addr = &mut self.buffers[self.next_buf as usize] as *mut u8;
         let buf_end = unsafe { start_addr.offset(BUFFER_SIZE as isize) };
 
         // The address must be 32-bit aligned, so allow for that here

--- a/hal/src/samd21/usb/bus.rs
+++ b/hal/src/samd21/usb/bus.rs
@@ -157,7 +157,7 @@ fn buffer() -> &'static mut [u8; BUFFER_SIZE] {
 }
 
 struct BufferAllocator {
-    buffers: &'static mut [u8; BUFFER_SIZE],
+    buffers: &'static mut [MaybeUninit<u8>; BUFFER_SIZE],
     next_buf: u16,
 }
 
@@ -172,7 +172,7 @@ impl BufferAllocator {
     fn allocate_buffer(&mut self, size: u16) -> UsbResult<*mut u8> {
         debug_assert!(size & 1 == 0);
 
-        let start_addr = &mut self.buffers[self.next_buf as usize] as *mut u8;
+        let start_addr = &mut self.buffers[self.next_buf as usize].as_mut_ptr();
         let buf_end = unsafe { start_addr.offset(BUFFER_SIZE as isize) };
 
         // The address must be 32-bit aligned, so allow for that here

--- a/hal/src/samd21/usb/bus.rs
+++ b/hal/src/samd21/usb/bus.rs
@@ -157,7 +157,7 @@ fn buffer() -> &'static mut [u8; BUFFER_SIZE] {
 }
 
 struct BufferAllocator {
-    buffers: &'static mut [MaybeUninit<u8>; BUFFER_SIZE],
+    buffers: &'static mut [u8; BUFFER_SIZE],
     next_buf: u16,
 }
 
@@ -172,7 +172,7 @@ impl BufferAllocator {
     fn allocate_buffer(&mut self, size: u16) -> UsbResult<*mut u8> {
         debug_assert!(size & 1 == 0);
 
-        let start_addr = &mut self.buffers[self.next_buf as usize].as_mut_ptr();
+        let start_addr = &mut self.buffers[self.next_buf as usize] as *mut u8;
         let buf_end = unsafe { start_addr.offset(BUFFER_SIZE as isize) };
 
         // The address must be 32-bit aligned, so allow for that here


### PR DESCRIPTION
**NOTE**: Based off of #381. Only look at the most recent commit for this PR.

Fixes USB-related clippy warnings. Tested & working on `feather_m0` & `feather_m4`.