### PR TITLE
feather M0 Adalogger/SD card reader support

### DIFF
--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -47,6 +47,10 @@ optional = true
 version = "0.1"
 optional = true
 
+[dependencies.embedded-sdmmc]
+version = "0.3"
+optional = true
+
 [dev-dependencies]
 cortex-m-semihosting = "0.3"
 ssd1306 = "0.3.1"
@@ -72,6 +76,9 @@ rfm = []
 express = []
 dma = ["atsamd-hal/dma"]
 max-channels = ["dma", "atsamd-hal/max-channels"]
+# Enable pins for the adalogger SD card reader
+adalogger = []
+sdmmc = ["embedded-sdmmc", "atsamd-hal/sdmmc"]
 
 [profile.dev]
 incremental = false
@@ -133,3 +140,7 @@ required-features = ["dma"]
 [[example]]
 name = "clock"
 required-features = ["usb", "unproven"]
+
+[[example]]
+name = "adalogger"
+required-features = ["adalogger", "usb", "sdmmc", "unproven"]

--- a/boards/feather_m0/examples/adalogger.rs
+++ b/boards/feather_m0/examples/adalogger.rs
@@ -124,6 +124,8 @@ fn main() -> ! {
 
     match controller.device().init() {
         Ok(_) => {
+            // speed up SPI and read out some info
+            controller.device().spi().reconfigure(|c| c.baud(4.mhz()));
             usbserial_write!("OK!\r\nCard size...\r\n");
             match controller.device().card_size_bytes() {
                 Ok(size) => usbserial_write!("{} bytes\r\n", size),

--- a/boards/feather_m0/examples/adalogger.rs
+++ b/boards/feather_m0/examples/adalogger.rs
@@ -1,0 +1,197 @@
+#![no_std]
+#![no_main]
+
+use feather_m0 as hal;
+use panic_halt as _;
+
+use core::fmt::Write;
+use core::sync::atomic;
+
+use cortex_m::interrupt::free as disable_interrupts;
+use cortex_m::peripheral::NVIC;
+use embedded_sdmmc::{Controller, SdMmcSpi, VolumeIdx};
+use usb_device::bus::UsbBusAllocator;
+use usb_device::prelude::*;
+use usbd_serial::{SerialPort, USB_CLASS_CDC};
+
+use feather_m0::hal::clock::{ClockGenId, ClockSource, GenericClockController};
+use feather_m0::hal::delay::Delay;
+use feather_m0::hal::pac::{interrupt, CorePeripherals, Peripherals};
+use feather_m0::hal::prelude::*;
+use feather_m0::hal::rtc;
+use feather_m0::hal::time::U32Ext;
+use feather_m0::hal::usb::UsbBus;
+use hal::entry;
+
+use heapless::consts::U1024;
+use heapless::String;
+
+#[entry]
+fn main() -> ! {
+    // setup basic peripherals
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    // configure the peripherals we'll need
+    // get the internal 32k running at 1024 Hz for the RTC
+    let timer_clock = clocks
+        .configure_gclk_divider_and_source(ClockGenId::GCLK3, 32, ClockSource::OSC32K, true)
+        .unwrap();
+    let rtc_clock = clocks.rtc(&timer_clock).unwrap();
+    let timer = rtc::Rtc::clock_mode(peripherals.RTC, rtc_clock.freq(), &mut peripherals.PM);
+    let pins = hal::Pins::new(peripherals.PORT);
+    let mut red_led = pins.d13.into_push_pull_output();
+
+    red_led.set_high().unwrap();
+    delay.delay_ms(500_u32);
+
+    let bus_allocator = unsafe {
+        USB_ALLOCATOR = Some(hal::usb_allocator(
+            peripherals.USB,
+            &mut clocks,
+            &mut peripherals.PM,
+            pins.usb_dm,
+            pins.usb_dp,
+        ));
+        USB_ALLOCATOR.as_ref().unwrap()
+    };
+
+    unsafe {
+        USB_SERIAL = Some(SerialPort::new(&bus_allocator));
+        USB_BUS = Some(
+            UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x16c0, 0x27dd))
+                .manufacturer("Fake company")
+                .product("Serial port")
+                .serial_number("TEST")
+                .device_class(USB_CLASS_CDC)
+                .build(),
+        );
+    }
+
+    unsafe {
+        core.NVIC.set_priority(interrupt::USB, 1);
+        NVIC::unmask(interrupt::USB);
+    }
+
+    red_led.set_low().unwrap();
+    delay.delay_ms(500_u32);
+
+    // Now work on the SD peripherals. Slow SPI speed required on init
+    let spi = hal::spi_master(
+        &mut clocks,
+        400_u32.khz(),
+        peripherals.SERCOM4,
+        &mut peripherals.PM,
+        pins.sclk,
+        pins.mosi,
+        pins.miso,
+    );
+
+    red_led.set_high().unwrap();
+    delay.delay_ms(500_u32);
+
+    let sd_cd = pins.sd_cd.into_pull_up_input();
+    let mut sd_cs = pins.sd_cs.into_push_pull_output();
+    sd_cs.set_high().unwrap();
+
+    red_led.set_low().unwrap();
+    delay.delay_ms(500_u32);
+
+    while USB_DATA_RECEIVED.load(atomic::Ordering::Relaxed) == false {
+        delay.delay_ms(250_u32);
+        red_led.toggle().unwrap();
+    }
+
+    if sd_cd.is_low().unwrap() {
+        usbserial_write!("No card detected. Waiting...\r\n");
+        while sd_cd.is_low().unwrap() {
+            delay.delay_ms(250_u32);
+        }
+    }
+    usbserial_write!("Card inserted!\r\n");
+    delay.delay_ms(250_u32);
+
+    let mut controller = Controller::new(SdMmcSpi::new(spi, sd_cs), timer);
+
+    match controller.device().init() {
+        Ok(_) => {
+            usbserial_write!("OK!\r\nCard size...\r\n");
+            match controller.device().card_size_bytes() {
+                Ok(size) => usbserial_write!("{} bytes\r\n", size),
+                Err(e) => usbserial_write!("Err: {:?}\r\n", e),
+            }
+
+            for i in 0..=3 {
+                let volume = controller.get_volume(VolumeIdx(i));
+                usbserial_write!("volume {:?}\r\n", volume);
+                if let Ok(volume) = volume {
+                    let root_dir = controller.open_root_dir(&volume).unwrap();
+                    usbserial_write!("Listing root directory:\r\n");
+                    controller
+                        .iterate_dir(&volume, &root_dir, |x| {
+                            usbserial_write!("\tFound: {:?}\r\n", x);
+                        })
+                        .unwrap();
+                }
+            }
+        }
+        Err(e) => usbserial_write!("Init err: {:?}!\r\n", e),
+    }
+
+    usbserial_write!("Done!\r\n");
+    loop {
+        delay.delay_ms(1_000_u32);
+        red_led.toggle().unwrap();
+    }
+}
+
+/// Writes the given message out over USB serial.
+#[macro_export]
+macro_rules! usbserial_write {
+    ($($tt:tt)*) => {{
+        let mut s: String<U1024> = String::new();
+        write!(s, $($tt)*).unwrap();
+        let message_bytes = s.as_bytes();
+        let mut total_written = 0;
+        while total_written < message_bytes.len() {
+            let bytes_written = disable_interrupts(|_| unsafe {
+                match USB_SERIAL.as_mut().unwrap().write(
+                    &message_bytes[total_written..]
+                ) {
+                    Ok(count) => count,
+                    Err(_) => 0,
+                }
+            });
+            total_written += bytes_written;
+        }
+    }};
+}
+
+static mut USB_ALLOCATOR: Option<UsbBusAllocator<UsbBus>> = None;
+static mut USB_BUS: Option<UsbDevice<UsbBus>> = None;
+static mut USB_SERIAL: Option<SerialPort<UsbBus>> = None;
+static USB_DATA_RECEIVED: atomic::AtomicBool = atomic::AtomicBool::new(false);
+
+#[interrupt]
+fn USB() {
+    unsafe {
+        USB_BUS.as_mut().map(|usb_dev| {
+            USB_SERIAL.as_mut().map(|serial| {
+                usb_dev.poll(&mut [serial]);
+                let mut buf = [0u8; 16];
+                if let Ok(count) = serial.read(&mut buf) {
+                    if count > 0 {
+                        USB_DATA_RECEIVED.store(true, atomic::Ordering::Relaxed);
+                    }
+                }
+            });
+        });
+    };
+}

--- a/boards/feather_m0/examples/adalogger.rs
+++ b/boards/feather_m0/examples/adalogger.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use feather_m0 as hal;
 use panic_halt as _;
 
 use core::fmt::Write;
@@ -14,14 +13,17 @@ use usb_device::bus::UsbBusAllocator;
 use usb_device::prelude::*;
 use usbd_serial::{SerialPort, USB_CLASS_CDC};
 
-use feather_m0::hal::clock::{ClockGenId, ClockSource, GenericClockController};
-use feather_m0::hal::delay::Delay;
-use feather_m0::hal::pac::{interrupt, CorePeripherals, Peripherals};
-use feather_m0::hal::prelude::*;
-use feather_m0::hal::rtc;
-use feather_m0::hal::time::U32Ext;
-use feather_m0::hal::usb::UsbBus;
-use hal::entry;
+use bsp::hal;
+use feather_m0 as bsp;
+
+use bsp::entry;
+use hal::clock::{ClockGenId, ClockSource, GenericClockController};
+use hal::delay::Delay;
+use hal::pac::{interrupt, CorePeripherals, Peripherals};
+use hal::prelude::*;
+use hal::rtc;
+use hal::time::U32Ext;
+use hal::usb::UsbBus;
 
 use heapless::consts::U1024;
 use heapless::String;
@@ -46,14 +48,14 @@ fn main() -> ! {
         .unwrap();
     let rtc_clock = clocks.rtc(&timer_clock).unwrap();
     let timer = rtc::Rtc::clock_mode(peripherals.RTC, rtc_clock.freq(), &mut peripherals.PM);
-    let pins = hal::Pins::new(peripherals.PORT);
+    let pins = bsp::Pins::new(peripherals.PORT);
     let mut red_led = pins.d13.into_push_pull_output();
 
     red_led.set_high().unwrap();
     delay.delay_ms(500_u32);
 
     let bus_allocator = unsafe {
-        USB_ALLOCATOR = Some(hal::usb_allocator(
+        USB_ALLOCATOR = Some(bsp::usb_allocator(
             peripherals.USB,
             &mut clocks,
             &mut peripherals.PM,
@@ -84,7 +86,7 @@ fn main() -> ! {
     delay.delay_ms(500_u32);
 
     // Now work on the SD peripherals. Slow SPI speed required on init
-    let spi = hal::spi_master(
+    let spi = bsp::spi_master(
         &mut clocks,
         400_u32.khz(),
         peripherals.SERCOM4,

--- a/boards/feather_m0/src/lib.rs
+++ b/boards/feather_m0/src/lib.rs
@@ -158,7 +158,7 @@ hal::bsp_pins!(
         /// SPI chip select for the RFM module
         name: rfm_cs
     }
-    #[cfg(all(feature = "rfm", not(feature = "express")))]
+    #[cfg(all(feature = "rfm", not(feature = "express"), not(feature = "adalogger")))]
     PA08 {
         /// Reset for the RFM module
         name: rfm_reset
@@ -180,7 +180,7 @@ hal::bsp_pins!(
         /// SPI clock for the external flash
         name: flash_sclk
     }
-    #[cfg(all(feature = "express", not(feature = "rfm")))]
+    #[cfg(all(feature = "express", not(feature = "rfm"), not(feature = "adalogger")))]
     PA08 {
         /// SPI MOSI for the external flash
         name: flash_mosi
@@ -195,6 +195,16 @@ hal::bsp_pins!(
         /// SPI chip select for the external flash
         name: flash_cs
     }
+
+    #[cfg(all(feature = "adalogger", not(feature = "rfm"), not(feature = "express")))]
+    PA08 {
+        /// SD card SPI chip select
+        name: sd_cs
+    },
+    PA21 {
+        /// SD card detect
+        name: sd_cd
+    },
 );
 
 type SpiPads = spi_pads_from_pins!(Sercom4, DI = Miso, DO = Mosi, CK = Sclk);

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -131,6 +131,11 @@ path = "../pac/atsame54p"
 version = "0.9"
 optional = true
 
+[dependencies.embedded-sdmmc]
+version = "0.3"
+optional = true
+
+
 [features]
 # This section lists our feature name to dependency mapping.  This are separated
 # out so that the board support crates can reference a single feature name to
@@ -189,3 +194,4 @@ use_rtt = ["jlink_rtt"]
 usb = ["usb-device"]
 dma = ["unproven"]
 max-channels = ["dma"]
+sdmmc = ["embedded-sdmmc"]


### PR DESCRIPTION
Implements support for the adalogger feather M0 variant & it's SD card reader, with an example. 

Adds pin names for the SD card chip select and card detect pins and implements the required `TimeSource` trait on the RTC for time stamping. Adds two new features, one for the pin aliases and another for enabling the [embedded-sdmmc](https://github.com/rust-embedded-community/embedded-sdmmc-rs) trait impl on RTC.

Example USB serial output of the example:
```
Card inserted!
OK!
Card size...
31914983424 bytes
volume Ok(Volume { idx: VolumeIdx(0), volume_type: Fat(FatVolume { lba_start: BlockIdx(8192), num_blocks: BlockCount(524288), name: "FEA_DAT    ", blocks_per_cluster: 8, first_data_block: BlockCount(545), fat_start: BlockCount(1), free_clusters_count: None, next_free_cluster: None, cluster_count: 65467, fat_specific_info: Fat16(Fat16Info { first_root_dir_block: BlockCount(513), root_entries_count: 512 }) }) })
Listing root directory:
        Found: DirEntry { name: ShortFileName("FEA_DAT"), mtime: Timestamp(2021-01-31 16:20:40), ctime: Timestamp(1980-01-01 00:00:00), attributes: FVA, cluster: Cluster(0), size: 0, entry_block: BlockIdx(8705), entry_offset: 0 }
        Found: DirEntry { name: ShortFileName("SPOTLI~1"), mtime: Timestamp(2021-01-31 16:20:20), ctime: Timestamp(2021-01-31 16:20:20), attributes: DH, cluster: Cluster(2), size: 0, entry_block: BlockIdx(8705), entry_offset: 96 }
        Found: DirEntry { name: ShortFileName("FSEVEN~1"), mtime: Timestamp(2021-01-31 16:20:20), ctime: Timestamp(2021-01-31 16:20:20), attributes: DH, cluster: Cluster(192), size: 0, entry_block: BlockIdx(8705), entry_offset: 160 }
        Found: DirEntry { name: ShortFileName("HELLO.TXT"), mtime: Timestamp(2021-01-31 16:20:46), ctime: Timestamp(2021-01-31 16:20:40), attributes: FA, cluster: Cluster(290), size: 12, entry_block: BlockIdx(8705), entry_offset: 192 }
volume Err(FormatError("Partition type not supported"))
volume Err(FormatError("Partition type not supported"))
volume Err(FormatError("Partition type not supported"))
Done!
```

**TODOs**:
- [x] refactor example to up the SPI baud rate after card detection (blocked by #427)
- [x] test code post rebase onto TOT