### PR TITLE
Improve v1/v2 compatibility and documentation

### DIFF
--- a/hal/src/common/sercom/v2/pads.rs
+++ b/hal/src/common/sercom/v2/pads.rs
@@ -2,29 +2,70 @@
 //!
 //! This module implements the [`Pad`] type, which represents a [`Pin`]
 //! configured to act as a SERCOM pad. A [`Pad`] is parameterized by three
-//! types. The first two types identify the pad by its [`Sercom`] and
-//! [`PadNum`]. However, each SERCOM pad can usually be mapped to several
-//! possible GPIO pins. The third type must implement the [`Map`] trait, which
-//! identifies a corresponding [`PinId`] and [`PinMode`]. The [`PinMode`] is
-//! usually [`AlternateC`] or [`AlternateD`].
+//! types. The first two types identify the [`Sercom`] and [`PadNum`]. However,
+//! each SERCOM pad can usually be mapped to several possible GPIO pins. The
+//! third type must implement the [`Map`] trait, which identifies a
+//! corresponding [`PinId`] and [`PinMode`]. The [`PinMode`] is usually
+//! [`AlternateC`] or [`AlternateD`].
+//!
+//! In SAMD51 and SAME5x chips, GPIO pins can only be used together as SERCOM
+//! pads if they belong to the same IOSET. For these chips, the HAL provides
+//! `IoSet` types. The `IoSet` types implement [`Map`] to specify the
+//! corresponding [`PinId`]s and [`PinMode`]s. For instance, implementations
+//! look like this:
+//!
+//! ```
+//! use crate::gpio::v2::pin::{PA08, AlternateC, AlternateD};
+//! use crate::sercom::v2::{Sercom0, Sercom2};
+//! use crate::sercom::v2::pads::{Pad0, Pad1, IoSet1, IoSet3, Map};
+//!
+//! impl Map<Sercom0, Pad0> for IoSet1 {
+//!     type Id = PA08;
+//!     type Mode = AlternateC;
+//! }
+//!
+//! impl Map<Sercom2, Pad1> for IoSet3 {
+//!     type Id = PA08;
+//!     type Mode = AlternateD;
+//! }
+//! ```
+//!
+//! SAMD11 and SAMD21 chips, on the other hand, have no concept of IOSET. Any
+//! set of GPIO pins can be used together as SERCOM pads. For these chips,
+//! [`Map`] is implemented directly on [`PinId`]s. For instance, here are the
+//! two equivalent implementations for SAMD21:
+//!
+//! ```
+//! use crate::gpio::v2::pin::{PA08, AlternateC, AlternateD};
+//! use crate::sercom::v2::{Sercom0, Sercom2};
+//! use crate::sercom::v2::pads::{Pad0, Map};
+//!
+//! impl Map<Sercom0, Pad0> for PA08 {
+//!     type Id = PA08;
+//!     type Mode = AlternateC;
+//! }
+//!
+//! impl Map<Sercom2, Pad0> for PA08 {
+//!     type Id = PA08;
+//!     type Mode = AlternateD;
+//! }
+//! ```
 //!
 //! To create a [`Pad`], use the [`From`]/[`Into`] traits. Upon creation, the
-//! [`Pad`] takes ownership of the [`Pin`]. The conversion from [`Pin`] to
-//! [`Pad`] is potentially many-valued, so it usually must be constrained. On
-//! the other hand, the conversion from [`Pad`] to [`Pin`] is always unique,
-//! because the [`Pad`] always knows which [`Pin`] it contains.
+//! [`Pad`] takes ownership of the [`Pin`].
+//!
+//! The conversion from [`Pin`] to [`Pad`] is frequently many-valued, so the
+//! types often can't be inferred. On the other hand, the conversion from
+//! [`Pad`] to [`Pin`] is always unique, because the [`Pad`] always knows which
+//! [`Pin`] it contains.
 //!
 //! ```
 //! let pad: Pad<Sercom0, Pad0, IoSet1> = pins.pa08.into();
-//! let pin: Pin<_, _> = pad.into();
+//! let pin: Pin<_, _> = pad.into(); // Is Pin<PA08, AlternateC>
 //! ```
 //!
-//! Because of differences in the way pins are mapped to SERCOM pads, the
-//! [`Map`] trait is implemented on different types, depending on the chip
-//! series. See the [`Map`] documentation for more details.
-//!
-//! As a result, the actual implementations of [`Map`] are not found in this
-//! module. They are included in the [`pad_map`] module.
+//! The actual implementations of [`Map`] are chip specific, so they are not
+//! found in this module. They are included in the [`pad_map`] module.
 //!
 //! [`pad_map`]: crate::sercom::v2::pad_map
 
@@ -151,8 +192,8 @@ where
 /// Type-level function mapping [`Pad`]s to [`Pin`]s
 ///
 /// This trait acts as a type-level function. It takes two types as arguments,
-/// the [`Sercom`] and [`PadNum`] of a [`Pad`], and returns the [`PinId`] and
-/// [`PinMode`] for the corresponding [`Pin`].
+/// a [`Sercom`] and [`PadNum`], and returns a corresponding [`PinId`] and
+/// [`PinMode`].
 ///
 /// For the SAMD51 and SAME5x series chips, all pins for a given SERCOM must
 /// come from the same IOSET. To account for this, we introduce a new

--- a/hal/src/common/thumbv7em/sercom/v1/pad_map.rs
+++ b/hal/src/common/thumbv7em/sercom/v1/pad_map.rs
@@ -1,14 +1,17 @@
 //! Implementations of the [`pads`] [`Map`] trait
 //!
-//! This module provides implementations of [`Map`] that are part of a
-//! compatibility shim for the [`v1`] API. The [`v1`] API did not account for
-//! the concept of [`IoSet`] in SAMD5x & SAME5x chips. Instead, it mapped pins
-//! directly to SERCOM pads. It was possible to accidentally mix pins from
-//! different IOSETs, which would not work.
+//! This module exists purely as part of a compatibility shim for the
+//! [`v1::pads`] API.
 //!
-//! This module provides implementations of [`Map`] directly on [`PinId`]s. The
-//! [`v1::pads`] shim will then transfer the mapping from [`PinId`] to
-//! configured pins.
+//! In the `v2` [`pads`] API, [`Map`] is implemented on [`IoSet`] types for the
+//! SAMD51 & SAME5x chips. However, the [`v1`] API did not account for the
+//! concept of [`IoSet`] at all. Instead, it mapped whole pins to SERCOM pads.
+//! As a consequence, it was possible to accidentally mix pins from different
+//! IOSETs, which would not work once flashed.
+//!
+//! This module provides implementations of [`Map`] directly on [`PinId`]s, just
+//! like the SAMD11 and SAMD21 chips. The [`v1::pads`] module then transfers the
+//! mappings from [`PinId`]s to configured [`Pin`]s.
 //!
 //! [`v1`]: crate::sercom::v1
 //! [`v1::pads`]: crate::sercom::v1::pads

--- a/hal/src/common/thumbv7em/sercom/v2/pad_map.rs
+++ b/hal/src/common/thumbv7em/sercom/v2/pad_map.rs
@@ -1,8 +1,8 @@
 //! Implementations of the [`pads`] [`Map`] trait
 //!
-//! This module provides implementations of [`Map`] on each [`IoSet`] for each
-//! valid pair of [`Sercom`] and [`PadNum`]. Each combination of [`Sercom`],
-//! [`PadNum`] and [`IoSet`] maps to a unique [`PinId`] and [`PinMode`].
+//! This module provides implementations of [`Map`] on each [`IoSet`]. For a
+//! given [`Sercom`] and [`PadNum`], the [`Map`] trait identifies the
+//! corresponding [`PinId`] and [`PinMode`] for the given [`IoSet`].
 //!
 //! [`pads`]: crate::sercom::v2::pads
 //! [`Sercom`]: crate::sercom::v2::pads::Sercom


### PR DESCRIPTION
Improve compatibility between `v1` & `v2` GPIO `Pin` types by implementing `AnyPin` for `v1` `Pin`s.

Improve the documentation surrounding the `sercom::v2::pads` module and the `Map` trait, especially pertaining to the implications for `v1` & `v2` compatibility.