### PR TITLE
Make UsbBus more flexible and fix warnings throughout boards

### DIFF
--- a/boards/arduino_mkrzero/examples/usb_logging.rs
+++ b/boards/arduino_mkrzero/examples/usb_logging.rs
@@ -45,7 +45,6 @@ fn main() -> ! {
             &mut peripherals.PM,
             pins.usb_n, // PA24, also usb_dm
             pins.usb_p, // PA24 also usb_dp
-            &mut pins.port,
         ));
         USB_ALLOCATOR.as_ref().unwrap()
     };

--- a/boards/arduino_mkrzero/src/lib.rs
+++ b/boards/arduino_mkrzero/src/lib.rs
@@ -11,6 +11,8 @@ pub use cortex_m_rt::entry;
 pub extern crate panic_halt;
 
 #[cfg(feature = "usb")]
+use gpio::v2::{AnyPin, PA24, PA25};
+#[cfg(feature = "usb")]
 use hal::clock::GenericClockController;
 #[cfg(feature = "usb")]
 use hal::usb::usb_device::bus::UsbBusAllocator;
@@ -123,20 +125,11 @@ pub fn usb_allocator(
     usb: pac::USB,
     clocks: &mut GenericClockController,
     pm: &mut pac::PM,
-    dm: gpio::Pa24<Input<Floating>>,
-    dp: gpio::Pa25<Input<Floating>>,
-    port: &mut Port,
+    dm: impl AnyPin<Id = PA24>,
+    dp: impl AnyPin<Id = PA25>,
 ) -> UsbBusAllocator<UsbBus> {
-    use gpio::IntoFunction;
-
     let gclk0 = clocks.gclk0();
     let usb_clock = &clocks.usb(&gclk0).unwrap();
 
-    UsbBusAllocator::new(UsbBus::new(
-        usb_clock,
-        pm,
-        dm.into_function(port),
-        dp.into_function(port),
-        usb,
-    ))
+    UsbBusAllocator::new(UsbBus::new(usb_clock, pm, dm, dp, usb))
 }

--- a/boards/arduino_nano33iot/examples/usb_logging.rs
+++ b/boards/arduino_nano33iot/examples/usb_logging.rs
@@ -39,7 +39,6 @@ fn main() -> ! {
             &mut peripherals.PM,
             pins.usb_dm,
             pins.usb_dp,
-            &mut pins.port,
         ));
         USB_ALLOCATOR.as_ref().unwrap()
     };

--- a/boards/arduino_nano33iot/src/lib.rs
+++ b/boards/arduino_nano33iot/src/lib.rs
@@ -23,6 +23,8 @@ pub use hal::samd21::*;
 pub use hal::target_device as pac;
 
 #[cfg(feature = "usb")]
+use gpio::v2::{AnyPin, PA24, PA25};
+#[cfg(feature = "usb")]
 use hal::usb::usb_device::bus::UsbBusAllocator;
 #[cfg(feature = "usb")]
 pub use hal::usb::UsbBus;
@@ -130,22 +132,13 @@ pub fn usb_allocator(
     usb: pac::USB,
     clocks: &mut GenericClockController,
     pm: &mut pac::PM,
-    dm: gpio::Pa24<Input<Floating>>,
-    dp: gpio::Pa25<Input<Floating>>,
-    port: &mut Port,
+    dm: impl AnyPin<Id = PA24>,
+    dp: impl AnyPin<Id = PA25>,
 ) -> UsbBusAllocator<UsbBus> {
-    use gpio::IntoFunction;
-
     let gclk0 = clocks.gclk0();
     let usb_clock = &clocks.usb(&gclk0).unwrap();
 
-    UsbBusAllocator::new(UsbBus::new(
-        usb_clock,
-        pm,
-        dm.into_function(port),
-        dp.into_function(port),
-        usb,
-    ))
+    UsbBusAllocator::new(UsbBus::new(usb_clock, pm, dm, dp, usb))
 }
 
 /// EXPERIMENTAL FEATURE STARTS HERE

--- a/boards/atsame54_xpro/src/pins.rs
+++ b/boards/atsame54_xpro/src/pins.rs
@@ -369,19 +369,12 @@ impl USB {
         usb: super::pac::USB,
         clocks: &mut GenericClockController,
         mclk: &mut MCLK,
-        port: &mut Port,
     ) -> UsbBusAllocator<UsbBus> {
         clocks.configure_gclk_divider_and_source(GEN_A::GCLK2, 1, SRC_A::DFLL, false);
         let usb_gclk = clocks.get_gclk(GEN_A::GCLK2).unwrap();
         let usb_clock = &clocks.usb(&usb_gclk).unwrap();
 
-        UsbBusAllocator::new(UsbBus::new(
-            usb_clock,
-            mclk,
-            self.dm.into_function(port),
-            self.dp.into_function(port),
-            usb,
-        ))
+        UsbBusAllocator::new(UsbBus::new(usb_clock, mclk, self.dm, self.dp, usb))
     }
 }
 

--- a/boards/edgebadge/examples/usb_poll.rs
+++ b/boards/edgebadge/examples/usb_poll.rs
@@ -27,12 +27,9 @@ fn main() -> ! {
 
     let mut pins = Pins::new(peripherals.PORT).split();
 
-    let usb_bus = pins.usb.init(
-        peripherals.USB,
-        &mut clocks,
-        &mut peripherals.MCLK,
-        &mut pins.port,
-    );
+    let usb_bus = pins
+        .usb
+        .init(peripherals.USB, &mut clocks, &mut peripherals.MCLK);
 
     let mut serial = SerialPort::new(&usb_bus);
     let mut led = pins.led_pin.into_open_drain_output(&mut pins.port);

--- a/boards/edgebadge/examples/usb_serial.rs
+++ b/boards/edgebadge/examples/usb_serial.rs
@@ -47,12 +47,10 @@ fn main() -> ! {
     let _ = neopixel.write((0..5).map(|_| RGB8::default()));
 
     let bus_allocator = unsafe {
-        USB_ALLOCATOR = Some(pins.usb.init(
-            peripherals.USB,
-            &mut clocks,
-            &mut peripherals.MCLK,
-            &mut pins.port,
-        ));
+        USB_ALLOCATOR = Some(
+            pins.usb
+                .init(peripherals.USB, &mut clocks, &mut peripherals.MCLK),
+        );
         USB_ALLOCATOR.as_ref().unwrap()
     };
 

--- a/boards/edgebadge/src/pins.rs
+++ b/boards/edgebadge/src/pins.rs
@@ -483,19 +483,12 @@ impl USB {
         usb: pac::USB,
         clocks: &mut GenericClockController,
         mclk: &mut MCLK,
-        port: &mut Port,
     ) -> UsbBusAllocator<UsbBus> {
         clocks.configure_gclk_divider_and_source(GEN_A::GCLK2, 1, SRC_A::DFLL, false);
         let usb_gclk = clocks.get_gclk(GEN_A::GCLK2).unwrap();
         let usb_clock = &clocks.usb(&usb_gclk).unwrap();
 
-        UsbBusAllocator::new(UsbBus::new(
-            usb_clock,
-            mclk,
-            self.dm.into_function(port),
-            self.dp.into_function(port),
-            usb,
-        ))
+        UsbBusAllocator::new(UsbBus::new(usb_clock, mclk, self.dm, self.dp, usb))
     }
 }
 

--- a/boards/feather_m0/examples/adc.rs
+++ b/boards/feather_m0/examples/adc.rs
@@ -34,7 +34,7 @@ fn main() -> ! {
 
     loop {
         let data: u16 = adc.read(&mut a0).unwrap();
-        hprintln!("{}", data);
+        hprintln!("{}", data).ok();
         delay.delay_ms(1000u16);
     }
 }

--- a/boards/feather_m0/examples/clock.rs
+++ b/boards/feather_m0/examples/clock.rs
@@ -60,7 +60,6 @@ fn main() -> ! {
             &mut peripherals.PM,
             pins.usb_dm,
             pins.usb_dp,
-            &mut pins.port,
         ));
         USB_ALLOCATOR.as_ref().unwrap()
     };

--- a/boards/feather_m0/examples/usb_echo.rs
+++ b/boards/feather_m0/examples/usb_echo.rs
@@ -10,7 +10,6 @@ extern crate usbd_serial;
 use hal::clock::GenericClockController;
 use hal::entry;
 use hal::pac::{interrupt, CorePeripherals, Peripherals};
-use hal::prelude::*;
 
 use hal::usb::UsbBus;
 use usb_device::bus::UsbBusAllocator;
@@ -41,7 +40,6 @@ fn main() -> ! {
             &mut peripherals.PM,
             pins.usb_dm,
             pins.usb_dp,
-            &mut pins.port,
         ));
         USB_ALLOCATOR.as_ref().unwrap()
     };
@@ -87,7 +85,7 @@ fn poll_usb() {
                         if i >= count {
                             break;
                         }
-                        serial.write(&[c.clone()]);
+                        serial.write(&[c.clone()]).ok();
                     }
                 };
             });

--- a/boards/feather_m0/src/lib.rs
+++ b/boards/feather_m0/src/lib.rs
@@ -20,6 +20,8 @@ use hal::sercom::{I2CMaster3, PadPin, SPIMaster4, UART0};
 use hal::time::Hertz;
 
 #[cfg(feature = "usb")]
+use gpio::v2::{AnyPin, PA24, PA25};
+#[cfg(feature = "usb")]
 use hal::usb::usb_device::bus::UsbBusAllocator;
 #[cfg(feature = "usb")]
 pub use hal::usb::UsbBus;
@@ -207,20 +209,11 @@ pub fn usb_allocator(
     usb: pac::USB,
     clocks: &mut GenericClockController,
     pm: &mut pac::PM,
-    dm: gpio::Pa24<Input<Floating>>,
-    dp: gpio::Pa25<Input<Floating>>,
-    port: &mut Port,
+    dm: impl AnyPin<Id = PA24>,
+    dp: impl AnyPin<Id = PA25>,
 ) -> UsbBusAllocator<UsbBus> {
-    use gpio::IntoFunction;
-
     let gclk0 = clocks.gclk0();
     let usb_clock = &clocks.usb(&gclk0).unwrap();
 
-    UsbBusAllocator::new(UsbBus::new(
-        usb_clock,
-        pm,
-        dm.into_function(port),
-        dp.into_function(port),
-        usb,
-    ))
+    UsbBusAllocator::new(UsbBus::new(usb_clock, pm, dm, dp, usb))
 }

--- a/boards/feather_m4/examples/usb_echo.rs
+++ b/boards/feather_m4/examples/usb_echo.rs
@@ -7,7 +7,6 @@ extern crate panic_halt;
 use hal::clock::GenericClockController;
 use hal::entry;
 use hal::pac::{interrupt, CorePeripherals, Peripherals};
-use hal::prelude::*;
 use hal::usb::UsbBus;
 
 use usb_device::bus::UsbBusAllocator;
@@ -38,7 +37,6 @@ fn main() -> ! {
             peripherals.USB,
             &mut clocks,
             &mut peripherals.MCLK,
-            &mut pins.port,
         ));
         USB_ALLOCATOR.as_ref().unwrap()
     };

--- a/boards/feather_m4/src/lib.rs
+++ b/boards/feather_m4/src/lib.rs
@@ -21,6 +21,8 @@ use hal::sercom::{I2CMaster2, PadPin, SPIMaster1, UART5};
 use hal::time::Hertz;
 
 #[cfg(feature = "usb")]
+use gpio::v2::{AnyPin, PA24, PA25};
+#[cfg(feature = "usb")]
 use hal::usb::usb_device::bus::UsbBusAllocator;
 #[cfg(feature = "usb")]
 pub use hal::usb::UsbBus;
@@ -175,25 +177,17 @@ pub fn uart<F: Into<Hertz>>(
 
 #[cfg(feature = "usb")]
 pub fn usb_allocator(
-    dm: gpio::Pa24<Input<Floating>>,
-    dp: gpio::Pa25<Input<Floating>>,
+    dm: impl AnyPin<Id = PA24>,
+    dp: impl AnyPin<Id = PA25>,
     usb: pac::USB,
     clocks: &mut GenericClockController,
     mclk: &mut pac::MCLK,
-    port: &mut Port,
 ) -> UsbBusAllocator<UsbBus> {
-    use gpio::IntoFunction;
     use pac::gclk::{genctrl::SRC_A, pchctrl::GEN_A};
 
     clocks.configure_gclk_divider_and_source(GEN_A::GCLK2, 1, SRC_A::DFLL, false);
     let usb_gclk = clocks.get_gclk(GEN_A::GCLK2).unwrap();
     let usb_clock = &clocks.usb(&usb_gclk).unwrap();
 
-    UsbBusAllocator::new(UsbBus::new(
-        usb_clock,
-        mclk,
-        dm.into_function_h(port),
-        dp.into_function_h(port),
-        usb,
-    ))
+    UsbBusAllocator::new(UsbBus::new(usb_clock, mclk, dm, dp, usb))
 }

--- a/boards/grand_central_m4/examples/usb_serial.rs
+++ b/boards/grand_central_m4/examples/usb_serial.rs
@@ -48,12 +48,10 @@ fn main() -> ! {
     let _ = neopixel.write((0..5).map(|_| RGB8::default()));
 
     let bus_allocator = unsafe {
-        USB_ALLOCATOR = Some(pins.usb.init(
-            peripherals.USB,
-            &mut clocks,
-            &mut peripherals.MCLK,
-            &mut pins.port,
-        ));
+        USB_ALLOCATOR = Some(
+            pins.usb
+                .init(peripherals.USB, &mut clocks, &mut peripherals.MCLK),
+        );
         USB_ALLOCATOR.as_ref().unwrap()
     };
 

--- a/boards/grand_central_m4/src/pins.rs
+++ b/boards/grand_central_m4/src/pins.rs
@@ -624,19 +624,12 @@ impl USB {
         usb: super::pac::USB,
         clocks: &mut GenericClockController,
         mclk: &mut MCLK,
-        port: &mut Port,
     ) -> UsbBusAllocator<UsbBus> {
         clocks.configure_gclk_divider_and_source(GEN_A::GCLK2, 1, SRC_A::DFLL, false);
         let usb_gclk = clocks.get_gclk(GEN_A::GCLK2).unwrap();
         let usb_clock = &clocks.usb(&usb_gclk).unwrap();
 
-        UsbBusAllocator::new(UsbBus::new(
-            usb_clock,
-            mclk,
-            self.dm.into_function(port),
-            self.dp.into_function(port),
-            usb,
-        ))
+        UsbBusAllocator::new(UsbBus::new(usb_clock, mclk, self.dm, self.dp, usb))
     }
 }
 

--- a/boards/itsybitsy_m0/examples/twitching_usb_mouse.rs
+++ b/boards/itsybitsy_m0/examples/twitching_usb_mouse.rs
@@ -44,7 +44,6 @@ fn main() -> ! {
             &mut peripherals.PM,
             pins.usb_dm,
             pins.usb_dp,
-            &mut pins.port,
         ));
         USB_ALLOCATOR.as_ref().unwrap()
     };

--- a/boards/itsybitsy_m0/examples/usb_echo.rs
+++ b/boards/itsybitsy_m0/examples/usb_echo.rs
@@ -10,7 +10,6 @@ extern crate usbd_serial;
 use hal::clock::GenericClockController;
 use hal::entry;
 use hal::pac::{interrupt, CorePeripherals, Peripherals};
-use hal::prelude::*;
 
 use hal::usb::UsbBus;
 use usb_device::bus::UsbBusAllocator;
@@ -41,7 +40,6 @@ fn main() -> ! {
             &mut peripherals.PM,
             pins.usb_dm,
             pins.usb_dp,
-            &mut pins.port,
         ));
         USB_ALLOCATOR.as_ref().unwrap()
     };
@@ -87,7 +85,7 @@ fn poll_usb() {
                         if i >= count {
                             break;
                         }
-                        serial.write(&[c.clone()]);
+                        serial.write(&[c.clone()]).ok();
                     }
                 };
             });

--- a/boards/itsybitsy_m0/src/lib.rs
+++ b/boards/itsybitsy_m0/src/lib.rs
@@ -23,6 +23,8 @@ use hal::sercom::{I2CMaster3, PadPin, SPIMaster4, SPIMaster5, UART0};
 use hal::time::Hertz;
 
 #[cfg(feature = "usb")]
+use gpio::v2::{AnyPin, PA24, PA25};
+#[cfg(feature = "usb")]
 use hal::usb::usb_device::bus::UsbBusAllocator;
 #[cfg(feature = "usb")]
 pub use hal::usb::UsbBus;
@@ -161,20 +163,11 @@ pub fn usb_allocator(
     usb: pac::USB,
     clocks: &mut GenericClockController,
     pm: &mut pac::PM,
-    dm: gpio::Pa24<Input<Floating>>,
-    dp: gpio::Pa25<Input<Floating>>,
-    port: &mut Port,
+    dm: impl AnyPin<Id = PA24>,
+    dp: impl AnyPin<Id = PA25>,
 ) -> UsbBusAllocator<UsbBus> {
-    use gpio::IntoFunction;
-
     let gclk0 = clocks.gclk0();
     let usb_clock = &clocks.usb(&gclk0).unwrap();
 
-    UsbBusAllocator::new(UsbBus::new(
-        usb_clock,
-        pm,
-        dm.into_function(port),
-        dp.into_function(port),
-        usb,
-    ))
+    UsbBusAllocator::new(UsbBus::new(usb_clock, pm, dm, dp, usb))
 }

--- a/boards/itsybitsy_m0/src/pins.rs
+++ b/boards/itsybitsy_m0/src/pins.rs
@@ -287,20 +287,11 @@ impl USB {
         usb: pac::USB,
         clocks: &mut GenericClockController,
         pm: &mut pac::PM,
-        port: &mut Port,
     ) -> UsbBusAllocator<UsbBus> {
-        use gpio::IntoFunction;
-
         let gclk0 = clocks.gclk0();
         let usb_clock = &clocks.usb(&gclk0).unwrap();
 
-        UsbBusAllocator::new(UsbBus::new(
-            usb_clock,
-            pm,
-            self.dm.into_function(port),
-            self.dp.into_function(port),
-            usb,
-        ))
+        UsbBusAllocator::new(UsbBus::new(usb_clock, pm, self.dm, self.dp, usb))
     }
 }
 

--- a/boards/itsybitsy_m4/examples/usb_serial.rs
+++ b/boards/itsybitsy_m4/examples/usb_serial.rs
@@ -70,7 +70,6 @@ fn main() -> ! {
             peripherals.USB,
             &mut clocks,
             &mut peripherals.MCLK,
-            &mut pins.port,
         ));
         USB_ALLOCATOR.as_ref().unwrap()
     };

--- a/boards/itsybitsy_m4/src/pins.rs
+++ b/boards/itsybitsy_m4/src/pins.rs
@@ -276,7 +276,6 @@ impl USB {
         usb: super::pac::USB,
         clocks: &mut GenericClockController,
         mclk: &mut MCLK,
-        port: &mut Port,
     ) -> UsbBusAllocator<UsbBus> {
         use super::pac::gclk::{genctrl::SRC_A, pchctrl::GEN_A};
 
@@ -284,13 +283,7 @@ impl USB {
         let usb_gclk = clocks.get_gclk(GEN_A::GCLK2).unwrap();
         let usb_clock = &clocks.usb(&usb_gclk).unwrap();
 
-        UsbBusAllocator::new(UsbBus::new(
-            usb_clock,
-            mclk,
-            self.dm.into_function(port),
-            self.dp.into_function(port),
-            usb,
-        ))
+        UsbBusAllocator::new(UsbBus::new(usb_clock, mclk, self.dm, self.dp, usb))
     }
 }
 

--- a/boards/metro_m0/examples/usb_serial.rs
+++ b/boards/metro_m0/examples/usb_serial.rs
@@ -7,7 +7,6 @@ extern crate panic_halt as _;
 use hal::clock::GenericClockController;
 use hal::entry;
 use hal::pac::{interrupt, CorePeripherals, Peripherals};
-use hal::prelude::*;
 
 use hal::usb::UsbBus;
 use usb_device::bus::UsbBusAllocator;
@@ -32,13 +31,12 @@ fn main() -> ! {
     let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
 
     let bus_allocator = unsafe {
-        USB_ALLOCATOR = Some(hal::usb_bus(
+        USB_ALLOCATOR = Some(hal::usb_allocator(
             peripherals.USB,
             &mut clocks,
             &mut peripherals.PM,
             pins.usb_dm,
             pins.usb_dp,
-            &mut pins.port,
         ));
         USB_ALLOCATOR.as_ref().unwrap()
     };
@@ -84,7 +82,7 @@ fn poll_usb() {
                         if i >= count {
                             break;
                         }
-                        serial.write(&[c.clone()]);
+                        serial.write(&[c.clone()]).ok();
                     }
                 };
             });

--- a/boards/metro_m4/examples/trng.rs
+++ b/boards/metro_m4/examples/trng.rs
@@ -30,7 +30,7 @@ fn main() -> ! {
     let trng = Trng::new(&mut peripherals.MCLK, peripherals.TRNG);
 
     loop {
-        hprintln!("{}", trng.random_u32());
+        hprintln!("{}", trng.random_u32()).ok();
         delay.delay_ms(1000u16);
     }
 }

--- a/boards/metro_m4/examples/usb_logging.rs
+++ b/boards/metro_m4/examples/usb_logging.rs
@@ -41,7 +41,6 @@ fn main() -> ! {
             peripherals.USB,
             &mut clocks,
             &mut peripherals.MCLK,
-            &mut pins.port,
         ));
         USB_ALLOCATOR.as_ref().unwrap()
     };

--- a/boards/metro_m4/src/lib.rs
+++ b/boards/metro_m4/src/lib.rs
@@ -22,6 +22,8 @@ use hal::time::Hertz;
 use pac::MCLK;
 
 #[cfg(feature = "usb")]
+use gpio::v2::{AnyPin, PA24, PA25};
+#[cfg(feature = "usb")]
 use hal::usb::usb_device::bus::UsbBusAllocator;
 #[cfg(feature = "usb")]
 pub use hal::usb::UsbBus;
@@ -195,12 +197,11 @@ pub fn uart<F: Into<Hertz>>(
 
 #[cfg(feature = "usb")]
 pub fn usb_allocator(
-    dm: gpio::Pa24<Input<Floating>>,
-    dp: gpio::Pa25<Input<Floating>>,
+    dm: impl AnyPin<Id = PA24>,
+    dp: impl AnyPin<Id = PA25>,
     usb: pac::USB,
     clocks: &mut GenericClockController,
     mclk: &mut MCLK,
-    port: &mut Port,
 ) -> UsbBusAllocator<UsbBus> {
     use pac::gclk::{genctrl::SRC_A, pchctrl::GEN_A};
 
@@ -208,11 +209,5 @@ pub fn usb_allocator(
     let usb_gclk = clocks.get_gclk(GEN_A::GCLK2).unwrap();
     let usb_clock = &clocks.usb(&usb_gclk).unwrap();
 
-    UsbBusAllocator::new(UsbBus::new(
-        usb_clock,
-        mclk,
-        dm.into_function_h(port),
-        dp.into_function_h(port),
-        usb,
-    ))
+    UsbBusAllocator::new(UsbBus::new(usb_clock, mclk, dm, dp, usb))
 }

--- a/boards/pygamer/examples/usb_poll.rs
+++ b/boards/pygamer/examples/usb_poll.rs
@@ -28,12 +28,9 @@ fn main() -> ! {
 
     let mut pins = Pins::new(peripherals.PORT).split();
 
-    let usb_bus = pins.usb.init(
-        peripherals.USB,
-        &mut clocks,
-        &mut peripherals.MCLK,
-        &mut pins.port,
-    );
+    let usb_bus = pins
+        .usb
+        .init(peripherals.USB, &mut clocks, &mut peripherals.MCLK);
 
     let mut serial = SerialPort::new(&usb_bus);
     let mut led = pins.led_pin.into_open_drain_output(&mut pins.port);

--- a/boards/pygamer/examples/usb_serial.rs
+++ b/boards/pygamer/examples/usb_serial.rs
@@ -48,12 +48,10 @@ fn main() -> ! {
     let _ = neopixel.write((0..5).map(|_| RGB8::default()));
 
     let bus_allocator = unsafe {
-        USB_ALLOCATOR = Some(pins.usb.init(
-            peripherals.USB,
-            &mut clocks,
-            &mut peripherals.MCLK,
-            &mut pins.port,
-        ));
+        USB_ALLOCATOR = Some(
+            pins.usb
+                .init(peripherals.USB, &mut clocks, &mut peripherals.MCLK),
+        );
         USB_ALLOCATOR.as_ref().unwrap()
     };
 

--- a/boards/pygamer/src/pins.rs
+++ b/boards/pygamer/src/pins.rs
@@ -494,19 +494,12 @@ impl USB {
         usb: pac::USB,
         clocks: &mut GenericClockController,
         mclk: &mut MCLK,
-        port: &mut Port,
     ) -> UsbBusAllocator<UsbBus> {
         clocks.configure_gclk_divider_and_source(GEN_A::GCLK2, 1, SRC_A::DFLL, false);
         let usb_gclk = clocks.get_gclk(GEN_A::GCLK2).unwrap();
         let usb_clock = &clocks.usb(&usb_gclk).unwrap();
 
-        UsbBusAllocator::new(UsbBus::new(
-            usb_clock,
-            mclk,
-            self.dm.into_function(port),
-            self.dp.into_function(port),
-            usb,
-        ))
+        UsbBusAllocator::new(UsbBus::new(usb_clock, mclk, self.dm, self.dp, usb))
     }
 }
 

--- a/boards/pyportal/src/lib.rs
+++ b/boards/pyportal/src/lib.rs
@@ -19,11 +19,6 @@ use hal::clock::GenericClockController;
 use hal::sercom::{I2CMaster5, PadPin, SPIMaster2, UART4};
 use hal::time::Hertz;
 
-#[cfg(feature = "usb")]
-pub use hal::usb::UsbBus;
-#[cfg(feature = "usb")]
-use usb_device::bus::UsbBusWrapper;
-
 /// This powers up SERCOM2 and configures it for use as an
 /// SPI Master in SPI Mode 0.
 /// Unlike the `flash_spi_master` function, this

--- a/boards/samd11_bare/examples/adc.rs
+++ b/boards/samd11_bare/examples/adc.rs
@@ -37,7 +37,7 @@ fn main() -> ! {
 
     loop {
         let data: u16 = adc.read(&mut a0).unwrap();
-        hprintln!("{}", data);
+        hprintln!("{}", data).ok();
         delay.delay_ms(1000u16);
     }
 }

--- a/boards/samd21_mini/src/lib.rs
+++ b/boards/samd21_mini/src/lib.rs
@@ -14,9 +14,6 @@ pub use hal::target_device as pac;
 use hal::prelude::*;
 use hal::*;
 
-#[cfg(feature = "usb")]
-pub use hal::usb;
-
 use gpio::{Floating, Input, Port};
 
 define_pins!(

--- a/boards/sodaq_one/src/lib.rs
+++ b/boards/sodaq_one/src/lib.rs
@@ -20,6 +20,8 @@ use hal::sercom::{I2CMaster3, PadPin, SPIMaster0};
 use hal::time::Hertz;
 
 #[cfg(feature = "usb")]
+use gpio::v2::{AnyPin, PA24, PA25};
+#[cfg(feature = "usb")]
 pub use hal::usb::UsbBus;
 #[cfg(feature = "usb")]
 use usb_device::bus::UsbBusWrapper;
@@ -175,21 +177,12 @@ pub fn usb_bus(
     usb: pac::USB,
     clocks: &mut GenericClockController,
     pm: &mut pac::PM,
-    dm: gpio::Pa24<Input<Floating>>,
-    dp: gpio::Pa25<Input<Floating>>,
-    port: &mut Port,
+    dm: impl AnyPin<Id = PA24>,
+    dp: impl AnyPin<Id = PA25>,
 ) -> UsbBusWrapper<UsbBus> {
-    use gpio::IntoFunction;
-
     let gclk0 = clocks.gclk0();
     dbgprint!("making usb clock");
     let usb_clock = &clocks.usb(&gclk0).unwrap();
     dbgprint!("got clock");
-    UsbBusWrapper::new(UsbBus::new(
-        usb_clock,
-        pm,
-        dm.into_function(port),
-        dp.into_function(port),
-        usb,
-    ))
+    UsbBusWrapper::new(UsbBus::new(usb_clock, pm, dm, dp, usb))
 }

--- a/boards/trellis_m4/examples/neopixel_keypad.rs
+++ b/boards/trellis_m4/examples/neopixel_keypad.rs
@@ -56,7 +56,7 @@ fn main() -> ! {
             for (i, value) in color_values.iter_mut().enumerate() {
                 let keypad_column = i % 8;
                 let keypad_row = i / 8;
-                let keypad_button: &InputPin<Error = ()> =
+                let keypad_button: &dyn InputPin<Error = ()> =
                     &keypad_inputs[keypad_row][keypad_column];
 
                 if keypad_button.is_high().unwrap() {

--- a/boards/trellis_m4/src/lib.rs
+++ b/boards/trellis_m4/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![recursion_limit = "1024"]
+#![allow(deprecated)]
 
 pub mod pins;
 

--- a/boards/trinket_m0/examples/usb_serial.rs
+++ b/boards/trinket_m0/examples/usb_serial.rs
@@ -7,7 +7,6 @@ use trinket_m0 as hal;
 use hal::clock::GenericClockController;
 use hal::entry;
 use hal::pac::{interrupt, CorePeripherals, Peripherals};
-use hal::prelude::*;
 
 use hal::usb::UsbBus;
 use usb_device::bus::UsbBusAllocator;
@@ -38,7 +37,6 @@ fn main() -> ! {
             &mut peripherals.PM,
             pins.usb_dm,
             pins.usb_dp,
-            &mut pins.port,
         ));
         USB_ALLOCATOR.as_ref().unwrap()
     };
@@ -84,7 +82,7 @@ fn poll_usb() {
                         if i >= count {
                             break;
                         }
-                        serial.write(&[c.clone()]);
+                        serial.write(&[c.clone()]).ok();
                     }
                 };
             });

--- a/boards/trinket_m0/src/lib.rs
+++ b/boards/trinket_m0/src/lib.rs
@@ -24,6 +24,8 @@ use apa102_spi::Apa102;
 use embedded_hal::timer::{CountDown, Periodic};
 
 #[cfg(feature = "usb")]
+use gpio::v2::{AnyPin, PA24, PA25};
+#[cfg(feature = "usb")]
 use hal::usb::usb_device::bus::UsbBusAllocator;
 #[cfg(feature = "usb")]
 pub use hal::usb::UsbBus;
@@ -308,18 +310,11 @@ impl USB {
         usb: pac::USB,
         clocks: &mut GenericClockController,
         pm: &mut pac::PM,
-        port: &mut Port,
     ) -> UsbBusAllocator<UsbBus> {
         let gclk0 = clocks.gclk0();
         let usb_clock = &clocks.usb(&gclk0).unwrap();
 
-        UsbBusAllocator::new(UsbBus::new(
-            usb_clock,
-            pm,
-            self.dm.into_function(port),
-            self.dp.into_function(port),
-            usb,
-        ))
+        UsbBusAllocator::new(UsbBus::new(usb_clock, pm, self.dm, self.dp, usb))
     }
 }
 
@@ -328,18 +323,11 @@ pub fn usb_allocator(
     usb: pac::USB,
     clocks: &mut GenericClockController,
     pm: &mut pac::PM,
-    dm: gpio::Pa24<Input<Floating>>,
-    dp: gpio::Pa25<Input<Floating>>,
-    port: &mut Port,
+    dm: impl AnyPin<Id = PA24>,
+    dp: impl AnyPin<Id = PA25>,
 ) -> UsbBusAllocator<UsbBus> {
     let gclk0 = clocks.gclk0();
     let usb_clock = &clocks.usb(&gclk0).unwrap();
 
-    UsbBusAllocator::new(UsbBus::new(
-        usb_clock,
-        pm,
-        dm.into_function(port),
-        dp.into_function(port),
-        usb,
-    ))
+    UsbBusAllocator::new(UsbBus::new(usb_clock, pm, dm, dp, usb))
 }

--- a/boards/wio_lite_mg126/examples/adc.rs
+++ b/boards/wio_lite_mg126/examples/adc.rs
@@ -34,7 +34,7 @@ fn main() -> ! {
 
     loop {
         let data: u16 = adc.read(&mut a0).unwrap();
-        hprintln!("{}", data);
+        hprintln!("{}", data).ok();
         delay.delay_ms(1000u16);
     }
 }

--- a/boards/wio_lite_mg126/examples/adc_usb.rs
+++ b/boards/wio_lite_mg126/examples/adc_usb.rs
@@ -48,7 +48,6 @@ fn main() -> ! {
             &mut peripherals.PM,
             pins.usb_dm, // PA24, also usb_dm
             pins.usb_dp, // PA24 also usb_dp
-            &mut pins.port,
         ));
         USB_ALLOCATOR.as_ref().unwrap()
     };

--- a/boards/wio_lite_mg126/src/lib.rs
+++ b/boards/wio_lite_mg126/src/lib.rs
@@ -24,6 +24,8 @@ use hal::sercom::{I2CMaster3, PadPin, SPIMaster4, UART2};
 use hal::time::Hertz;
 
 #[cfg(feature = "usb")]
+use gpio::v2::{AnyPin, PA24, PA25};
+#[cfg(feature = "usb")]
 use hal::usb::usb_device::bus::UsbBusAllocator;
 #[cfg(feature = "usb")]
 pub use hal::usb::UsbBus;
@@ -196,18 +198,11 @@ pub fn usb_allocator(
     usb: pac::USB,
     clocks: &mut GenericClockController,
     pm: &mut pac::PM,
-    dm: gpio::Pa24<Input<Floating>>,
-    dp: gpio::Pa25<Input<Floating>>,
-    port: &mut Port,
+    dm: impl AnyPin<Id = PA24>,
+    dp: impl AnyPin<Id = PA25>,
 ) -> UsbBusAllocator<UsbBus> {
     let gclk0 = clocks.gclk0();
     let usb_clock = &clocks.usb(&gclk0).unwrap();
 
-    UsbBusAllocator::new(UsbBus::new(
-        usb_clock,
-        pm,
-        dm.into_function(port),
-        dp.into_function(port),
-        usb,
-    ))
+    UsbBusAllocator::new(UsbBus::new(usb_clock, pm, dm, dp, usb))
 }

--- a/boards/wio_terminal/examples/clock.rs
+++ b/boards/wio_terminal/examples/clock.rs
@@ -90,7 +90,6 @@ fn main() -> ! {
             peripherals.USB,
             &mut clocks,
             &mut peripherals.MCLK,
-            &mut sets.port,
         ));
         USB_ALLOCATOR.as_ref().unwrap()
     };

--- a/boards/wio_terminal/examples/microphone.rs
+++ b/boards/wio_terminal/examples/microphone.rs
@@ -6,10 +6,10 @@ use panic_halt as _;
 use wio_terminal as wio;
 
 use cortex_m::peripheral::NVIC;
-use wio::hal::adc::{FreeRunning, InterruptAdc, SingleConversion};
+use wio::hal::adc::{FreeRunning, InterruptAdc};
 use wio::hal::clock::GenericClockController;
 use wio::hal::delay::Delay;
-use wio::pac::{adc0::refctrl::REFSEL_A, gclk::pchctrl::GEN_A::GCLK11, interrupt, ADC1};
+use wio::pac::{interrupt, ADC1};
 use wio::pac::{CorePeripherals, Peripherals};
 use wio::prelude::*;
 use wio::{entry, Pins, Sets};
@@ -106,7 +106,7 @@ fn main() -> ! {
         // the adc.rs, actual sampling rate seems 83.333[kSPS], which is 1/3 of
         // expected sampling rate.
         let count_max = 83333;
-        for count in 0..count_max {
+        for _count in 0..count_max {
             // Uncomment if you use single conversion mode.
             // unsafe { CTX.as_mut().unwrap().adc.start_conversion(&mut microphone_pin); }
             let value = loop {

--- a/boards/wio_terminal/examples/qspi.rs
+++ b/boards/wio_terminal/examples/qspi.rs
@@ -138,7 +138,7 @@ fn main() -> ! {
     textbuffer.truncate(0);
 
     // Switch to XIP mode and read those 4 bytes natively.
-    let mut flash = flash.into_xip();
+    let flash = flash.into_xip();
     let mut read_buf = [0u8; 4];
     unsafe {
         core::ptr::copy(

--- a/boards/wio_terminal/examples/usb_serial_display.rs
+++ b/boards/wio_terminal/examples/usb_serial_display.rs
@@ -70,7 +70,6 @@ fn main() -> ! {
             peripherals.USB,
             &mut clocks,
             &mut peripherals.MCLK,
-            &mut sets.port,
         ));
         USB_ALLOCATOR.as_ref().unwrap()
     };

--- a/boards/wio_terminal/src/serial.rs
+++ b/boards/wio_terminal/src/serial.rs
@@ -1,5 +1,5 @@
 use atsamd_hal::clock::GenericClockController;
-use atsamd_hal::gpio::{Floating, Input, IntoFunction, Pa24, Pa25, Pb26, Pb27, PfC, Port};
+use atsamd_hal::gpio::{Floating, Input, Pa24, Pa25, Pb26, Pb27, PfC, Port};
 use atsamd_hal::sercom::{PadPin, Sercom2Pad0, Sercom2Pad1, UART2};
 use atsamd_hal::target_device::{self, MCLK, SERCOM2};
 use atsamd_hal::time::Hertz;
@@ -57,18 +57,11 @@ impl USB {
         usb: target_device::USB,
         clocks: &mut GenericClockController,
         mclk: &mut MCLK,
-        port: &mut Port,
     ) -> UsbBusAllocator<UsbBus> {
         clocks.configure_gclk_divider_and_source(GEN_A::GCLK2, 1, SRC_A::DFLL, false);
         let usb_gclk = clocks.get_gclk(GEN_A::GCLK2).unwrap();
         let usb_clock = &clocks.usb(&usb_gclk).unwrap();
 
-        UsbBusAllocator::new(UsbBus::new(
-            usb_clock,
-            mclk,
-            self.dm.into_function(port),
-            self.dp.into_function(port),
-            usb,
-        ))
+        UsbBusAllocator::new(UsbBus::new(usb_clock, mclk, self.dm, self.dp, usb))
     }
 }

--- a/boards/xiao_m0/examples/usb_serial.rs
+++ b/boards/xiao_m0/examples/usb_serial.rs
@@ -41,7 +41,6 @@ fn main() -> ! {
             &mut peripherals.PM,
             pins.usb_dm,
             pins.usb_dp,
-            &mut pins.port,
         ));
         USB_ALLOCATOR.as_ref().unwrap()
     };

--- a/boards/xiao_m0/src/lib.rs
+++ b/boards/xiao_m0/src/lib.rs
@@ -22,6 +22,8 @@ use hal::{
 };
 
 #[cfg(feature = "usb")]
+use hal::gpio::v2::{AnyPin, PA24, PA25};
+#[cfg(feature = "usb")]
 use hal::usb::usb_device::bus::UsbBusAllocator;
 #[cfg(feature = "usb")]
 pub use hal::usb::UsbBus;
@@ -151,20 +153,11 @@ pub fn usb_allocator(
     usb: pac::USB,
     clocks: &mut GenericClockController,
     pm: &mut pac::PM,
-    dm: gpio::Pa24<Input<Floating>>,
-    dp: gpio::Pa25<Input<Floating>>,
-    port: &mut Port,
+    dm: impl AnyPin<Id = PA24>,
+    dp: impl AnyPin<Id = PA25>,
 ) -> UsbBusAllocator<UsbBus> {
-    use gpio::IntoFunction;
-
     let gclk0 = clocks.gclk0();
     let usb_clock = &clocks.usb(&gclk0).unwrap();
 
-    UsbBusAllocator::new(UsbBus::new(
-        usb_clock,
-        pm,
-        dm.into_function(port),
-        dp.into_function(port),
-        usb,
-    ))
+    UsbBusAllocator::new(UsbBus::new(usb_clock, pm, dm, dp, usb))
 }

--- a/build-all.py
+++ b/build-all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import json
 import shlex

--- a/crates.json
+++ b/crates.json
@@ -4,22 +4,22 @@
       "build": "cargo build --examples --features=unproven,usb"
     },
     "arduino_mkrvidor4000": {
-      "build": "cargo build --examples --features=unproven"
+      "build": "cargo build --examples --features=unproven,usb"
     },
     "arduino_mkrzero": {
       "build": "cargo build --examples --features=unproven,usb"
     },
     "arduino_nano33iot": {
-      "build": "cargo build --examples --features=unproven"
+      "build": "cargo build --examples --features=unproven,usb"
     },
     "atsame54_xpro": {
-      "build": "cargo build --examples --features=unproven"
+      "build": "cargo build --examples --features=unproven,usb"
     },
     "circuit_playground_express": {
       "build": "cargo build --examples --features=unproven"
     },
     "edgebadge": {
-      "build": "cargo build --examples --features=unproven"
+      "build": "cargo build --examples --features=unproven,usb"
     },
     "feather_m0": {
       "build": "cargo build --examples --example=pwm --features=unproven,usb"
@@ -31,10 +31,10 @@
       "build": "cargo build --examples --features=unproven"
     },
     "grand_central_m4": {
-      "build": "cargo build --examples --features=unproven"
+      "build": "cargo build --examples --features=unproven,usb"
     },
     "itsybitsy_m0": {
-      "build": "cargo build --examples --features=unproven"
+      "build": "cargo build --examples --features=unproven,usb"
     },
     "itsybitsy_m4": {
       "build": "cargo build --examples --features=unproven,usb,use_rtt"

--- a/hal/src/common/thumbv7em/usb/mod.rs
+++ b/hal/src/common/thumbv7em/usb/mod.rs
@@ -2,7 +2,6 @@
 
 use crate::gpio;
 
-use private::UsbSealed;
 pub use usb_device;
 
 mod bus;
@@ -17,38 +16,3 @@ pub type SofPad = gpio::v1::Pa23<gpio::v1::PfH>;
 pub type DmPad = gpio::v1::Pa24<gpio::v1::PfH>;
 /// Default USB D+ pad
 pub type DpPad = gpio::v1::Pa25<gpio::v1::PfH>;
-
-/// Indicates pin can be used as USB D-
-pub trait UsbPadDm: Send + private::UsbSealed {}
-
-/// Indicates pin can be used as USB D+
-pub trait UsbPadDp: Send + private::UsbSealed {}
-
-/// Indicates pin can be used as SOF (1kHz signal)
-pub trait UsbPadSof: Send + private::UsbSealed {}
-
-// v1 pin impls
-impl UsbPadSof for gpio::v1::Pa23<gpio::v1::PfH> {}
-impl UsbPadDm for gpio::v1::Pa24<gpio::v1::PfH> {}
-impl UsbPadDp for gpio::v1::Pa25<gpio::v1::PfH> {}
-
-// v2 pin impls
-impl UsbPadSof for gpio::v2::Pin<gpio::v2::PA23, gpio::v2::AlternateH> {}
-impl UsbPadDm for gpio::v2::Pin<gpio::v2::PA24, gpio::v2::AlternateH> {}
-impl UsbPadDp for gpio::v2::Pin<gpio::v2::PA25, gpio::v2::AlternateH> {}
-
-mod private {
-    use crate::gpio;
-
-    pub trait UsbSealed {}
-
-    // v1 pin impls
-    impl UsbSealed for gpio::v1::Pa23<gpio::v1::PfH> {}
-    impl UsbSealed for gpio::v1::Pa24<gpio::v1::PfH> {}
-    impl UsbSealed for gpio::v1::Pa25<gpio::v1::PfH> {}
-
-    // v2 pin impls
-    impl UsbSealed for gpio::v2::Pin<gpio::v2::PA23, gpio::v2::AlternateH> {}
-    impl UsbSealed for gpio::v2::Pin<gpio::v2::PA24, gpio::v2::AlternateH> {}
-    impl UsbSealed for gpio::v2::Pin<gpio::v2::PA25, gpio::v2::AlternateH> {}
-}

--- a/hal/src/samd11/clock.rs
+++ b/hal/src/samd11/clock.rs
@@ -216,7 +216,7 @@ impl GenericClockController {
         gclk: GCLK,
         pm: &mut PM,
         sysctrl: &mut SYSCTRL,
-        nvmctrl: &mut NVMCTRL,
+        _nvmctrl: &mut NVMCTRL,
     ) -> Self {
         let mut state = State { gclk };
 

--- a/hal/src/samd21/usb/bus.rs
+++ b/hal/src/samd21/usb/bus.rs
@@ -5,9 +5,10 @@
 // people doing that should be familiar with the USB standard. http://ww1.microchip.com/downloads/en/DeviceDoc/60001507E.pdf
 // http://ww1.microchip.com/downloads/en/AppNotes/Atmel-42261-SAM-D21-USB_Application-Note_AT06475.pdf
 
-use super::{Descriptors, DmPad, DpPad};
+use super::Descriptors;
 use crate::calibration::{usb_transn_cal, usb_transp_cal, usb_trim_cal};
 use crate::clock;
+use crate::gpio::v2::{AlternateG, AnyPin, Pin, PA24, PA25};
 use crate::target_device;
 use crate::target_device::usb::DEVICE;
 use crate::target_device::{PM, USB};
@@ -197,8 +198,8 @@ impl BufferAllocator {
 
 struct Inner {
     desc: RefCell<Descriptors>,
-    _dm_pad: DmPad,
-    _dp_pad: DpPad,
+    _dm_pad: Pin<PA24, AlternateG>,
+    _dp_pad: Pin<PA25, AlternateG>,
     endpoints: RefCell<AllEndpoints>,
     buffers: RefCell<BufferAllocator>,
 }
@@ -581,8 +582,8 @@ impl UsbBus {
     pub fn new(
         _clock: &clock::UsbClock,
         pm: &mut PM,
-        dm_pad: DmPad,
-        dp_pad: DpPad,
+        dm_pad: impl AnyPin<Id = PA24>,
+        dp_pad: impl AnyPin<Id = PA25>,
         _usb: USB,
     ) -> Self {
         dbgprint!("******** UsbBus::new\n");
@@ -591,8 +592,8 @@ impl UsbBus {
         let desc = RefCell::new(Descriptors::new());
 
         let inner = Inner {
-            _dm_pad: dm_pad,
-            _dp_pad: dp_pad,
+            _dm_pad: dm_pad.into().into_mode::<AlternateG>(),
+            _dp_pad: dp_pad.into().into_mode::<AlternateG>(),
             desc,
             buffers: RefCell::new(BufferAllocator::new()),
             endpoints: RefCell::new(AllEndpoints::new()),


### PR DESCRIPTION
Change the USB modules to accept the corrects pin in any mode. v2::Pins
do not need access to the Port to change mode, so also remove the Port
argument from corresponding BSP functions.

Fix warnings throughout the board modules, so that everything builds
cleanly.

@ryankurte, this implements the proposed solution in #404. But it ended up being a little more complicated than I originally thought. I'll expand on that in #404.

Edit: closes #404