### PR TITLE
Adds RTIC Monotonic implementation based on the RTC

### DIFF
--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -79,6 +79,7 @@ max-channels = ["dma", "atsamd-hal/max-channels"]
 # Enable pins for the adalogger SD card reader
 adalogger = []
 sdmmc = ["embedded-sdmmc", "atsamd-hal/sdmmc"]
+rtic = ["atsamd-hal/rtic"]
 
 [profile.dev]
 incremental = false

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -65,8 +65,7 @@ nom = { version = "5.1", default-features= false }
 heapless = "0.5"
 
 [dev-dependencies.cortex-m-rtic]
-git = "https://github.com/rtic-rs/cortex-m-rtic"
-branch = "new_monotonic"
+version = "0.6.0-alpha.2"
 
 [features]
 # ask the HAL to enable atsamd21g support

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -49,6 +49,7 @@ optional = true
 
 [dependencies.embedded-sdmmc]
 version = "0.3"
+optional = true
 
 [dependencies.rtic-monotonic]
 version = "=0.1.0-alpha.0"
@@ -154,4 +155,4 @@ required-features = ["adalogger", "usb", "sdmmc", "unproven"]
 
 [[example]]
 name = "blinky_rtic"
-required-features = ["rtic"]
+required-features = ["rtic", "unproven"]

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -59,6 +59,7 @@ nb = "0.1"
 drogue-nom-utils = "0.1"
 nom = { version = "5.1", default-features= false }
 heapless = "0.5"
+cortex-m-rtic = "0.5.5"
 
 [features]
 # ask the HAL to enable atsamd21g support
@@ -145,3 +146,7 @@ required-features = ["usb", "unproven"]
 [[example]]
 name = "adalogger"
 required-features = ["adalogger", "usb", "sdmmc", "unproven"]
+
+[[example]]
+name = "blinky_rtic"
+required-features = ["rtic"]

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -51,8 +51,7 @@ optional = true
 version = "0.3"
 
 [dependencies.rtic-monotonic]
-git = "https://github.com/rtic-rs/rtic-monotonic"
-branch = "master"
+version = "=0.1.0-alpha.0"
 optional = true
 
 [dev-dependencies]

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -49,6 +49,10 @@ optional = true
 
 [dependencies.embedded-sdmmc]
 version = "0.3"
+
+[dependencies.rtic-monotonic]
+git = "https://github.com/rtic-rs/rtic-monotonic"
+branch = "master"
 optional = true
 
 [dev-dependencies]
@@ -59,7 +63,10 @@ nb = "0.1"
 drogue-nom-utils = "0.1"
 nom = { version = "5.1", default-features= false }
 heapless = "0.5"
-cortex-m-rtic = "0.5.5"
+
+[dev-dependencies.cortex-m-rtic]
+git = "https://github.com/rtic-rs/cortex-m-rtic"
+branch = "new_monotonic"
 
 [features]
 # ask the HAL to enable atsamd21g support
@@ -80,7 +87,7 @@ max-channels = ["dma", "atsamd-hal/max-channels"]
 # Enable pins for the adalogger SD card reader
 adalogger = []
 sdmmc = ["embedded-sdmmc", "atsamd-hal/sdmmc"]
-rtic = ["atsamd-hal/rtic"]
+rtic = ["atsamd-hal/rtic", "rtic-monotonic"]
 
 [profile.dev]
 incremental = false

--- a/boards/feather_m0/examples/blinky_rtic.rs
+++ b/boards/feather_m0/examples/blinky_rtic.rs
@@ -18,7 +18,7 @@ extern crate rtic;
 mod app {
     use hal::clock::{ClockGenId, ClockSource, GenericClockController};
     use hal::pac::Peripherals;
-    use hal::rtc::{Rtc, Count32Mode};
+    use hal::rtc::{Count32Mode, Rtc};
     use rtic_monotonic::Extensions;
 
     #[resources]

--- a/boards/feather_m0/examples/blinky_rtic.rs
+++ b/boards/feather_m0/examples/blinky_rtic.rs
@@ -18,7 +18,7 @@ extern crate rtic;
 mod app {
     use hal::clock::{ClockGenId, ClockSource, GenericClockController};
     use hal::pac::Peripherals;
-    use hal::rtc::Rtc;
+    use hal::rtc::{Rtc, Count32Mode};
     use rtic_monotonic::Extensions;
 
     #[resources]
@@ -28,7 +28,7 @@ mod app {
     }
 
     #[monotonic(binds = RTC, default = true)]
-    type RtcMonotonic = Rtc;
+    type RtcMonotonic = Rtc<Count32Mode>;
 
     #[init]
     fn init(cx: init::Context) -> (init::LateResources, init::Monotonics) {
@@ -47,8 +47,7 @@ mod app {
             .unwrap();
         clocks.configure_standby(ClockGenId::GCLK2, true);
         let rtc_clock = clocks.rtc(&rtc_clock_src).unwrap();
-        let mut rtc = Rtc::new(peripherals.RTC, rtc_clock.freq(), &mut peripherals.PM);
-        rtc.timer_mode();
+        let rtc = Rtc::count32_mode(peripherals.RTC, rtc_clock.freq(), &mut peripherals.PM);
         let red_led = pins.d13.into_open_drain_output(&mut pins.port);
 
         // We can use the RTC in standby for maximum power savings

--- a/boards/feather_m0/examples/blinky_rtic.rs
+++ b/boards/feather_m0/examples/blinky_rtic.rs
@@ -2,7 +2,6 @@
 //!
 //! The idle task is sleeping the CPU, so in practice this gives similar power
 //! figure as the "sleeping_timer_rtc" example.
-//!
 #![no_std]
 #![no_main]
 
@@ -15,61 +14,55 @@ extern crate panic_halt;
 extern crate panic_semihosting;
 extern crate rtic;
 
-use hal::clock::{enable_internal_32kosc, ClockGenId, ClockSource, GenericClockController};
-use hal::delay::Delay;
-use hal::entry;
-use hal::pac::{CorePeripherals, Peripherals};
-use hal::prelude::*;
-use hal::rtc::{Rtc, RtcMonotonic, Instant, U32Ext as _};
+#[rtic::app(device = hal::pac, peripherals = true, dispatchers = [EVSYS])]
+mod app {
+    use hal::clock::{ClockGenId, ClockSource, GenericClockController};
+    use hal::pac::Peripherals;
+    use hal::rtc::Rtc;
+    use rtic_monotonic::Extensions;
 
-#[rtic::app(device = hal::pac, peripherals = true, monotonic = crate::RtcMonotonic)]
-const APP: () = {
-  struct Resources {
-    red_led: hal::gpio::Pin<hal::gpio::v2::PA17, hal::gpio::v2::Output<hal::gpio::v2::PushPull>>,
-  }
-
-  #[init(spawn = [blink])]
-  fn init(cx: init::Context) -> init::LateResources {
-    let mut peripherals: Peripherals = cx.device;
-    let mut pins = hal::Pins::new(peripherals.PORT);
-    let mut core: rtic::Peripherals = cx.core;
-    let mut clocks = GenericClockController::with_external_32kosc(
-      peripherals.GCLK,
-      &mut peripherals.PM,
-      &mut peripherals.SYSCTRL,
-      &mut peripherals.NVMCTRL,
-    );
-    let gclk = clocks.gclk0();
-    let rtc_clock_src = clocks
-        .configure_gclk_divider_and_source(ClockGenId::GCLK2, 1, ClockSource::XOSC32K, false)
-        .unwrap();
-    clocks.configure_standby(ClockGenId::GCLK2, true);
-    let rtc_clock = clocks.rtc(&rtc_clock_src).unwrap();
-    let rtc = Rtc::new(peripherals.RTC, rtc_clock.freq(), &mut peripherals.PM);
-    let _: RtcMonotonic = rtc.into();
-    let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
-
-    // We can use the RTC in standby for maximum power savings
-    core.SCB.set_sleepdeep();
-
-    // Start the blink task
-    cx.spawn.blink().unwrap();
-
-    init::LateResources {
-      red_led,
+    #[resources]
+    struct Resources {
+        red_led:
+            hal::gpio::Pin<hal::gpio::v2::PA17, hal::gpio::v2::Output<hal::gpio::v2::PushPull>>,
     }
-  }
 
-  #[task(schedule = [blink], resources = [red_led])]
-  fn blink(mut cx: blink::Context) {
-    cx.resources.red_led.toggle();
-    cx.schedule.blink(cx.scheduled + 32768.cycles()); // 1 second
-  }
+    #[monotonic(binds = RTC, default = true)]
+    type RtcMonotonic = Rtc;
 
-  // RTIC requires that unused interrupts are declared in an extern block when
-  // using software tasks; these free interrupts will be used to dispatch the
-  // software tasks.
-  extern "C" {
-    fn EVSYS();
-  }
-};
+    #[init]
+    fn init(cx: init::Context) -> (init::LateResources, init::Monotonics) {
+        let mut peripherals: Peripherals = cx.device;
+        let mut pins = hal::Pins::new(peripherals.PORT);
+        let mut core: rtic::export::Peripherals = cx.core;
+        let mut clocks = GenericClockController::with_external_32kosc(
+            peripherals.GCLK,
+            &mut peripherals.PM,
+            &mut peripherals.SYSCTRL,
+            &mut peripherals.NVMCTRL,
+        );
+        let _gclk = clocks.gclk0();
+        let rtc_clock_src = clocks
+            .configure_gclk_divider_and_source(ClockGenId::GCLK2, 1, ClockSource::XOSC32K, false)
+            .unwrap();
+        clocks.configure_standby(ClockGenId::GCLK2, true);
+        let rtc_clock = clocks.rtc(&rtc_clock_src).unwrap();
+        let mut rtc = Rtc::new(peripherals.RTC, rtc_clock.freq(), &mut peripherals.PM);
+        rtc.timer_mode();
+        let red_led = pins.d13.into_open_drain_output(&mut pins.port);
+
+        // We can use the RTC in standby for maximum power savings
+        core.SCB.set_sleepdeep();
+
+        // Start the blink task
+        blink::spawn().unwrap();
+
+        (init::LateResources { red_led }, init::Monotonics(rtc))
+    }
+
+    #[task(resources = [red_led])]
+    fn blink(mut _cx: blink::Context) {
+        _cx.resources.red_led.lock(|led| led.toggle());
+        blink::spawn_after(1_u32.seconds()).ok();
+    }
+}

--- a/boards/feather_m0/examples/blinky_rtic.rs
+++ b/boards/feather_m0/examples/blinky_rtic.rs
@@ -1,0 +1,75 @@
+//! Uses RTIC with the RTC as time source to blink an LED.
+//!
+//! The idle task is sleeping the CPU, so in practice this gives similar power
+//! figure as the "sleeping_timer_rtc" example.
+//!
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate cortex_m_semihosting;
+extern crate feather_m0 as hal;
+#[cfg(not(feature = "use_semihosting"))]
+extern crate panic_halt;
+#[cfg(feature = "use_semihosting")]
+extern crate panic_semihosting;
+extern crate rtic;
+
+use hal::clock::{enable_internal_32kosc, ClockGenId, ClockSource, GenericClockController};
+use hal::delay::Delay;
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+use hal::rtc::{Rtc, RtcMonotonic, Instant, U32Ext as _};
+
+#[rtic::app(device = hal::pac, peripherals = true, monotonic = crate::RtcMonotonic)]
+const APP: () = {
+  struct Resources {
+    red_led: hal::gpio::Pin<hal::gpio::v2::PA17, hal::gpio::v2::Output<hal::gpio::v2::PushPull>>,
+  }
+
+  #[init(spawn = [blink])]
+  fn init(cx: init::Context) -> init::LateResources {
+    let mut peripherals: Peripherals = cx.device;
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut core: rtic::Peripherals = cx.core;
+    let mut clocks = GenericClockController::with_external_32kosc(
+      peripherals.GCLK,
+      &mut peripherals.PM,
+      &mut peripherals.SYSCTRL,
+      &mut peripherals.NVMCTRL,
+    );
+    let gclk = clocks.gclk0();
+    let rtc_clock_src = clocks
+        .configure_gclk_divider_and_source(ClockGenId::GCLK2, 1, ClockSource::XOSC32K, false)
+        .unwrap();
+    clocks.configure_standby(ClockGenId::GCLK2, true);
+    let rtc_clock = clocks.rtc(&rtc_clock_src).unwrap();
+    let rtc = Rtc::new(peripherals.RTC, rtc_clock.freq(), &mut peripherals.PM);
+    let _: RtcMonotonic = rtc.into();
+    let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
+
+    // We can use the RTC in standby for maximum power savings
+    core.SCB.set_sleepdeep();
+
+    // Start the blink task
+    cx.spawn.blink().unwrap();
+
+    init::LateResources {
+      red_led,
+    }
+  }
+
+  #[task(schedule = [blink], resources = [red_led])]
+  fn blink(mut cx: blink::Context) {
+    cx.resources.red_led.toggle();
+    cx.schedule.blink(cx.scheduled + 32768.cycles()); // 1 second
+  }
+
+  // RTIC requires that unused interrupts are declared in an extern block when
+  // using software tasks; these free interrupts will be used to dispatch the
+  // software tasks.
+  extern "C" {
+    fn EVSYS();
+  }
+};

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -44,6 +44,10 @@ version = "0.2.14"
 version = "0.2"
 optional = true
 
+[dependencies.cortex-m-rtic]
+optional = true
+version = "0.5"
+
 [dependencies.void]
 default-features = false
 version = "1.0"
@@ -195,3 +199,4 @@ usb = ["usb-device"]
 dma = ["unproven"]
 max-channels = ["dma"]
 sdmmc = ["embedded-sdmmc"]
+rtic = ["cortex-m-rtic"]

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -46,7 +46,13 @@ optional = true
 
 [dependencies.cortex-m-rtic]
 optional = true
-version = "0.5"
+git = "https://github.com/rtic-rs/cortex-m-rtic"
+branch = "new_monotonic"
+
+[dependencies.rtic-monotonic]
+optional = true
+git = "https://github.com/rtic-rs/rtic-monotonic"
+branch = "master"
 
 [dependencies.void]
 default-features = false
@@ -199,4 +205,4 @@ usb = ["usb-device"]
 dma = ["unproven"]
 max-channels = ["dma"]
 sdmmc = ["embedded-sdmmc"]
-rtic = ["cortex-m-rtic"]
+rtic = ["cortex-m-rtic", "rtic-monotonic"]

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -46,13 +46,11 @@ optional = true
 
 [dependencies.cortex-m-rtic]
 optional = true
-git = "https://github.com/rtic-rs/cortex-m-rtic"
-branch = "new_monotonic"
+version = "0.6.0-alpha.2"
 
 [dependencies.rtic-monotonic]
 optional = true
-git = "https://github.com/rtic-rs/rtic-monotonic"
-branch = "master"
+version = "0.1.0-alpha.0"
 
 [dependencies.void]
 default-features = false

--- a/hal/src/rtc.rs
+++ b/hal/src/rtc.rs
@@ -10,6 +10,14 @@ use void::Void;
 
 #[cfg(feature = "sdmmc")]
 use embedded_sdmmc::{TimeSource, Timestamp};
+use core::{
+    cmp::Ordering,
+    convert::{Infallible, TryInto},
+    fmt, ops,
+  };
+
+#[cfg(feature = "rtic")]
+use rtic::{Fraction, Monotonic};
 
 // SAMx5x imports
 #[cfg(feature = "min-samd51g")]
@@ -433,5 +441,236 @@ impl TimerParams {
         let cycles: u32 = ticks / divider_value as u32;
 
         TimerParams { divider, cycles }
+    }
+}
+
+  /// A measurement of the RTC counter. Opaque and useful only with `Duration`
+  ///
+  /// # Correctness
+  ///
+  /// Adding or subtracting a `Duration` of more than `(1 << 31)` cycles to an `Instant` effectively
+  /// makes it "wrap around" and creates an incorrect value. This is also true if the operation is
+  /// done in steps, e.g. `(instant + dur) + dur` where `dur` is `(1 << 30)` ticks.
+  #[derive(Clone, Copy, Eq, PartialEq)]
+  pub struct Instant {
+    inner: i32,
+  }
+
+  impl Instant {
+    /// Returns an instant corresponding to "now"
+    pub fn now() -> Self {
+        Instant {
+            inner: unsafe {
+              let rtc = &*RTC::ptr();
+              rtc.mode0().count.read().bits() as i32
+            },
+        }
+    }
+
+    /// Returns the amount of time elapsed since this instant was created.
+    pub fn elapsed(&self) -> Duration {
+        let diff = Instant::now().inner.wrapping_sub(self.inner);
+        assert!(diff >= 0, "instant now is earlier than self");
+        Duration { inner: diff as u32 }
+    }
+
+    /// Returns the amount of time elapsed from another instant to this one.
+    pub fn duration_since(&self, earlier: Instant) -> Duration {
+        let diff = self.inner.wrapping_sub(earlier.inner);
+        assert!(diff >= 0, "second instant is later than self");
+        Duration { inner: diff as u32 }
+    }
+  }
+
+  impl fmt::Debug for Instant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Instant")
+            .field(&(self.inner as u32))
+            .finish()
+    }
+  }
+
+  impl ops::AddAssign<Duration> for Instant {
+    fn add_assign(&mut self, dur: Duration) {
+        // NOTE this is a debug assertion because there's no foolproof way to detect a wrap around;
+        // the user may write `(instant + dur) + dur` where `dur` is `(1<<31)-1` ticks.
+        debug_assert!(dur.inner < (1 << 31));
+        self.inner = self.inner.wrapping_add(dur.inner as i32);
+    }
+  }
+
+  impl ops::Add<Duration> for Instant {
+    type Output = Self;
+
+    fn add(mut self, dur: Duration) -> Self {
+        self += dur;
+        self
+    }
+  }
+
+  impl ops::SubAssign<Duration> for Instant {
+    fn sub_assign(&mut self, dur: Duration) {
+        // NOTE see the NOTE in `<Instant as AddAssign<Duration>>::add_assign`
+        debug_assert!(dur.inner < (1 << 31));
+        self.inner = self.inner.wrapping_sub(dur.inner as i32);
+    }
+  }
+
+  impl ops::Sub<Duration> for Instant {
+    type Output = Self;
+
+    fn sub(mut self, dur: Duration) -> Self {
+        self -= dur;
+        self
+    }
+  }
+
+  impl ops::Sub<Instant> for Instant {
+    type Output = Duration;
+
+    fn sub(self, other: Instant) -> Duration {
+        self.duration_since(other)
+    }
+  }
+
+  impl Ord for Instant {
+    fn cmp(&self, rhs: &Self) -> Ordering {
+        self.inner.wrapping_sub(rhs.inner).cmp(&0)
+    }
+  }
+
+  impl PartialOrd for Instant {
+    fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
+        Some(self.cmp(rhs))
+    }
+  }
+
+  /// A `Duration` type to represent a span of time.
+  ///
+  /// # Correctness
+  ///
+  /// This type is *not* appropriate for representing time spans in the order of, or larger than,
+  /// seconds because it can hold a maximum of `(1 << 31)` "ticks" where each tick is the inverse of
+  /// the CPU frequency, which usually is dozens of MHz.
+  #[derive(Clone, Copy, Default, Eq, Ord, PartialEq, PartialOrd)]
+  pub struct Duration {
+    inner: u32,
+  }
+
+  impl Duration {
+    /// Creates a new `Duration` from the specified number of clock cycles
+    pub fn from_cycles(cycles: u32) -> Self {
+        Duration { inner: cycles }
+    }
+
+    /// Returns the total number of clock cycles contained by this `Duration`
+    pub fn as_cycles(&self) -> u32 {
+        self.inner
+    }
+  }
+
+  impl TryInto<u32> for Duration {
+    type Error = Infallible;
+
+    fn try_into(self) -> Result<u32, Infallible> {
+        Ok(self.as_cycles())
+    }
+  }
+
+  impl ops::AddAssign for Duration {
+    fn add_assign(&mut self, dur: Duration) {
+        self.inner += dur.inner;
+    }
+  }
+
+  impl ops::Add<Duration> for Duration {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Duration {
+            inner: self.inner + other.inner,
+        }
+    }
+  }
+
+  impl ops::SubAssign for Duration {
+    fn sub_assign(&mut self, rhs: Duration) {
+        self.inner -= rhs.inner;
+    }
+  }
+
+  impl ops::Sub<Duration> for Duration {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self {
+        Duration {
+            inner: self.inner - rhs.inner,
+        }
+    }
+  }
+
+/// Adds the `cycles` method to the `u32` type
+pub trait U32Ext {
+    /// Converts the `u32` value into RTC counter cycles
+    fn cycles(self) -> Duration;
+}
+
+impl U32Ext for u32 {
+    fn cycles(self) -> Duration {
+        Duration { inner: self }
+    }
+}
+
+/// RtcCounter is a counter based on the RTC peripheral for keeping track of time in RTIC
+pub struct RtcCounter {}
+
+impl RtcCounter {
+    pub fn initialize(rtc: RTC, pm: &mut PM) {
+      pm.apbamask.modify(|_, w| w.rtc_().set_bit());
+      // disable RTC
+      rtc.mode0().ctrl.modify(|_, w| w.enable().clear_bit());
+      while rtc.mode0().status.read().syncbusy().bit_is_set() {}
+
+      // reset RTC
+      rtc.mode0().ctrl.modify(|_, w| w.swrst().set_bit());
+      while rtc.mode0().status.read().syncbusy().bit_is_set() {}
+
+      // Explicitly drop rtc instance so it cannot be reused or reconfigured
+      drop(rtc)
+    }
+  }
+
+/// Implementation of the `Monotonic` trait based on the RTC counter
+#[cfg(feature = "rtic")]
+impl Monotonic for RtcCounter {
+    type Instant = Instant;
+
+    fn ratio() -> Fraction {
+        Fraction {
+            numerator: 1,
+            denominator: 1,
+        }
+    }
+
+    unsafe fn reset() {
+        // This is safe because reset is only called once by the RTIC framework.
+        let rtc = &*RTC::ptr();
+
+        rtc.mode0().ctrl.modify(|_, w| w.enable().clear_bit());
+        while rtc.mode0().status.read().syncbusy().bit_is_set() {}
+
+        rtc.mode0().ctrl.modify(|_, w| w.swrst().set_bit());
+        while rtc.mode0().status.read().syncbusy().bit_is_set() {}
+
+        rtc.mode0().ctrl.modify(|_, w| w.enable().set_bit());
+        while rtc.mode0().status.read().syncbusy().bit_is_set() {}
+    }
+
+    fn now() -> Instant {
+        Instant::now()
+    }
+
+    fn zero() -> Instant {
+        Instant { inner: 0 }
     }
 }

--- a/hal/src/rtc.rs
+++ b/hal/src/rtc.rs
@@ -10,11 +10,6 @@ use void::Void;
 
 #[cfg(feature = "sdmmc")]
 use embedded_sdmmc::{TimeSource, Timestamp};
-use core::{
-    cmp::Ordering,
-    convert::{Infallible, TryInto},
-    fmt, ops,
-};
 
 #[cfg(feature = "rtic")]
 use rtic_monotonic::{embedded_time, Clock, Fraction, Instant, Monotonic};

--- a/hal/src/rtc.rs
+++ b/hal/src/rtc.rs
@@ -457,7 +457,8 @@ impl Clock for Rtc {
 #[cfg(feature = "rtic")]
 impl Monotonic for Rtc {
     fn reset(&mut self) {
-        // Since reset is only called once, we use it to enable the interrupt generation bit.
+        // Since reset is only called once, we use it to enable the interrupt generation
+        // bit.
         self.mode0().intenset.write(|w| w.cmp0().set_bit());
     }
 

--- a/hal/src/rtc.rs
+++ b/hal/src/rtc.rs
@@ -14,7 +14,7 @@ use core::{
     cmp::Ordering,
     convert::{Infallible, TryInto},
     fmt, ops,
-  };
+};
 
 #[cfg(feature = "rtic")]
 use rtic::{Fraction, Monotonic};
@@ -444,25 +444,26 @@ impl TimerParams {
     }
 }
 
-  /// A measurement of the RTC counter. Opaque and useful only with `Duration`
-  ///
-  /// # Correctness
-  ///
-  /// Adding or subtracting a `Duration` of more than `(1 << 31)` cycles to an `Instant` effectively
-  /// makes it "wrap around" and creates an incorrect value. This is also true if the operation is
-  /// done in steps, e.g. `(instant + dur) + dur` where `dur` is `(1 << 30)` ticks.
-  #[derive(Clone, Copy, Eq, PartialEq)]
-  pub struct Instant {
+/// A measurement of the RTC counter. Opaque and useful only with `Duration`
+///
+/// # Correctness
+///
+/// Adding or subtracting a `Duration` of more than `(1 << 31)` cycles to an
+/// `Instant` effectively makes it "wrap around" and creates an incorrect value.
+/// This is also true if the operation is done in steps, e.g. `(instant + dur) +
+/// dur` where `dur` is `(1 << 30)` ticks.
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct Instant {
     inner: i32,
-  }
+}
 
-  impl Instant {
+impl Instant {
     /// Returns an instant corresponding to "now"
     pub fn now() -> Self {
         Instant {
             inner: unsafe {
-              let rtc = &*RTC::ptr();
-              rtc.mode0().count.read().bits() as i32
+                let rtc = &*RTC::ptr();
+                rtc.mode0().count.read().bits() as i32
             },
         }
     }
@@ -480,84 +481,86 @@ impl TimerParams {
         assert!(diff >= 0, "second instant is later than self");
         Duration { inner: diff as u32 }
     }
-  }
+}
 
-  impl fmt::Debug for Instant {
+impl fmt::Debug for Instant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Instant")
             .field(&(self.inner as u32))
             .finish()
     }
-  }
+}
 
-  impl ops::AddAssign<Duration> for Instant {
+impl ops::AddAssign<Duration> for Instant {
     fn add_assign(&mut self, dur: Duration) {
-        // NOTE this is a debug assertion because there's no foolproof way to detect a wrap around;
-        // the user may write `(instant + dur) + dur` where `dur` is `(1<<31)-1` ticks.
+        // NOTE this is a debug assertion because there's no foolproof way to detect a
+        // wrap around; the user may write `(instant + dur) + dur` where `dur`
+        // is `(1<<31)-1` ticks.
         debug_assert!(dur.inner < (1 << 31));
         self.inner = self.inner.wrapping_add(dur.inner as i32);
     }
-  }
+}
 
-  impl ops::Add<Duration> for Instant {
+impl ops::Add<Duration> for Instant {
     type Output = Self;
 
     fn add(mut self, dur: Duration) -> Self {
         self += dur;
         self
     }
-  }
+}
 
-  impl ops::SubAssign<Duration> for Instant {
+impl ops::SubAssign<Duration> for Instant {
     fn sub_assign(&mut self, dur: Duration) {
         // NOTE see the NOTE in `<Instant as AddAssign<Duration>>::add_assign`
         debug_assert!(dur.inner < (1 << 31));
         self.inner = self.inner.wrapping_sub(dur.inner as i32);
     }
-  }
+}
 
-  impl ops::Sub<Duration> for Instant {
+impl ops::Sub<Duration> for Instant {
     type Output = Self;
 
     fn sub(mut self, dur: Duration) -> Self {
         self -= dur;
         self
     }
-  }
+}
 
-  impl ops::Sub<Instant> for Instant {
+impl ops::Sub<Instant> for Instant {
     type Output = Duration;
 
     fn sub(self, other: Instant) -> Duration {
         self.duration_since(other)
     }
-  }
+}
 
-  impl Ord for Instant {
+impl Ord for Instant {
     fn cmp(&self, rhs: &Self) -> Ordering {
         self.inner.wrapping_sub(rhs.inner).cmp(&0)
     }
-  }
+}
 
-  impl PartialOrd for Instant {
+impl PartialOrd for Instant {
     fn partial_cmp(&self, rhs: &Self) -> Option<Ordering> {
         Some(self.cmp(rhs))
     }
-  }
+}
 
-  /// A `Duration` type to represent a span of time.
-  ///
-  /// # Correctness
-  ///
-  /// This type is *not* appropriate for representing time spans in the order of, or larger than,
-  /// seconds because it can hold a maximum of `(1 << 31)` "ticks" where each tick is the inverse of
-  /// the CPU frequency, which usually is dozens of MHz.
-  #[derive(Clone, Copy, Default, Eq, Ord, PartialEq, PartialOrd)]
-  pub struct Duration {
+/// A `Duration` type to represent a span of time.
+///
+/// # Correctness
+///
+/// This type is *not* appropriate for representing time spans in the order of,
+/// or larger than, seconds because it can hold a maximum of `(1 << 31)` "ticks"
+/// where each tick is the inverse of the CPU frequency, which usually is dozens
+/// of MHz.
+#[derive(Clone, Copy, Default, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Duration {
     inner: u32,
-  }
+}
 
-  impl Duration {
+impl Duration {
     /// Creates a new `Duration` from the specified number of clock cycles
     pub fn from_cycles(cycles: u32) -> Self {
         Duration { inner: cycles }
@@ -567,23 +570,23 @@ impl TimerParams {
     pub fn as_cycles(&self) -> u32 {
         self.inner
     }
-  }
+}
 
-  impl TryInto<u32> for Duration {
+impl TryInto<u32> for Duration {
     type Error = Infallible;
 
     fn try_into(self) -> Result<u32, Infallible> {
         Ok(self.as_cycles())
     }
-  }
+}
 
-  impl ops::AddAssign for Duration {
+impl ops::AddAssign for Duration {
     fn add_assign(&mut self, dur: Duration) {
         self.inner += dur.inner;
     }
-  }
+}
 
-  impl ops::Add<Duration> for Duration {
+impl ops::Add<Duration> for Duration {
     type Output = Self;
 
     fn add(self, other: Self) -> Self {
@@ -591,15 +594,15 @@ impl TimerParams {
             inner: self.inner + other.inner,
         }
     }
-  }
+}
 
-  impl ops::SubAssign for Duration {
+impl ops::SubAssign for Duration {
     fn sub_assign(&mut self, rhs: Duration) {
         self.inner -= rhs.inner;
     }
-  }
+}
 
-  impl ops::Sub<Duration> for Duration {
+impl ops::Sub<Duration> for Duration {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self {
@@ -607,7 +610,7 @@ impl TimerParams {
             inner: self.inner - rhs.inner,
         }
     }
-  }
+}
 
 /// Adds the `cycles` method to the `u32` type
 pub trait U32Ext {
@@ -621,24 +624,25 @@ impl U32Ext for u32 {
     }
 }
 
-/// RtcCounter is a counter based on the RTC peripheral for keeping track of time in RTIC
+/// RtcCounter is a counter based on the RTC peripheral for keeping track of
+/// time in RTIC
 pub struct RtcCounter {}
 
 impl RtcCounter {
     pub fn initialize(rtc: RTC, pm: &mut PM) {
-      pm.apbamask.modify(|_, w| w.rtc_().set_bit());
-      // disable RTC
-      rtc.mode0().ctrl.modify(|_, w| w.enable().clear_bit());
-      while rtc.mode0().status.read().syncbusy().bit_is_set() {}
+        pm.apbamask.modify(|_, w| w.rtc_().set_bit());
+        // disable RTC
+        rtc.mode0().ctrl.modify(|_, w| w.enable().clear_bit());
+        while rtc.mode0().status.read().syncbusy().bit_is_set() {}
 
-      // reset RTC
-      rtc.mode0().ctrl.modify(|_, w| w.swrst().set_bit());
-      while rtc.mode0().status.read().syncbusy().bit_is_set() {}
+        // reset RTC
+        rtc.mode0().ctrl.modify(|_, w| w.swrst().set_bit());
+        while rtc.mode0().status.read().syncbusy().bit_is_set() {}
 
-      // Explicitly drop rtc instance so it cannot be reused or reconfigured
-      drop(rtc)
+        // Explicitly drop rtc instance so it cannot be reused or reconfigured
+        drop(rtc)
     }
-  }
+}
 
 /// Implementation of the `Monotonic` trait based on the RTC counter
 #[cfg(feature = "rtic")]


### PR DESCRIPTION
I still need to add an example for this, but it would be good to know if this is in the right direction.

The semantics of an RTIC Monotonic is a bit weird compared to the HAL Rtc, so I made sure to take the RTC instance in initialize and drop it, to make sure nobody tries to use both at the same time. Suggestions on improving this are welcome.

See https://docs.rs/cortex-m-rtic/0.5.5/rtic/trait.Monotonic.html

Ping @TDHolmes @twitchyliquid64 