### PR TITLE
Fix v2 SPI bugs and improve bsp_pins macro

### DIFF
--- a/hal/src/common/gpio/v2/pin.rs
+++ b/hal/src/common/gpio/v2/pin.rs
@@ -1561,14 +1561,14 @@ define_pins!(
 /// for each [`Pin`], and it defines type aliases and constants to make it
 /// easier to work with the [`Pin`]s and [`DynPin`](super::DynPin)s.
 ///
-/// The types and constants are defined within a public module named
-/// `bsp_pins_mod` and are then re-exported with `pub use bsp_pins_mod::*;`.
+/// When specifying pin aliases, be sure to use a [`PinMode`]. See
+/// [here](self#types) for a list of the available [`PinMode`] type aliases.
 ///
 /// # Example
 ///
 /// The following example macro call
 ///
-/// ```rust
+/// ```
 /// atsamd_hal::bsp_pins!(
 ///     #[cfg(feature = "unproven")]
 ///     PA24 {
@@ -1579,167 +1579,171 @@ define_pins!(
 ///             AlternateM: UsbPin
 ///         }
 ///     }
+///     PA25 {
+///         name: led_fail
+///     }
 /// );
 /// ```
 ///
-/// would expand to this
+/// would expand to something like this
 ///
-/// ```rust
-/// pub mod bsp_pins_mod {
-///     use atsamd_hal::target_device::PORT;
-///     use atsamd_hal::gpio::v2::{
-///         self as gpio, Pin, PinId, PinMode, Reset, DynPinId, DynPinMode
-///     };
-///
-///     pub struct Pins {
-///         port: Option<PORT>,
-///         #[cfg(feature = "unproven")]
-///         pub led_pass: Pin<gpio::PA24, Reset>,
-///     }
-///
-///     impl Pins {
-///
-///         pub fn new(port: PORT) -> Self {
-///             let pins = gpio::Pins::new(port);
-///             Self {
-///                 port: Some(unsafe { pins.port() }),
-///                 #[cfg(feature = "unproven")]
-///                 led_pass: pins.pa24,
-///             }
-///         }
-///
-///         #[inline]
-///         pub unsafe fn port(&mut self) -> PORT {
-///             self.port.take().unwrap()
-///         }
-///     }
-///
+/// ```
+/// pub struct Pins {
+///     port: Option<PORT>,
 ///     #[cfg(feature = "unproven")]
-///     pub type LedPass = Pin<gpio::PA24, gpio::AlternateH>;
-///     #[cfg(feature = "unproven")]
-///     pub const LED_PASS_ID: DynPinId = <gpio::PA24 as PinId>::DYN;
-///     #[cfg(feature = "unproven")]
-///     pub const LED_PASS_MODE: DynPinMode = <gpio::AlternateH as PinMode>::DYN;
-///
-///     #[cfg(feature = "unproven")]
-///     #[cfg(feature = "usb")]
-///     pub type UsbPin = Pin<gpio::PA24, gpio::AlternateM>;
-///     #[cfg(feature = "unproven")]
-///     #[cfg(feature = "usb")]
-///     pub const USB_PIN_ID: DynPinId = <gpio::PA24 as PinId>::DYN;
-///     #[cfg(feature = "unproven")]
-///     #[cfg(feature = "usb")]
-///     pub const USB_PIN_MODE: DynPinMode = <gpio::AlternateM as PinMode>::DYN;
+///     pub led_pass: Pin<PA24, Reset>,
+///     pub led_fail: Pin<PA25, Reset>,
 /// }
-/// pub use bsp_pins_mod::*;
+///
+/// impl Pins {
+///
+///     pub fn new(port: PORT) -> Self {
+///         let pins = gpio::Pins::new(port);
+///         Self {
+///             port: Some(unsafe { pins.port() }),
+///             #[cfg(feature = "unproven")]
+///             led_pass: pins.pa24,
+///             led_fail: pins.pa25,
+///         }
+///     }
+///
+///     #[inline]
+///     pub unsafe fn port(&mut self) -> PORT {
+///         self.port.take().unwrap()
+///     }
+/// }
+///
+/// #[cfg(feature = "unproven")]
+/// pub type LedPass = Pin<PA24, AlternateH>;
+///
+/// #[cfg(feature = "unproven")]
+/// pub const LED_PASS_ID: DynPinId = <PA24 as PinId>::DYN;
+///
+/// #[cfg(feature = "unproven")]
+/// pub const LED_PASS_MODE: DynPinMode = <AlternateH as PinMode>::DYN;
+///
+/// #[cfg(feature = "unproven")]
+/// #[cfg(feature = "usb")]
+/// pub type UsbPin = Pin<PA24, AlternateM>;
+///
+/// #[cfg(feature = "unproven")]
+/// #[cfg(feature = "usb")]
+/// pub const USB_PIN_ID: DynPinId = <PA24 as PinId>::DYN;
+///
+/// #[cfg(feature = "unproven")]
+/// #[cfg(feature = "usb")]
+/// pub const USB_PIN_MODE: DynPinMode = <AlternateM as PinMode>::DYN;
 /// ```
 #[macro_export]
 macro_rules! bsp_pins {
     (
         $(
-            $( #[$name_cfg:meta] )?
+            $( #[$name_cfg:meta] )*
             $Id:ty {
                 name: $name:ident $(,)?
                 $(
                     aliases: {
                         $(
-                            $( #[$alias_cfg:meta] )?
+                            $( #[$alias_cfg:meta] )*
                             $Mode:ty: $Alias:ident
                         ),+
                     }
                 )?
-            }
+            } $(,)?
         )+
     ) => {
-        atsamd_hal::paste::paste! {
-            pub mod bsp_pins_mod {
-                use atsamd_hal::target_device::PORT;
-                use atsamd_hal::gpio::v2::{
-                    self as gpio, Pin, PinId, PinMode, Reset, DynPinId, DynPinMode
-                };
+        $crate::paste::paste! {
 
-                /// BSP replacement for the HAL
-                /// [`Pins`](atsamd_hal::gpio::v2::Pins) type
-                ///
-                /// This type is intended to provide more meaningful names for
-                /// the given pins.
-                pub struct Pins {
-                    port: Option<PORT>,
-                    $(
-                        $( #[$name_cfg] )?
-                        pub $name: Pin<gpio::$Id, Reset>,
-                    )+
-                }
-
-                impl Pins {
-
-                    /// Take ownership of the PAC [`PORT`] and split it into
-                    /// discrete [`Pin`]s.
-                    ///
-                    /// This struct serves as a replacement for the HAL [`Pins`]
-                    /// struct. It is intended to provide more meaningful names
-                    /// for each [`Pin`] in a BSP. Any [`Pin`] not defined by
-                    /// the BSP is dropped.
-                    ///
-                    /// [`PORT`](atsamd_hal::target_device::PORT)
-                    /// [`Pin`](atsamd_hal::gpio::v2::Pin)
-                    /// [`Pins`](atsamd_hal::gpio::v2::Pins)
-                    pub fn new(port: PORT) -> Self {
-                        let mut pins = gpio::Pins::new(port);
-                        Self {
-                            port: Some(unsafe{ pins.port() }),
-                            $(
-                                $( #[$name_cfg] )?
-                                $name: pins.[<$Id:lower>],
-                            )+
-                        }
-                    }
-
-                    /// Take the PAC [`PORT`]
-                    ///
-                    /// The [`PORT`] can only be taken once. Subsequent calls to
-                    /// this function will panic.
-                    ///
-                    /// # Safety
-                    ///
-                    /// Direct access to the [`PORT`] could allow you to invalidate
-                    /// the compiler's type-level tracking, so it is unsafe.
-                    ///
-                    /// [`PORT`](atsamd_hal::target_device::PORT)
-                    #[inline]
-                    pub unsafe fn port(&mut self) -> PORT {
-                        self.port.take().unwrap()
-                    }
-                }
-
+            /// BSP replacement for the HAL
+            /// [`Pins`](atsamd_hal::gpio::v2::Pins) type
+            ///
+            /// This type is intended to provide more meaningful names for the
+            /// given pins.
+            pub struct Pins {
+                port: Option<$crate::target_device::PORT>,
                 $(
-                    $( #[$name_cfg] )?
-                    $(
-                        $(
-                            $( #[$alias_cfg] )?
-                            /// Alias for a configured [`Pin`](atsamd_hal::gpio::v2::Pin)
-                            pub type $Alias = Pin<gpio::$Id, gpio::$Mode>;
-                        )+
-                    )?
-                    $( #[$name_cfg] )?
-                    $(
-                        $(
-                            $( #[$alias_cfg] )?
-                            #[doc = "[DynPinId](atsamd_hal::gpio::v2::DynPinId) for the `" $Alias "` alias."]
-                            pub const [<$Alias:snake:upper _ID>]: DynPinId = <gpio::$Id as PinId>::DYN;
-                        )+
-                    )?
-                    $( #[$name_cfg] )?
-                    $(
-                        $(
-                            $( #[$alias_cfg] )?
-                            #[doc = "[DynPinMode](atsamd_hal::gpio::v2::DynPinMode) for the `" $Alias "` alias."]
-                            pub const [<$Alias:snake:upper _MODE>]: DynPinMode = <gpio::$Mode as PinMode>::DYN;
-                        )+
-                    )?
+                    $( #[$name_cfg] )*
+                    pub $name: $crate::gpio::v2::Pin<
+                        $crate::gpio::v2::$Id,
+                        $crate::gpio::v2::Reset
+                    >,
                 )+
             }
-            pub use bsp_pins_mod::*;
+
+            impl Pins {
+
+                /// Take ownership of the PAC [`PORT`] and split it into
+                /// discrete [`Pin`]s.
+                ///
+                /// This struct serves as a replacement for the HAL [`Pins`]
+                /// struct. It is intended to provide more meaningful names for
+                /// each [`Pin`] in a BSP. Any [`Pin`] not defined by the BSP is
+                /// dropped.
+                ///
+                /// [`PORT`](atsamd_hal::target_device::PORT)
+                /// [`Pin`](atsamd_hal::gpio::v2::Pin)
+                /// [`Pins`](atsamd_hal::gpio::v2::Pins)
+                pub fn new(port: $crate::target_device::PORT) -> Self {
+                    let mut pins = $crate::gpio::v2::Pins::new(port);
+                    Self {
+                        port: Some(unsafe{ pins.port() }),
+                        $(
+                            $( #[$name_cfg] )*
+                            $name: pins.[<$Id:lower>],
+                        )+
+                    }
+                }
+
+                /// Take the PAC [`PORT`]
+                ///
+                /// The [`PORT`] can only be taken once. Subsequent calls to
+                /// this function will panic.
+                ///
+                /// # Safety
+                ///
+                /// Direct access to the [`PORT`] could allow you to invalidate
+                /// the compiler's type-level tracking, so it is unsafe.
+                ///
+                /// [`PORT`](atsamd_hal::target_device::PORT)
+                #[inline]
+                pub unsafe fn port(&mut self) -> $crate::target_device::PORT {
+                    self.port.take().unwrap()
+                }
+            }
+
+            $(
+                $( #[$name_cfg] )*
+                $(
+                    $(
+                        $( #[$alias_cfg] )*
+                        /// Alias for a configured [`Pin`](atsamd_hal::gpio::v2::Pin)
+                        pub type $Alias = $crate::gpio::v2::Pin<
+                            $crate::gpio::v2::$Id,
+                            $crate::gpio::v2::$Mode
+                        >;
+                    )+
+                )?
+                $( #[$name_cfg] )*
+                $(
+                    $(
+                        $( #[$alias_cfg] )*
+                        #[doc = "[DynPinId](atsamd_hal::gpio::v2::DynPinId) "]
+                        #[doc = "for the `" $Alias "` alias."]
+                        pub const [<$Alias:snake:upper _ID>]: $crate::gpio::v2::DynPinId =
+                        <$crate::gpio::v2::$Id as $crate::gpio::v2::PinId>::DYN;
+                    )+
+                )?
+                $( #[$name_cfg] )*
+                $(
+                    $(
+                        $( #[$alias_cfg] )*
+                        #[doc = "[DynPinMode](atsamd_hal::gpio::v2::DynPinMode) "]
+                        #[doc = "for the `" $Alias "` alias."]
+                        pub const [<$Alias:snake:upper _MODE>]: $crate::gpio::v2::DynPinMode =
+                        <$crate::gpio::v2::$Mode as $crate::gpio::v2::PinMode>::DYN;
+                    )+
+                )?
+            )+
         }
     };
 }

--- a/hal/src/common/sercom/v2/spi_future.rs
+++ b/hal/src/common/sercom/v2/spi_future.rs
@@ -195,6 +195,12 @@ use core::mem::size_of;
 #[cfg(any(feature = "samd11", feature = "samd21"))]
 use super::spi::SpiWord;
 
+#[cfg(any(feature = "samd11", feature = "samd21"))]
+type Data = u16;
+
+#[cfg(feature = "min-samd51g")]
+type Data = u32;
+
 //=============================================================================
 // CheckBufLen
 //=============================================================================
@@ -322,7 +328,7 @@ where
 
     #[inline]
     fn deassert(&mut self) {
-        self.set_low().unwrap();
+        self.set_high().unwrap();
     }
 }
 
@@ -461,7 +467,7 @@ where
                 }
             }
             let word = u32::from_le_bytes(bytes);
-            unsafe { self.spi.as_mut().write_data(word) };
+            unsafe { self.spi.as_mut().write_data(word as Data) };
             self.sent += self.spi.step();
         }
         if self.sent >= buf.len() {
@@ -482,7 +488,7 @@ where
         if self.rcvd < self.sent {
             let buf = unsafe { buf.get_unchecked_mut(self.rcvd..) };
             let mut data = buf.into_iter();
-            let word = unsafe { self.spi.as_mut().read_data() };
+            let word = unsafe { self.spi.as_mut().read_data() as u32 };
             let bytes = word.to_le_bytes();
             let mut iter = bytes.iter();
             for _ in 0..self.spi.step() {

--- a/hal/src/common/thumbv6m/sercom/v2/spi.rs
+++ b/hal/src/common/thumbv6m/sercom/v2/spi.rs
@@ -614,6 +614,7 @@ macro_rules! pads_alias {
 }
 
 #[macro_export]
+#[doc(hidden)]
 macro_rules! __pad_type {
     () => { NoneT };
     ($Sercom:ident, $PadNum:ident, $Id:ident) => {
@@ -1488,8 +1489,8 @@ impl<C: ValidConfig> Spi<C> {
     /// clear the RXC flag, which could break assumptions made elsewhere in
     /// this module.
     #[inline]
-    pub unsafe fn read_data(&mut self) -> u32 {
-        self.sercom().spi().data.read().bits()
+    pub unsafe fn read_data(&mut self) -> u16 {
+        self.sercom().spi().data.read().data().bits()
     }
 
     /// Write to the DATA register
@@ -1498,8 +1499,8 @@ impl<C: ValidConfig> Spi<C> {
     /// the DRE flag, which could break assumptions made elsewhere in this
     /// module.
     #[inline]
-    pub unsafe fn write_data(&mut self, data: u32) {
-        self.sercom().spi().data.write(|w| w.bits(data))
+    pub unsafe fn write_data(&mut self, data: u16) {
+        self.sercom().spi().data.write(|w| w.data().bits(data))
     }
 
     /// Disable the SPI peripheral and return the [`Config`] struct
@@ -1615,7 +1616,7 @@ where
     M: MasterMode,
     C: CharSize,
     C::Word: PrimInt,
-    u32: AsPrimitive<C::Word>,
+    u16: AsPrimitive<C::Word>,
 {
     type Error = Error;
 
@@ -1657,7 +1658,7 @@ where
     P: DipoDopo + Rx + NotTx,
     C: CharSize,
     C::Word: PrimInt,
-    u32: AsPrimitive<C::Word>,
+    u16: AsPrimitive<C::Word>,
 {
     type Error = Error;
 
@@ -1685,7 +1686,7 @@ impl<C> Write<SpiWord<C>> for Spi<C>
 where
     C: ValidConfig,
     C::Pads: Tx + NotRx,
-    SpiWord<C>: PrimInt + AsPrimitive<u32>,
+    SpiWord<C>: PrimInt + AsPrimitive<u16>,
 {
     type Error = Error;
 
@@ -1730,8 +1731,8 @@ where
     C: ValidConfig,
     C::Pads: Tx + Rx,
     C::Mode: MasterMode,
-    SpiWord<C>: PrimInt + AsPrimitive<u32>,
-    u32: AsPrimitive<SpiWord<C>>,
+    SpiWord<C>: PrimInt + AsPrimitive<u16>,
+    u16: AsPrimitive<SpiWord<C>>,
 {
     type Error = Error;
 

--- a/hal/src/common/thumbv7em/sercom/v2/spi.rs
+++ b/hal/src/common/thumbv7em/sercom/v2/spi.rs
@@ -498,6 +498,7 @@ macro_rules! pads_alias {
 }
 
 #[macro_export]
+#[doc(hidden)]
 macro_rules! __pad_type {
     () => { NoneT };
     ($Sercom:ident, $PadNum:ident, $IoSet:ident) => {


### PR DESCRIPTION
### SPI

The DATA register is only 16-bits for SAMD11 & SAMD21 chips, but it is
represented as a 32-bit register by the SVD. Change the SPI API to
accept u16 instead of u32.

Also correct a bug in SpiFuture, where the SS pin would never be
properly deasserted.

Thanks to @jbeaurivage for finding both of these.

### `bsp_pins`

Allow commas after each pin block, and improve the docs to point out
where to find a list of PinModes.

Thanks to @TDHolmes for trying out the `bsp_pins` macro in #396.