### PR TITLE
Remove generic_array dependency & improve GPIO docs

### DIFF
--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -23,11 +23,11 @@ bitfield = "0.13"
 bitflags = "1.2.1"
 cortex-m = "0.6"
 embedded-hal = "0.2"
-generic-array = "0.14.4"
 nb = "0.1"
 paste = "1.0"
 rand_core = "0.5"
 seq-macro = "0.2.1"
+typenum = "1.12.0"
 vcell = "0.1"
 
 [dependencies.jlink_rtt]

--- a/hal/src/common/gpio/mod.rs
+++ b/hal/src/common/gpio/mod.rs
@@ -6,18 +6,95 @@
 //! ## Versions
 //!
 //! There are currently two versions of the GPIO module. The inital GPIO API
-//! was based on a macro-heavy implementation. The discussion in issue
-//! [#214](https://github.com/atsamd-rs/atsamd/issues/214) spurred the creation
-//! of a new module with less macro-use and a refactored API.
+//! used a macro-heavy implementation, and it contained a few mistakes. The
+//! discussion in issue [#214](https://github.com/atsamd-rs/atsamd/issues/214)
+//! spurred the creation of a new module with fewer macros and a corrected,
+//! refactored API.
 //!
-//! The new module is provided in [v2]. The old module was removed, but a
-//! compatibility shim is provided in [v1] to support existing code.
+//! The new module is provided in [`v2`]. The old module was removed, but a
+//! compatibility shim is provided in [`v1`] to support existing code. Users
+//! should expect to eventually migrate to [`v2`].
 //!
-//! ## Migration
+//! ## Errors in [`v1`]
 //!
-//! The [v2] module will eventually replace [v1]. New users are encouraged to
-//! use [v2] instead of [v1]. Existing code should expect to migrate to [v2]
-//! before this crate reaches `1.0`.
+//! [`v2`] fixes a number of errors in [`v1`]:
+//!
+//! - [`v1`] implements an open-drain output mode, but SAMD chips do not have
+//!   open-drain outputs. There is (almost) no mention of "open-drain" anywhere
+//!   in the datasheets. In fact, the SAMD21 datasheet notes a removal of the
+//!   term in Rev. E. Open-drain outputs have been has been removed in [`v2`].
+//! - [`v1`] allows users to enable a pull-up resistor while in an output mode,
+//!   but this is not possible for SAMD chips. There is no corresponding entry
+//!   in the "Pin Configurations Summary" table in any of the three datasheets.
+//!   Moreover, when a pull resistor is enabled for inputs, its direction is set
+//!   using the `OUT` bit, which would not be possible in an output mode.
+//! - [`v1`] does not implement any of the disabled pin modes, i.e. when both
+//!   `DIR` and `INEN` are `0`. As a consequence, the state of [`v1`] pins at
+//!   reset is incorrect. [`v1`] assumes they are in floating input mode, but
+//!   they are actually in floating disabled mode.
+//!
+//! ## New features
+//!
+//! The [`v2`] module has several new features:
+//!
+//! - Converting between pin modes no longer requires access to the [`Port`]
+//!   type.
+//!
+//! For example, the follow code in [`v1`],
+//! ```
+//! let pins = peripherals.PORT.split();
+//! let pa8 = pins.pa8.into_push_pull_output(&mut pins.port);
+//! ```
+//! would look like this in [`v2`].
+//! ```
+//! let pins = v2::Pins::new(peripherals.PORT);
+//! let pa08 = pins.pa08.into_push_pull_output();
+//! ```
+//! As a consequence, pin mode conversions can now be implemented using
+//! [`From`]/[`Into`].
+//! ```
+//! let pins = Pins::new(peripherals.PORT);
+//! let pa08: Pin<PA08, PushPullOutput> = pins.pa08.into();
+//! ```
+//!
+//! - [`v2`] defines a new [`AnyPin`] trait that can be used to simplify
+//!   function arguments and reduce the number of type parameters required when
+//!   dealing with GPIO pins.
+//! - [`v2`] offers a type-erased, [`DynPin`] type, for run-time tracking of
+//!   pins.
+//! - [`v2`] provides a new [`bsp_pins`] macro to help BSP authors provide
+//!   meaningful names and type aliases for their GPIO pins.
+//!
+//! ## Compatibility
+//!
+//! The original [`v1`] module has been removed. It has been replaced with a
+//! compatibility shim to support existing code. The shim implements all [`v1`]
+//! pin types in terms of [`v2::Pin`]. In fact, it declares its own [`v1::Pin`]
+//! type as a newtype wrapper around a [`v2::Pin`], and it defines the
+//! individual `Pa0`, `Pa1`, etc. pin types as type aliases of the new
+//! [`v1::Pin`] type.
+//!
+//! As a consequence, it is easy to define the conversion between a [`v1::Pin`]
+//! and its corresponding [`v2::Pin`] using [`From`]/[`Into`].
+//! ```
+//! let pins = peripherals.PORT.split();
+//! let pa8: v1::Pa8<_> = pins.pa8;
+//! let pa08 = v2::Pin<_, _> = pa8.into();
+//! ```
+//! Moreover, all [`v1::Pin`] and [`v2::Pin`] types implement the [`AnyPin`]
+//! trait, which is particularly useful for supporting both module versions
+//! simultaneously. See the [`AnyPin`] documentation for more details.
+//! ```
+//! /// Take the v1 or v2 representation of pin PA08, in any mode, then convert
+//! /// it to a push-pull output and set it high
+//! fn example(pin: impl AnyPin<Id = PA08>) {
+//!     let mut pin = pin.into().into_push_pull_output();
+//!     pin.set_high().ok();
+//! }
+//! ```
+//! [`AnyPin`]: v2::AnyPin
+//! [`DynPin`]: v2::DynPin
+//! [`bsp_pins`]: crate::bsp_pins
 
 pub mod v1;
 pub use v1::*;

--- a/hal/src/common/sercom/v2/spi_future.rs
+++ b/hal/src/common/sercom/v2/spi_future.rs
@@ -184,16 +184,13 @@ use crate::typelevel::NoneT;
 use super::spi::{AnySpi, Error, Flags};
 
 #[cfg(feature = "min-samd51g")]
-use super::spi::{Config, DynLength, Mode, Spi, SpiLength, StaticLength, TxOrRx, ValidConfig};
-
-#[cfg(feature = "min-samd51g")]
-use generic_array::typenum::Unsigned;
-
-#[cfg(any(feature = "samd11", feature = "samd21"))]
-use core::mem::size_of;
+use {
+    super::spi::{Config, DynLength, Mode, Spi, SpiLength, StaticLength, TxOrRx, ValidConfig},
+    typenum::Unsigned,
+};
 
 #[cfg(any(feature = "samd11", feature = "samd21"))]
-use super::spi::SpiWord;
+use {super::spi::SpiWord, core::mem::size_of};
 
 #[cfg(any(feature = "samd11", feature = "samd21"))]
 type Data = u16;


### PR DESCRIPTION
Edit: Merge #410 first, since this PR contains those commits.

`generic_array` was only being used to check the length of slices in the
SPI moduel at run-time. Instead, substitute a simple `assert_eq!` and
use real arrays for the SPI `Length` trait `Word` associated type. This
will also play well with `min_const_generics` in the future.

This also improves the GPIO documentation concerning `v1` vs. `v2`.
@jaredwolff and @TDHolmes, this should hopefully clarify some things.