### PR TITLE
Add SPI, UART, and USB conveniences for samd21_mini

### DIFF
--- a/boards/samd21_mini/Cargo.toml
+++ b/boards/samd21_mini/Cargo.toml
@@ -23,6 +23,14 @@ path = "../../hal"
 version = "0.12"
 default-features = false
 
+[dependencies.usb-device]
+version = "0.2"
+optional = true
+
+[dependencies.usbd-serial]
+version = "0.1"
+optional = true
+
 [dev-dependencies]
 panic-halt = "0.2"
 panic-semihosting = "0.5"
@@ -34,4 +42,16 @@ cortex-m-rtic = "0.5.1"
 default = ["rt", "atsamd-hal/samd21g"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
 unproven = ["atsamd-hal/unproven"]
+usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
 use_semihosting = []
+
+[profile.dev]
+incremental = false
+codegen-units = 1
+debug = true
+lto = false
+
+[profile.release]
+debug = true
+lto = true
+opt-level = "s"

--- a/boards/samd21_mini/src/lib.rs
+++ b/boards/samd21_mini/src/lib.rs
@@ -14,7 +14,17 @@ pub use hal::target_device as pac;
 use hal::prelude::*;
 use hal::*;
 
-use gpio::{Floating, Input, Port};
+use gpio::{Floating, Input, Port, PfC};
+use hal::clock::GenericClockController;
+use hal::sercom::{PadPin, SPIMaster1, UART0};
+use hal::time::Hertz;
+
+#[cfg(feature = "usb")]
+use gpio::v2::{AnyPin, PA24, PA25};
+#[cfg(feature = "usb")]
+use hal::usb::usb_device::bus::UsbBusAllocator;
+#[cfg(feature = "usb")]
+pub use hal::usb::UsbBus;
 
 define_pins!(
     /// Maps the pins to their arduino names and

--- a/boards/samd21_mini/src/lib.rs
+++ b/boards/samd21_mini/src/lib.rs
@@ -53,3 +53,75 @@ define_pins!(
     pin dm = a24,
     pin dp = a25,
 );
+
+/// Convenience for setting up the labelled SPI peripheral.
+/// This powers up SERCOM1 and configures it for use as an
+/// SPI Master in SPI Mode 0.
+pub fn spi_sercom1<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    bus_speed: F,
+    sercom1: pac::SERCOM1,
+    pm: &mut pac::PM,
+    sck: gpio::Pa19<Input<Floating>>,
+    mosi: gpio::Pa18<Input<Floating>>,
+    miso: gpio::Pa16<Input<Floating>>,
+    port: &mut Port,
+) -> SPIMaster1<
+    hal::sercom::Sercom1Pad0<gpio::Pa16<gpio::PfC>>,
+    hal::sercom::Sercom1Pad2<gpio::Pa18<gpio::PfC>>,
+    hal::sercom::Sercom1Pad3<gpio::Pa19<gpio::PfC>>,
+> {
+    let gclk0 = clocks.gclk0();
+    SPIMaster1::new(
+        &clocks.sercom1_core(&gclk0).unwrap(),
+        bus_speed.into(),
+        hal::hal::spi::Mode {
+            phase: hal::hal::spi::Phase::CaptureOnFirstTransition,
+            polarity: hal::hal::spi::Polarity::IdleLow,
+        },
+        sercom1,
+        pm,
+        (miso.into_pad(port), mosi.into_pad(port), sck.into_pad(port)),
+    )
+}
+
+/// Convenience for setting up the labelled RX, TX pins to
+/// operate as a UART device running at the specified baud.
+pub fn uart<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    baud: F,
+    sercom0: pac::SERCOM0,
+    pm: &mut pac::PM,
+    d0: gpio::Pa11<Input<Floating>>,
+    d1: gpio::Pa10<Input<Floating>>,
+    port: &mut Port,
+) -> UART0<
+    hal::sercom::Sercom0Pad3<gpio::Pa11<PfC>>,
+    hal::sercom::Sercom0Pad2<gpio::Pa10<PfC>>,
+    (),
+    (),
+> {
+    let gclk0 = clocks.gclk0();
+
+    UART0::new(
+        &clocks.sercom0_core(&gclk0).unwrap(),
+        baud.into(),
+        sercom0,
+        pm,
+        (d0.into_pad(port), d1.into_pad(port)),
+    )
+}
+
+#[cfg(feature = "usb")]
+pub fn usb_allocator(
+    usb: pac::USB,
+    clocks: &mut GenericClockController,
+    pm: &mut pac::PM,
+    dm: impl AnyPin<Id = PA24>,
+    dp: impl AnyPin<Id = PA25>,
+) -> UsbBusAllocator<UsbBus> {
+    let gclk0 = clocks.gclk0();
+    let usb_clock = &clocks.usb(&gclk0).unwrap();
+
+    UsbBusAllocator::new(UsbBus::new(usb_clock, pm, dm, dp, usb))
+}


### PR DESCRIPTION
I just took the peripherals from the feather_m0 and changed the SERCOM on the SPI to SERCOM1 as the mini doesn't have the pins exposed for the SERCOM that the feather uses.

I've tested the new SPI (using it to run an OLED display) but I haven't tested the UART/USB. They should be fine as it's the same chip in both boards.

Let me know if this needs any changes.