### PR TITLE
Add PTC support for samd21e.

### DIFF
--- a/hal/src/common/thumbv6m/mod.rs
+++ b/hal/src/common/thumbv6m/mod.rs
@@ -10,6 +10,9 @@ pub use serial_number::*;
 pub mod adc;
 
 #[cfg(feature = "unproven")]
+pub mod ptc;
+
+#[cfg(feature = "unproven")]
 pub mod pwm;
 
 #[cfg(feature = "unproven")]

--- a/hal/src/common/thumbv6m/ptc.rs
+++ b/hal/src/common/thumbv6m/ptc.rs
@@ -1,0 +1,200 @@
+use crate::clock::GenericClockController;
+use crate::gpio::v1;
+use crate::gpio::v2::*;
+use crate::hal::adc::{Channel, OneShot};
+use crate::target_device::{
+    ptc::{
+        convctrl::ADCACCUM_A, freqctrl::SAMPLEDELAY_A, serres::RESISTOR_A, xselect::XMUX_A,
+        yselect::YMUX_A,
+    },
+    PM, PTC,
+};
+
+pub struct Ptc<PTC> {
+    ptc: PTC,
+}
+
+impl Ptc<PTC> {
+    pub fn ptc(ptc: PTC, pm: &mut PM, clocks: &mut GenericClockController) -> Self {
+        // Enable PTC in the APBC mask
+        pm.apbcmask.modify(|_, w| w.ptc_().set_bit());
+        let gclk1 = clocks.gclk1();
+        // Enable the PTC clock
+        clocks.ptc(&gclk1).expect("ptc clock setup failed");
+        while ptc.ctrlb.read().syncflag().bit_is_set() {}
+
+        // Reset the PTC module
+        ptc.ctrla.modify(|_, w| w.swrst().set_bit());
+        while ptc.ctrlb.read().syncflag().bit_is_set() {}
+
+        // Magic writes? Honestly dunno what these are for.
+        // f7 => 11110111
+        // fb => 11111011
+        // fc => 11111100
+        ptc.unk4c04.write(|w| unsafe { w.bits(0xf7) });
+        ptc.unk4c04.write(|w| unsafe { w.bits(0xfb) });
+        ptc.unk4c04.write(|w| unsafe { w.bits(0xfc) });
+        while ptc.ctrlb.read().syncflag().bit_is_set() {}
+
+        // Next in the init sequence in the FreeTouch repo, writes of the following two
+        // values are made to FREQCTRL:
+        // 9f => 10011111
+        //       ---baaaa
+        // ef => 11101111
+        //       ---baaaa
+        // The upper three bits are unused, so I'm unsure what the point of this is
+        // beyond setting all of the SAMPLEDELAY field to 1 and toggling
+        // FREQSPREADEN. Furthermore, the next thing done is setting SAMPLEDELAY
+        // to 0, thus ending up with (in theory):   11101111
+        // & 11110000
+        // ----------
+        //   11100000
+        // So honestly, I'm just going to set them to 0 in one step.
+        ptc.freqctrl.write(|w| {
+            w.freqspreaden().clear_bit();
+            w.sampledelay().variant(SAMPLEDELAY_A::FREQHOP1)
+        });
+        while ptc.ctrlb.read().syncflag().bit_is_set() {}
+
+        // Software init
+        ptc.ctrlc.write(|w| w.init().set_bit());
+        // Set to run in standby
+        ptc.ctrla.write(|w| w.runstdby().set_bit());
+        while ptc.ctrlb.read().syncflag().bit_is_set() {}
+
+        // Set interrupt enables
+        ptc.intenclr.write(|w| {
+            w.wco().set_bit();
+            w.eoc().set_bit()
+        });
+        while ptc.ctrlb.read().syncflag().bit_is_set() {}
+
+        Self { ptc }
+    }
+
+    pub fn compcap(&mut self, compcap: u16) {
+        self.ptc
+            .compcap
+            .write(|w| unsafe { w.value().bits(compcap) });
+        while self.ptc.ctrlb.read().syncflag().bit_is_set() {}
+    }
+
+    pub fn intcap(&mut self, intcap: u8) {
+        self.ptc.intcap.write(|w| unsafe { w.value().bits(intcap) });
+        while self.ptc.ctrlb.read().syncflag().bit_is_set() {}
+    }
+
+    pub fn oversample(&mut self, oversample: ADCACCUM_A) {
+        self.ptc
+            .convctrl
+            .write(|w| w.adcaccum().variant(oversample));
+        while self.ptc.ctrlb.read().syncflag().bit_is_set() {}
+    }
+
+    pub fn sample_delay(&mut self, sampledelay: SAMPLEDELAY_A) {
+        match sampledelay {
+            SAMPLEDELAY_A::FREQHOP1 => self.ptc.freqctrl.write(|w| w.freqspreaden().clear_bit()),
+            _ => self.ptc.freqctrl.write(|w| w.freqspreaden().set_bit()),
+        }
+        self.ptc
+            .freqctrl
+            .write(|w| w.sampledelay().variant(sampledelay));
+        while self.ptc.ctrlb.read().syncflag().bit_is_set() {}
+    }
+
+    pub fn series_resistance(&mut self, serres: RESISTOR_A) {
+        self.ptc.serres.write(|w| w.resistor().variant(serres));
+        while self.ptc.ctrlb.read().syncflag().bit_is_set() {}
+    }
+
+    pub fn xselect(&mut self, xselect: XMUX_A) {
+        self.ptc.xselect.write(|w| w.xmux().variant(xselect));
+    }
+
+    pub fn yselect(&mut self, yselect: YMUX_A) {
+        self.ptc.yselect.write(|w| w.ymux().variant(yselect));
+    }
+
+    fn power_up(&mut self) {
+        while self.ptc.ctrlb.read().syncflag().bit_is_set() {}
+        self.ptc.ctrla.modify(|_, w| w.enable().set_bit());
+        while self.ptc.ctrlb.read().syncflag().bit_is_set() {}
+    }
+
+    fn power_down(&mut self) {
+        while self.ptc.ctrlb.read().syncflag().bit_is_set() {}
+        self.ptc.ctrla.modify(|_, w| w.enable().clear_bit());
+        while self.ptc.ctrlb.read().syncflag().bit_is_set() {}
+    }
+
+    fn convert(&mut self) -> u16 {
+        self.ptc
+            .burstmode
+            .write(|w| unsafe { w.burstmode().bits(0xa4) });
+        while self.ptc.ctrlb.read().syncflag().bit_is_set() {}
+
+        self.ptc.convctrl.write(|w| w.convert().set_bit());
+        while self.ptc.ctrlb.read().syncflag().bit_is_set() {}
+
+        self.ptc.result.read().result().bits()
+    }
+}
+
+impl<WORD, PIN> OneShot<PTC, WORD, PIN> for Ptc<PTC>
+where
+    WORD: From<u16>,
+    PIN: Channel<PTC, ID = u8>,
+{
+    type Error = ();
+
+    fn read(&mut self, _pin: &mut PIN) -> nb::Result<WORD, Self::Error> {
+        let channel = PIN::channel();
+        while self.ptc.ctrlb.read().syncflag().bit_is_set() {}
+
+        self.ptc
+            .yselect
+            .write(|w| unsafe { w.ymux().bits(1 << channel) });
+        self.ptc
+            .yselecten
+            .modify(|r, w| unsafe { w.bits(r.bits() | (1 << channel)) });
+        self.power_up();
+        let result = self.convert();
+        self.power_down();
+
+        Ok(result.into())
+    }
+}
+
+macro_rules! ptc_pins {
+    ($($PinId:ident: $Chan:literal),+) => {
+        $(
+            impl Channel<PTC> for Pin<$PinId, AlternateB> {
+                type ID = u8;
+                fn channel() -> u8 { $Chan }
+            }
+        )+
+    }
+}
+
+/// Implement ['Channel`] for [`v1::Pin`]s based on the implementations for
+/// `v2` [`Pin`]s
+impl<I> Channel<PTC> for v1::Pin<I, v1::PfB>
+where
+    I: PinId,
+    Pin<I, AlternateB>: Channel<PTC, ID = u8>,
+{
+    type ID = u8;
+    fn channel() -> u8 {
+        Pin::<I, AlternateB>::channel()
+    }
+}
+
+#[cfg(feature = "samd21e")]
+ptc_pins! {
+    PA02: 0,
+    PA03: 1,
+    PA04: 2,
+    PA05: 3,
+    PA06: 4,
+    PA07: 5
+}

--- a/hal/src/samd21/clock.rs
+++ b/hal/src/samd21/clock.rs
@@ -417,6 +417,7 @@ clock_generator!(
     (ac_ana, AcAnaClock, AC_ANA),
     (ac_dig, AcDigClock, AC_DIG),
     (dac, DacClock, DAC),
+    (ptc, PtcClock, PTC),
     (i2s0, I2S0Clock, I2S_0),
     (i2s1, I2S1Clock, I2S_1),
 );

--- a/pac/atsamd21e/device.x
+++ b/pac/atsamd21e/device.x
@@ -20,5 +20,6 @@ PROVIDE(TC5 = DefaultHandler);
 PROVIDE(ADC = DefaultHandler);
 PROVIDE(AC = DefaultHandler);
 PROVIDE(DAC = DefaultHandler);
+PROVIDE(PTC = DefaultHandler);
 PROVIDE(I2S = DefaultHandler);
 

--- a/pac/atsamd21e/src/gclk/clkctrl.rs
+++ b/pac/atsamd21e/src/gclk/clkctrl.rs
@@ -82,6 +82,8 @@ pub enum ID_A {
     AC_ANA = 32,
     #[doc = "33: DAC"]
     DAC = 33,
+    #[doc = "34: PTCReserved"]
+    PTC = 34,
     #[doc = "35: I2S_0"]
     I2S_0 = 35,
     #[doc = "36: I2S_1"]
@@ -135,6 +137,7 @@ impl ID_R {
             31 => Val(ID_A::AC_DIG),
             32 => Val(ID_A::AC_ANA),
             33 => Val(ID_A::DAC),
+            34 => Val(ID_A::PTC),
             35 => Val(ID_A::I2S_0),
             36 => Val(ID_A::I2S_1),
             i => Res(i),
@@ -309,6 +312,11 @@ impl ID_R {
     #[inline(always)]
     pub fn is_dac(&self) -> bool {
         *self == ID_A::DAC
+    }
+    #[doc = "Checks if the value of the field is `PTC`"]
+    #[inline(always)]
+    pub fn is_ptc(&self) -> bool {
+        *self == ID_A::PTC
     }
     #[doc = "Checks if the value of the field is `I2S_0`"]
     #[inline(always)]
@@ -500,6 +508,11 @@ impl<'a> ID_W<'a> {
     #[inline(always)]
     pub fn dac(self) -> &'a mut W {
         self.variant(ID_A::DAC)
+    }
+    #[doc = "PTCReserved"]
+    #[inline(always)]
+    pub fn ptc(self) -> &'a mut W {
+        self.variant(ID_A::PTC)
     }
     #[doc = "I2S_0"]
     #[inline(always)]

--- a/pac/atsamd21e/src/lib.rs
+++ b/pac/atsamd21e/src/lib.rs
@@ -52,6 +52,7 @@ extern "C" {
     fn ADC();
     fn AC();
     fn DAC();
+    fn PTC();
     fn I2S();
 }
 #[doc(hidden)]
@@ -90,7 +91,7 @@ pub static __INTERRUPTS: [Vector; 28] = [
     Vector { _handler: ADC },
     Vector { _handler: AC },
     Vector { _handler: DAC },
-    Vector { _reserved: 0 },
+    Vector { _handler: PTC },
     Vector { _handler: I2S },
 ];
 #[doc = r"Enumeration of all the interrupts"]
@@ -141,6 +142,8 @@ pub enum Interrupt {
     AC = 24,
     #[doc = "25 - DAC"]
     DAC = 25,
+    #[doc = "26 - PTC"]
+    PTC = 26,
     #[doc = "27 - I2S"]
     I2S = 27,
 }
@@ -513,6 +516,27 @@ impl Deref for PORT {
 }
 #[doc = "Port Module"]
 pub mod port;
+#[doc = "Peripheral Touch Controller"]
+pub struct PTC {
+    _marker: PhantomData<*const ()>,
+}
+unsafe impl Send for PTC {}
+impl PTC {
+    #[doc = r"Returns a pointer to the register block"]
+    #[inline(always)]
+    pub const fn ptr() -> *const ptc::RegisterBlock {
+        0x4200_4c00 as *const _
+    }
+}
+impl Deref for PTC {
+    type Target = ptc::RegisterBlock;
+    #[inline(always)]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*PTC::ptr() }
+    }
+}
+#[doc = "Peripheral Touch Controller"]
+pub mod ptc;
 #[doc = "Port Module (IOBUS)"]
 pub struct PORT_IOBUS {
     _marker: PhantomData<*const ()>,
@@ -851,6 +875,8 @@ pub struct Peripherals {
     pub PM: PM,
     #[doc = "PORT"]
     pub PORT: PORT,
+    #[doc = "PTC"]
+    pub PTC: PTC,
     #[doc = "PORT_IOBUS"]
     pub PORT_IOBUS: PORT_IOBUS,
     #[doc = "RTC"]
@@ -948,6 +974,9 @@ impl Peripherals {
                 _marker: PhantomData,
             },
             PORT: PORT {
+                _marker: PhantomData,
+            },
+            PTC: PTC {
                 _marker: PhantomData,
             },
             PORT_IOBUS: PORT_IOBUS {

--- a/pac/atsamd21e/src/ptc.rs
+++ b/pac/atsamd21e/src/ptc.rs
@@ -1,0 +1,307 @@
+#[doc = r"Register block"]
+#[repr(C)]
+pub struct RegisterBlock {
+    #[doc = "0x00 - Control A"]
+    pub ctrla: CTRLA,
+    #[doc = "0x01 - Control B"]
+    pub ctrlb: CTRLB,
+    _reserved2: [u8; 2usize],
+    #[doc = "0x04 - Unknown Register 0x42004C04"]
+    pub unk4c04: UNK4C04,
+    #[doc = "0x05 - Control C"]
+    pub ctrlc: CTRLC,
+    _reserved4: [u8; 2usize],
+    #[doc = "0x08 - Interrupt Enable Clear"]
+    pub intenclr: INTENCLR,
+    #[doc = "0x09 - Interrupt Enable Set"]
+    pub intenset: INTENSET,
+    #[doc = "0x0a - Interrupt Flag Status and Clear"]
+    pub intflag: INTFLAG,
+    _reserved7: [u8; 1usize],
+    #[doc = "0x0c - Frequency Control"]
+    pub freqctrl: FREQCTRL,
+    #[doc = "0x0d - Conversion control"]
+    pub convctrl: CONVCTRL,
+    _reserved9: [u8; 2usize],
+    #[doc = "0x10 - Select Y line"]
+    pub yselect: YSELECT,
+    #[doc = "0x12 - Select X line"]
+    pub xselect: XSELECT,
+    #[doc = "0x14 - Enable Y lines"]
+    pub yselecten: YSELECTEN,
+    #[doc = "0x16 - Enable X lines"]
+    pub xselecten: XSELECTEN,
+    #[doc = "0x18 - Compensation capacitor value"]
+    pub compcap: COMPCAP,
+    #[doc = "0x1a - Internal capacitor value"]
+    pub intcap: INTCAP,
+    #[doc = "0x1b - Series resistor for PTC measurements"]
+    pub serres: SERRES,
+    #[doc = "0x1c - Conversion result"]
+    pub result: RESULT,
+    _reserved17: [u8; 2usize],
+    #[doc = "0x20 - Enable burst or clear to send low power mode"]
+    pub burstmode: BURSTMODE,
+    #[doc = "0x21 - Set WCO mode"]
+    pub wcomode: WCOMODE,
+    _reserved19: [u8; 2usize],
+    #[doc = "0x24 - Set lower WCO threshold for port A"]
+    pub wcothresholdal: WCOTHRESHOLDAL,
+    #[doc = "0x25 - Set upper WCO threshold for port A"]
+    pub wcothresholdah: WCOTHRESHOLDAH,
+    #[doc = "0x26 - Set lower WCO threshold for port B"]
+    pub wcothresholdbl: WCOTHRESHOLDBL,
+    #[doc = "0x27 - Set upper WCO threshold for port B"]
+    pub wcothresholdbh: WCOTHRESHOLDBH,
+}
+#[doc = "Control A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctrla](ctrla) module"]
+pub type CTRLA = crate::Reg<u8, _CTRLA>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLA;
+#[doc = "`read()` method returns [ctrla::R](ctrla::R) reader structure"]
+impl crate::Readable for CTRLA {}
+#[doc = "`write(|w| ..)` method takes [ctrla::W](ctrla::W) writer structure"]
+impl crate::Writable for CTRLA {}
+#[doc = "Control A"]
+pub mod ctrla;
+#[doc = "Control B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctrlb](ctrlb) module"]
+pub type CTRLB = crate::Reg<u8, _CTRLB>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLB;
+#[doc = "`read()` method returns [ctrlb::R](ctrlb::R) reader structure"]
+impl crate::Readable for CTRLB {}
+#[doc = "`write(|w| ..)` method takes [ctrlb::W](ctrlb::W) writer structure"]
+impl crate::Writable for CTRLB {}
+#[doc = "Control B"]
+pub mod ctrlb;
+#[doc = "Unknown Register 0x42004C04\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [unk4c04](unk4c04) module"]
+pub type UNK4C04 = crate::Reg<u8, _UNK4C04>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _UNK4C04;
+#[doc = "`read()` method returns [unk4c04::R](unk4c04::R) reader structure"]
+impl crate::Readable for UNK4C04 {}
+#[doc = "`write(|w| ..)` method takes [unk4c04::W](unk4c04::W) writer structure"]
+impl crate::Writable for UNK4C04 {}
+#[doc = "Unknown Register 0x42004C04"]
+pub mod unk4c04;
+#[doc = "Control C\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [ctrlc](ctrlc) module"]
+pub type CTRLC = crate::Reg<u8, _CTRLC>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CTRLC;
+#[doc = "`read()` method returns [ctrlc::R](ctrlc::R) reader structure"]
+impl crate::Readable for CTRLC {}
+#[doc = "`write(|w| ..)` method takes [ctrlc::W](ctrlc::W) writer structure"]
+impl crate::Writable for CTRLC {}
+#[doc = "Control C"]
+pub mod ctrlc;
+#[doc = "Interrupt Enable Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [intenclr](intenclr) module"]
+pub type INTENCLR = crate::Reg<u8, _INTENCLR>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENCLR;
+#[doc = "`read()` method returns [intenclr::R](intenclr::R) reader structure"]
+impl crate::Readable for INTENCLR {}
+#[doc = "`write(|w| ..)` method takes [intenclr::W](intenclr::W) writer structure"]
+impl crate::Writable for INTENCLR {}
+#[doc = "Interrupt Enable Clear"]
+pub mod intenclr;
+#[doc = "Interrupt Enable Set\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [intenset](intenset) module"]
+pub type INTENSET = crate::Reg<u8, _INTENSET>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTENSET;
+#[doc = "`read()` method returns [intenset::R](intenset::R) reader structure"]
+impl crate::Readable for INTENSET {}
+#[doc = "`write(|w| ..)` method takes [intenset::W](intenset::W) writer structure"]
+impl crate::Writable for INTENSET {}
+#[doc = "Interrupt Enable Set"]
+pub mod intenset;
+#[doc = "Interrupt Flag Status and Clear\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [intflag](intflag) module"]
+pub type INTFLAG = crate::Reg<u8, _INTFLAG>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTFLAG;
+#[doc = "`read()` method returns [intflag::R](intflag::R) reader structure"]
+impl crate::Readable for INTFLAG {}
+#[doc = "`write(|w| ..)` method takes [intflag::W](intflag::W) writer structure"]
+impl crate::Writable for INTFLAG {}
+#[doc = "Interrupt Flag Status and Clear"]
+pub mod intflag;
+#[doc = "Frequency Control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [freqctrl](freqctrl) module"]
+pub type FREQCTRL = crate::Reg<u8, _FREQCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _FREQCTRL;
+#[doc = "`read()` method returns [freqctrl::R](freqctrl::R) reader structure"]
+impl crate::Readable for FREQCTRL {}
+#[doc = "`write(|w| ..)` method takes [freqctrl::W](freqctrl::W) writer structure"]
+impl crate::Writable for FREQCTRL {}
+#[doc = "Frequency Control"]
+pub mod freqctrl;
+#[doc = "Conversion control\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [convctrl](convctrl) module"]
+pub type CONVCTRL = crate::Reg<u8, _CONVCTRL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _CONVCTRL;
+#[doc = "`read()` method returns [convctrl::R](convctrl::R) reader structure"]
+impl crate::Readable for CONVCTRL {}
+#[doc = "`write(|w| ..)` method takes [convctrl::W](convctrl::W) writer structure"]
+impl crate::Writable for CONVCTRL {}
+#[doc = "Conversion control"]
+pub mod convctrl;
+#[doc = "Select Y line\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [yselect](yselect) module"]
+pub type YSELECT = crate::Reg<u16, _YSELECT>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _YSELECT;
+#[doc = "`read()` method returns [yselect::R](yselect::R) reader structure"]
+impl crate::Readable for YSELECT {}
+#[doc = "`write(|w| ..)` method takes [yselect::W](yselect::W) writer structure"]
+impl crate::Writable for YSELECT {}
+#[doc = "Select Y line"]
+pub mod yselect;
+#[doc = "Select X line\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [xselect](xselect) module"]
+pub type XSELECT = crate::Reg<u16, _XSELECT>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _XSELECT;
+#[doc = "`read()` method returns [xselect::R](xselect::R) reader structure"]
+impl crate::Readable for XSELECT {}
+#[doc = "`write(|w| ..)` method takes [xselect::W](xselect::W) writer structure"]
+impl crate::Writable for XSELECT {}
+#[doc = "Select X line"]
+pub mod xselect;
+#[doc = "Enable Y lines\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [yselecten](yselecten) module"]
+pub type YSELECTEN = crate::Reg<u16, _YSELECTEN>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _YSELECTEN;
+#[doc = "`read()` method returns [yselecten::R](yselecten::R) reader structure"]
+impl crate::Readable for YSELECTEN {}
+#[doc = "`write(|w| ..)` method takes [yselecten::W](yselecten::W) writer structure"]
+impl crate::Writable for YSELECTEN {}
+#[doc = "Enable Y lines"]
+pub mod yselecten;
+#[doc = "Enable X lines\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [xselecten](xselecten) module"]
+pub type XSELECTEN = crate::Reg<u16, _XSELECTEN>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _XSELECTEN;
+#[doc = "`read()` method returns [xselecten::R](xselecten::R) reader structure"]
+impl crate::Readable for XSELECTEN {}
+#[doc = "`write(|w| ..)` method takes [xselecten::W](xselecten::W) writer structure"]
+impl crate::Writable for XSELECTEN {}
+#[doc = "Enable X lines"]
+pub mod xselecten;
+#[doc = "Compensation capacitor value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [compcap](compcap) module"]
+pub type COMPCAP = crate::Reg<u16, _COMPCAP>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _COMPCAP;
+#[doc = "`read()` method returns [compcap::R](compcap::R) reader structure"]
+impl crate::Readable for COMPCAP {}
+#[doc = "`write(|w| ..)` method takes [compcap::W](compcap::W) writer structure"]
+impl crate::Writable for COMPCAP {}
+#[doc = "Compensation capacitor value"]
+pub mod compcap;
+#[doc = "Internal capacitor value\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [intcap](intcap) module"]
+pub type INTCAP = crate::Reg<u8, _INTCAP>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _INTCAP;
+#[doc = "`read()` method returns [intcap::R](intcap::R) reader structure"]
+impl crate::Readable for INTCAP {}
+#[doc = "`write(|w| ..)` method takes [intcap::W](intcap::W) writer structure"]
+impl crate::Writable for INTCAP {}
+#[doc = "Internal capacitor value"]
+pub mod intcap;
+#[doc = "Series resistor for PTC measurements\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [serres](serres) module"]
+pub type SERRES = crate::Reg<u8, _SERRES>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _SERRES;
+#[doc = "`read()` method returns [serres::R](serres::R) reader structure"]
+impl crate::Readable for SERRES {}
+#[doc = "`write(|w| ..)` method takes [serres::W](serres::W) writer structure"]
+impl crate::Writable for SERRES {}
+#[doc = "Series resistor for PTC measurements"]
+pub mod serres;
+#[doc = "Conversion result\n\nThis register you can [`read`](crate::generic::Reg::read). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [result](result) module"]
+pub type RESULT = crate::Reg<u16, _RESULT>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _RESULT;
+#[doc = "`read()` method returns [result::R](result::R) reader structure"]
+impl crate::Readable for RESULT {}
+#[doc = "Conversion result"]
+pub mod result;
+#[doc = "Enable burst or clear to send low power mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [burstmode](burstmode) module"]
+pub type BURSTMODE = crate::Reg<u8, _BURSTMODE>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _BURSTMODE;
+#[doc = "`read()` method returns [burstmode::R](burstmode::R) reader structure"]
+impl crate::Readable for BURSTMODE {}
+#[doc = "`write(|w| ..)` method takes [burstmode::W](burstmode::W) writer structure"]
+impl crate::Writable for BURSTMODE {}
+#[doc = "Enable burst or clear to send low power mode"]
+pub mod burstmode;
+#[doc = "Set WCO mode\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [wcomode](wcomode) module"]
+pub type WCOMODE = crate::Reg<u8, _WCOMODE>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WCOMODE;
+#[doc = "`read()` method returns [wcomode::R](wcomode::R) reader structure"]
+impl crate::Readable for WCOMODE {}
+#[doc = "`write(|w| ..)` method takes [wcomode::W](wcomode::W) writer structure"]
+impl crate::Writable for WCOMODE {}
+#[doc = "Set WCO mode"]
+pub mod wcomode;
+#[doc = "Set lower WCO threshold for port A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [wcothresholdal](wcothresholdal) module"]
+pub type WCOTHRESHOLDAL = crate::Reg<u8, _WCOTHRESHOLDAL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WCOTHRESHOLDAL;
+#[doc = "`read()` method returns [wcothresholdal::R](wcothresholdal::R) reader structure"]
+impl crate::Readable for WCOTHRESHOLDAL {}
+#[doc = "`write(|w| ..)` method takes [wcothresholdal::W](wcothresholdal::W) writer structure"]
+impl crate::Writable for WCOTHRESHOLDAL {}
+#[doc = "Set lower WCO threshold for port A"]
+pub mod wcothresholdal;
+#[doc = "Set upper WCO threshold for port A\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [wcothresholdah](wcothresholdah) module"]
+pub type WCOTHRESHOLDAH = crate::Reg<u8, _WCOTHRESHOLDAH>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WCOTHRESHOLDAH;
+#[doc = "`read()` method returns [wcothresholdah::R](wcothresholdah::R) reader structure"]
+impl crate::Readable for WCOTHRESHOLDAH {}
+#[doc = "`write(|w| ..)` method takes [wcothresholdah::W](wcothresholdah::W) writer structure"]
+impl crate::Writable for WCOTHRESHOLDAH {}
+#[doc = "Set upper WCO threshold for port A"]
+pub mod wcothresholdah;
+#[doc = "Set lower WCO threshold for port B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [wcothresholdbl](wcothresholdbl) module"]
+pub type WCOTHRESHOLDBL = crate::Reg<u8, _WCOTHRESHOLDBL>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WCOTHRESHOLDBL;
+#[doc = "`read()` method returns [wcothresholdbl::R](wcothresholdbl::R) reader structure"]
+impl crate::Readable for WCOTHRESHOLDBL {}
+#[doc = "`write(|w| ..)` method takes [wcothresholdbl::W](wcothresholdbl::W) writer structure"]
+impl crate::Writable for WCOTHRESHOLDBL {}
+#[doc = "Set lower WCO threshold for port B"]
+pub mod wcothresholdbl;
+#[doc = "Set upper WCO threshold for port B\n\nThis register you can [`read`](crate::generic::Reg::read), [`reset`](crate::generic::Reg::reset), [`write`](crate::generic::Reg::write), [`write_with_zero`](crate::generic::Reg::write_with_zero), [`modify`](crate::generic::Reg::modify). See [API](https://docs.rs/svd2rust/#read--modify--write-api).\n\nFor information about available fields see [wcothresholdbh](wcothresholdbh) module"]
+pub type WCOTHRESHOLDBH = crate::Reg<u8, _WCOTHRESHOLDBH>;
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub struct _WCOTHRESHOLDBH;
+#[doc = "`read()` method returns [wcothresholdbh::R](wcothresholdbh::R) reader structure"]
+impl crate::Readable for WCOTHRESHOLDBH {}
+#[doc = "`write(|w| ..)` method takes [wcothresholdbh::W](wcothresholdbh::W) writer structure"]
+impl crate::Writable for WCOTHRESHOLDBH {}
+#[doc = "Set upper WCO threshold for port B"]
+pub mod wcothresholdbh;

--- a/pac/atsamd21e/src/ptc/burstmode.rs
+++ b/pac/atsamd21e/src/ptc/burstmode.rs
@@ -1,0 +1,74 @@
+#[doc = "Reader of register BURSTMODE"]
+pub type R = crate::R<u8, super::BURSTMODE>;
+#[doc = "Writer for register BURSTMODE"]
+pub type W = crate::W<u8, super::BURSTMODE>;
+#[doc = "Register BURSTMODE `reset()`'s with value 0"]
+impl crate::ResetValue for super::BURSTMODE {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `CTSLOWPOWEREN`"]
+pub type CTSLOWPOWEREN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CTSLOWPOWEREN`"]
+pub struct CTSLOWPOWEREN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CTSLOWPOWEREN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `BURSTMODE`"]
+pub type BURSTMODE_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `BURSTMODE`"]
+pub struct BURSTMODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> BURSTMODE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x0f << 4)) | (((value as u8) & 0x0f) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 2 - Enable clear to send low power mode"]
+    #[inline(always)]
+    pub fn ctslowpoweren(&self) -> CTSLOWPOWEREN_R {
+        CTSLOWPOWEREN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bits 4:7 - Burst mode setting"]
+    #[inline(always)]
+    pub fn burstmode(&self) -> BURSTMODE_R {
+        BURSTMODE_R::new(((self.bits >> 4) & 0x0f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bit 2 - Enable clear to send low power mode"]
+    #[inline(always)]
+    pub fn ctslowpoweren(&mut self) -> CTSLOWPOWEREN_W {
+        CTSLOWPOWEREN_W { w: self }
+    }
+    #[doc = "Bits 4:7 - Burst mode setting"]
+    #[inline(always)]
+    pub fn burstmode(&mut self) -> BURSTMODE_W {
+        BURSTMODE_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/compcap.rs
+++ b/pac/atsamd21e/src/ptc/compcap.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register COMPCAP"]
+pub type R = crate::R<u16, super::COMPCAP>;
+#[doc = "Writer for register COMPCAP"]
+pub type W = crate::W<u16, super::COMPCAP>;
+#[doc = "Register COMPCAP `reset()`'s with value 0"]
+impl crate::ResetValue for super::COMPCAP {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `VALUE`"]
+pub type VALUE_R = crate::R<u16, u16>;
+#[doc = "Write proxy for field `VALUE`"]
+pub struct VALUE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> VALUE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x3fff) | ((value as u16) & 0x3fff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:13 - Value"]
+    #[inline(always)]
+    pub fn value(&self) -> VALUE_R {
+        VALUE_R::new((self.bits & 0x3fff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:13 - Value"]
+    #[inline(always)]
+    pub fn value(&mut self) -> VALUE_W {
+        VALUE_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/convctrl.rs
+++ b/pac/atsamd21e/src/ptc/convctrl.rs
@@ -1,0 +1,191 @@
+#[doc = "Reader of register CONVCTRL"]
+pub type R = crate::R<u8, super::CONVCTRL>;
+#[doc = "Writer for register CONVCTRL"]
+pub type W = crate::W<u8, super::CONVCTRL>;
+#[doc = "Register CONVCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::CONVCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "ADC Accumulator\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
+pub enum ADCACCUM_A {
+    #[doc = "0: 1 sample per report"]
+    OVERSAMPLE1 = 0,
+    #[doc = "1: 2 samples per report"]
+    OVERSAMPLE2 = 1,
+    #[doc = "2: 4 samples per report"]
+    OVERSAMPLE4 = 2,
+    #[doc = "3: 8 samples per report"]
+    OVERSAMPLE8 = 3,
+    #[doc = "4: 16 samples per report"]
+    OVERSAMPLE16 = 4,
+    #[doc = "5: 32 samples per report"]
+    OVERSAMPLE32 = 5,
+    #[doc = "6: 64 samples per report"]
+    OVERSAMPLE64 = 6,
+}
+impl From<ADCACCUM_A> for u8 {
+    #[inline(always)]
+    fn from(variant: ADCACCUM_A) -> Self {
+        variant as _
+    }
+}
+#[doc = "Reader of field `ADCACCUM`"]
+pub type ADCACCUM_R = crate::R<u8, ADCACCUM_A>;
+impl ADCACCUM_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u8, ADCACCUM_A> {
+        use crate::Variant::*;
+        match self.bits {
+            0 => Val(ADCACCUM_A::OVERSAMPLE1),
+            1 => Val(ADCACCUM_A::OVERSAMPLE2),
+            2 => Val(ADCACCUM_A::OVERSAMPLE4),
+            3 => Val(ADCACCUM_A::OVERSAMPLE8),
+            4 => Val(ADCACCUM_A::OVERSAMPLE16),
+            5 => Val(ADCACCUM_A::OVERSAMPLE32),
+            6 => Val(ADCACCUM_A::OVERSAMPLE64),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `OVERSAMPLE1`"]
+    #[inline(always)]
+    pub fn is_oversample1(&self) -> bool {
+        *self == ADCACCUM_A::OVERSAMPLE1
+    }
+    #[doc = "Checks if the value of the field is `OVERSAMPLE2`"]
+    #[inline(always)]
+    pub fn is_oversample2(&self) -> bool {
+        *self == ADCACCUM_A::OVERSAMPLE2
+    }
+    #[doc = "Checks if the value of the field is `OVERSAMPLE4`"]
+    #[inline(always)]
+    pub fn is_oversample4(&self) -> bool {
+        *self == ADCACCUM_A::OVERSAMPLE4
+    }
+    #[doc = "Checks if the value of the field is `OVERSAMPLE8`"]
+    #[inline(always)]
+    pub fn is_oversample8(&self) -> bool {
+        *self == ADCACCUM_A::OVERSAMPLE8
+    }
+    #[doc = "Checks if the value of the field is `OVERSAMPLE16`"]
+    #[inline(always)]
+    pub fn is_oversample16(&self) -> bool {
+        *self == ADCACCUM_A::OVERSAMPLE16
+    }
+    #[doc = "Checks if the value of the field is `OVERSAMPLE32`"]
+    #[inline(always)]
+    pub fn is_oversample32(&self) -> bool {
+        *self == ADCACCUM_A::OVERSAMPLE32
+    }
+    #[doc = "Checks if the value of the field is `OVERSAMPLE64`"]
+    #[inline(always)]
+    pub fn is_oversample64(&self) -> bool {
+        *self == ADCACCUM_A::OVERSAMPLE64
+    }
+}
+#[doc = "Write proxy for field `ADCACCUM`"]
+pub struct ADCACCUM_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ADCACCUM_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: ADCACCUM_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "1 sample per report"]
+    #[inline(always)]
+    pub fn oversample1(self) -> &'a mut W {
+        self.variant(ADCACCUM_A::OVERSAMPLE1)
+    }
+    #[doc = "2 samples per report"]
+    #[inline(always)]
+    pub fn oversample2(self) -> &'a mut W {
+        self.variant(ADCACCUM_A::OVERSAMPLE2)
+    }
+    #[doc = "4 samples per report"]
+    #[inline(always)]
+    pub fn oversample4(self) -> &'a mut W {
+        self.variant(ADCACCUM_A::OVERSAMPLE4)
+    }
+    #[doc = "8 samples per report"]
+    #[inline(always)]
+    pub fn oversample8(self) -> &'a mut W {
+        self.variant(ADCACCUM_A::OVERSAMPLE8)
+    }
+    #[doc = "16 samples per report"]
+    #[inline(always)]
+    pub fn oversample16(self) -> &'a mut W {
+        self.variant(ADCACCUM_A::OVERSAMPLE16)
+    }
+    #[doc = "32 samples per report"]
+    #[inline(always)]
+    pub fn oversample32(self) -> &'a mut W {
+        self.variant(ADCACCUM_A::OVERSAMPLE32)
+    }
+    #[doc = "64 samples per report"]
+    #[inline(always)]
+    pub fn oversample64(self) -> &'a mut W {
+        self.variant(ADCACCUM_A::OVERSAMPLE64)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u8) & 0x07);
+        self.w
+    }
+}
+#[doc = "Reader of field `CONVERT`"]
+pub type CONVERT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `CONVERT`"]
+pub struct CONVERT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> CONVERT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - ADC Accumulator"]
+    #[inline(always)]
+    pub fn adcaccum(&self) -> ADCACCUM_R {
+        ADCACCUM_R::new((self.bits & 0x07) as u8)
+    }
+    #[doc = "Bit 7 - Start conversion"]
+    #[inline(always)]
+    pub fn convert(&self) -> CONVERT_R {
+        CONVERT_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - ADC Accumulator"]
+    #[inline(always)]
+    pub fn adcaccum(&mut self) -> ADCACCUM_W {
+        ADCACCUM_W { w: self }
+    }
+    #[doc = "Bit 7 - Start conversion"]
+    #[inline(always)]
+    pub fn convert(&mut self) -> CONVERT_W {
+        CONVERT_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/ctrla.rs
+++ b/pac/atsamd21e/src/ptc/ctrla.rs
@@ -1,0 +1,118 @@
+#[doc = "Reader of register CTRLA"]
+pub type R = crate::R<u8, super::CTRLA>;
+#[doc = "Writer for register CTRLA"]
+pub type W = crate::W<u8, super::CTRLA>;
+#[doc = "Register CTRLA `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLA {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SWRST`"]
+pub type SWRST_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SWRST`"]
+pub struct SWRST_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SWRST_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `ENABLE`"]
+pub type ENABLE_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `ENABLE`"]
+pub struct ENABLE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> ENABLE_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `RUNSTDBY`"]
+pub type RUNSTDBY_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `RUNSTDBY`"]
+pub struct RUNSTDBY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RUNSTDBY_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u8) & 0x01) << 2);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&self) -> SWRST_R {
+        SWRST_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&self) -> ENABLE_R {
+        ENABLE_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&self) -> RUNSTDBY_R {
+        RUNSTDBY_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Software Reset"]
+    #[inline(always)]
+    pub fn swrst(&mut self) -> SWRST_W {
+        SWRST_W { w: self }
+    }
+    #[doc = "Bit 1 - Enable"]
+    #[inline(always)]
+    pub fn enable(&mut self) -> ENABLE_W {
+        ENABLE_W { w: self }
+    }
+    #[doc = "Bit 2 - Run in Standby"]
+    #[inline(always)]
+    pub fn runstdby(&mut self) -> RUNSTDBY_W {
+        RUNSTDBY_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/ctrlb.rs
+++ b/pac/atsamd21e/src/ptc/ctrlb.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register CTRLB"]
+pub type R = crate::R<u8, super::CTRLB>;
+#[doc = "Writer for register CTRLB"]
+pub type W = crate::W<u8, super::CTRLB>;
+#[doc = "Register CTRLB `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLB {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `SYNCFLAG`"]
+pub type SYNCFLAG_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `SYNCFLAG`"]
+pub struct SYNCFLAG_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SYNCFLAG_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u8) & 0x01) << 7);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 7 - Synchronisation flag"]
+    #[inline(always)]
+    pub fn syncflag(&self) -> SYNCFLAG_R {
+        SYNCFLAG_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 7 - Synchronisation flag"]
+    #[inline(always)]
+    pub fn syncflag(&mut self) -> SYNCFLAG_W {
+        SYNCFLAG_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/ctrlc.rs
+++ b/pac/atsamd21e/src/ptc/ctrlc.rs
@@ -1,0 +1,50 @@
+#[doc = "Reader of register CTRLC"]
+pub type R = crate::R<u8, super::CTRLC>;
+#[doc = "Writer for register CTRLC"]
+pub type W = crate::W<u8, super::CTRLC>;
+#[doc = "Register CTRLC `reset()`'s with value 0"]
+impl crate::ResetValue for super::CTRLC {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `INIT`"]
+pub type INIT_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `INIT`"]
+pub struct INIT_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> INIT_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Initialize"]
+    #[inline(always)]
+    pub fn init(&self) -> INIT_R {
+        INIT_R::new((self.bits & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Initialize"]
+    #[inline(always)]
+    pub fn init(&mut self) -> INIT_W {
+        INIT_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/freqctrl.rs
+++ b/pac/atsamd21e/src/ptc/freqctrl.rs
@@ -1,0 +1,309 @@
+#[doc = "Reader of register FREQCTRL"]
+pub type R = crate::R<u8, super::FREQCTRL>;
+#[doc = "Writer for register FREQCTRL"]
+pub type W = crate::W<u8, super::FREQCTRL>;
+#[doc = "Register FREQCTRL `reset()`'s with value 0"]
+impl crate::ResetValue for super::FREQCTRL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Sample delay\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
+pub enum SAMPLEDELAY_A {
+    #[doc = "0: `0`"]
+    FREQHOP1 = 0,
+    #[doc = "1: `1`"]
+    FREQHOP2 = 1,
+    #[doc = "2: `10`"]
+    FREQHOP3 = 2,
+    #[doc = "3: `11`"]
+    FREQHOP4 = 3,
+    #[doc = "4: `100`"]
+    FREQHOP5 = 4,
+    #[doc = "5: `101`"]
+    FREQHOP6 = 5,
+    #[doc = "6: `110`"]
+    FREQHOP7 = 6,
+    #[doc = "7: `111`"]
+    FREQHOP8 = 7,
+    #[doc = "8: `1000`"]
+    FREQHOP9 = 8,
+    #[doc = "9: `1001`"]
+    FREQHOP10 = 9,
+    #[doc = "10: `1010`"]
+    FREQHOP11 = 10,
+    #[doc = "11: `1011`"]
+    FREQHOP12 = 11,
+    #[doc = "12: `1100`"]
+    FREQHOP13 = 12,
+    #[doc = "13: `1101`"]
+    FREQHOP14 = 13,
+    #[doc = "14: `1110`"]
+    FREQHOP15 = 14,
+    #[doc = "15: `1111`"]
+    FREQHOP16 = 15,
+}
+impl From<SAMPLEDELAY_A> for u8 {
+    #[inline(always)]
+    fn from(variant: SAMPLEDELAY_A) -> Self {
+        variant as _
+    }
+}
+#[doc = "Reader of field `SAMPLEDELAY`"]
+pub type SAMPLEDELAY_R = crate::R<u8, SAMPLEDELAY_A>;
+impl SAMPLEDELAY_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> SAMPLEDELAY_A {
+        match self.bits {
+            0 => SAMPLEDELAY_A::FREQHOP1,
+            1 => SAMPLEDELAY_A::FREQHOP2,
+            2 => SAMPLEDELAY_A::FREQHOP3,
+            3 => SAMPLEDELAY_A::FREQHOP4,
+            4 => SAMPLEDELAY_A::FREQHOP5,
+            5 => SAMPLEDELAY_A::FREQHOP6,
+            6 => SAMPLEDELAY_A::FREQHOP7,
+            7 => SAMPLEDELAY_A::FREQHOP8,
+            8 => SAMPLEDELAY_A::FREQHOP9,
+            9 => SAMPLEDELAY_A::FREQHOP10,
+            10 => SAMPLEDELAY_A::FREQHOP11,
+            11 => SAMPLEDELAY_A::FREQHOP12,
+            12 => SAMPLEDELAY_A::FREQHOP13,
+            13 => SAMPLEDELAY_A::FREQHOP14,
+            14 => SAMPLEDELAY_A::FREQHOP15,
+            15 => SAMPLEDELAY_A::FREQHOP16,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP1`"]
+    #[inline(always)]
+    pub fn is_freqhop1(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP1
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP2`"]
+    #[inline(always)]
+    pub fn is_freqhop2(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP2
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP3`"]
+    #[inline(always)]
+    pub fn is_freqhop3(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP3
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP4`"]
+    #[inline(always)]
+    pub fn is_freqhop4(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP4
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP5`"]
+    #[inline(always)]
+    pub fn is_freqhop5(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP5
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP6`"]
+    #[inline(always)]
+    pub fn is_freqhop6(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP6
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP7`"]
+    #[inline(always)]
+    pub fn is_freqhop7(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP7
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP8`"]
+    #[inline(always)]
+    pub fn is_freqhop8(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP8
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP9`"]
+    #[inline(always)]
+    pub fn is_freqhop9(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP9
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP10`"]
+    #[inline(always)]
+    pub fn is_freqhop10(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP10
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP11`"]
+    #[inline(always)]
+    pub fn is_freqhop11(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP11
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP12`"]
+    #[inline(always)]
+    pub fn is_freqhop12(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP12
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP13`"]
+    #[inline(always)]
+    pub fn is_freqhop13(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP13
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP14`"]
+    #[inline(always)]
+    pub fn is_freqhop14(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP14
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP15`"]
+    #[inline(always)]
+    pub fn is_freqhop15(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP15
+    }
+    #[doc = "Checks if the value of the field is `FREQHOP16`"]
+    #[inline(always)]
+    pub fn is_freqhop16(&self) -> bool {
+        *self == SAMPLEDELAY_A::FREQHOP16
+    }
+}
+#[doc = "Write proxy for field `SAMPLEDELAY`"]
+pub struct SAMPLEDELAY_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> SAMPLEDELAY_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: SAMPLEDELAY_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "`0`"]
+    #[inline(always)]
+    pub fn freqhop1(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP1)
+    }
+    #[doc = "`1`"]
+    #[inline(always)]
+    pub fn freqhop2(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP2)
+    }
+    #[doc = "`10`"]
+    #[inline(always)]
+    pub fn freqhop3(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP3)
+    }
+    #[doc = "`11`"]
+    #[inline(always)]
+    pub fn freqhop4(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP4)
+    }
+    #[doc = "`100`"]
+    #[inline(always)]
+    pub fn freqhop5(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP5)
+    }
+    #[doc = "`101`"]
+    #[inline(always)]
+    pub fn freqhop6(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP6)
+    }
+    #[doc = "`110`"]
+    #[inline(always)]
+    pub fn freqhop7(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP7)
+    }
+    #[doc = "`111`"]
+    #[inline(always)]
+    pub fn freqhop8(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP8)
+    }
+    #[doc = "`1000`"]
+    #[inline(always)]
+    pub fn freqhop9(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP9)
+    }
+    #[doc = "`1001`"]
+    #[inline(always)]
+    pub fn freqhop10(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP10)
+    }
+    #[doc = "`1010`"]
+    #[inline(always)]
+    pub fn freqhop11(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP11)
+    }
+    #[doc = "`1011`"]
+    #[inline(always)]
+    pub fn freqhop12(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP12)
+    }
+    #[doc = "`1100`"]
+    #[inline(always)]
+    pub fn freqhop13(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP13)
+    }
+    #[doc = "`1101`"]
+    #[inline(always)]
+    pub fn freqhop14(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP14)
+    }
+    #[doc = "`1110`"]
+    #[inline(always)]
+    pub fn freqhop15(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP15)
+    }
+    #[doc = "`1111`"]
+    #[inline(always)]
+    pub fn freqhop16(self) -> &'a mut W {
+        self.variant(SAMPLEDELAY_A::FREQHOP16)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x0f) | ((value as u8) & 0x0f);
+        self.w
+    }
+}
+#[doc = "Reader of field `FREQSPREADEN`"]
+pub type FREQSPREADEN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `FREQSPREADEN`"]
+pub struct FREQSPREADEN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> FREQSPREADEN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u8) & 0x01) << 4);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:3 - Sample delay"]
+    #[inline(always)]
+    pub fn sampledelay(&self) -> SAMPLEDELAY_R {
+        SAMPLEDELAY_R::new((self.bits & 0x0f) as u8)
+    }
+    #[doc = "Bit 4 - Enable frequency spread"]
+    #[inline(always)]
+    pub fn freqspreaden(&self) -> FREQSPREADEN_R {
+        FREQSPREADEN_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bits 0:3 - Sample delay"]
+    #[inline(always)]
+    pub fn sampledelay(&mut self) -> SAMPLEDELAY_W {
+        SAMPLEDELAY_W { w: self }
+    }
+    #[doc = "Bit 4 - Enable frequency spread"]
+    #[inline(always)]
+    pub fn freqspreaden(&mut self) -> FREQSPREADEN_W {
+        FREQSPREADEN_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/intcap.rs
+++ b/pac/atsamd21e/src/ptc/intcap.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register INTCAP"]
+pub type R = crate::R<u8, super::INTCAP>;
+#[doc = "Writer for register INTCAP"]
+pub type W = crate::W<u8, super::INTCAP>;
+#[doc = "Register INTCAP `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTCAP {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `VALUE`"]
+pub type VALUE_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `VALUE`"]
+pub struct VALUE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> VALUE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x3f) | ((value as u8) & 0x3f);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:5 - Value"]
+    #[inline(always)]
+    pub fn value(&self) -> VALUE_R {
+        VALUE_R::new((self.bits & 0x3f) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:5 - Value"]
+    #[inline(always)]
+    pub fn value(&mut self) -> VALUE_W {
+        VALUE_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/intenclr.rs
+++ b/pac/atsamd21e/src/ptc/intenclr.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register INTENCLR"]
+pub type R = crate::R<u8, super::INTENCLR>;
+#[doc = "Writer for register INTENCLR"]
+pub type W = crate::W<u8, super::INTENCLR>;
+#[doc = "Register INTENCLR `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENCLR {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `EOC`"]
+pub type EOC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EOC`"]
+pub struct EOC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EOC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `WCO`"]
+pub type WCO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WCO`"]
+pub struct WCO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WCO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Interrupt on end of comparison"]
+    #[inline(always)]
+    pub fn eoc(&self) -> EOC_R {
+        EOC_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Watch crystal oscillator interrupt"]
+    #[inline(always)]
+    pub fn wco(&self) -> WCO_R {
+        WCO_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Interrupt on end of comparison"]
+    #[inline(always)]
+    pub fn eoc(&mut self) -> EOC_W {
+        EOC_W { w: self }
+    }
+    #[doc = "Bit 1 - Watch crystal oscillator interrupt"]
+    #[inline(always)]
+    pub fn wco(&mut self) -> WCO_W {
+        WCO_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/intenset.rs
+++ b/pac/atsamd21e/src/ptc/intenset.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register INTENSET"]
+pub type R = crate::R<u8, super::INTENSET>;
+#[doc = "Writer for register INTENSET"]
+pub type W = crate::W<u8, super::INTENSET>;
+#[doc = "Register INTENSET `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTENSET {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `EOC`"]
+pub type EOC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EOC`"]
+pub struct EOC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EOC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `WCO`"]
+pub type WCO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WCO`"]
+pub struct WCO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WCO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Interrupt on end of comparison"]
+    #[inline(always)]
+    pub fn eoc(&self) -> EOC_R {
+        EOC_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Watch crystal oscillator interrupt"]
+    #[inline(always)]
+    pub fn wco(&self) -> WCO_R {
+        WCO_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Interrupt on end of comparison"]
+    #[inline(always)]
+    pub fn eoc(&mut self) -> EOC_W {
+        EOC_W { w: self }
+    }
+    #[doc = "Bit 1 - Watch crystal oscillator interrupt"]
+    #[inline(always)]
+    pub fn wco(&mut self) -> WCO_W {
+        WCO_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/intflag.rs
+++ b/pac/atsamd21e/src/ptc/intflag.rs
@@ -1,0 +1,84 @@
+#[doc = "Reader of register INTFLAG"]
+pub type R = crate::R<u8, super::INTFLAG>;
+#[doc = "Writer for register INTFLAG"]
+pub type W = crate::W<u8, super::INTFLAG>;
+#[doc = "Register INTFLAG `reset()`'s with value 0"]
+impl crate::ResetValue for super::INTFLAG {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `EOC`"]
+pub type EOC_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `EOC`"]
+pub struct EOC_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> EOC_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u8) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `WCO`"]
+pub type WCO_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `WCO`"]
+pub struct WCO_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> WCO_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u8) & 0x01) << 1);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - Interrupt end of comparison"]
+    #[inline(always)]
+    pub fn eoc(&self) -> EOC_R {
+        EOC_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - Watch crystal oscillator interrupt"]
+    #[inline(always)]
+    pub fn wco(&self) -> WCO_R {
+        WCO_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - Interrupt end of comparison"]
+    #[inline(always)]
+    pub fn eoc(&mut self) -> EOC_W {
+        EOC_W { w: self }
+    }
+    #[doc = "Bit 1 - Watch crystal oscillator interrupt"]
+    #[inline(always)]
+    pub fn wco(&mut self) -> WCO_W {
+        WCO_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/result.rs
+++ b/pac/atsamd21e/src/ptc/result.rs
@@ -1,0 +1,11 @@
+#[doc = "Reader of register RESULT"]
+pub type R = crate::R<u16, super::RESULT>;
+#[doc = "Reader of field `RESULT`"]
+pub type RESULT_R = crate::R<u16, u16>;
+impl R {
+    #[doc = "Bits 0:15 - Result of conversion"]
+    #[inline(always)]
+    pub fn result(&self) -> RESULT_R {
+        RESULT_R::new((self.bits & 0xffff) as u16)
+    }
+}

--- a/pac/atsamd21e/src/ptc/serres.rs
+++ b/pac/atsamd21e/src/ptc/serres.rs
@@ -1,0 +1,119 @@
+#[doc = "Reader of register SERRES"]
+pub type R = crate::R<u8, super::SERRES>;
+#[doc = "Writer for register SERRES"]
+pub type W = crate::W<u8, super::SERRES>;
+#[doc = "Register SERRES `reset()`'s with value 0"]
+impl crate::ResetValue for super::SERRES {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Resistor value\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
+pub enum RESISTOR_A {
+    #[doc = "0: No series resistor"]
+    RES0 = 0,
+    #[doc = "1: 20 kiloohm series resistor"]
+    RES20K = 1,
+    #[doc = "2: 50 kiloohm series resistor"]
+    RES50K = 2,
+    #[doc = "3: 100 kiloohm series resistor"]
+    RES100K = 3,
+}
+impl From<RESISTOR_A> for u8 {
+    #[inline(always)]
+    fn from(variant: RESISTOR_A) -> Self {
+        variant as _
+    }
+}
+#[doc = "Reader of field `RESISTOR`"]
+pub type RESISTOR_R = crate::R<u8, RESISTOR_A>;
+impl RESISTOR_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> RESISTOR_A {
+        match self.bits {
+            0 => RESISTOR_A::RES0,
+            1 => RESISTOR_A::RES20K,
+            2 => RESISTOR_A::RES50K,
+            3 => RESISTOR_A::RES100K,
+            _ => unreachable!(),
+        }
+    }
+    #[doc = "Checks if the value of the field is `RES0`"]
+    #[inline(always)]
+    pub fn is_res0(&self) -> bool {
+        *self == RESISTOR_A::RES0
+    }
+    #[doc = "Checks if the value of the field is `RES20K`"]
+    #[inline(always)]
+    pub fn is_res20k(&self) -> bool {
+        *self == RESISTOR_A::RES20K
+    }
+    #[doc = "Checks if the value of the field is `RES50K`"]
+    #[inline(always)]
+    pub fn is_res50k(&self) -> bool {
+        *self == RESISTOR_A::RES50K
+    }
+    #[doc = "Checks if the value of the field is `RES100K`"]
+    #[inline(always)]
+    pub fn is_res100k(&self) -> bool {
+        *self == RESISTOR_A::RES100K
+    }
+}
+#[doc = "Write proxy for field `RESISTOR`"]
+pub struct RESISTOR_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> RESISTOR_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: RESISTOR_A) -> &'a mut W {
+        {
+            self.bits(variant.into())
+        }
+    }
+    #[doc = "No series resistor"]
+    #[inline(always)]
+    pub fn res0(self) -> &'a mut W {
+        self.variant(RESISTOR_A::RES0)
+    }
+    #[doc = "20 kiloohm series resistor"]
+    #[inline(always)]
+    pub fn res20k(self) -> &'a mut W {
+        self.variant(RESISTOR_A::RES20K)
+    }
+    #[doc = "50 kiloohm series resistor"]
+    #[inline(always)]
+    pub fn res50k(self) -> &'a mut W {
+        self.variant(RESISTOR_A::RES50K)
+    }
+    #[doc = "100 kiloohm series resistor"]
+    #[inline(always)]
+    pub fn res100k(self) -> &'a mut W {
+        self.variant(RESISTOR_A::RES100K)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x03) | ((value as u8) & 0x03);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:1 - Resistor value"]
+    #[inline(always)]
+    pub fn resistor(&self) -> RESISTOR_R {
+        RESISTOR_R::new((self.bits & 0x03) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:1 - Resistor value"]
+    #[inline(always)]
+    pub fn resistor(&mut self) -> RESISTOR_W {
+        RESISTOR_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/unk4c04.rs
+++ b/pac/atsamd21e/src/ptc/unk4c04.rs
@@ -1,0 +1,14 @@
+#[doc = "Reader of register UNK4C04"]
+pub type R = crate::R<u8, super::UNK4C04>;
+#[doc = "Writer for register UNK4C04"]
+pub type W = crate::W<u8, super::UNK4C04>;
+#[doc = "Register UNK4C04 `reset()`'s with value 0"]
+impl crate::ResetValue for super::UNK4C04 {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+impl R {}
+impl W {}

--- a/pac/atsamd21e/src/ptc/wcomode.rs
+++ b/pac/atsamd21e/src/ptc/wcomode.rs
@@ -1,0 +1,40 @@
+#[doc = "Reader of register WCOMODE"]
+pub type R = crate::R<u8, super::WCOMODE>;
+#[doc = "Writer for register WCOMODE"]
+pub type W = crate::W<u8, super::WCOMODE>;
+#[doc = "Register WCOMODE `reset()`'s with value 0"]
+impl crate::ResetValue for super::WCOMODE {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `MODE`"]
+pub type MODE_R = crate::R<u8, u8>;
+#[doc = "Write proxy for field `MODE`"]
+pub struct MODE_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> MODE_W<'a> {
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u8) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x07) | ((value as u8) & 0x07);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:2 - Set WCO mode"]
+    #[inline(always)]
+    pub fn mode(&self) -> MODE_R {
+        MODE_R::new((self.bits & 0x07) as u8)
+    }
+}
+impl W {
+    #[doc = "Bits 0:2 - Set WCO mode"]
+    #[inline(always)]
+    pub fn mode(&mut self) -> MODE_W {
+        MODE_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/wcothresholdah.rs
+++ b/pac/atsamd21e/src/ptc/wcothresholdah.rs
@@ -1,0 +1,14 @@
+#[doc = "Reader of register WCOTHRESHOLDAH"]
+pub type R = crate::R<u8, super::WCOTHRESHOLDAH>;
+#[doc = "Writer for register WCOTHRESHOLDAH"]
+pub type W = crate::W<u8, super::WCOTHRESHOLDAH>;
+#[doc = "Register WCOTHRESHOLDAH `reset()`'s with value 0"]
+impl crate::ResetValue for super::WCOTHRESHOLDAH {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+impl R {}
+impl W {}

--- a/pac/atsamd21e/src/ptc/wcothresholdal.rs
+++ b/pac/atsamd21e/src/ptc/wcothresholdal.rs
@@ -1,0 +1,14 @@
+#[doc = "Reader of register WCOTHRESHOLDAL"]
+pub type R = crate::R<u8, super::WCOTHRESHOLDAL>;
+#[doc = "Writer for register WCOTHRESHOLDAL"]
+pub type W = crate::W<u8, super::WCOTHRESHOLDAL>;
+#[doc = "Register WCOTHRESHOLDAL `reset()`'s with value 0"]
+impl crate::ResetValue for super::WCOTHRESHOLDAL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+impl R {}
+impl W {}

--- a/pac/atsamd21e/src/ptc/wcothresholdbh.rs
+++ b/pac/atsamd21e/src/ptc/wcothresholdbh.rs
@@ -1,0 +1,14 @@
+#[doc = "Reader of register WCOTHRESHOLDBH"]
+pub type R = crate::R<u8, super::WCOTHRESHOLDBH>;
+#[doc = "Writer for register WCOTHRESHOLDBH"]
+pub type W = crate::W<u8, super::WCOTHRESHOLDBH>;
+#[doc = "Register WCOTHRESHOLDBH `reset()`'s with value 0"]
+impl crate::ResetValue for super::WCOTHRESHOLDBH {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+impl R {}
+impl W {}

--- a/pac/atsamd21e/src/ptc/wcothresholdbl.rs
+++ b/pac/atsamd21e/src/ptc/wcothresholdbl.rs
@@ -1,0 +1,14 @@
+#[doc = "Reader of register WCOTHRESHOLDBL"]
+pub type R = crate::R<u8, super::WCOTHRESHOLDBL>;
+#[doc = "Writer for register WCOTHRESHOLDBL"]
+pub type W = crate::W<u8, super::WCOTHRESHOLDBL>;
+#[doc = "Register WCOTHRESHOLDBL `reset()`'s with value 0"]
+impl crate::ResetValue for super::WCOTHRESHOLDBL {
+    type Type = u8;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+impl R {}
+impl W {}

--- a/pac/atsamd21e/src/ptc/xselect.rs
+++ b/pac/atsamd21e/src/ptc/xselect.rs
@@ -1,0 +1,274 @@
+#[doc = "Reader of register XSELECT"]
+pub type R = crate::R<u16, super::XSELECT>;
+#[doc = "Writer for register XSELECT"]
+pub type W = crate::W<u16, super::XSELECT>;
+#[doc = "Register XSELECT `reset()`'s with value 0"]
+impl crate::ResetValue for super::XSELECT {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "X line selection MUX\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u16)]
+pub enum XMUX_A {
+    #[doc = "1: PTC X0 Pin"]
+    X0 = 1,
+    #[doc = "2: PTC X1 Pin"]
+    X1 = 2,
+    #[doc = "4: PTC X2 Pin"]
+    X2 = 4,
+    #[doc = "8: PTC X3 Pin"]
+    X3 = 8,
+    #[doc = "16: PTC X4 Pin"]
+    X4 = 16,
+    #[doc = "32: PTC X5 Pin"]
+    X5 = 32,
+    #[doc = "64: PTC X6 Pin"]
+    X6 = 64,
+    #[doc = "128: PTC X7 Pin"]
+    X7 = 128,
+    #[doc = "256: PTC X8 Pin"]
+    X8 = 256,
+    #[doc = "512: PTC X9 Pin"]
+    X9 = 512,
+    #[doc = "1024: PTC X10 Pin"]
+    X10 = 1024,
+    #[doc = "2048: PTC X11 Pin"]
+    X11 = 2048,
+    #[doc = "4096: PTC X12 Pin"]
+    X12 = 4096,
+    #[doc = "8192: PTC X13 Pin"]
+    X13 = 8192,
+    #[doc = "16384: PTC X14 Pin"]
+    X14 = 16384,
+    #[doc = "32768: PTC X15 Pin"]
+    X15 = 32768,
+}
+impl From<XMUX_A> for u16 {
+    #[inline(always)]
+    fn from(variant: XMUX_A) -> Self {
+        variant as _
+    }
+}
+#[doc = "Reader of field `XMUX`"]
+pub type XMUX_R = crate::R<u16, XMUX_A>;
+impl XMUX_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u16, XMUX_A> {
+        use crate::Variant::*;
+        match self.bits {
+            1 => Val(XMUX_A::X0),
+            2 => Val(XMUX_A::X1),
+            4 => Val(XMUX_A::X2),
+            8 => Val(XMUX_A::X3),
+            16 => Val(XMUX_A::X4),
+            32 => Val(XMUX_A::X5),
+            64 => Val(XMUX_A::X6),
+            128 => Val(XMUX_A::X7),
+            256 => Val(XMUX_A::X8),
+            512 => Val(XMUX_A::X9),
+            1024 => Val(XMUX_A::X10),
+            2048 => Val(XMUX_A::X11),
+            4096 => Val(XMUX_A::X12),
+            8192 => Val(XMUX_A::X13),
+            16384 => Val(XMUX_A::X14),
+            32768 => Val(XMUX_A::X15),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `X0`"]
+    #[inline(always)]
+    pub fn is_x0(&self) -> bool {
+        *self == XMUX_A::X0
+    }
+    #[doc = "Checks if the value of the field is `X1`"]
+    #[inline(always)]
+    pub fn is_x1(&self) -> bool {
+        *self == XMUX_A::X1
+    }
+    #[doc = "Checks if the value of the field is `X2`"]
+    #[inline(always)]
+    pub fn is_x2(&self) -> bool {
+        *self == XMUX_A::X2
+    }
+    #[doc = "Checks if the value of the field is `X3`"]
+    #[inline(always)]
+    pub fn is_x3(&self) -> bool {
+        *self == XMUX_A::X3
+    }
+    #[doc = "Checks if the value of the field is `X4`"]
+    #[inline(always)]
+    pub fn is_x4(&self) -> bool {
+        *self == XMUX_A::X4
+    }
+    #[doc = "Checks if the value of the field is `X5`"]
+    #[inline(always)]
+    pub fn is_x5(&self) -> bool {
+        *self == XMUX_A::X5
+    }
+    #[doc = "Checks if the value of the field is `X6`"]
+    #[inline(always)]
+    pub fn is_x6(&self) -> bool {
+        *self == XMUX_A::X6
+    }
+    #[doc = "Checks if the value of the field is `X7`"]
+    #[inline(always)]
+    pub fn is_x7(&self) -> bool {
+        *self == XMUX_A::X7
+    }
+    #[doc = "Checks if the value of the field is `X8`"]
+    #[inline(always)]
+    pub fn is_x8(&self) -> bool {
+        *self == XMUX_A::X8
+    }
+    #[doc = "Checks if the value of the field is `X9`"]
+    #[inline(always)]
+    pub fn is_x9(&self) -> bool {
+        *self == XMUX_A::X9
+    }
+    #[doc = "Checks if the value of the field is `X10`"]
+    #[inline(always)]
+    pub fn is_x10(&self) -> bool {
+        *self == XMUX_A::X10
+    }
+    #[doc = "Checks if the value of the field is `X11`"]
+    #[inline(always)]
+    pub fn is_x11(&self) -> bool {
+        *self == XMUX_A::X11
+    }
+    #[doc = "Checks if the value of the field is `X12`"]
+    #[inline(always)]
+    pub fn is_x12(&self) -> bool {
+        *self == XMUX_A::X12
+    }
+    #[doc = "Checks if the value of the field is `X13`"]
+    #[inline(always)]
+    pub fn is_x13(&self) -> bool {
+        *self == XMUX_A::X13
+    }
+    #[doc = "Checks if the value of the field is `X14`"]
+    #[inline(always)]
+    pub fn is_x14(&self) -> bool {
+        *self == XMUX_A::X14
+    }
+    #[doc = "Checks if the value of the field is `X15`"]
+    #[inline(always)]
+    pub fn is_x15(&self) -> bool {
+        *self == XMUX_A::X15
+    }
+}
+#[doc = "Write proxy for field `XMUX`"]
+pub struct XMUX_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> XMUX_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: XMUX_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "PTC X0 Pin"]
+    #[inline(always)]
+    pub fn x0(self) -> &'a mut W {
+        self.variant(XMUX_A::X0)
+    }
+    #[doc = "PTC X1 Pin"]
+    #[inline(always)]
+    pub fn x1(self) -> &'a mut W {
+        self.variant(XMUX_A::X1)
+    }
+    #[doc = "PTC X2 Pin"]
+    #[inline(always)]
+    pub fn x2(self) -> &'a mut W {
+        self.variant(XMUX_A::X2)
+    }
+    #[doc = "PTC X3 Pin"]
+    #[inline(always)]
+    pub fn x3(self) -> &'a mut W {
+        self.variant(XMUX_A::X3)
+    }
+    #[doc = "PTC X4 Pin"]
+    #[inline(always)]
+    pub fn x4(self) -> &'a mut W {
+        self.variant(XMUX_A::X4)
+    }
+    #[doc = "PTC X5 Pin"]
+    #[inline(always)]
+    pub fn x5(self) -> &'a mut W {
+        self.variant(XMUX_A::X5)
+    }
+    #[doc = "PTC X6 Pin"]
+    #[inline(always)]
+    pub fn x6(self) -> &'a mut W {
+        self.variant(XMUX_A::X6)
+    }
+    #[doc = "PTC X7 Pin"]
+    #[inline(always)]
+    pub fn x7(self) -> &'a mut W {
+        self.variant(XMUX_A::X7)
+    }
+    #[doc = "PTC X8 Pin"]
+    #[inline(always)]
+    pub fn x8(self) -> &'a mut W {
+        self.variant(XMUX_A::X8)
+    }
+    #[doc = "PTC X9 Pin"]
+    #[inline(always)]
+    pub fn x9(self) -> &'a mut W {
+        self.variant(XMUX_A::X9)
+    }
+    #[doc = "PTC X10 Pin"]
+    #[inline(always)]
+    pub fn x10(self) -> &'a mut W {
+        self.variant(XMUX_A::X10)
+    }
+    #[doc = "PTC X11 Pin"]
+    #[inline(always)]
+    pub fn x11(self) -> &'a mut W {
+        self.variant(XMUX_A::X11)
+    }
+    #[doc = "PTC X12 Pin"]
+    #[inline(always)]
+    pub fn x12(self) -> &'a mut W {
+        self.variant(XMUX_A::X12)
+    }
+    #[doc = "PTC X13 Pin"]
+    #[inline(always)]
+    pub fn x13(self) -> &'a mut W {
+        self.variant(XMUX_A::X13)
+    }
+    #[doc = "PTC X14 Pin"]
+    #[inline(always)]
+    pub fn x14(self) -> &'a mut W {
+        self.variant(XMUX_A::X14)
+    }
+    #[doc = "PTC X15 Pin"]
+    #[inline(always)]
+    pub fn x15(self) -> &'a mut W {
+        self.variant(XMUX_A::X15)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff) | ((value as u16) & 0xffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:15 - X line selection MUX"]
+    #[inline(always)]
+    pub fn xmux(&self) -> XMUX_R {
+        XMUX_R::new((self.bits & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - X line selection MUX"]
+    #[inline(always)]
+    pub fn xmux(&mut self) -> XMUX_W {
+        XMUX_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/xselecten.rs
+++ b/pac/atsamd21e/src/ptc/xselecten.rs
@@ -1,0 +1,560 @@
+#[doc = "Reader of register XSELECTEN"]
+pub type R = crate::R<u16, super::XSELECTEN>;
+#[doc = "Writer for register XSELECTEN"]
+pub type W = crate::W<u16, super::XSELECTEN>;
+#[doc = "Register XSELECTEN `reset()`'s with value 0"]
+impl crate::ResetValue for super::XSELECTEN {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `X0EN`"]
+pub type X0EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X0EN`"]
+pub struct X0EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X0EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `X1EN`"]
+pub type X1EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X1EN`"]
+pub struct X1EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X1EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `X2EN`"]
+pub type X2EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X2EN`"]
+pub struct X2EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X2EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `X3EN`"]
+pub type X3EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X3EN`"]
+pub struct X3EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X3EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u16) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `X4EN`"]
+pub type X4EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X4EN`"]
+pub struct X4EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X4EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `X5EN`"]
+pub type X5EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X5EN`"]
+pub struct X5EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X5EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `X6EN`"]
+pub type X6EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X6EN`"]
+pub struct X6EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X6EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `X7EN`"]
+pub type X7EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X7EN`"]
+pub struct X7EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X7EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `X8EN`"]
+pub type X8EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X8EN`"]
+pub struct X8EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X8EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `X9EN`"]
+pub type X9EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X9EN`"]
+pub struct X9EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X9EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u16) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `X10EN`"]
+pub type X10EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X10EN`"]
+pub struct X10EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X10EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u16) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `X11EN`"]
+pub type X11EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X11EN`"]
+pub struct X11EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X11EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u16) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `X12EN`"]
+pub type X12EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X12EN`"]
+pub struct X12EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X12EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u16) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `X13EN`"]
+pub type X13EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X13EN`"]
+pub struct X13EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X13EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u16) & 0x01) << 13);
+        self.w
+    }
+}
+#[doc = "Reader of field `X14EN`"]
+pub type X14EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X14EN`"]
+pub struct X14EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X14EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u16) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `X15EN`"]
+pub type X15EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `X15EN`"]
+pub struct X15EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> X15EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u16) & 0x01) << 15);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - PTC X0 pin enable"]
+    #[inline(always)]
+    pub fn x0en(&self) -> X0EN_R {
+        X0EN_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - PTC X1 pin enable"]
+    #[inline(always)]
+    pub fn x1en(&self) -> X1EN_R {
+        X1EN_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - PTC X2 pin enable"]
+    #[inline(always)]
+    pub fn x2en(&self) -> X2EN_R {
+        X2EN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - PTC X3 pin enable"]
+    #[inline(always)]
+    pub fn x3en(&self) -> X3EN_R {
+        X3EN_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - PTC X4 pin enable"]
+    #[inline(always)]
+    pub fn x4en(&self) -> X4EN_R {
+        X4EN_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - PTC X5 pin enable"]
+    #[inline(always)]
+    pub fn x5en(&self) -> X5EN_R {
+        X5EN_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - PTC X6 pin enable"]
+    #[inline(always)]
+    pub fn x6en(&self) -> X6EN_R {
+        X6EN_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - PTC X7 pin enable"]
+    #[inline(always)]
+    pub fn x7en(&self) -> X7EN_R {
+        X7EN_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - PTC X8 pin enable"]
+    #[inline(always)]
+    pub fn x8en(&self) -> X8EN_R {
+        X8EN_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - PTC X9 pin enable"]
+    #[inline(always)]
+    pub fn x9en(&self) -> X9EN_R {
+        X9EN_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - PTC X10 pin enable"]
+    #[inline(always)]
+    pub fn x10en(&self) -> X10EN_R {
+        X10EN_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - PTC X11 pin enable"]
+    #[inline(always)]
+    pub fn x11en(&self) -> X11EN_R {
+        X11EN_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - PTC X12 pin enable"]
+    #[inline(always)]
+    pub fn x12en(&self) -> X12EN_R {
+        X12EN_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - PTC X13 pin enable"]
+    #[inline(always)]
+    pub fn x13en(&self) -> X13EN_R {
+        X13EN_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+    #[doc = "Bit 14 - PTC X14 pin enable"]
+    #[inline(always)]
+    pub fn x14en(&self) -> X14EN_R {
+        X14EN_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - PTC X15 pin enable"]
+    #[inline(always)]
+    pub fn x15en(&self) -> X15EN_R {
+        X15EN_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - PTC X0 pin enable"]
+    #[inline(always)]
+    pub fn x0en(&mut self) -> X0EN_W {
+        X0EN_W { w: self }
+    }
+    #[doc = "Bit 1 - PTC X1 pin enable"]
+    #[inline(always)]
+    pub fn x1en(&mut self) -> X1EN_W {
+        X1EN_W { w: self }
+    }
+    #[doc = "Bit 2 - PTC X2 pin enable"]
+    #[inline(always)]
+    pub fn x2en(&mut self) -> X2EN_W {
+        X2EN_W { w: self }
+    }
+    #[doc = "Bit 3 - PTC X3 pin enable"]
+    #[inline(always)]
+    pub fn x3en(&mut self) -> X3EN_W {
+        X3EN_W { w: self }
+    }
+    #[doc = "Bit 4 - PTC X4 pin enable"]
+    #[inline(always)]
+    pub fn x4en(&mut self) -> X4EN_W {
+        X4EN_W { w: self }
+    }
+    #[doc = "Bit 5 - PTC X5 pin enable"]
+    #[inline(always)]
+    pub fn x5en(&mut self) -> X5EN_W {
+        X5EN_W { w: self }
+    }
+    #[doc = "Bit 6 - PTC X6 pin enable"]
+    #[inline(always)]
+    pub fn x6en(&mut self) -> X6EN_W {
+        X6EN_W { w: self }
+    }
+    #[doc = "Bit 7 - PTC X7 pin enable"]
+    #[inline(always)]
+    pub fn x7en(&mut self) -> X7EN_W {
+        X7EN_W { w: self }
+    }
+    #[doc = "Bit 8 - PTC X8 pin enable"]
+    #[inline(always)]
+    pub fn x8en(&mut self) -> X8EN_W {
+        X8EN_W { w: self }
+    }
+    #[doc = "Bit 9 - PTC X9 pin enable"]
+    #[inline(always)]
+    pub fn x9en(&mut self) -> X9EN_W {
+        X9EN_W { w: self }
+    }
+    #[doc = "Bit 10 - PTC X10 pin enable"]
+    #[inline(always)]
+    pub fn x10en(&mut self) -> X10EN_W {
+        X10EN_W { w: self }
+    }
+    #[doc = "Bit 11 - PTC X11 pin enable"]
+    #[inline(always)]
+    pub fn x11en(&mut self) -> X11EN_W {
+        X11EN_W { w: self }
+    }
+    #[doc = "Bit 12 - PTC X12 pin enable"]
+    #[inline(always)]
+    pub fn x12en(&mut self) -> X12EN_W {
+        X12EN_W { w: self }
+    }
+    #[doc = "Bit 13 - PTC X13 pin enable"]
+    #[inline(always)]
+    pub fn x13en(&mut self) -> X13EN_W {
+        X13EN_W { w: self }
+    }
+    #[doc = "Bit 14 - PTC X14 pin enable"]
+    #[inline(always)]
+    pub fn x14en(&mut self) -> X14EN_W {
+        X14EN_W { w: self }
+    }
+    #[doc = "Bit 15 - PTC X15 pin enable"]
+    #[inline(always)]
+    pub fn x15en(&mut self) -> X15EN_W {
+        X15EN_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/yselect.rs
+++ b/pac/atsamd21e/src/ptc/yselect.rs
@@ -1,0 +1,274 @@
+#[doc = "Reader of register YSELECT"]
+pub type R = crate::R<u16, super::YSELECT>;
+#[doc = "Writer for register YSELECT"]
+pub type W = crate::W<u16, super::YSELECT>;
+#[doc = "Register YSELECT `reset()`'s with value 0"]
+impl crate::ResetValue for super::YSELECT {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Y line selection MUX\n\nValue on reset: 0"]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u16)]
+pub enum YMUX_A {
+    #[doc = "1: PTC Y0 Pin"]
+    Y0 = 1,
+    #[doc = "2: PTC Y1 Pin"]
+    Y1 = 2,
+    #[doc = "4: PTC Y2 Pin"]
+    Y2 = 4,
+    #[doc = "8: PTC Y3 Pin"]
+    Y3 = 8,
+    #[doc = "16: PTC Y4 Pin"]
+    Y4 = 16,
+    #[doc = "32: PTC Y5 Pin"]
+    Y5 = 32,
+    #[doc = "64: PTC Y6 Pin"]
+    Y6 = 64,
+    #[doc = "128: PTC Y7 Pin"]
+    Y7 = 128,
+    #[doc = "256: PTC Y8 Pin"]
+    Y8 = 256,
+    #[doc = "512: PTC Y9 Pin"]
+    Y9 = 512,
+    #[doc = "1024: PTC Y10 Pin"]
+    Y10 = 1024,
+    #[doc = "2048: PTC Y11 Pin"]
+    Y11 = 2048,
+    #[doc = "4096: PTC Y12 Pin"]
+    Y12 = 4096,
+    #[doc = "8192: PTC Y13 Pin"]
+    Y13 = 8192,
+    #[doc = "16384: PTC Y14 Pin"]
+    Y14 = 16384,
+    #[doc = "32768: PTC Y15 Pin"]
+    Y15 = 32768,
+}
+impl From<YMUX_A> for u16 {
+    #[inline(always)]
+    fn from(variant: YMUX_A) -> Self {
+        variant as _
+    }
+}
+#[doc = "Reader of field `YMUX`"]
+pub type YMUX_R = crate::R<u16, YMUX_A>;
+impl YMUX_R {
+    #[doc = r"Get enumerated values variant"]
+    #[inline(always)]
+    pub fn variant(&self) -> crate::Variant<u16, YMUX_A> {
+        use crate::Variant::*;
+        match self.bits {
+            1 => Val(YMUX_A::Y0),
+            2 => Val(YMUX_A::Y1),
+            4 => Val(YMUX_A::Y2),
+            8 => Val(YMUX_A::Y3),
+            16 => Val(YMUX_A::Y4),
+            32 => Val(YMUX_A::Y5),
+            64 => Val(YMUX_A::Y6),
+            128 => Val(YMUX_A::Y7),
+            256 => Val(YMUX_A::Y8),
+            512 => Val(YMUX_A::Y9),
+            1024 => Val(YMUX_A::Y10),
+            2048 => Val(YMUX_A::Y11),
+            4096 => Val(YMUX_A::Y12),
+            8192 => Val(YMUX_A::Y13),
+            16384 => Val(YMUX_A::Y14),
+            32768 => Val(YMUX_A::Y15),
+            i => Res(i),
+        }
+    }
+    #[doc = "Checks if the value of the field is `Y0`"]
+    #[inline(always)]
+    pub fn is_y0(&self) -> bool {
+        *self == YMUX_A::Y0
+    }
+    #[doc = "Checks if the value of the field is `Y1`"]
+    #[inline(always)]
+    pub fn is_y1(&self) -> bool {
+        *self == YMUX_A::Y1
+    }
+    #[doc = "Checks if the value of the field is `Y2`"]
+    #[inline(always)]
+    pub fn is_y2(&self) -> bool {
+        *self == YMUX_A::Y2
+    }
+    #[doc = "Checks if the value of the field is `Y3`"]
+    #[inline(always)]
+    pub fn is_y3(&self) -> bool {
+        *self == YMUX_A::Y3
+    }
+    #[doc = "Checks if the value of the field is `Y4`"]
+    #[inline(always)]
+    pub fn is_y4(&self) -> bool {
+        *self == YMUX_A::Y4
+    }
+    #[doc = "Checks if the value of the field is `Y5`"]
+    #[inline(always)]
+    pub fn is_y5(&self) -> bool {
+        *self == YMUX_A::Y5
+    }
+    #[doc = "Checks if the value of the field is `Y6`"]
+    #[inline(always)]
+    pub fn is_y6(&self) -> bool {
+        *self == YMUX_A::Y6
+    }
+    #[doc = "Checks if the value of the field is `Y7`"]
+    #[inline(always)]
+    pub fn is_y7(&self) -> bool {
+        *self == YMUX_A::Y7
+    }
+    #[doc = "Checks if the value of the field is `Y8`"]
+    #[inline(always)]
+    pub fn is_y8(&self) -> bool {
+        *self == YMUX_A::Y8
+    }
+    #[doc = "Checks if the value of the field is `Y9`"]
+    #[inline(always)]
+    pub fn is_y9(&self) -> bool {
+        *self == YMUX_A::Y9
+    }
+    #[doc = "Checks if the value of the field is `Y10`"]
+    #[inline(always)]
+    pub fn is_y10(&self) -> bool {
+        *self == YMUX_A::Y10
+    }
+    #[doc = "Checks if the value of the field is `Y11`"]
+    #[inline(always)]
+    pub fn is_y11(&self) -> bool {
+        *self == YMUX_A::Y11
+    }
+    #[doc = "Checks if the value of the field is `Y12`"]
+    #[inline(always)]
+    pub fn is_y12(&self) -> bool {
+        *self == YMUX_A::Y12
+    }
+    #[doc = "Checks if the value of the field is `Y13`"]
+    #[inline(always)]
+    pub fn is_y13(&self) -> bool {
+        *self == YMUX_A::Y13
+    }
+    #[doc = "Checks if the value of the field is `Y14`"]
+    #[inline(always)]
+    pub fn is_y14(&self) -> bool {
+        *self == YMUX_A::Y14
+    }
+    #[doc = "Checks if the value of the field is `Y15`"]
+    #[inline(always)]
+    pub fn is_y15(&self) -> bool {
+        *self == YMUX_A::Y15
+    }
+}
+#[doc = "Write proxy for field `YMUX`"]
+pub struct YMUX_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> YMUX_W<'a> {
+    #[doc = r"Writes `variant` to the field"]
+    #[inline(always)]
+    pub fn variant(self, variant: YMUX_A) -> &'a mut W {
+        unsafe { self.bits(variant.into()) }
+    }
+    #[doc = "PTC Y0 Pin"]
+    #[inline(always)]
+    pub fn y0(self) -> &'a mut W {
+        self.variant(YMUX_A::Y0)
+    }
+    #[doc = "PTC Y1 Pin"]
+    #[inline(always)]
+    pub fn y1(self) -> &'a mut W {
+        self.variant(YMUX_A::Y1)
+    }
+    #[doc = "PTC Y2 Pin"]
+    #[inline(always)]
+    pub fn y2(self) -> &'a mut W {
+        self.variant(YMUX_A::Y2)
+    }
+    #[doc = "PTC Y3 Pin"]
+    #[inline(always)]
+    pub fn y3(self) -> &'a mut W {
+        self.variant(YMUX_A::Y3)
+    }
+    #[doc = "PTC Y4 Pin"]
+    #[inline(always)]
+    pub fn y4(self) -> &'a mut W {
+        self.variant(YMUX_A::Y4)
+    }
+    #[doc = "PTC Y5 Pin"]
+    #[inline(always)]
+    pub fn y5(self) -> &'a mut W {
+        self.variant(YMUX_A::Y5)
+    }
+    #[doc = "PTC Y6 Pin"]
+    #[inline(always)]
+    pub fn y6(self) -> &'a mut W {
+        self.variant(YMUX_A::Y6)
+    }
+    #[doc = "PTC Y7 Pin"]
+    #[inline(always)]
+    pub fn y7(self) -> &'a mut W {
+        self.variant(YMUX_A::Y7)
+    }
+    #[doc = "PTC Y8 Pin"]
+    #[inline(always)]
+    pub fn y8(self) -> &'a mut W {
+        self.variant(YMUX_A::Y8)
+    }
+    #[doc = "PTC Y9 Pin"]
+    #[inline(always)]
+    pub fn y9(self) -> &'a mut W {
+        self.variant(YMUX_A::Y9)
+    }
+    #[doc = "PTC Y10 Pin"]
+    #[inline(always)]
+    pub fn y10(self) -> &'a mut W {
+        self.variant(YMUX_A::Y10)
+    }
+    #[doc = "PTC Y11 Pin"]
+    #[inline(always)]
+    pub fn y11(self) -> &'a mut W {
+        self.variant(YMUX_A::Y11)
+    }
+    #[doc = "PTC Y12 Pin"]
+    #[inline(always)]
+    pub fn y12(self) -> &'a mut W {
+        self.variant(YMUX_A::Y12)
+    }
+    #[doc = "PTC Y13 Pin"]
+    #[inline(always)]
+    pub fn y13(self) -> &'a mut W {
+        self.variant(YMUX_A::Y13)
+    }
+    #[doc = "PTC Y14 Pin"]
+    #[inline(always)]
+    pub fn y14(self) -> &'a mut W {
+        self.variant(YMUX_A::Y14)
+    }
+    #[doc = "PTC Y15 Pin"]
+    #[inline(always)]
+    pub fn y15(self) -> &'a mut W {
+        self.variant(YMUX_A::Y15)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub unsafe fn bits(self, value: u16) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0xffff) | ((value as u16) & 0xffff);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bits 0:15 - Y line selection MUX"]
+    #[inline(always)]
+    pub fn ymux(&self) -> YMUX_R {
+        YMUX_R::new((self.bits & 0xffff) as u16)
+    }
+}
+impl W {
+    #[doc = "Bits 0:15 - Y line selection MUX"]
+    #[inline(always)]
+    pub fn ymux(&mut self) -> YMUX_W {
+        YMUX_W { w: self }
+    }
+}

--- a/pac/atsamd21e/src/ptc/yselecten.rs
+++ b/pac/atsamd21e/src/ptc/yselecten.rs
@@ -1,0 +1,560 @@
+#[doc = "Reader of register YSELECTEN"]
+pub type R = crate::R<u16, super::YSELECTEN>;
+#[doc = "Writer for register YSELECTEN"]
+pub type W = crate::W<u16, super::YSELECTEN>;
+#[doc = "Register YSELECTEN `reset()`'s with value 0"]
+impl crate::ResetValue for super::YSELECTEN {
+    type Type = u16;
+    #[inline(always)]
+    fn reset_value() -> Self::Type {
+        0
+    }
+}
+#[doc = "Reader of field `Y0EN`"]
+pub type Y0EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y0EN`"]
+pub struct Y0EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y0EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !0x01) | ((value as u16) & 0x01);
+        self.w
+    }
+}
+#[doc = "Reader of field `Y1EN`"]
+pub type Y1EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y1EN`"]
+pub struct Y1EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y1EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 1)) | (((value as u16) & 0x01) << 1);
+        self.w
+    }
+}
+#[doc = "Reader of field `Y2EN`"]
+pub type Y2EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y2EN`"]
+pub struct Y2EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y2EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 2)) | (((value as u16) & 0x01) << 2);
+        self.w
+    }
+}
+#[doc = "Reader of field `Y3EN`"]
+pub type Y3EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y3EN`"]
+pub struct Y3EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y3EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 3)) | (((value as u16) & 0x01) << 3);
+        self.w
+    }
+}
+#[doc = "Reader of field `Y4EN`"]
+pub type Y4EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y4EN`"]
+pub struct Y4EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y4EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 4)) | (((value as u16) & 0x01) << 4);
+        self.w
+    }
+}
+#[doc = "Reader of field `Y5EN`"]
+pub type Y5EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y5EN`"]
+pub struct Y5EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y5EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 5)) | (((value as u16) & 0x01) << 5);
+        self.w
+    }
+}
+#[doc = "Reader of field `Y6EN`"]
+pub type Y6EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y6EN`"]
+pub struct Y6EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y6EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 6)) | (((value as u16) & 0x01) << 6);
+        self.w
+    }
+}
+#[doc = "Reader of field `Y7EN`"]
+pub type Y7EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y7EN`"]
+pub struct Y7EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y7EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 7)) | (((value as u16) & 0x01) << 7);
+        self.w
+    }
+}
+#[doc = "Reader of field `Y8EN`"]
+pub type Y8EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y8EN`"]
+pub struct Y8EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y8EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 8)) | (((value as u16) & 0x01) << 8);
+        self.w
+    }
+}
+#[doc = "Reader of field `Y9EN`"]
+pub type Y9EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y9EN`"]
+pub struct Y9EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y9EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 9)) | (((value as u16) & 0x01) << 9);
+        self.w
+    }
+}
+#[doc = "Reader of field `Y10EN`"]
+pub type Y10EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y10EN`"]
+pub struct Y10EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y10EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 10)) | (((value as u16) & 0x01) << 10);
+        self.w
+    }
+}
+#[doc = "Reader of field `Y11EN`"]
+pub type Y11EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y11EN`"]
+pub struct Y11EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y11EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 11)) | (((value as u16) & 0x01) << 11);
+        self.w
+    }
+}
+#[doc = "Reader of field `Y12EN`"]
+pub type Y12EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y12EN`"]
+pub struct Y12EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y12EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 12)) | (((value as u16) & 0x01) << 12);
+        self.w
+    }
+}
+#[doc = "Reader of field `Y13EN`"]
+pub type Y13EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y13EN`"]
+pub struct Y13EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y13EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 13)) | (((value as u16) & 0x01) << 13);
+        self.w
+    }
+}
+#[doc = "Reader of field `Y14EN`"]
+pub type Y14EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y14EN`"]
+pub struct Y14EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y14EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 14)) | (((value as u16) & 0x01) << 14);
+        self.w
+    }
+}
+#[doc = "Reader of field `Y15EN`"]
+pub type Y15EN_R = crate::R<bool, bool>;
+#[doc = "Write proxy for field `Y15EN`"]
+pub struct Y15EN_W<'a> {
+    w: &'a mut W,
+}
+impl<'a> Y15EN_W<'a> {
+    #[doc = r"Sets the field bit"]
+    #[inline(always)]
+    pub fn set_bit(self) -> &'a mut W {
+        self.bit(true)
+    }
+    #[doc = r"Clears the field bit"]
+    #[inline(always)]
+    pub fn clear_bit(self) -> &'a mut W {
+        self.bit(false)
+    }
+    #[doc = r"Writes raw bits to the field"]
+    #[inline(always)]
+    pub fn bit(self, value: bool) -> &'a mut W {
+        self.w.bits = (self.w.bits & !(0x01 << 15)) | (((value as u16) & 0x01) << 15);
+        self.w
+    }
+}
+impl R {
+    #[doc = "Bit 0 - PTC Y0 pin enable"]
+    #[inline(always)]
+    pub fn y0en(&self) -> Y0EN_R {
+        Y0EN_R::new((self.bits & 0x01) != 0)
+    }
+    #[doc = "Bit 1 - PTC Y1 pin enable"]
+    #[inline(always)]
+    pub fn y1en(&self) -> Y1EN_R {
+        Y1EN_R::new(((self.bits >> 1) & 0x01) != 0)
+    }
+    #[doc = "Bit 2 - PTC Y2 pin enable"]
+    #[inline(always)]
+    pub fn y2en(&self) -> Y2EN_R {
+        Y2EN_R::new(((self.bits >> 2) & 0x01) != 0)
+    }
+    #[doc = "Bit 3 - PTC Y3 pin enable"]
+    #[inline(always)]
+    pub fn y3en(&self) -> Y3EN_R {
+        Y3EN_R::new(((self.bits >> 3) & 0x01) != 0)
+    }
+    #[doc = "Bit 4 - PTC Y4 pin enable"]
+    #[inline(always)]
+    pub fn y4en(&self) -> Y4EN_R {
+        Y4EN_R::new(((self.bits >> 4) & 0x01) != 0)
+    }
+    #[doc = "Bit 5 - PTC Y5 pin enable"]
+    #[inline(always)]
+    pub fn y5en(&self) -> Y5EN_R {
+        Y5EN_R::new(((self.bits >> 5) & 0x01) != 0)
+    }
+    #[doc = "Bit 6 - PTC Y6 pin enable"]
+    #[inline(always)]
+    pub fn y6en(&self) -> Y6EN_R {
+        Y6EN_R::new(((self.bits >> 6) & 0x01) != 0)
+    }
+    #[doc = "Bit 7 - PTC Y7 pin enable"]
+    #[inline(always)]
+    pub fn y7en(&self) -> Y7EN_R {
+        Y7EN_R::new(((self.bits >> 7) & 0x01) != 0)
+    }
+    #[doc = "Bit 8 - PTC Y8 pin enable"]
+    #[inline(always)]
+    pub fn y8en(&self) -> Y8EN_R {
+        Y8EN_R::new(((self.bits >> 8) & 0x01) != 0)
+    }
+    #[doc = "Bit 9 - PTC Y9 pin enable"]
+    #[inline(always)]
+    pub fn y9en(&self) -> Y9EN_R {
+        Y9EN_R::new(((self.bits >> 9) & 0x01) != 0)
+    }
+    #[doc = "Bit 10 - PTC Y10 pin enable"]
+    #[inline(always)]
+    pub fn y10en(&self) -> Y10EN_R {
+        Y10EN_R::new(((self.bits >> 10) & 0x01) != 0)
+    }
+    #[doc = "Bit 11 - PTC Y11 pin enable"]
+    #[inline(always)]
+    pub fn y11en(&self) -> Y11EN_R {
+        Y11EN_R::new(((self.bits >> 11) & 0x01) != 0)
+    }
+    #[doc = "Bit 12 - PTC Y12 pin enable"]
+    #[inline(always)]
+    pub fn y12en(&self) -> Y12EN_R {
+        Y12EN_R::new(((self.bits >> 12) & 0x01) != 0)
+    }
+    #[doc = "Bit 13 - PTC Y13 pin enable"]
+    #[inline(always)]
+    pub fn y13en(&self) -> Y13EN_R {
+        Y13EN_R::new(((self.bits >> 13) & 0x01) != 0)
+    }
+    #[doc = "Bit 14 - PTC Y14 pin enable"]
+    #[inline(always)]
+    pub fn y14en(&self) -> Y14EN_R {
+        Y14EN_R::new(((self.bits >> 14) & 0x01) != 0)
+    }
+    #[doc = "Bit 15 - PTC Y15 pin enable"]
+    #[inline(always)]
+    pub fn y15en(&self) -> Y15EN_R {
+        Y15EN_R::new(((self.bits >> 15) & 0x01) != 0)
+    }
+}
+impl W {
+    #[doc = "Bit 0 - PTC Y0 pin enable"]
+    #[inline(always)]
+    pub fn y0en(&mut self) -> Y0EN_W {
+        Y0EN_W { w: self }
+    }
+    #[doc = "Bit 1 - PTC Y1 pin enable"]
+    #[inline(always)]
+    pub fn y1en(&mut self) -> Y1EN_W {
+        Y1EN_W { w: self }
+    }
+    #[doc = "Bit 2 - PTC Y2 pin enable"]
+    #[inline(always)]
+    pub fn y2en(&mut self) -> Y2EN_W {
+        Y2EN_W { w: self }
+    }
+    #[doc = "Bit 3 - PTC Y3 pin enable"]
+    #[inline(always)]
+    pub fn y3en(&mut self) -> Y3EN_W {
+        Y3EN_W { w: self }
+    }
+    #[doc = "Bit 4 - PTC Y4 pin enable"]
+    #[inline(always)]
+    pub fn y4en(&mut self) -> Y4EN_W {
+        Y4EN_W { w: self }
+    }
+    #[doc = "Bit 5 - PTC Y5 pin enable"]
+    #[inline(always)]
+    pub fn y5en(&mut self) -> Y5EN_W {
+        Y5EN_W { w: self }
+    }
+    #[doc = "Bit 6 - PTC Y6 pin enable"]
+    #[inline(always)]
+    pub fn y6en(&mut self) -> Y6EN_W {
+        Y6EN_W { w: self }
+    }
+    #[doc = "Bit 7 - PTC Y7 pin enable"]
+    #[inline(always)]
+    pub fn y7en(&mut self) -> Y7EN_W {
+        Y7EN_W { w: self }
+    }
+    #[doc = "Bit 8 - PTC Y8 pin enable"]
+    #[inline(always)]
+    pub fn y8en(&mut self) -> Y8EN_W {
+        Y8EN_W { w: self }
+    }
+    #[doc = "Bit 9 - PTC Y9 pin enable"]
+    #[inline(always)]
+    pub fn y9en(&mut self) -> Y9EN_W {
+        Y9EN_W { w: self }
+    }
+    #[doc = "Bit 10 - PTC Y10 pin enable"]
+    #[inline(always)]
+    pub fn y10en(&mut self) -> Y10EN_W {
+        Y10EN_W { w: self }
+    }
+    #[doc = "Bit 11 - PTC Y11 pin enable"]
+    #[inline(always)]
+    pub fn y11en(&mut self) -> Y11EN_W {
+        Y11EN_W { w: self }
+    }
+    #[doc = "Bit 12 - PTC Y12 pin enable"]
+    #[inline(always)]
+    pub fn y12en(&mut self) -> Y12EN_W {
+        Y12EN_W { w: self }
+    }
+    #[doc = "Bit 13 - PTC Y13 pin enable"]
+    #[inline(always)]
+    pub fn y13en(&mut self) -> Y13EN_W {
+        Y13EN_W { w: self }
+    }
+    #[doc = "Bit 14 - PTC Y14 pin enable"]
+    #[inline(always)]
+    pub fn y14en(&mut self) -> Y14EN_W {
+        Y14EN_W { w: self }
+    }
+    #[doc = "Bit 15 - PTC Y15 pin enable"]
+    #[inline(always)]
+    pub fn y15en(&mut self) -> Y15EN_W {
+        Y15EN_W { w: self }
+    }
+}

--- a/svd/ATSAMD21E18A.svd
+++ b/svd/ATSAMD21E18A.svd
@@ -5390,6 +5390,11 @@
                   <value>0x21</value>
                 </enumeratedValue>
                 <enumeratedValue>
+                  <name>PTC</name>
+                  <description>PTCReserved</description>
+                  <value>0x22</value>
+                </enumeratedValue>
+                <enumeratedValue>
                   <name>I2S_0</name>
                   <description>I2S_0</description>
                   <value>0x23</value>
@@ -8202,6 +8207,834 @@
               <access>write-only</access>
             </field>
           </fields>
+        </register>
+      </registers>
+    </peripheral>
+    <!--This section is a best guess based on Adafruit's FreeTouch repo.-->
+    <peripheral>
+      <name>PTC</name>
+      <version>1.0.0</version>
+      <description>Peripheral Touch Controller</description>
+      <groupName>PTC</groupName>
+      <prependToName>PTC_</prependToName>
+      <baseAddress>0x42004C00</baseAddress>
+      <addressBlock>
+        <offset>0</offset>
+        <size>0x28</size>
+        <usage>registers</usage>
+      </addressBlock>
+      <interrupt>
+        <name>PTC</name>
+        <value>26</value>
+      </interrupt>
+      <registers>
+        <register>
+          <name>CTRLA</name>
+          <description>Control A</description>
+          <addressOffset>0x00</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SWRST</name>
+              <description>Software Reset</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>ENABLE</name>
+              <description>Enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>RUNSTDBY</name>
+              <description>Run in Standby</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CTRLB</name>
+          <description>Control B</description>
+          <addressOffset>0x01</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SYNCFLAG</name>
+              <description>Synchronisation flag</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <!--Maybe this is like REFCTRL in ADC?-->
+          <name>UNK4C04</name>
+          <description>Unknown Register 0x42004C04</description>
+          <addressOffset>0x04</addressOffset>
+          <size>8</size>
+        </register>
+        <register>
+          <name>CTRLC</name>
+          <description>Control C</description>
+          <addressOffset>0x05</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>INIT</name>
+              <description>Initialize</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENCLR</name>
+          <description>Interrupt Enable Clear</description>
+          <addressOffset>0x08</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EOC</name>
+              <description>Interrupt on end of comparison</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WCO</name>
+              <description>Watch crystal oscillator interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTENSET</name>
+          <description>Interrupt Enable Set</description>
+          <addressOffset>0x09</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EOC</name>
+              <description>Interrupt on end of comparison</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WCO</name>
+              <description>Watch crystal oscillator interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTFLAG</name>
+          <description>Interrupt Flag Status and Clear</description>
+          <addressOffset>0x0A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>EOC</name>
+              <description>Interrupt end of comparison</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>WCO</name>
+              <description>Watch crystal oscillator interrupt</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>FREQCTRL</name>
+          <description>Frequency Control</description>
+          <addressOffset>0x0C</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>SAMPLEDELAY</name>
+              <description>Sample delay</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>4</bitWidth>
+              <enumeratedValues>
+                <name>FREQHOP</name>
+                <enumeratedValue>
+                  <name>FREQHOP1</name>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FREQHOP2</name>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FREQHOP3</name>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FREQHOP4</name>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FREQHOP5</name>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FREQHOP6</name>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FREQHOP7</name>
+                  <value>0x6</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FREQHOP8</name>
+                  <value>0x7</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FREQHOP9</name>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FREQHOP10</name>
+                  <value>0x9</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FREQHOP11</name>
+                  <value>0xA</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FREQHOP12</name>
+                  <value>0xB</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FREQHOP13</name>
+                  <value>0xC</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FREQHOP14</name>
+                  <value>0xD</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FREQHOP15</name>
+                  <value>0xE</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>FREQHOP16</name>
+                  <value>0xF</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>FREQSPREADEN</name>
+              <description>Enable frequency spread</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>CONVCTRL</name>
+          <description>Conversion control</description>
+          <addressOffset>0x0D</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>ADCACCUM</name>
+              <description>ADC Accumulator</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+              <enumeratedValues>
+                <name>OVERSAMPLECOUNT</name>
+                <enumeratedValue>
+                  <name>OVERSAMPLE1</name>
+                  <description>1 sample per report</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OVERSAMPLE2</name>
+                  <description>2 samples per report</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OVERSAMPLE4</name>
+                  <description>4 samples per report</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OVERSAMPLE8</name>
+                  <description>8 samples per report</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OVERSAMPLE16</name>
+                  <description>16 samples per report</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OVERSAMPLE32</name>
+                  <description>32 samples per report</description>
+                  <value>0x5</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>OVERSAMPLE64</name>
+                  <description>64 samples per report</description>
+                  <value>0x6</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+            <field>
+              <name>CONVERT</name>
+              <description>Start conversion</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>YSELECT</name>
+          <description>Select Y line</description>
+          <addressOffset>0x10</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>YMUX</name>
+              <description>Y line selection MUX</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <enumeratedValues>
+                <name>YMUXSelect</name>
+                <enumeratedValue>
+                  <name>Y0</name>
+                  <description>PTC Y0 Pin</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Y1</name>
+                  <description>PTC Y1 Pin</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Y2</name>
+                  <description>PTC Y2 Pin</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Y3</name>
+                  <description>PTC Y3 Pin</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Y4</name>
+                  <description>PTC Y4 Pin</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Y5</name>
+                  <description>PTC Y5 Pin</description>
+                  <value>0x20</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Y6</name>
+                  <description>PTC Y6 Pin</description>
+                  <value>0x40</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Y7</name>
+                  <description>PTC Y7 Pin</description>
+                  <value>0x80</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Y8</name>
+                  <description>PTC Y8 Pin</description>
+                  <value>0x100</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Y9</name>
+                  <description>PTC Y9 Pin</description>
+                  <value>0x200</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Y10</name>
+                  <description>PTC Y10 Pin</description>
+                  <value>0x400</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Y11</name>
+                  <description>PTC Y11 Pin</description>
+                  <value>0x800</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Y12</name>
+                  <description>PTC Y12 Pin</description>
+                  <value>0x1000</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Y13</name>
+                  <description>PTC Y13 Pin</description>
+                  <value>0x2000</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Y14</name>
+                  <description>PTC Y14 Pin</description>
+                  <value>0x4000</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>Y15</name>
+                  <description>PTC Y15 Pin</description>
+                  <value>0x8000</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>XSELECT</name>
+          <description>Select X line</description>
+          <addressOffset>0x12</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>XMUX</name>
+              <description>X line selection MUX</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <enumeratedValues>
+                <name>XMUXSelect</name>
+                <enumeratedValue>
+                  <name>X0</name>
+                  <description>PTC X0 Pin</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>X1</name>
+                  <description>PTC X1 Pin</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>X2</name>
+                  <description>PTC X2 Pin</description>
+                  <value>0x4</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>X3</name>
+                  <description>PTC X3 Pin</description>
+                  <value>0x8</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>X4</name>
+                  <description>PTC X4 Pin</description>
+                  <value>0x10</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>X5</name>
+                  <description>PTC X5 Pin</description>
+                  <value>0x20</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>X6</name>
+                  <description>PTC X6 Pin</description>
+                  <value>0x40</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>X7</name>
+                  <description>PTC X7 Pin</description>
+                  <value>0x80</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>X8</name>
+                  <description>PTC X8 Pin</description>
+                  <value>0x100</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>X9</name>
+                  <description>PTC X9 Pin</description>
+                  <value>0x200</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>X10</name>
+                  <description>PTC X10 Pin</description>
+                  <value>0x400</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>X11</name>
+                  <description>PTC X11 Pin</description>
+                  <value>0x800</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>X12</name>
+                  <description>PTC X12 Pin</description>
+                  <value>0x1000</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>X13</name>
+                  <description>PTC X13 Pin</description>
+                  <value>0x2000</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>X14</name>
+                  <description>PTC X14 Pin</description>
+                  <value>0x4000</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>X15</name>
+                  <description>PTC X15 Pin</description>
+                  <value>0x8000</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>YSELECTEN</name>
+          <description>Enable Y lines</description>
+          <addressOffset>0x14</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>Y0EN</name>
+              <description>PTC Y0 pin enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>Y1EN</name>
+              <description>PTC Y1 pin enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>Y2EN</name>
+              <description>PTC Y2 pin enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>Y3EN</name>
+              <description>PTC Y3 pin enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>Y4EN</name>
+              <description>PTC Y4 pin enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>Y5EN</name>
+              <description>PTC Y5 pin enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>Y6EN</name>
+              <description>PTC Y6 pin enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>Y7EN</name>
+              <description>PTC Y7 pin enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>Y8EN</name>
+              <description>PTC Y8 pin enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>Y9EN</name>
+              <description>PTC Y9 pin enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>Y10EN</name>
+              <description>PTC Y10 pin enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>Y11EN</name>
+              <description>PTC Y11 pin enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>Y12EN</name>
+              <description>PTC Y12 pin enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>Y13EN</name>
+              <description>PTC Y13 pin enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>Y14EN</name>
+              <description>PTC Y14 pin enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>Y15EN</name>
+              <description>PTC Y15 pin enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>XSELECTEN</name>
+          <description>Enable X lines</description>
+          <addressOffset>0x16</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>X0EN</name>
+              <description>PTC X0 pin enable</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>X1EN</name>
+              <description>PTC X1 pin enable</description>
+              <bitOffset>1</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>X2EN</name>
+              <description>PTC X2 pin enable</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>X3EN</name>
+              <description>PTC X3 pin enable</description>
+              <bitOffset>3</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>X4EN</name>
+              <description>PTC X4 pin enable</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>X5EN</name>
+              <description>PTC X5 pin enable</description>
+              <bitOffset>5</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>X6EN</name>
+              <description>PTC X6 pin enable</description>
+              <bitOffset>6</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>X7EN</name>
+              <description>PTC X7 pin enable</description>
+              <bitOffset>7</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>X8EN</name>
+              <description>PTC X8 pin enable</description>
+              <bitOffset>8</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>X9EN</name>
+              <description>PTC X9 pin enable</description>
+              <bitOffset>9</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>X10EN</name>
+              <description>PTC X10 pin enable</description>
+              <bitOffset>10</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>X11EN</name>
+              <description>PTC X11 pin enable</description>
+              <bitOffset>11</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>X12EN</name>
+              <description>PTC X12 pin enable</description>
+              <bitOffset>12</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>X13EN</name>
+              <description>PTC X13 pin enable</description>
+              <bitOffset>13</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>X14EN</name>
+              <description>PTC X14 pin enable</description>
+              <bitOffset>14</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>X15EN</name>
+              <description>PTC X15 pin enable</description>
+              <bitOffset>15</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>COMPCAP</name>
+          <description>Compensation capacitor value</description>
+          <addressOffset>0x18</addressOffset>
+          <size>16</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>14</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>INTCAP</name>
+          <description>Internal capacitor value</description>
+          <addressOffset>0x1A</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>VALUE</name>
+              <description>Value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>6</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>SERRES</name>
+          <description>Series resistor for PTC measurements</description>
+          <addressOffset>0x1B</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>RESISTOR</name>
+              <description>Resistor value</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>2</bitWidth>
+              <enumeratedValues>
+                <name>RESVALUE</name>
+                <enumeratedValue>
+                  <name>RES0</name>
+                  <description>No series resistor</description>
+                  <value>0x0</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RES20K</name>
+                  <description>20 kiloohm series resistor</description>
+                  <value>0x1</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RES50K</name>
+                  <description>50 kiloohm series resistor</description>
+                  <value>0x2</value>
+                </enumeratedValue>
+                <enumeratedValue>
+                  <name>RES100K</name>
+                  <description>100 kiloohm series resistor</description>
+                  <value>0x3</value>
+                </enumeratedValue>
+              </enumeratedValues>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>RESULT</name>
+          <description>Conversion result</description>
+          <addressOffset>0x1C</addressOffset>
+          <size>16</size>
+          <access>read-only</access>
+          <fields>
+            <field>
+              <name>RESULT</name>
+              <description>Result of conversion</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>16</bitWidth>
+              <access>read-only</access>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>BURSTMODE</name>
+          <description>Enable burst or clear to send low power mode</description>
+          <addressOffset>0x20</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>CTSLOWPOWEREN</name>
+              <description>Enable clear to send low power mode</description>
+              <bitOffset>2</bitOffset>
+              <bitWidth>1</bitWidth>
+            </field>
+            <field>
+              <name>BURSTMODE</name>
+              <description>Burst mode setting</description>
+              <bitOffset>4</bitOffset>
+              <bitWidth>4</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <!--The rest of these are unused or have unknown uses, but are included for the sake of completeness.-->
+        <register>
+          <name>WCOMODE</name>
+          <description>Set WCO mode</description>
+          <addressOffset>0x21</addressOffset>
+          <size>8</size>
+          <fields>
+            <field>
+              <name>MODE</name>
+              <description>Set WCO mode</description>
+              <bitOffset>0</bitOffset>
+              <bitWidth>3</bitWidth>
+            </field>
+          </fields>
+        </register>
+        <register>
+          <name>WCOTHRESHOLDAL</name>
+          <description>Set lower WCO threshold for port A</description>
+          <addressOffset>0x24</addressOffset>
+          <size>8</size>
+        </register>
+        <register>
+          <name>WCOTHRESHOLDAH</name>
+          <description>Set upper WCO threshold for port A</description>
+          <addressOffset>0x25</addressOffset>
+          <size>8</size>
+        </register>
+        <register>
+          <name>WCOTHRESHOLDBL</name>
+          <description>Set lower WCO threshold for port B</description>
+          <addressOffset>0x26</addressOffset>
+          <size>8</size>
+        </register>
+        <register>
+          <name>WCOTHRESHOLDBH</name>
+          <description>Set upper WCO threshold for port B</description>
+          <addressOffset>0x27</addressOffset>
+          <size>8</size>
         </register>
       </registers>
     </peripheral>


### PR DESCRIPTION
I went to rewrite some firmware for a little Trinket M0 device I got recently when I noticed that the [Adafruit `FreeTouch` library](https://github.com/adafruit/Adafruit_FreeTouch) it depended on uses the board's PTC capabilities, which I was unable to find any documentation or information on in `embedded-hal`, `atsamd-hal`, etc. So I took a look into the SVD file for the board (specifically ATSAMD21E18) and found that PTC information was missing from it completely. I also went to Microchip's website and got the most up-to-date SVD files I could, which similarly were missing them. That being the case, I wrote in that information as best I could based on the [SAMD21{E,G,J} datasheet](https://cdn.sparkfun.com/datasheets/Dev/Arduino/Boards/Atmel-42181-SAM-D21_Datasheet.pdf) and the `FreeTouch` repository, specifically relying heavily on `adafruit_ptc.c` and `samd21_ptc_component.h`. I did take some liberties when translating the contents of `samd21_ptc_component.h` into the SVD file based on the contents of the rest of the file (especially the `ADC` peripheral section). It's also the first time I've ever done any work with SVD files. I mention this as a sort of warning in case what I made is just horrifically bad, since I don't know what's good yet.

I've only implemented PTC for SAMD21E so far, though it should be relatively simple to add it to the G and J variants as well by copying the PTC peripheral and generic clock section ID enumerated value to the SVD files for those chips, and adding the correct pin mappings according to the datasheet linked to earlier (found in table 6.1). A little bit more work needs to be done to handle the X signal lines for use in mutual-capacitance PTC, though I think that could be done by just treating Y lines as channels [0, 16) and X lines as channels [16, 32), doing a check for the channel ID being greater than 15, and subtracting 16 from the ID and using that to enable an X line. Maybe that'll be my next commit. But as of now, self-capacitance PTC should be working.

Last thing of note, then: I currently am unable to verify whether this works on hardware. While having this implementation is nice, it's just the boilerplate necessary to create an implementation of `FreeTouch`, which I can then use to verify functionality. So what I'm PRing with now is a, "Hey, I did this thing that smells about right," sort of deal.