### PR TITLE
Add support for the P1AM-100 board

### DIFF
--- a/boards/p1am_100/.cargo/config
+++ b/boards/p1am_100/.cargo/config
@@ -1,0 +1,15 @@
+# samd21 is a Cortex-M0 and thus thumbv6m
+
+[build]
+target = "thumbv6m-none-eabi"
+
+[target.thumbv6m-none-eabi]
+runner = 'arm-none-eabi-gdb'
+rustflags = [
+
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+  
+  "-C", "link-arg=-Tlink.x",
+]

--- a/boards/p1am_100/Cargo.toml
+++ b/boards/p1am_100/Cargo.toml
@@ -112,9 +112,5 @@ name = "sleeping_timer"
 name = "sleeping_timer_rtc"
 
 [[example]]
-name = "dmac"
-required-features = ["dma"]
-
-[[example]]
 name = "clock"
 required-features = ["usb"]

--- a/boards/p1am_100/Cargo.toml
+++ b/boards/p1am_100/Cargo.toml
@@ -18,6 +18,10 @@ nb = "0.1"
 version = "0.6.12"
 optional = true
 
+[dependencies.cortex-m-rtic]
+version = "0.5.1"
+optional = true
+
 [dependencies.atsamd-hal]
 path = "../../hal"
 version = "0.12"
@@ -55,6 +59,7 @@ nb = "0.1"
 drogue-nom-utils = "0.1"
 nom = { version = "5.1", default-features= false }
 heapless = "0.5"
+cortex-m-rtic = "0.5.1"
 
 [features]
 # ask the HAL to enable atsamd21g support
@@ -114,7 +119,11 @@ name = "ssd1306_terminalmode_128x64_spi"
 
 [[example]]
 name = "usb_echo"
-required-features = ["usb"]
+required-features = ["usb", "unproven"]
+
+[[example]]
+name = "usb_echo_rtic"
+required-features = ["usb", "unproven"]
 
 [[example]]
 name = "sleeping_timer"

--- a/boards/p1am_100/Cargo.toml
+++ b/boards/p1am_100/Cargo.toml
@@ -1,0 +1,131 @@
+[package]
+name = "p1am_100"
+version = "0.1.0"
+authors = ["Quentin Smith <quentin@mit.edu>"]
+description = "Board Support crate for the Facts Engineering P1AM-100"
+keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/atsamd-rs/atsamd"
+readme = "README.md"
+edition = "2018"
+
+[dependencies]
+cortex-m = "0.6"
+embedded-hal = "0.2.3"
+nb = "0.1"
+
+[dependencies.cortex-m-rt]
+version = "0.6.12"
+optional = true
+
+[dependencies.atsamd-hal]
+path = "../../hal"
+version = "0.12"
+default-features = false
+
+[dependencies.panic-abort]
+version = "0.3"
+optional = true
+
+[dependencies.panic-halt]
+version = "0.2"
+optional = true
+
+[dependencies.panic-semihosting]
+version = "0.5"
+optional = true
+
+[dependencies.panic_rtt]
+version = "0.1"
+optional = true
+
+[dependencies.usb-device]
+version = "0.2"
+optional = true
+
+[dependencies.usbd-serial]
+version = "0.1"
+optional = true
+
+[dev-dependencies]
+cortex-m-semihosting = "0.3"
+ssd1306 = "0.3.1"
+embedded-graphics = "0.6.0"
+nb = "0.1"
+drogue-nom-utils = "0.1"
+nom = { version = "5.1", default-features= false }
+heapless = "0.5"
+
+[features]
+# ask the HAL to enable atsamd21g support
+default = ["rt", "atsamd-hal/samd21g", "panic_halt"]
+rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
+unproven = ["atsamd-hal/unproven"]
+use_rtt = ["atsamd-hal/use_rtt", "panic_rtt"]
+usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
+panic_halt = ["panic-halt"]
+panic_abort = ["panic-abort"]
+panic_semihosting = ["panic-semihosting"]
+dma = ["atsamd-hal/dma"]
+max-channels = ["dma", "atsamd-hal/max-channels"]
+
+[profile.dev]
+incremental = false
+codegen-units = 1
+debug = true
+lto = false
+
+[profile.release]
+debug = true
+lto = true
+opt-level = "s"
+
+[[example]]
+name = "blinky_basic"
+
+[[example]]
+name = "timers"
+
+[[example]]
+name = "pwm"
+required-features = ["unproven"]
+
+[[example]]
+name = "adc"
+required-features = ["unproven"]
+
+[[example]]
+name = "ssd1306_graphicsmode_128x64_i2c"
+
+[[example]]
+name = "ssd1306_graphicsmode_128x32_i2c"
+
+[[example]]
+name = "ssd1306_terminalmode_128x32_i2c"
+
+[[example]]
+name = "ssd1306_terminalmode_128x64_i2c"
+
+[[example]]
+name = "ssd1306_graphicsmode_128x64_spi"
+
+[[example]]
+name = "ssd1306_terminalmode_128x64_spi"
+
+[[example]]
+name = "usb_echo"
+required-features = ["usb"]
+
+[[example]]
+name = "sleeping_timer"
+
+[[example]]
+name = "sleeping_timer_rtc"
+
+[[example]]
+name = "dmac"
+required-features = ["dma"]
+
+[[example]]
+name = "clock"
+required-features = ["usb"]

--- a/boards/p1am_100/Cargo.toml
+++ b/boards/p1am_100/Cargo.toml
@@ -53,8 +53,6 @@ optional = true
 
 [dev-dependencies]
 cortex-m-semihosting = "0.3"
-ssd1306 = "0.3.1"
-embedded-graphics = "0.6.0"
 nb = "0.1"
 drogue-nom-utils = "0.1"
 nom = { version = "5.1", default-features= false }
@@ -98,24 +96,6 @@ required-features = ["unproven"]
 [[example]]
 name = "adc"
 required-features = ["unproven"]
-
-[[example]]
-name = "ssd1306_graphicsmode_128x64_i2c"
-
-[[example]]
-name = "ssd1306_graphicsmode_128x32_i2c"
-
-[[example]]
-name = "ssd1306_terminalmode_128x32_i2c"
-
-[[example]]
-name = "ssd1306_terminalmode_128x64_i2c"
-
-[[example]]
-name = "ssd1306_graphicsmode_128x64_spi"
-
-[[example]]
-name = "ssd1306_terminalmode_128x64_spi"
 
 [[example]]
 name = "usb_echo"

--- a/boards/p1am_100/README.md
+++ b/boards/p1am_100/README.md
@@ -1,0 +1,29 @@
+# Adafruit Feather M0 Board Support Crate
+
+This crate provides a type-safe API for working with the [Adafruit Feather M0
+board](https://www.adafruit.com/product/2772).
+
+## Prerequisites
+* Install the cross compile toolchain `rustup target add thumbv6m-none-eabi`
+* Install [cargo-hf2 the hf2 bootloader flasher tool](https://crates.io/crates/cargo-hf2) however your platform requires
+
+## Uploading an example
+Check out the repository for examples:
+
+https://github.com/atsamd-rs/atsamd/tree/master/boards/feather_m0/examples
+
+* Be in this directory `cd boards/feather_m0`
+* Put your device in bootloader mode usually by hitting the reset button twice.
+* Build and upload in one step
+```
+$ cargo hf2 --release --example blinky_basic
+    Finished release [optimized + debuginfo] target(s) in 0.19s
+    Searching for a connected device with known vid/pid pair.
+    Trying  Ok(Some("Adafruit Industries")) Ok(Some("PyBadge"))
+    Flashing "/Users/User/atsamd/boards/feather_m0/target/thumbv7em-none-eabihf/release/examples/blinky_basic"
+    Finished in 0.079s
+$
+```
+
+Note that some older Feather M0 boards do not come with support for HF2. For these boards,
+you can upload using the `bossa` tool as described in the [atsamd crate documentation](https://github.com/atsamd-rs/atsamd#getting-code-onto-the-device-gemma-m0).

--- a/boards/p1am_100/build.rs
+++ b/boards/p1am_100/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+fn main() {
+    if env::var_os("CARGO_FEATURE_RT").is_some() {
+        let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+        File::create(out.join("memory.x"))
+            .unwrap()
+            .write_all(include_bytes!("memory.x"))
+            .unwrap();
+        println!("cargo:rustc-link-search={}", out.display());
+        println!("cargo:rerun-if-changed=memory.x");
+    }
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/boards/p1am_100/examples/adc.rs
+++ b/boards/p1am_100/examples/adc.rs
@@ -1,0 +1,40 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate cortex_m_semihosting;
+extern crate embedded_hal;
+extern crate p1am_100 as hal;
+#[cfg(not(feature = "use_semihosting"))]
+extern crate panic_halt;
+#[cfg(feature = "use_semihosting")]
+extern crate panic_semihosting;
+
+use cortex_m_semihosting::hprintln;
+use hal::adc::Adc;
+use hal::clock::GenericClockController;
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let pins = hal::Pins::new(peripherals.PORT);
+    let mut delay = hal::delay::Delay::new(core.SYST, &mut clocks);
+    let mut adc = Adc::adc(peripherals.ADC, &mut peripherals.PM, &mut clocks);
+    let mut a0: hal::A0 = pins.d15.into();
+
+    loop {
+        let data: u16 = adc.read(&mut a0).unwrap();
+        hprintln!("{}", data).ok();
+        delay.delay_ms(1000u16);
+    }
+}

--- a/boards/p1am_100/examples/blinky_basic.rs
+++ b/boards/p1am_100/examples/blinky_basic.rs
@@ -1,0 +1,37 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate cortex_m_semihosting;
+extern crate p1am_100 as hal;
+#[cfg(not(feature = "use_semihosting"))]
+extern crate panic_halt;
+#[cfg(feature = "use_semihosting")]
+extern crate panic_semihosting;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::entry;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let pins = hal::Pins::new(peripherals.PORT);
+    let mut led: hal::Led = pins.led.into();
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+    loop {
+        delay.delay_ms(200u8);
+        led.set_high().unwrap();
+        delay.delay_ms(200u8);
+        led.set_low().unwrap();
+    }
+}

--- a/boards/p1am_100/examples/clock.rs
+++ b/boards/p1am_100/examples/clock.rs
@@ -1,0 +1,184 @@
+#![no_std]
+#![no_main]
+
+extern crate p1am_100 as hal;
+use panic_halt as _;
+
+use cortex_m::interrupt::free as disable_interrupts;
+use cortex_m::peripheral::NVIC;
+
+use hal::clock::{ClockGenId, ClockSource, GenericClockController};
+use hal::delay::Delay;
+use hal::pac::{interrupt, CorePeripherals, Peripherals};
+use hal::prelude::*;
+use hal::{entry, Pins};
+
+use core::fmt::Write;
+use hal::rtc;
+use heapless::consts::U16;
+use heapless::String;
+
+use hal::usb::UsbBus;
+use usb_device::bus::UsbBusAllocator;
+use usb_device::prelude::*;
+use usbd_serial::{SerialPort, USB_CLASS_CDC};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut core = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+    let pins = Pins::new(peripherals.PORT);
+    let mut led: hal::Led = pins.led.into();
+
+    // get the internal 32k running at 1024 Hz for the RTC
+    let timer_clock = clocks
+        .configure_gclk_divider_and_source(ClockGenId::GCLK3, 32, ClockSource::OSC32K, true)
+        .unwrap();
+    clocks.configure_standby(ClockGenId::GCLK3, true);
+    let rtc_clock = clocks.rtc(&timer_clock).unwrap();
+    let rtc = rtc::Rtc::clock_mode(peripherals.RTC, rtc_clock.freq(), &mut peripherals.PM);
+
+    unsafe {
+        RTC = Some(rtc);
+    }
+
+    // initialize USB
+    let bus_allocator = unsafe {
+        USB_ALLOCATOR = Some(hal::usb_allocator(
+            peripherals.USB,
+            &mut clocks,
+            &mut peripherals.PM,
+            pins.usb_dm,
+            pins.usb_dp,
+        ));
+        USB_ALLOCATOR.as_ref().unwrap()
+    };
+    unsafe {
+        USB_SERIAL = Some(SerialPort::new(&bus_allocator));
+        USB_BUS = Some(
+            UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x16c0, 0x27dd))
+                .manufacturer("Fake company")
+                .product("Serial port")
+                .serial_number("TEST")
+                .device_class(USB_CLASS_CDC)
+                .build(),
+        );
+    }
+    unsafe {
+        core.NVIC.set_priority(interrupt::USB, 1);
+        NVIC::unmask(interrupt::USB);
+    }
+
+    // Print the time forever!
+    loop {
+        led.toggle();
+        let time =
+            disable_interrupts(|_| unsafe { RTC.as_mut().map(|rtc| rtc.current_time()) }).unwrap();
+
+        let mut data = String::<U16>::new();
+        write!(
+            data,
+            "{:02}:{:02}:{:02}\r\n",
+            time.hours, time.minutes, time.seconds
+        )
+        .ok()
+        .unwrap();
+        write_serial(data.as_bytes());
+
+        delay.delay_ms(1_000_u32);
+    }
+}
+
+static mut USB_ALLOCATOR: Option<UsbBusAllocator<UsbBus>> = None;
+static mut USB_BUS: Option<UsbDevice<UsbBus>> = None;
+static mut USB_SERIAL: Option<SerialPort<UsbBus>> = None;
+static mut RTC: Option<rtc::Rtc<rtc::ClockMode>> = None;
+
+fn write_serial(bytes: &[u8]) {
+    unsafe {
+        USB_SERIAL.as_mut().map(|serial| {
+            serial.write(bytes).unwrap();
+        });
+    }
+}
+
+fn poll_usb() {
+    unsafe {
+        USB_BUS.as_mut().map(|usb_dev| {
+            USB_SERIAL.as_mut().map(|serial| {
+                usb_dev.poll(&mut [serial]);
+                let mut buf = [0u8; 32];
+
+                if let Ok(count) = serial.read(&mut buf) {
+                    let mut buffer: &[u8] = &buf[..count];
+                    // echo to terminal
+                    serial.write(buffer).unwrap();
+
+                    // Look for setting of time
+                    while buffer.len() > 5 {
+                        match timespec(buffer) {
+                            Ok((remaining, time)) => {
+                                buffer = remaining;
+                                disable_interrupts(|_| {
+                                    RTC.as_mut().map(|rtc| {
+                                        rtc.set_time(rtc::Datetime {
+                                            seconds: time.second as u8,
+                                            minutes: time.minute as u8,
+                                            hours: time.hour as u8,
+                                            day: 0,
+                                            month: 0,
+                                            year: 0,
+                                        });
+                                    });
+                                });
+                            }
+                            _ => break,
+                        };
+                    }
+                };
+            });
+        });
+    };
+}
+
+#[interrupt]
+fn USB() {
+    poll_usb();
+}
+
+#[derive(Clone)]
+pub struct Time {
+    hour: usize,
+    minute: usize,
+    second: usize,
+}
+
+#[macro_use]
+extern crate nom;
+use drogue_nom_utils::parse_usize;
+
+named!(
+    pub timespec<Time>,
+    do_parse!(
+        opt!( char!('\r') ) >>
+        tag!("time=") >>
+        hour: parse_usize >>
+        char!(':') >>
+        minute: parse_usize >>
+        char!(':') >>
+        second: parse_usize >>
+        tag!("\r") >>
+        (
+            Time{ hour, minute, second }
+        )
+    )
+);

--- a/boards/p1am_100/examples/pwm.rs
+++ b/boards/p1am_100/examples/pwm.rs
@@ -1,0 +1,47 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m_rt;
+extern crate p1am_100 as hal;
+extern crate panic_halt;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+use hal::pwm::Pwm4;
+
+use cortex_m_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+    let mut pins = hal::Pins::new(peripherals.PORT);
+
+    let _led = pins.led.into_mode::<hal::gpio::v2::AlternateE>();
+
+    let gclk0 = clocks.gclk0();
+    let mut pwm4 = Pwm4::new(
+        &clocks.tc4_tc5(&gclk0).unwrap(),
+        1.khz(),
+        peripherals.TC4,
+        &mut peripherals.PM,
+    );
+    let max_duty = pwm4.get_max_duty();
+
+    loop {
+        pwm4.set_duty(max_duty / 2);
+        delay.delay_ms(1000u16);
+        pwm4.set_duty(max_duty / 8);
+        delay.delay_ms(1000u16);
+    }
+}

--- a/boards/p1am_100/examples/sleeping_timer.rs
+++ b/boards/p1am_100/examples/sleeping_timer.rs
@@ -1,0 +1,109 @@
+//! Uses a timer in standby mode to blink an LED for maximum power savings.
+//!
+//! We also use the internal 8MHz RC oscillator & the internal 32k oscillator
+//! to save power as it doesn't require the PLL.
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate p1am_100 as hal;
+#[cfg(not(feature = "use_semihosting"))]
+extern crate panic_halt;
+#[cfg(feature = "use_semihosting")]
+extern crate panic_semihosting;
+
+use hal::clock::{enable_internal_32kosc, ClockGenId, ClockSource, GenericClockController};
+use hal::entry;
+use hal::pac::{interrupt, CorePeripherals, Peripherals, TC4};
+use hal::prelude::*;
+use hal::sleeping_delay::SleepingDelay;
+use hal::timer;
+
+use core::sync::atomic;
+use cortex_m::peripheral::NVIC;
+
+/// Shared atomic between TC4 interrupt and sleeping_delay module
+static INTERRUPT_FIRED: atomic::AtomicBool = atomic::AtomicBool::new(false);
+
+#[entry]
+fn main() -> ! {
+    // Configure all of our peripherals/clocks
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_8mhz(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+    // Get a clock & make a sleeping delay object. use internal 32k clock that runs
+    // in standby
+    enable_internal_32kosc(&mut peripherals.SYSCTRL);
+    let timer_clock = clocks
+        .configure_gclk_divider_and_source(ClockGenId::GCLK1, 1, ClockSource::OSC32K, false)
+        .unwrap();
+    clocks.configure_standby(ClockGenId::GCLK1, true);
+    let tc45 = &clocks.tc4_tc5(&timer_clock).unwrap();
+    let timer = timer::TimerCounter::tc4_(tc45, peripherals.TC4, &mut peripherals.PM);
+    let mut sleeping_delay = SleepingDelay::new(timer, &INTERRUPT_FIRED);
+
+    // Timer overflow interrupts are asynchronous, we can use IDLE2 sleep for max
+    //   power savings. The CPU, AHB and APB clock domains are stopped
+    // peripherals.PM.sleep.modify(|_, w| w.idle().apb());
+
+    // We can also use it in standby mode, if all of the clocks are configured to
+    //   opperate in standby, for even more power savings
+    core.SCB.set_sleepdeep();
+
+    // enable interrupts
+    unsafe {
+        core.NVIC.set_priority(interrupt::TC4, 2);
+        NVIC::unmask(interrupt::TC4);
+    }
+
+    // Turn off unnecessary peripherals
+    peripherals.PM.ahbmask.modify(|_, w| {
+        w.usb_().clear_bit();
+        w.dmac_().clear_bit()
+    });
+    peripherals.PM.apbamask.modify(|_, w| {
+        w.eic_().clear_bit();
+        w.wdt_().clear_bit();
+        w.sysctrl_().clear_bit();
+        w.pac0_().clear_bit()
+    });
+    peripherals.PM.apbbmask.modify(|_, w| {
+        w.usb_().clear_bit();
+        w.dmac_().clear_bit();
+        w.nvmctrl_().clear_bit();
+        w.dsu_().clear_bit();
+        w.pac1_().clear_bit()
+    });
+    // Thankfully the only one default on here is ADC
+    peripherals.PM.apbcmask.modify(|_, w| w.adc_().clear_bit());
+
+    // Configure our red LED and blink forever, sleeping between!
+    let pins = hal::Pins::new(peripherals.PORT);
+    let mut led: hal::Led = pins.led.into();
+    loop {
+        led.set_low().unwrap();
+        sleeping_delay.delay_ms(1_000u32);
+        led.set_high().unwrap();
+        sleeping_delay.delay_ms(100u32);
+    }
+}
+
+#[interrupt]
+fn TC4() {
+    // Let the sleepingtimer know that the interrupt fired, and clear it
+    INTERRUPT_FIRED.store(true, atomic::Ordering::Relaxed);
+    unsafe {
+        TC4::ptr()
+            .as_ref()
+            .unwrap()
+            .count16()
+            .intflag
+            .modify(|_, w| w.ovf().set_bit());
+    }
+}

--- a/boards/p1am_100/examples/sleeping_timer_rtc.rs
+++ b/boards/p1am_100/examples/sleeping_timer_rtc.rs
@@ -1,0 +1,104 @@
+//! Uses an RTC in standby mode to blink an LED for maximum power savings.
+//!
+//! We also use the internal 8MHz RC oscillator & the internal 32k oscillator
+//! to save power as it doesn't require the PLL.
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate p1am_100 as hal;
+#[cfg(not(feature = "use_semihosting"))]
+extern crate panic_halt;
+#[cfg(feature = "use_semihosting")]
+extern crate panic_semihosting;
+
+use hal::clock::{enable_internal_32kosc, ClockGenId, ClockSource, GenericClockController};
+use hal::entry;
+use hal::pac::{interrupt, CorePeripherals, Peripherals, RTC};
+use hal::prelude::*;
+use hal::rtc;
+use hal::sleeping_delay::SleepingDelay;
+
+use core::sync::atomic;
+use cortex_m::peripheral::NVIC;
+
+/// Shared atomic between RTC interrupt and sleeping_delay module
+static INTERRUPT_FIRED: atomic::AtomicBool = atomic::AtomicBool::new(false);
+
+#[entry]
+fn main() -> ! {
+    // Configure all of our peripherals/clocks
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_8mhz(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+    // Get a clock & make a sleeping delay object. use internal 32k clock that runs
+    // in standby
+    enable_internal_32kosc(&mut peripherals.SYSCTRL);
+    let timer_clock = clocks
+        .configure_gclk_divider_and_source(ClockGenId::GCLK1, 1, ClockSource::OSC32K, false)
+        .unwrap();
+    clocks.configure_standby(ClockGenId::GCLK1, true);
+    let rtc_clock = clocks.rtc(&timer_clock).unwrap();
+    let timer = rtc::Rtc::count32_mode(peripherals.RTC, rtc_clock.freq(), &mut peripherals.PM);
+    let mut sleeping_delay = SleepingDelay::new(timer, &INTERRUPT_FIRED);
+
+    // We can use the RTC in standby for maximum power savings
+    core.SCB.set_sleepdeep();
+
+    // enable interrupts
+    unsafe {
+        core.NVIC.set_priority(interrupt::RTC, 2);
+        NVIC::unmask(interrupt::RTC);
+    }
+
+    // Turn off unnecessary peripherals
+    peripherals.PM.ahbmask.modify(|_, w| {
+        w.usb_().clear_bit();
+        w.dmac_().clear_bit()
+    });
+    peripherals.PM.apbamask.modify(|_, w| {
+        w.eic_().clear_bit();
+        w.wdt_().clear_bit();
+        w.sysctrl_().clear_bit();
+        w.pac0_().clear_bit()
+    });
+    peripherals.PM.apbbmask.modify(|_, w| {
+        w.usb_().clear_bit();
+        w.dmac_().clear_bit();
+        w.nvmctrl_().clear_bit();
+        w.dsu_().clear_bit();
+        w.pac1_().clear_bit()
+    });
+    // Thankfully the only one default on here is ADC
+    peripherals.PM.apbcmask.modify(|_, w| w.adc_().clear_bit());
+
+    // Configure our red LED and blink forever, sleeping between!
+    let pins = hal::Pins::new(peripherals.PORT);
+    let mut led: hal::Led = pins.led.into();
+    loop {
+        led.set_low().unwrap();
+        sleeping_delay.delay_ms(1_000u32);
+        led.set_high().unwrap();
+        sleeping_delay.delay_ms(100u32);
+    }
+}
+
+#[interrupt]
+fn RTC() {
+    // Let the sleepingtimer know that the interrupt fired, and clear it
+    INTERRUPT_FIRED.store(true, atomic::Ordering::Relaxed);
+    unsafe {
+        RTC::ptr()
+            .as_ref()
+            .unwrap()
+            .mode0()
+            .intflag
+            .modify(|_, w| w.cmp0().set_bit());
+    }
+}

--- a/boards/p1am_100/examples/timers.rs
+++ b/boards/p1am_100/examples/timers.rs
@@ -1,0 +1,49 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate cortex_m_semihosting;
+extern crate p1am_100 as hal;
+extern crate nb;
+#[cfg(not(feature = "use_semihosting"))]
+extern crate panic_halt;
+#[cfg(feature = "use_semihosting")]
+extern crate panic_semihosting;
+
+use hal::clock::GenericClockController;
+use hal::entry;
+use hal::pac::Peripherals;
+use hal::prelude::*;
+use hal::timer::TimerCounter;
+
+use nb::block;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let pins = hal::Pins::new(peripherals.PORT);
+    let mut led: hal::Led = pins.led.into();
+
+    // gclk0 represents a configured clock using the system 48MHz oscillator
+    let gclk0 = clocks.gclk0();
+    // configure a clock for the TC4 and TC5 peripherals
+    let tc45 = &clocks.tc4_tc5(&gclk0).unwrap();
+    // instantiate a timer objec for the TC4 peripheral
+    let mut timer = TimerCounter::tc4_(tc45, peripherals.TC4, &mut peripherals.PM);
+    // start a 5Hz timer
+    timer.start(5.hz());
+
+    // toggle the red LED at the frequency set by the timer
+    loop {
+        block!(timer.wait()).unwrap();
+        led.set_high().unwrap();
+        block!(timer.wait()).unwrap();
+        led.set_low().unwrap();
+    }
+}

--- a/boards/p1am_100/examples/usb_echo.rs
+++ b/boards/p1am_100/examples/usb_echo.rs
@@ -1,0 +1,100 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate p1am_100 as hal;
+extern crate panic_halt;
+extern crate usb_device;
+extern crate usbd_serial;
+
+use hal::clock::GenericClockController;
+use hal::entry;
+use hal::pac::{interrupt, CorePeripherals, Peripherals};
+use hal::prelude::*;
+
+use hal::usb::UsbBus;
+use usb_device::bus::UsbBusAllocator;
+
+use usb_device::prelude::*;
+use usbd_serial::{SerialPort, USB_CLASS_CDC};
+
+use cortex_m::asm::delay as cycle_delay;
+use cortex_m::peripheral::NVIC;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let mut pins = hal::Pins::new(peripherals.PORT);
+    let mut led: hal::Led = pins.led.into();
+
+    let bus_allocator = unsafe {
+        USB_ALLOCATOR = Some(hal::usb_allocator(
+            peripherals.USB,
+            &mut clocks,
+            &mut peripherals.PM,
+            pins.usb_dm,
+            pins.usb_dp,
+        ));
+        USB_ALLOCATOR.as_ref().unwrap()
+    };
+
+    unsafe {
+        USB_SERIAL = Some(SerialPort::new(&bus_allocator));
+        USB_BUS = Some(
+            UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x16c0, 0x27dd))
+                .manufacturer("Fake company")
+                .product("Serial port")
+                .serial_number("TEST")
+                .device_class(USB_CLASS_CDC)
+                .build(),
+        );
+    }
+
+    unsafe {
+        core.NVIC.set_priority(interrupt::USB, 1);
+        NVIC::unmask(interrupt::USB);
+    }
+
+    // Flash the LED in a spin loop to demonstrate that USB is
+    // entirely interrupt driven.
+    loop {
+        cycle_delay(15 * 1024 * 1024);
+        led.toggle();
+    }
+}
+
+static mut USB_ALLOCATOR: Option<UsbBusAllocator<UsbBus>> = None;
+static mut USB_BUS: Option<UsbDevice<UsbBus>> = None;
+static mut USB_SERIAL: Option<SerialPort<UsbBus>> = None;
+
+fn poll_usb() {
+    unsafe {
+        USB_BUS.as_mut().map(|usb_dev| {
+            USB_SERIAL.as_mut().map(|serial| {
+                usb_dev.poll(&mut [serial]);
+                let mut buf = [0u8; 64];
+
+                if let Ok(count) = serial.read(&mut buf) {
+                    for (i, c) in buf.iter().enumerate() {
+                        if i >= count {
+                            break;
+                        }
+                        serial.write(&[c.clone()]).ok();
+                    }
+                };
+            });
+        });
+    };
+}
+
+#[interrupt]
+fn USB() {
+    poll_usb();
+}

--- a/boards/p1am_100/examples/usb_echo_rtic.rs
+++ b/boards/p1am_100/examples/usb_echo_rtic.rs
@@ -1,0 +1,90 @@
+#![no_std]
+#![no_main]
+
+extern crate cortex_m;
+extern crate p1am_100 as hal;
+extern crate panic_halt;
+extern crate usb_device;
+extern crate usbd_serial;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::prelude::*;
+
+use hal::usb::UsbBus;
+use usb_device::bus::UsbBusAllocator;
+
+use usb_device::prelude::*;
+use usbd_serial::{SerialPort, USB_CLASS_CDC};
+
+#[rtic::app(device = hal::pac, peripherals = true)]
+const APP: () = {
+    struct Resources {
+        led: hal::Led,
+        usb_serial: SerialPort<'static, UsbBus>,
+        usb_dev: UsbDevice<'static, UsbBus>,
+        delay: Delay,
+    }
+    #[init()]
+    fn init(cx: init::Context) -> init::LateResources {
+        static mut USB_ALLOCATOR: Option<UsbBusAllocator<UsbBus>> = None;
+
+        let mut peripherals = cx.device;
+        let mut clocks = GenericClockController::with_internal_32kosc(
+            peripherals.GCLK,
+            &mut peripherals.PM,
+            &mut peripherals.SYSCTRL,
+            &mut peripherals.NVMCTRL,
+        );
+        let pins = hal::Pins::new(peripherals.PORT);
+        let led: hal::Led = pins.led.into();
+
+        *USB_ALLOCATOR = Some(hal::usb_allocator(
+            peripherals.USB,
+            &mut clocks,
+            &mut peripherals.PM,
+            pins.usb_dm,
+            pins.usb_dp,
+        ));
+
+        let usb_allocator = USB_ALLOCATOR.as_ref().unwrap();
+
+        let usb_serial = SerialPort::new(&usb_allocator);
+        let usb_dev = 
+            UsbDeviceBuilder::new(&usb_allocator, UsbVidPid(0x16c0, 0x27dd))
+                .manufacturer("Fake company")
+                .product("Serial port RTIC")
+                .serial_number("TEST")
+                .device_class(USB_CLASS_CDC)
+                .build();
+
+        let delay = Delay::new(cx.core.SYST, &mut clocks);
+
+        init::LateResources { led, usb_serial, usb_dev, delay }
+    }
+
+    #[idle(resources=[led, delay])]
+    fn idle(cx: idle::Context) -> ! {
+        // Flash the LED in a spin loop to demonstrate that USB is
+        // entirely interrupt driven.
+        loop {
+            cx.resources.delay.delay_ms(200u32);
+            cx.resources.led.toggle().unwrap();
+        }
+    }
+
+#[task(binds = USB, resources=[usb_dev, usb_serial], priority = 2)]
+fn poll_usb(cx: poll_usb::Context) {
+    cx.resources.usb_dev.poll(&mut [cx.resources.usb_serial]);
+    let mut buf = [0u8; 64];
+
+    if let Ok(count) = cx.resources.usb_serial.read(&mut buf) {
+        for (i, c) in buf.iter().enumerate() {
+            if i >= count {
+                break;
+            }
+            cx.resources.usb_serial.write(&[c.clone()]).ok();
+        }
+    };
+}
+};

--- a/boards/p1am_100/memory.x
+++ b/boards/p1am_100/memory.x
@@ -1,0 +1,8 @@
+MEMORY
+{
+  /* Leave 8k for the default bootloader on the Feather M0 */
+  FLASH (rx) : ORIGIN = 0x00000000 + 8K, LENGTH = 256K - 8K
+  RAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 32K
+}
+_stack_start = ORIGIN(RAM) + LENGTH(RAM);
+

--- a/boards/p1am_100/src/lib.rs
+++ b/boards/p1am_100/src/lib.rs
@@ -134,14 +134,14 @@ bsp_pins!(
     PA22 { name: d0 }
     PA23 { name: d1 }
     PA24 {
-        name: pa24,
+        name: usb_dm,
         aliases: {
             #[cfg(feature = "usb")]
             AlternateG: UsbDm
         }
     }
     PA25 {
-        name: pa25,
+        name: usb_dp,
         aliases: {
             #[cfg(feature = "usb")]
             AlternateG: UsbDp

--- a/boards/p1am_100/src/lib.rs
+++ b/boards/p1am_100/src/lib.rs
@@ -1,0 +1,298 @@
+#![no_std]
+
+extern crate atsamd_hal as hal;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::entry;
+
+use hal::prelude::*;
+use hal::*;
+
+pub use hal::common::*;
+
+pub use hal::target_device as pac;
+
+use gpio::{Floating, Input, PfC, Port};
+use hal::clock::GenericClockController;
+use hal::sercom::{I2CMaster3, PadPin, SPIMaster4, UART0};
+use hal::time::Hertz;
+
+#[cfg(feature = "usb")]
+use gpio::v2::{AnyPin, PA24, PA25};
+#[cfg(feature = "usb")]
+use hal::usb::usb_device::bus::UsbBusAllocator;
+#[cfg(feature = "usb")]
+pub use hal::usb::UsbBus;
+
+bsp_pins!(
+    PA02 {
+        name: d15,
+        aliases: {
+            AlternateB: A0
+        }
+    }
+    PA04 {
+        name: d18,
+        aliases: {
+            AlternateB: A3,
+            PushPullOutput: BaseSlaveSelect
+        }
+    }
+    PA05 {
+        name: d19,
+        aliases: {
+            AlternateB: A4,
+            PullUpInput: BaseSlaveAck
+        }
+    }
+    PA06 {
+        name: d20,
+        aliases: {
+            AlternateB: A5
+        }
+    }
+    PA07 {
+        name: d21,
+        aliases: {
+            AlternateB: A6,
+            AlternateG: I2sSerialData
+        }
+    }
+    PA08 {
+        name: d11,
+        aliases: {
+            AlternateC: SdaPin
+        }
+    }
+    PA09 {
+        name: d12,
+        aliases: {
+            AlternateC: SclPin
+        }
+    }
+    PA10 {
+        name: d2,
+        aliases: {
+            AlternateG: I2sSerialClock
+        }
+    }
+    PA11 { name: d3 }
+    PA12 {
+        name: pa12,
+        aliases: {
+            AlternateC: SdSdo
+        }
+    }
+    PA13 {
+        name: pa13,
+        aliases: {
+            AlternateC: SdSck
+        }
+    }
+    PA14 {
+        name: pa14,
+        aliases: {
+            PushPullOutput: SdSlaveSelect
+        }
+    }
+    PA15 {
+        name: pa15,
+        aliases: {
+            AlternateC: SdSdi
+        }
+    }
+    PA16 {
+        name: d8,
+        aliases: {
+            AlternateC: Spi0Sdo
+        }
+    }
+    PA17 {
+        name: d9,
+        aliases: {
+            AlternateC: Spi0Sck
+        }
+    }
+    PA18 {
+        name: pa18,
+        aliases: {
+            /// Host Enable, drive high to switch into USB host mode
+            #[cfg(feature = "usb")]
+            PushPullOutput: UsbId
+        }
+    }
+    PA19 {
+        name: d10,
+        aliases: {
+            AlternateC: Spi0Sdi
+        }
+    }
+    PA20 { name: d6 }
+    PA21 { name: d7 }
+    PA22 { name: d0 }
+    PA23 { name: d1 }
+    PA24 {
+        name: pa24,
+        aliases: {
+            #[cfg(feature = "usb")]
+            AlternateG: UsbDm
+        }
+    }
+    PA25 {
+        name: pa25,
+        aliases: {
+            #[cfg(feature = "usb")]
+            AlternateG: UsbDp
+        }
+    }
+    PA27 {
+        name: pa27,
+        aliases: {
+            PullUpInput: SdCardDetect
+        }
+    }
+    PA28 {
+        name: switch,
+        aliases: {
+            PullUpInput: Switch
+        }
+    }
+    PB02 {
+        name: d16,
+        aliases: {
+            AlternateB: A1
+        }
+    }
+    PB03 {
+        name: d17,
+        aliases: {
+            AlternateB: A2
+        }
+    }
+    PB08 {
+        name: led,
+        aliases: {
+            PushPullOutput: Led
+        }
+    }
+    PB09 {
+        name: pb09,
+        aliases: {
+            PushPullOutput: BaseEnable,
+            AlternateB: AdcBattery
+        }
+    }
+    PB10 { name: d4 }
+    PB11 { name: d5 }
+    PB22 {
+        name: d14,
+        aliases: {
+            AlternateD: UartTx
+        }
+    }
+    PB23 {
+        name: d13,
+        aliases: {
+            AlternateD: UartRx
+        }
+    }
+);
+
+/// Convenience for setting up the labelled SPI peripheral.
+/// This powers up SERCOM4 and configures it for use as an
+/// SPI Master in SPI Mode 0.
+pub fn spi_master<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    bus_speed: F,
+    sercom4: pac::SERCOM4,
+    pm: &mut pac::PM,
+    sck: gpio::Pb11<Input<Floating>>,
+    mosi: gpio::Pb10<Input<Floating>>,
+    miso: gpio::Pa12<Input<Floating>>,
+    port: &mut Port,
+) -> SPIMaster4<
+    hal::sercom::Sercom4Pad0<gpio::Pa12<gpio::PfD>>,
+    hal::sercom::Sercom4Pad2<gpio::Pb10<gpio::PfD>>,
+    hal::sercom::Sercom4Pad3<gpio::Pb11<gpio::PfD>>,
+> {
+    let gclk0 = clocks.gclk0();
+    SPIMaster4::new(
+        &clocks.sercom4_core(&gclk0).unwrap(),
+        bus_speed.into(),
+        hal::hal::spi::Mode {
+            phase: hal::hal::spi::Phase::CaptureOnFirstTransition,
+            polarity: hal::hal::spi::Polarity::IdleLow,
+        },
+        sercom4,
+        pm,
+        (miso.into_pad(port), mosi.into_pad(port), sck.into_pad(port)),
+    )
+}
+
+/// Convenience for setting up the labelled SDA, SCL pins to
+/// operate as an I2C master running at the specified frequency.
+pub fn i2c_master<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    bus_speed: F,
+    sercom3: pac::SERCOM3,
+    pm: &mut pac::PM,
+    sda: gpio::Pa22<Input<Floating>>,
+    scl: gpio::Pa23<Input<Floating>>,
+    port: &mut Port,
+) -> I2CMaster3<
+    hal::sercom::Sercom3Pad0<hal::gpio::Pa22<hal::gpio::PfC>>,
+    hal::sercom::Sercom3Pad1<hal::gpio::Pa23<hal::gpio::PfC>>,
+> {
+    let gclk0 = clocks.gclk0();
+    I2CMaster3::new(
+        &clocks.sercom3_core(&gclk0).unwrap(),
+        bus_speed.into(),
+        sercom3,
+        pm,
+        sda.into_pad(port),
+        scl.into_pad(port),
+    )
+}
+
+/// Convenience for setting up the labelled RX, TX pins to
+/// operate as a UART device running at the specified baud.
+pub fn uart<F: Into<Hertz>>(
+    clocks: &mut GenericClockController,
+    baud: F,
+    sercom0: pac::SERCOM0,
+    pm: &mut pac::PM,
+    d0: gpio::Pa11<Input<Floating>>,
+    d1: gpio::Pa10<Input<Floating>>,
+    port: &mut Port,
+) -> UART0<
+    hal::sercom::Sercom0Pad3<gpio::Pa11<PfC>>,
+    hal::sercom::Sercom0Pad2<gpio::Pa10<PfC>>,
+    (),
+    (),
+> {
+    let gclk0 = clocks.gclk0();
+
+    UART0::new(
+        &clocks.sercom0_core(&gclk0).unwrap(),
+        baud.into(),
+        sercom0,
+        pm,
+        (d0.into_pad(port), d1.into_pad(port)),
+    )
+}
+
+#[cfg(feature = "usb")]
+pub fn usb_allocator(
+    usb: pac::USB,
+    clocks: &mut GenericClockController,
+    pm: &mut pac::PM,
+    dm: impl AnyPin<Id = PA24>,
+    dp: impl AnyPin<Id = PA25>,
+) -> UsbBusAllocator<UsbBus> {
+    let gclk0 = clocks.gclk0();
+    let usb_clock = &clocks.usb(&gclk0).unwrap();
+
+    UsbBusAllocator::new(UsbBus::new(usb_clock, pm, dm, dp, usb))
+}

--- a/boards/p1am_100/src/lib.rs
+++ b/boards/p1am_100/src/lib.rs
@@ -14,9 +14,9 @@ pub use hal::common::*;
 
 pub use hal::target_device as pac;
 
-use gpio::{Floating, Input, PfC, Port};
+use gpio::{Floating, Input, Port};
 use hal::clock::GenericClockController;
-use hal::sercom::{I2CMaster3, PadPin, SPIMaster4, UART0};
+use hal::sercom::{I2CMaster3, PadPin, SPIMaster4, UART5};
 use hal::time::Hertz;
 
 #[cfg(feature = "usb")]
@@ -261,25 +261,24 @@ pub fn i2c_master<F: Into<Hertz>>(
 pub fn uart<F: Into<Hertz>>(
     clocks: &mut GenericClockController,
     baud: F,
-    sercom0: pac::SERCOM0,
+    sercom5: pac::SERCOM5,
     pm: &mut pac::PM,
-    d0: gpio::Pa11<Input<Floating>>,
-    d1: gpio::Pa10<Input<Floating>>,
-    port: &mut Port,
-) -> UART0<
-    hal::sercom::Sercom0Pad3<gpio::Pa11<PfC>>,
-    hal::sercom::Sercom0Pad2<gpio::Pa10<PfC>>,
+    rx: UartRx,
+    tx: UartTx,
+) -> UART5<
+    hal::sercom::Sercom5Pad3<hal::gpio::v2::PB23>,
+    hal::sercom::Sercom5Pad2<hal::gpio::v2::PB22>,
     (),
     (),
 > {
     let gclk0 = clocks.gclk0();
 
-    UART0::new(
-        &clocks.sercom0_core(&gclk0).unwrap(),
+    UART5::new(
+        &clocks.sercom5_core(&gclk0).unwrap(),
         baud.into(),
-        sercom0,
+        sercom5,
         pm,
-        (d0.into_pad(port), d1.into_pad(port)),
+        (rx.into(), tx.into()),
     )
 }
 


### PR DESCRIPTION
I've marked this as a draft because there's a number of things I'm unsure about. Can someone who is more familiar with the new v2 APIs please tell me if I'm making appropriate use of them?

I'm not sure if I'm properly using the new pin aliases, for instance. It seems poor that I need to use the pin's name in combination with the alias (e.g. `let ss: hal::BaseSlaveSelect = pins.d18.into();`). Also the `uart` function has an explicit `PB22` and `PB23` because I couldn't figure out how to turn an alias into a `PinId`.

TODO:
- [ ] Implement helper for base controller SPI
- [ ] Implement helper for SD card IO
- [ ] Write example for UART and test