### PR TITLE
DMAC peripherals

### DIFF
--- a/boards/feather_m0/examples/dmac.rs
+++ b/boards/feather_m0/examples/dmac.rs
@@ -42,18 +42,15 @@ fn main() -> ! {
     let channels = dmac.split();
 
     // Initialize DMA Channel 0
-    let chan0 = channels.0.init(&mut dmac, PriorityLevel::LVL0);
+    let chan0 = channels.0.init(PriorityLevel::LVL0);
 
     // Setup a DMA transfer (memory-to-memory -> incrementing source, incrementing
     // destination) with a 8-bit beat size
-    let xfer = Transfer::new_from_arrays(chan0, buf_src, buf_dest, false).begin(
-        &mut dmac,
-        TriggerSource::DISABLE,
-        TriggerAction::BLOCK,
-    );
-
+    let xfer = Transfer::new_from_arrays(chan0, buf_src, buf_dest, false)
+        .with_waker(|| asm::nop())
+        .begin(TriggerSource::DISABLE, TriggerAction::BLOCK);
     // Wait for transfer to complete and grab resulting buffers
-    let (chan0, buf_src, buf_dest, _) = xfer.wait(&mut dmac);
+    let (chan0, buf_src, buf_dest, _) = xfer.wait();
 
     // Read the returned buffers
     let _a = buf_src[LENGTH - 1];
@@ -67,9 +64,9 @@ fn main() -> ! {
     // destination) with a 16-bit beat size. Demonstrate payload management.
     let xfer = Transfer::new(chan0, const_16, buf_16, false)
         .with_payload(pm)
-        .begin(&mut dmac, TriggerSource::DISABLE, TriggerAction::BLOCK);
+        .begin(TriggerSource::DISABLE, TriggerAction::BLOCK);
 
-    let (chan0, const_16, buf_16, _pm) = xfer.wait(&mut dmac);
+    let (chan0, const_16, buf_16, _pm) = xfer.wait();
 
     // Read the returned buffers
     let _a = *const_16;
@@ -82,13 +79,10 @@ fn main() -> ! {
 
     // Setup a DMA transfer (memory-to-memory -> incrementing source, fixed
     // destination) with a 16-bit beat size
-    let xfer = Transfer::new(chan0, buf_16, const_16, false).begin(
-        &mut dmac,
-        TriggerSource::DISABLE,
-        TriggerAction::BLOCK,
-    );
+    let xfer = Transfer::new(chan0, buf_16, const_16, false)
+        .begin(TriggerSource::DISABLE, TriggerAction::BLOCK);
 
-    let (_chan0, buf_16, const_16, _) = xfer.wait(&mut dmac);
+    let (_chan0, buf_16, const_16, _) = xfer.wait();
 
     // Read the returned buffers
     let _a = *const_16; // We expect the value "LENGTH - 1" to end up here

--- a/boards/feather_m0/examples/dmac.rs
+++ b/boards/feather_m0/examples/dmac.rs
@@ -39,7 +39,7 @@ fn main() -> ! {
     // Initialize DMA Controller
     let mut dmac = DmaController::init(dmac, &mut pm);
     // Get individual handles to DMA channels
-    let channels = dmac.split();
+    let mut channels = dmac.split();
 
     // Initialize DMA Channel 0
     let chan0 = channels.0.init(PriorityLevel::LVL0);
@@ -63,10 +63,11 @@ fn main() -> ! {
     // Setup a DMA transfer (memory-to-memory -> fixed source, incrementing
     // destination) with a 16-bit beat size. Demonstrate payload management.
     let xfer = Transfer::new(chan0, const_16, buf_16, false)
+        .unwrap()
         .with_payload(pm)
         .begin(TriggerSource::DISABLE, TriggerAction::BLOCK);
 
-    let (chan0, const_16, buf_16, _pm) = xfer.wait();
+    let (chan0, const_16, buf_16, mut pm) = xfer.wait();
 
     // Read the returned buffers
     let _a = *const_16;
@@ -80,13 +81,19 @@ fn main() -> ! {
     // Setup a DMA transfer (memory-to-memory -> incrementing source, fixed
     // destination) with a 16-bit beat size
     let xfer = Transfer::new(chan0, buf_16, const_16, false)
+        .unwrap()
         .begin(TriggerSource::DISABLE, TriggerAction::BLOCK);
 
-    let (_chan0, buf_16, const_16, _) = xfer.wait();
+    let (chan0, buf_16, const_16, _) = xfer.wait();
 
     // Read the returned buffers
     let _a = *const_16; // We expect the value "LENGTH - 1" to end up here
     let _b = buf_16[LENGTH - 1];
+
+    // Move split channels back into the Channels struct
+    channels.0 = chan0.into();
+    // Free the DmaController and return the PAC DMAC struct
+    let _dmac = dmac.free(channels, &mut pm);
 
     loop {
         asm::nop();

--- a/boards/feather_m0/examples/dmac.rs
+++ b/boards/feather_m0/examples/dmac.rs
@@ -42,7 +42,7 @@ fn main() -> ! {
     let channels = dmac.split();
 
     // Initialize DMA Channel 0
-    let chan0 = channels.0.init(&mut dmac, PriorityLevel::LVL0, false);
+    let chan0 = channels.0.init(&mut dmac, PriorityLevel::LVL0);
 
     // Setup a DMA transfer (memory-to-memory -> incrementing source, incrementing
     // destination) with a 8-bit beat size

--- a/boards/feather_m0/examples/dmac.rs
+++ b/boards/feather_m0/examples/dmac.rs
@@ -47,7 +47,7 @@ fn main() -> ! {
     // Setup a DMA transfer (memory-to-memory -> incrementing source, incrementing
     // destination) with a 8-bit beat size
     let xfer = Transfer::new_from_arrays(chan0, buf_src, buf_dest, false)
-        .with_waker(|| asm::nop())
+        .with_waker(|_status| asm::nop())
         .begin(TriggerSource::DISABLE, TriggerAction::BLOCK);
     // Wait for transfer to complete and grab resulting buffers
     let (chan0, buf_src, buf_dest, _) = xfer.wait();

--- a/boards/feather_m4/examples/dmac.rs
+++ b/boards/feather_m4/examples/dmac.rs
@@ -48,18 +48,15 @@ fn main() -> ! {
     let channels = dmac.split();
 
     // Initialize DMA Channel 0
-    let chan0 = channels.0.init(&mut dmac, PriorityLevel::LVL0);
+    let chan0 = channels.0.init(PriorityLevel::LVL0);
 
     // Setup a DMA transfer (memory-to-memory -> incrementing source, incrementing
     // destination) with a 8-bit beat size
-    let xfer = Transfer::new_from_arrays(chan0, buf_src, buf_dest, false).begin(
-        &mut dmac,
-        TriggerSource::DISABLE,
-        TriggerAction::BLOCK,
-    );
+    let xfer = Transfer::new_from_arrays(chan0, buf_src, buf_dest, false)
+        .begin(TriggerSource::DISABLE, TriggerAction::BLOCK);
 
     // Wait for transfer to complete and grab resulting buffers
-    let (chan0, buf_src, buf_dest, _) = xfer.wait(&mut dmac);
+    let (chan0, buf_src, buf_dest, _) = xfer.wait();
 
     // Read the returned buffers
     let _a = buf_src[LENGTH - 1];
@@ -73,9 +70,9 @@ fn main() -> ! {
     // destination) with a 16-bit beat size. Demonstrate payload management.
     let xfer = Transfer::new(chan0, const_16, buf_16, false)
         .with_payload(pm)
-        .begin(&mut dmac, TriggerSource::DISABLE, TriggerAction::BLOCK);
+        .begin(TriggerSource::DISABLE, TriggerAction::BLOCK);
 
-    let (chan0, const_16, buf_16, _pm) = xfer.wait(&mut dmac);
+    let (chan0, const_16, buf_16, _pm) = xfer.wait();
 
     // Read the returned buffers
     let _a = *const_16;
@@ -88,13 +85,10 @@ fn main() -> ! {
 
     // Setup a DMA transfer (memory-to-memory -> incrementing source, fixed
     // destination) with a 16-bit beat size
-    let xfer = Transfer::new(chan0, buf_16, const_16, false).begin(
-        &mut dmac,
-        TriggerSource::DISABLE,
-        TriggerAction::BLOCK,
-    );
+    let xfer = Transfer::new(chan0, buf_16, const_16, false)
+        .begin(TriggerSource::DISABLE, TriggerAction::BLOCK);
 
-    let (_chan0, buf_16, const_16, _) = xfer.wait(&mut dmac);
+    let (_chan0, buf_16, const_16, _) = xfer.wait();
 
     // Read the returned buffers
     let _a = *const_16; // We expect the value "LENGTH - 1" to end up here

--- a/boards/feather_m4/examples/dmac.rs
+++ b/boards/feather_m4/examples/dmac.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     let channels = dmac.split();
 
     // Initialize DMA Channel 0
-    let chan0 = channels.0.init(&mut dmac, PriorityLevel::LVL0, false);
+    let chan0 = channels.0.init(&mut dmac, PriorityLevel::LVL0);
 
     // Setup a DMA transfer (memory-to-memory -> incrementing source, incrementing
     // destination) with a 8-bit beat size

--- a/hal/src/dmac/channel.rs
+++ b/hal/src/dmac/channel.rs
@@ -187,6 +187,7 @@ impl<Id: ChId, S: Status> Channel<Id, S> {
     /// # Return
     ///
     /// A `Channel` with a `Ready` status
+    #[inline]
     pub fn init(mut self, lvl: PriorityLevel) -> Channel<Id, Ready> {
         // Software reset the channel for good measure
         self._reset_private();
@@ -206,12 +207,14 @@ impl<Id: ChId, S: Status> Channel<Id, S> {
         }
     }
 
+    #[inline]
     pub fn enable_interrupts(&mut self, flags: InterruptFlags) {
         // SAFETY: This is safe as InterruptFlags is only capable of writing in
         // non-reserved bits
         self.with_chid(|d| d.chintenset.write(|w| unsafe { w.bits(flags.into()) }))
     }
 
+    #[inline]
     pub fn disable_interrupts(&mut self, flags: InterruptFlags) {
         // SAFETY: This is safe as InterruptFlags is only capable of writing in
         // non-reserved bits
@@ -281,6 +284,7 @@ impl<Id: ChId> Channel<Id, Ready> {
     /// # Return
     ///
     /// A `Channel` with a `Busy` status.
+    #[inline]
     pub(crate) fn start(
         mut self,
         trig_src: TriggerSource,
@@ -378,7 +382,7 @@ impl<Id: ChId> Channel<Id, Busy> {
 
     #[inline]
     #[cfg(any(feature = "samd11", feature = "samd21"))]
-    pub fn callback(&mut self) {
+    pub(super) fn callback(&mut self) {
         let mut xfer_complete = false;
         self.with_chid(|d| {
             // Transfer complete

--- a/hal/src/dmac/channel.rs
+++ b/hal/src/dmac/channel.rs
@@ -31,14 +31,15 @@
 //! `Uninitialized` state. You will be required to call [`Channel::init`]
 //! again before being able to use it with a `Transfer`.
 
-use super::dma_controller::{ChId, DmaController, PriorityLevel, TriggerAction, TriggerSource};
+use super::dma_controller::{ChId, PriorityLevel, TriggerAction, TriggerSource};
 use crate::{
-    target_device::DMAC,
+    target_device::{self, DMAC},
     typelevel::{Is, Sealed},
 };
 
 use core::{marker::PhantomData, mem};
 use modular_bitfield::prelude::*;
+use target_device::Peripherals;
 
 #[cfg(feature = "min-samd51g")]
 use super::dma_controller::{BurstLength, FifoThreshold};
@@ -142,15 +143,22 @@ impl<Id: ChId, S: Status> Channel<Id, S> {
     /// If an interrupt were to change the CHID register, we would be faced
     /// with undefined behaviour.
     #[cfg(any(feature = "samd11", feature = "samd21"))]
-    fn with_chid<F: FnMut(&DMAC)>(&mut self, dmac: &DMAC, mut fun: F) {
+    fn with_chid<F: FnMut(&DMAC)>(&mut self, mut fun: F) {
         cortex_m::interrupt::free(|_| {
-            // SAFETY: this is actually safe as long as we write a correct channel number to
-            // the CHID register
-            unsafe {
+            // SAFETY: This is ONLY safe if the individual channels are GUARANTEED not to
+            // mess with either:
+            // - The global DMAC configuration
+            // - The configuration of other channels.
+            //
+            // In practice, this means that the DMAC registers should only be accessed
+            // through the `with_chid` method.
+            let dmac = unsafe {
+                let dmac = Peripherals::steal().DMAC;
                 dmac.chid.modify(|_, w| w.id().bits(Id::U8));
+                dmac
             };
 
-            fun(dmac);
+            fun(&dmac);
         });
     }
 
@@ -160,8 +168,16 @@ impl<Id: ChId, S: Status> Channel<Id, S> {
     /// to the correct channel number and run the closure on that.
     #[cfg(feature = "min-samd51g")]
     #[inline]
-    fn with_chid<F: FnMut(&CHANNEL)>(&mut self, dmac: &DMAC, fun: F) {
-        let mut ch = &dmac.channel[Id::USIZE];
+    fn with_chid<F: FnMut(&CHANNEL)>(&mut self, fun: F) {
+        // SAFETY: This is ONLY safe if the individual channels are GUARANTEED not to
+        // mess with either:
+        // - The global DMAC configuration
+        // - The configuration of other channels.
+        //
+        // In practice, this means that the DMAC registers should only be accessed
+        // through the `with_chid` method.
+        let dmac = unsafe { Peripherals::steal().DMAC };
+        let mut ch = dmac.channel[Id::USIZE];
         fun(&mut ch);
     }
 
@@ -171,17 +187,11 @@ impl<Id: ChId, S: Status> Channel<Id, S> {
     /// # Return
     ///
     /// A `Channel` with a `Ready` status
-    pub fn init(
-        mut self,
-        controller: &mut DmaController,
-        lvl: PriorityLevel,
-    ) -> Channel<Id, Ready> {
-        let dmac = controller.dmac();
-
+    pub fn init(mut self, lvl: PriorityLevel) -> Channel<Id, Ready> {
         // Software reset the channel for good measure
-        self._reset_private(dmac);
+        self._reset_private();
 
-        self.with_chid(dmac, |d| {
+        self.with_chid(|d| {
             #[cfg(any(feature = "samd11", feature = "samd21"))]
             // Setup priority level
             d.chctrlb.modify(|_, w| w.lvl().bits(lvl as u8));
@@ -196,21 +206,21 @@ impl<Id: ChId, S: Status> Channel<Id, S> {
         }
     }
 
-    pub fn enable_interrupts(&mut self, dmac: &mut DmaController, flags: InterruptFlags) {
-        self.with_chid(dmac.dmac(), |d| {
-            d.chintenset.write(|w| unsafe { w.bits(flags.into()) })
-        })
+    pub fn enable_interrupts(&mut self, flags: InterruptFlags) {
+        // SAFETY: This is safe as InterruptFlags is only capable of writing in
+        // non-reserved bits
+        self.with_chid(|d| d.chintenset.write(|w| unsafe { w.bits(flags.into()) }))
     }
 
-    pub fn disable_interrupts(&mut self, dmac: &mut DmaController, flags: InterruptFlags) {
-        self.with_chid(dmac.dmac(), |d| {
-            d.chintenclr.write(|w| unsafe { w.bits(flags.into()) })
-        })
+    pub fn disable_interrupts(&mut self, flags: InterruptFlags) {
+        // SAFETY: This is safe as InterruptFlags is only capable of writing in
+        // non-reserved bits
+        self.with_chid(|d| d.chintenclr.write(|w| unsafe { w.bits(flags.into()) }))
     }
 
     #[inline]
-    fn _reset_private(&mut self, dmac: &DMAC) {
-        self.with_chid(dmac, |d| {
+    fn _reset_private(&mut self) {
+        self.with_chid(|d| {
             // Reset the channel to its startup state and wait for reset to complete
             d.chctrla.modify(|_, w| w.swrst().set_bit());
             while d.chctrla.read().swrst().bit_is_set() {}
@@ -218,11 +228,14 @@ impl<Id: ChId, S: Status> Channel<Id, S> {
     }
 
     #[inline]
-    fn _trigger_private(&mut self, dmac: &DMAC) {
-        // SAFETY: This is safe because we are writing the correct channel
-        // number into the register
+    fn _trigger_private(&mut self) {
+        // SAFETY: This is safe because we are only writing to a bit that belongs to
+        // this channel.
         unsafe {
-            dmac.swtrigctrl.modify(|_, w| w.bits(1 << Id::U8));
+            Peripherals::steal()
+                .DMAC
+                .swtrigctrl
+                .modify(|_, w| w.bits(1 << Id::U8));
         }
     }
 }
@@ -232,8 +245,8 @@ impl<Id: ChId> Channel<Id, Ready> {
     /// Issue a software reset to the channel. This will return the channel to
     /// its startup state
     #[inline]
-    pub fn reset(mut self, dmac: &DMAC) -> Channel<Id, Uninitialized> {
-        self._reset_private(dmac);
+    pub fn reset(mut self) -> Channel<Id, Uninitialized> {
+        self._reset_private();
 
         Channel {
             _id: self._id,
@@ -246,9 +259,8 @@ impl<Id: ChId> Channel<Id, Ready> {
     /// transfer, reducing the DMA transfer latency.
     #[cfg(feature = "min-samd51g")]
     #[inline]
-    pub fn fifo_threshold(&mut self, dmac: &mut DmaController, threshold: FifoThreshold) {
-        let dmac = dmac.dmac();
-        self.with_chid(dmac, |d| {
+    pub fn fifo_threshold(&mut self, threshold: FifoThreshold) {
+        self.with_chid(|d| {
             d.chctrla.modify(|_, w| w.threshold().bits(threshold as u8));
         })
     }
@@ -257,9 +269,8 @@ impl<Id: ChId> Channel<Id, Ready> {
     /// is an atomic, uninterruptible operation.
     #[cfg(feature = "min-samd51g")]
     #[inline]
-    pub fn burst_length(&mut self, dmac: &mut DmaController, burst_length: BurstLength) {
-        let dmac = dmac.dmac();
-        self.with_chid(dmac, |d| {
+    pub fn burst_length(&mut self, burst_length: BurstLength) {
+        self.with_chid(|d| {
             d.chctrla
                 .modify(|_, w| w.burstlen().bits(burst_length as u8));
         })
@@ -272,13 +283,12 @@ impl<Id: ChId> Channel<Id, Ready> {
     /// A `Channel` with a `Busy` status.
     pub(crate) fn start(
         mut self,
-        dmac: &DMAC,
         trig_src: TriggerSource,
         trig_act: TriggerAction,
     ) -> Channel<Id, Busy> {
         // Set the channel ID. We assume the CHID register doesn't change
         // for the duration of this function.
-        self.with_chid(dmac, |d| {
+        self.with_chid(|d| {
             // Configure the trigger source and trigger action
             // SAFETY: This is actually safe because we are writing the correct enum value
             // (imported from the PAC) into the register
@@ -289,6 +299,8 @@ impl<Id: ChId> Channel<Id, Ready> {
             #[cfg(feature = "min-samd51g")]
             let trigger_channel = &d.chctrla;
 
+            // SAFETY: This is safe as we only write valid bits into the registers because
+            // of TriggerSource and TriggerAction.
             unsafe {
                 trigger_channel.modify(|_, w| {
                     w.trigsrc().bits(trig_src as u8);
@@ -302,7 +314,7 @@ impl<Id: ChId> Channel<Id, Ready> {
 
         // If trigger source is DISABLE, manually trigger transfer
         if trig_src == TriggerSource::DISABLE {
-            self._trigger_private(dmac);
+            self._trigger_private();
         }
 
         Channel {
@@ -316,8 +328,8 @@ impl<Id: ChId> Channel<Id, Ready> {
 impl<Id: ChId> Channel<Id, Busy> {
     /// Issue a software trigger to the channel
     #[inline]
-    pub(crate) fn software_trigger(&mut self, dmac: &DMAC) {
-        self._trigger_private(dmac);
+    pub(crate) fn software_trigger(&mut self) {
+        self._trigger_private();
     }
 
     /// Stop transfer on channel whether or not the transfer has completed
@@ -327,9 +339,9 @@ impl<Id: ChId> Channel<Id, Busy> {
     /// A `Channel` with a `Ready` status, ready to be reused by a new
     /// [`Transfer`](super::transfer::Transfer)
     #[inline]
-    pub(crate) fn stop(mut self, dmac: &DMAC) -> Channel<Id, Ready> {
-        self.with_chid(dmac, |d| d.chctrla.modify(|_, w| w.enable().clear_bit()));
-        self.free(dmac)
+    pub(crate) fn stop(mut self) -> Channel<Id, Ready> {
+        self.with_chid(|d| d.chctrla.modify(|_, w| w.enable().clear_bit()));
+        self.free()
     }
 
     /// Returns whether or not the transfer is complete.
@@ -342,8 +354,10 @@ impl<Id: ChId> Channel<Id, Busy> {
     /// and BUSYCH is set. To make sure the transfer is actually complete, the
     /// channel needs to be both NOT PENDING and NOT BUSY.
     #[inline]
-    pub(crate) fn xfer_complete(&self, dmac: &DMAC) -> bool {
+    pub(crate) fn xfer_complete(&self) -> bool {
         let id = Id::U8;
+        // SAFETY: This is safe as we only read bits that belong to this channel.
+        let dmac = unsafe { Peripherals::steal().DMAC };
         dmac.busych.read().bits() & (1 << id) == 0 && dmac.pendch.read().bits() & (1 << id) == 0
     }
 
@@ -354,8 +368,8 @@ impl<Id: ChId> Channel<Id, Busy> {
     /// A `Channel` with a `Ready` status, ready to be reused by a new
     /// [`Transfer`](super::transfer::Transfer)
     #[inline]
-    pub(crate) fn free(self, dmac: &DMAC) -> Channel<Id, Ready> {
-        while !self.xfer_complete(dmac) {}
+    pub(crate) fn free(self) -> Channel<Id, Ready> {
+        while !self.xfer_complete() {}
         Channel {
             _id: self._id,
             _status: PhantomData,
@@ -364,9 +378,9 @@ impl<Id: ChId> Channel<Id, Busy> {
 
     #[inline]
     #[cfg(any(feature = "samd11", feature = "samd21"))]
-    pub fn callback(&mut self, dmac: &DMAC) {
+    pub fn callback(&mut self) {
         let mut xfer_complete = false;
-        self.with_chid(dmac, |d| {
+        self.with_chid(|d| {
             // Transfer complete
             if d.chintflag.read().tcmpl().bit_is_set() {
                 // TODO Do something here

--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -33,7 +33,7 @@
 
 use super::dma_controller::{ChId, PriorityLevel, TriggerAction, TriggerSource};
 use crate::typelevel::{Is, Sealed};
-use core::{marker::PhantomData, mem};
+use core::marker::PhantomData;
 use modular_bitfield::prelude::*;
 
 mod reg;
@@ -333,6 +333,15 @@ impl<Id: ChId> Channel<Id, Busy> {
     #[inline]
     pub(crate) fn restart(&mut self) {
         self.regs.chctrla.modify(|_, w| w.enable().set_bit());
+    }
+}
+
+impl<Id: ChId> From<Channel<Id, Ready>> for Channel<Id, Uninitialized> {
+    fn from(item: Channel<Id, Ready>) -> Self {
+        Channel {
+            regs: item.regs,
+            _status: PhantomData,
+        }
     }
 }
 

--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -289,7 +289,7 @@ impl<Id: ChId> Channel<Id, Busy> {
 
     /// Returns whether or not the transfer is complete.
     #[inline]
-    pub(crate) fn xfer_complete(&self) -> bool {
+    pub(crate) fn xfer_complete(&mut self) -> bool {
         !self.regs.chctrla.read().enable().bit_is_set()
     }
 

--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -38,7 +38,7 @@ use modular_bitfield::prelude::*;
 
 mod reg;
 
-use reg::{ModifyRegister, ReadBit, ReadRegister, RegisterBlock, WriteBit, WriteRegister};
+use reg::RegisterBlock;
 
 #[cfg(feature = "min-samd51g")]
 use super::dma_controller::{BurstLength, FifoThreshold};
@@ -183,7 +183,7 @@ impl<Id: ChId, S: Status> Channel<Id, S> {
 
     #[inline]
     fn _trigger_private(&mut self) {
-        self.regs.swtrigctrl.write(true);
+        self.regs.swtrigctrl.write_bit(true);
     }
 }
 
@@ -296,7 +296,7 @@ impl<Id: ChId> Channel<Id, Busy> {
     /// channel needs to be both NOT PENDING and NOT BUSY.
     #[inline]
     pub(crate) fn xfer_complete(&self) -> bool {
-        !self.regs.busych.read() && !self.regs.pendch.read()
+        !self.regs.busych.read_bit() && !self.regs.pendch.read_bit()
     }
 
     /// Wait for the channel to clear its busy status, then release the channel.

--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -156,6 +156,7 @@ impl<Id: ChId, S: Status> Channel<Id, S> {
         }
     }
 
+    /// Selectively enable interrupts
     #[inline]
     pub fn enable_interrupts(&mut self, flags: InterruptFlags) {
         // SAFETY: This is safe as InterruptFlags is only capable of writing in
@@ -165,6 +166,7 @@ impl<Id: ChId, S: Status> Channel<Id, S> {
             .write(|w| unsafe { w.bits(flags.into()) });
     }
 
+    /// Selectively disable interrupts
     #[inline]
     pub fn disable_interrupts(&mut self, flags: InterruptFlags) {
         // SAFETY: This is safe as InterruptFlags is only capable of writing in

--- a/hal/src/dmac/channel/reg.rs
+++ b/hal/src/dmac/channel/reg.rs
@@ -1,0 +1,317 @@
+//! # Channel registers
+//!
+//! This module adds a [`RegisterBlock`] struct, which acts as a proxy for the
+//! registers a single DMAC [`Channel`] can read/write. Its purpose is to
+//! remediate the inadequacies of the PAC. In particular, for SAMD11/SAMD21, the
+//! CHID register must be written with the correct channel ID before accessing
+//! the channel specific registers. There is a provided `with_chid` method that
+//! takes a closure with the register read/write proxies to ensure any
+//! read/write to these registers are done in an interrupt-safe way. For
+//! SAMD51+, `with_chid` returns the register block which contains the registers
+//! owned by a specific channel.
+
+use super::super::dma_controller::ChId;
+use core::marker::PhantomData;
+use paste::paste;
+
+use crate::target_device::{
+    self,
+    dmac::{BUSYCH, INTSTATUS, PENDCH, SWTRIGCTRL},
+    Peripherals, DMAC,
+};
+
+#[cfg(any(feature = "samd11", feature = "samd21"))]
+use target_device::dmac as channel_regs;
+
+#[cfg(feature = "min-samd51g")]
+use target_device::dmac::channel as channel_regs;
+
+use channel_regs::{CHCTRLA, CHCTRLB, CHINTENCLR, CHINTENSET, CHINTFLAG, CHSTATUS};
+
+#[cfg(feature = "min-samd51g")]
+use target_device::dmac::{channel::CHPRILVL, CHANNEL};
+
+//==============================================================================
+// RegisterBlock
+//==============================================================================
+/// Read/write proxy for DMAC registers accessible to individual channels.
+pub(super) trait Register<Id: ChId> {
+    /// Set channel ID and run the closure. A closure is needed to ensure
+    /// the registers are accessed in an interrupt-safe way, as the SAMD21
+    /// DMAC is a little funky - It requires setting the channel number in
+    /// the CHID register, then access the channel control registers.
+    /// If an interrupt were to change the CHID register, we would be faced
+    /// with undefined behaviour.
+    #[cfg(any(feature = "samd11", feature = "samd21"))]
+    #[inline]
+    fn with_chid<F: FnOnce(&DMAC) -> R, R>(&self, dmac: &DMAC, fun: F) -> R {
+        cortex_m::interrupt::free(|_| {
+            // SAFETY: This is ONLY safe if the individual channels are GUARANTEED not to
+            // mess with either:
+            // - The global DMAC configuration
+            // - The configuration of other channels.
+            //
+            // In practice, this means that the DMAC registers should only be accessed
+            // through the `with_chid` method.
+            unsafe {
+                dmac.chid.modify(|_, w| w.id().bits(Id::U8));
+            };
+
+            fun(dmac)
+        })
+    }
+
+    /// Set channel ID and run the closure. A closure is needed to ensure
+    /// the registers are accessed in an interrupt-safe way, as the SAMD21
+    /// DMAC is a little funky. For the SAMD51/SAMEx, we simply take a reference
+    /// to the correct channel number and run the closure on that.
+    #[cfg(feature = "min-samd51g")]
+    #[inline]
+    fn with_chid<F: FnOnce(&CHANNEL) -> R, R>(&self, dmac: &DMAC, fun: F) -> R {
+        // SAFETY: This is ONLY safe if the individual channels are GUARANTEED not to
+        // mess with either:
+        // - The global DMAC configuration
+        // - The configuration of other channels.
+        //
+        // In practice, this means that the DMAC registers should only be accessed
+        // through the `with_chid` method.
+        let mut ch = &dmac.channel[Id::USIZE];
+        fun(&mut ch)
+    }
+}
+
+/// Readable register which belongs to a specific channel in its entirety
+pub(super) trait ReadRegister<Id: ChId, REG>: Register<Id>
+where
+    REG: target_device::generic::Readable,
+{
+    /// PAC read proxy
+    type R;
+    /// Read the register in a safe way.
+    fn read(&self) -> Self::R;
+}
+/// Writable register which belongs to a specific channel in its entirety
+pub(super) trait WriteRegister<Id: ChId, REG>: Register<Id>
+where
+    REG: target_device::generic::Writable,
+{
+    /// PAC write proxy
+    type W;
+    /// Write to the register in a safe way
+    fn write<F>(&mut self, func: F)
+    where
+        for<'w> F: FnOnce(&'w mut Self::W) -> &'w mut Self::W;
+}
+
+/// Readable/writable register which belongs to a specific channel in its
+/// entirety
+pub(super) trait ModifyRegister<Id: ChId, REG>: Register<Id>
+where
+    REG: target_device::generic::Readable + target_device::generic::Writable,
+{
+    /// PAC read proxy
+    type R;
+    /// PAC write proxy
+    type W;
+
+    /// Modify the register in a safe way
+    fn modify<F>(&mut self, func: F)
+    where
+        for<'w> F: FnOnce(&Self::R, &'w mut Self::W) -> &'w mut Self::W;
+}
+
+macro_rules! channel_reg_read {
+    ($reg:ident, $obj:ty) => {
+        paste! {
+            /// Register proxy tied to a specific channel
+            pub(super) struct [< $obj:camel Proxy >]<Id: ChId, REG> {
+                dmac: DMAC,
+                _id: PhantomData<Id>,
+                _reg: PhantomData<REG>,
+            }
+
+            impl<Id: ChId> [< $obj:camel Proxy >]<Id, $obj> {
+                /// Create a new register proxy
+                #[inline]
+                pub(super) fn new() -> Self {
+                    Self {
+                        // SAFETY: This is safe as long as the register
+                        // only reads/writes registers through
+                        // the `with_chid` method.
+                        dmac: unsafe { Peripherals::steal().DMAC },
+                        _id: PhantomData,
+                        _reg: PhantomData,
+                    }
+                }
+            }
+
+            impl<Id: ChId> Register<Id> for [< $obj:camel Proxy >]<Id, $obj> {}
+
+            impl<Id: ChId> ReadRegister<Id, $obj> for [<$obj:camel Proxy>]<Id, $obj> {
+                type R = channel_regs::$reg::R;
+
+                #[inline]
+                fn read(&self) -> Self::R {
+                    self.with_chid(&self.dmac, |d| d.$reg.read())
+                }
+            }
+        }
+    };
+}
+macro_rules! channel_reg_write {
+    ($reg:ident, $obj:ty) => {
+        paste! {
+        impl<Id: ChId> WriteRegister<Id, $obj> for [< $obj:camel Proxy >]<Id, $obj> {
+            type W = channel_regs::$reg::W;
+
+            #[inline]
+            fn write<F>(&mut self, func: F)
+            where
+                for<'w> F: FnOnce(&'w mut Self::W) -> &'w mut Self::W,
+            {
+                self.with_chid(&self.dmac, |d| d.$reg.write(|w| func(w)));
+            }
+        }
+
+        impl<Id: ChId> ModifyRegister<Id, $obj> for [< $obj:camel Proxy >]<Id, $obj> {
+            type R = channel_regs::$reg::R;
+            type W = channel_regs::$reg::W;
+
+            #[inline]
+            fn modify<F>(&mut self, func: F)
+            where
+                for<'w> F: FnOnce(&Self::R, &'w mut Self::W) -> &'w mut Self::W,
+            {
+                self.with_chid(&self.dmac, |d| d.$reg.modify(|r, w| func(r, w)));
+            }
+        }}
+    };
+}
+
+channel_reg_read!(chctrla, CHCTRLA);
+channel_reg_read!(chctrlb, CHCTRLB);
+channel_reg_read!(chintenclr, CHINTENCLR);
+channel_reg_read!(chintenset, CHINTENSET);
+channel_reg_read!(chintflag, CHINTFLAG);
+channel_reg_read!(chstatus, CHSTATUS);
+#[cfg(feature = "min-samd51g")]
+channel_reg_read!(chprilvl, CHPRILVL);
+
+channel_reg_write!(chctrla, CHCTRLA);
+channel_reg_write!(chctrlb, CHCTRLB);
+channel_reg_write!(chintenclr, CHINTENCLR);
+channel_reg_write!(chintenset, CHINTENSET);
+channel_reg_write!(chintflag, CHINTFLAG);
+#[cfg(feature = "min-samd51g")]
+channel_reg_write!(chprilvl, CHPRILVL);
+pub(super) trait ReadBit<Id: ChId, REG>: Register<Id>
+where
+    REG: target_device::generic::Readable,
+{
+    fn read(&self) -> bool;
+}
+
+macro_rules! channel_bit_read {
+    ($reg:ident, $obj:ty) => {
+        paste! {
+            /// Register proxy tied to a specific channel
+            pub(super) struct [< $obj:camel Proxy >]<Id: ChId, REG> {
+                dmac: DMAC,
+                _id: PhantomData<Id>,
+                _reg: PhantomData<REG>,
+            }
+
+            impl<Id: ChId> [< $obj:camel Proxy >]<Id, $obj> {
+                /// Create a new register proxy
+                #[inline]
+                pub(super) fn new() -> Self {
+                    Self {
+                        // SAFETY: This is safe as long as the register
+                        // only reads/writes the bits it controls
+                        // within registers.
+                        dmac: unsafe { Peripherals::steal().DMAC },
+                        _id: PhantomData,
+                        _reg: PhantomData,
+                    }
+                }
+            }
+
+            impl<Id: ChId> Register<Id> for [< $obj:camel Proxy >]<Id, $obj> {}
+
+            impl<Id: ChId> ReadBit<Id, $obj> for [< $obj:camel Proxy >]<Id, $obj> {
+                #[inline]
+                fn read(&self) -> bool {
+                    self.dmac.$reg.read().bits() & (1 << Id::U8) != 0
+                }
+            }
+        }
+    };
+}
+
+channel_bit_read!(intstatus, INTSTATUS);
+channel_bit_read!(busych, BUSYCH);
+channel_bit_read!(pendch, PENDCH);
+channel_bit_read!(swtrigctrl, SWTRIGCTRL);
+
+pub(super) trait WriteBit<Id: ChId, REG>: Register<Id>
+where
+    REG: target_device::generic::Writable,
+{
+    fn write(&self, bit: bool);
+}
+
+macro_rules! channel_bit_write {
+    ($reg: ident, $obj:ty) => {
+        paste! {
+            impl<Id: ChId> WriteBit<Id, $obj> for [< $obj:camel Proxy >]<Id, $obj> {
+                #[inline]
+                fn write(&self, bit: bool) {
+                    // SAFETY: This is safe because we are only writing
+                    // to the bit controlled by the channel.
+                    self.dmac
+                        .$reg
+                        .modify(|r, w| unsafe { w.bits(r.bits() & ((bit as u32) << Id::U8)) });
+                }
+            }
+        }
+    };
+}
+
+channel_bit_write!(swtrigctrl, SWTRIGCTRL);
+
+/// Acts as a proxy to the PAC DMAC object. Only registers and bits
+/// within registers that should be readable/writable by specific
+/// [`Channel`]s are exposed.
+pub(super) struct RegisterBlock<Id: ChId> {
+    pub chctrla: ChctrlaProxy<Id, CHCTRLA>,
+    pub chctrlb: ChctrlbProxy<Id, CHCTRLB>,
+    pub chintenclr: ChintenclrProxy<Id, CHINTENCLR>,
+    pub chintenset: ChintensetProxy<Id, CHINTENSET>,
+    pub chintflag: ChintflagProxy<Id, CHINTFLAG>,
+    pub chstatus: ChstatusProxy<Id, CHSTATUS>,
+    pub intstatus: IntstatusProxy<Id, INTSTATUS>,
+    pub busych: BusychProxy<Id, BUSYCH>,
+    pub pendch: PendchProxy<Id, PENDCH>,
+    pub swtrigctrl: SwtrigctrlProxy<Id, SWTRIGCTRL>,
+    #[cfg(feature = "min-samd51g")]
+    pub chprilvl: ChprilvlProxy<Id, CHPRILVL>,
+}
+
+impl<Id: ChId> RegisterBlock<Id> {
+    pub(super) fn new(_id: PhantomData<Id>) -> Self {
+        Self {
+            chctrla: ChctrlaProxy::new(),
+            chctrlb: ChctrlbProxy::new(),
+            chintenclr: ChintenclrProxy::new(),
+            chintenset: ChintensetProxy::new(),
+            chintflag: ChintflagProxy::new(),
+            chstatus: ChstatusProxy::new(),
+            intstatus: IntstatusProxy::new(),
+            busych: BusychProxy::new(),
+            pendch: PendchProxy::new(),
+            swtrigctrl: SwtrigctrlProxy::new(),
+            #[cfg(feature = "min-samd51g")]
+            chprilvl: ChprilvlProxy::new(),
+        }
+    }
+}

--- a/hal/src/dmac/dma_controller.rs
+++ b/hal/src/dmac/dma_controller.rs
@@ -128,18 +128,6 @@ pub struct RoundRobinMask {
 }
 
 impl DmaController {
-    /// Return a shared reference to the underlying DMAC object exposed by the
-    /// PAC.
-    ///
-    /// # Safety
-    ///
-    /// This function is unsafe because `DmaController` may expect certain
-    /// registers to retain a configuration. Messing with that configuration may
-    /// be unsafe.
-    pub(super) fn dmac(&mut self) -> &DMAC {
-        &mut self.dmac
-    }
-
     /// Initialize the DMAC and return a DmaController object useable by
     /// [`Transfer`](super::transfer::Transfer)'s. By default, all
     /// priority levels are enabled unless subsequently disabled using the

--- a/hal/src/dmac/dma_controller.rs
+++ b/hal/src/dmac/dma_controller.rs
@@ -81,6 +81,7 @@ pub struct DmaController {
     dmac: DMAC,
 }
 
+/// Mask representing which priority levels should be enabled/disabled
 #[bitfield]
 #[repr(u16)]
 pub struct PriorityLevelMask {
@@ -102,6 +103,7 @@ pub struct PriorityLevelMask {
     _reserved: B4,
 }
 
+/// Mask representing which priority levels should be configured as round-robin
 #[bitfield]
 #[repr(u32)]
 pub struct RoundRobinMask {
@@ -221,8 +223,8 @@ impl DmaController {
     /// Release the DMAC and return the register block.
     ///
     /// **Note**: The [`Channels`] struct is consumed by this method. This means
-    /// that any [`Channel`] obtained by [`split`] must be moved back into the
-    /// [`Channels`] struct before being able to pass it into [`free`].
+    /// that any [`Channel`] obtained by [`split`](DmaController::split) must be moved back into the
+    /// [`Channels`] struct before being able to pass it into [`free`](DmaController::free).
     pub fn free(mut self, _channels: Channels, _pm: &mut PM) -> DMAC {
         self.dmac.ctrl.modify(|_, w| w.dmaenable().clear_bit());
 

--- a/hal/src/dmac/dma_controller.rs
+++ b/hal/src/dmac/dma_controller.rs
@@ -218,8 +218,12 @@ impl DmaController {
         }
     }
 
-    /// Release the DMAC and return the register block
-    pub fn free(mut self, _pm: &mut PM) -> DMAC {
+    /// Release the DMAC and return the register block.
+    ///
+    /// **Note**: The [`Channels`] struct is consumed by this method. This means
+    /// that any [`Channel`] obtained by [`split`] must be moved back into the
+    /// [`Channels`] struct before being able to pass it into [`free`].
+    pub fn free(mut self, _channels: Channels, _pm: &mut PM) -> DMAC {
         self.dmac.ctrl.modify(|_, w| w.dmaenable().clear_bit());
 
         Self::swreset(&mut self.dmac);

--- a/hal/src/dmac/dma_controller.rs
+++ b/hal/src/dmac/dma_controller.rs
@@ -223,8 +223,9 @@ impl DmaController {
     /// Release the DMAC and return the register block.
     ///
     /// **Note**: The [`Channels`] struct is consumed by this method. This means
-    /// that any [`Channel`] obtained by [`split`](DmaController::split) must be moved back into the
-    /// [`Channels`] struct before being able to pass it into [`free`](DmaController::free).
+    /// that any [`Channel`] obtained by [`split`](DmaController::split) must be
+    /// moved back into the [`Channels`] struct before being able to pass it
+    /// into [`free`](DmaController::free).
     pub fn free(mut self, _channels: Channels, _pm: &mut PM) -> DMAC {
         self.dmac.ctrl.modify(|_, w| w.dmaenable().clear_bit());
 

--- a/hal/src/dmac/dma_controller.rs
+++ b/hal/src/dmac/dma_controller.rs
@@ -134,6 +134,7 @@ impl DmaController {
     /// [`Transfer`](super::transfer::Transfer)'s. By default, all
     /// priority levels are enabled unless subsequently disabled using the
     /// `level_x_enabled` methods.
+    #[inline]
     pub fn init(mut dmac: DMAC, _pm: &mut PM) -> Self {
         // ----- Initialize clocking ----- //
         #[cfg(any(feature = "samd11", feature = "samd21"))]
@@ -226,6 +227,7 @@ impl DmaController {
     /// that any [`Channel`] obtained by [`split`](DmaController::split) must be
     /// moved back into the [`Channels`] struct before being able to pass it
     /// into [`free`](DmaController::free).
+    #[inline]
     pub fn free(mut self, _channels: Channels, _pm: &mut PM) -> DMAC {
         self.dmac.ctrl.modify(|_, w| w.dmaenable().clear_bit());
 
@@ -254,6 +256,7 @@ macro_rules! define_split {
     ($num_channels:literal) => {
         seq!(N in 0..$num_channels {
             /// Split the DMAC into individual channels
+            #[inline]
             pub fn split(&mut self) -> Channels {
                 Channels(
                     #(

--- a/hal/src/dmac/mod.rs
+++ b/hal/src/dmac/mod.rs
@@ -156,12 +156,16 @@
 //!
 //! # [`Transfer`] recycling
 //!
-//! A common use-case with DMAC transfers is to trigger a new transfer as soon as the old transfer is completed.
-//! To avoid having to [`stop`](Transfer::stop) a [`Transfer`], build a new [`Transfer`] (with [`new`](Transfer::new) or
-//! [`new_from_arrays`](Transfer::new_from_arrays)) then call [`begin`](Transfer::begin), a [`Transfer::recycle`] method
-//! is provided. If the buffer lengths match and the previous transfer is completed, a new transfer will immediately be triggered
-//! using the provided source and destination buffers. If the recycling operation is succesful, `Ok((source, destination))` containing
-//! the old source and destination buffers is returned. Otherwise, `Err(_)` is returned.
+//! A common use-case with DMAC transfers is to trigger a new transfer as soon
+//! as the old transfer is completed. To avoid having to
+//! [`stop`](Transfer::stop) a [`Transfer`], build a new [`Transfer`] (with
+//! [`new`](Transfer::new) or [`new_from_arrays`](Transfer::new_from_arrays))
+//! then call [`begin`](Transfer::begin), a [`Transfer::recycle`] method
+//! is provided. If the buffer lengths match and the previous transfer is
+//! completed, a new transfer will immediately be triggered using the provided
+//! source and destination buffers. If the recycling operation is succesful,
+//! `Ok((source, destination))` containing the old source and destination
+//! buffers is returned. Otherwise, `Err(_)` is returned.
 //!
 //! ```
 //! let new_source = produce_source();
@@ -173,8 +177,8 @@
 //!
 //! # Waker operation
 //!
-//! A [`Transfer`] can also accept a function or closure that will be called on completion of the transaction,
-//! acting like a [`Waker`].
+//! A [`Transfer`] can also accept a function or closure that will be called on
+//! completion of the transaction, acting like a [`Waker`].
 //!
 //! ```
 //! fn wake_up() {
@@ -198,8 +202,8 @@
 //! The [RTIC] framework provides a convenient way to store a `static`ally
 //! allocated [`Transfer`], so that it can be accessed by both the interrupt
 //! handlers and user code. The following example shows how [`Transfer`]s might
-//! be used for a series of transactions. It uses features from the latest release of
-//! [RTIC], `v0.6-alpha.4`.
+//! be used for a series of transactions. It uses features from the latest
+//! release of [RTIC], `v0.6-alpha.4`.
 //!
 //! ```
 //! use atsamd_hal::dmac::*;

--- a/hal/src/dmac/mod.rs
+++ b/hal/src/dmac/mod.rs
@@ -150,6 +150,9 @@
 //! let (chan0, buf_src, buf_dest, _) = xfer.wait(&mut dmac);
 //! ```
 
+// This is necessary until modular_bitfield fixes all their unused brace warnings
+#![allow(unused_braces)]
+
 use modular_bitfield::prelude::*;
 
 #[cfg(feature = "min-samd51g")]

--- a/hal/src/dmac/mod.rs
+++ b/hal/src/dmac/mod.rs
@@ -155,6 +155,7 @@
 
 use modular_bitfield::prelude::*;
 
+pub use channel::CallbackStatus;
 #[cfg(feature = "min-samd51g")]
 pub use dma_controller::{BurstLength, FifoThreshold};
 pub use dma_controller::{

--- a/hal/src/dmac/mod.rs
+++ b/hal/src/dmac/mod.rs
@@ -164,6 +164,24 @@ pub use dma_controller::{
 use transfer::BeatSize;
 pub use transfer::{Beat, Buffer, Transfer};
 
+#[derive(Debug)]
+pub enum DmacError {
+    /// Supplied buffers both have lengths > 1 beat, but not equal to each other
+    ///
+    /// Buffers need to either have the same length in beats, or one should have
+    /// length == 1.  In cases where one buffer is length 1, that buffer will be
+    /// the source or destination of each beat in the transfer.  If both buffers
+    /// had length >1, but not equal to each other, then it would not be clear
+    /// how to structure the transfer.
+    LengthMismatch,
+
+    /// Operation is not valid in the current state of the object.
+    InvalidState,
+}
+
+/// Result for DMAC operations
+pub type Result<T> = core::result::Result<T, DmacError>;
+
 #[cfg(all(feature = "samd11", feature = "max-channels"))]
 #[macro_export]
 macro_rules! with_num_channels {

--- a/hal/src/dmac/mod.rs
+++ b/hal/src/dmac/mod.rs
@@ -148,7 +148,109 @@
 //!
 //! // Wait for transfer to complete and grab resulting buffers
 //! let (chan0, buf_src, buf_dest, _) = xfer.wait(&mut dmac);
+//!
+//! // (Optional) free the [`DmaController`] struct and return the underlying PAC struct
+//! channels.0 = chan0.into();
+//! let dmac = dmac.free(channels, &mut peripherals.PM);
 //! ```
+//!
+//! # [`Transfer`] recycling
+//!
+//! A common use-case with DMAC transfers is to trigger a new transfer as soon as the old transfer is completed.
+//! To avoid having to [`stop`](Transfer::stop) a [`Transfer`], build a new [`Transfer`] (with [`new`](Transfer::new) or
+//! [`new_from_arrays`](Transfer::new_from_arrays)) then call [`begin`](Transfer::begin), a [`Transfer::recycle`] method
+//! is provided. If the buffer lengths match and the previous transfer is completed, a new transfer will immediately be triggered
+//! using the provided source and destination buffers. If the recycling operation is succesful, `Ok((source, destination))` containing
+//! the old source and destination buffers is returned. Otherwise, `Err(_)` is returned.
+//!
+//! ```
+//! let new_source = produce_source();
+//! let new_destination = produce_destination();
+//!
+//! // Assume xfer is a `Busy` `Transfer`
+//! let (old_source, old_dest) = xfer.recycle(new_source, new_destination).unwrap();
+//! ```
+//!
+//! # Waker operation
+//!
+//! A [`Transfer`] can also accept a function or closure that will be called on completion of the transaction,
+//! acting like a [`Waker`].
+//!
+//! ```
+//! fn wake_up() {
+//!     //...
+//! }
+//!
+//! fn use_waker<const N: usize>(dmac: DmaController,
+//!     source: &'static mut [u8; N],
+//!     destination: &'static mut [u8; N]
+//! ){
+//!     let chan0 = dmac.split().0;
+//!     let xfer = Transfer::new_from_arrays(chan0, source, destination, false)
+//!         .with_waker(wake_up)
+//!         .begin();
+//!     //...
+//! }
+//! ```
+//!
+//! ## RTIC example
+//!
+//! The [RTIC] framework provides a convenient way to store a `static`ally
+//! allocated [`Transfer`], so that it can be accessed by both the interrupt
+//! handlers and user code. The following example shows how [`Transfer`]s might
+//! be used for a series of transactions. It uses features from the latest release of
+//! [RTIC], `v0.6-alpha.4`.
+//!
+//! ```
+//! use atsamd_hal::dmac::*;
+//!
+//! const LENGTH: usize = 50;
+//! type TransferBuffer = &'static mut [u8; LENGTH];
+//! type Xfer = Transfer<Channel<Ch0, Busy>, TransferBuffer, TransferBuffer>;
+//!
+//! #[resources]
+//! struct Resources {
+//!     #[lock_free]
+//!     #[init(None)]
+//!     opt_xfer: Option<Xfer>,
+//!
+//!     #[lock_free]
+//!     #[init(None)]
+//!     opt_channel: Option<Channel<Ch0, Ready>>,
+//! }
+//!
+//! // Note: Assume interrupts have already been enabled for the concerned channel
+//! #[task(resources = [opt_xfer, opt_channel])]
+//! fn task(ctx: task::Context) {
+//!     let task::Context { opt_xfer } = ctx;
+//!     match opt_xfer {
+//!         Some(xfer) => {
+//!             if xfer.complete() {
+//!                 let (chan0, _source, dest, _payload) = xfer.take().unwrap().stop();
+//!                 *opt_channel = Some(chan0);
+//!                 consume_data(buf);
+//!             }
+//!         }
+//!         None => {
+//!             if let Some(chan0) = opt_channel.take() {
+//!                 let source: [u8; 50] = produce_source();
+//!                 let dest: [u8; 50] = produce_destination();
+//!                 let xfer = opt_xfer.get_or_insert(
+//!                     Transfer::new_from_arrays(channel0, source, destination)
+//!                         .with_waker(|| { task::spawn().ok(); })
+//!                         .begin()
+//!                 );
+//!             }
+//!         }
+//!     }
+//! }
+//!
+//! #[task(binds = DMAC, resources = [opt_future])]
+//! fn tcmpl(ctx: tcmpl::Context) {
+//!     ctx.resources.opt_xfer.as_mut().unwrap().callback();
+//! }
+//! ```
+//! [RTIC]: https://rtic.rs
 
 // This is necessary until modular_bitfield fixes all their unused brace warnings
 #![allow(unused_braces)]
@@ -165,7 +267,8 @@ use transfer::BeatSize;
 pub use transfer::{Beat, Buffer, Transfer};
 
 #[derive(Debug)]
-pub enum DmacError {
+/// Runtime errors that may occur when dealing with DMA transfers.
+pub enum Error {
     /// Supplied buffers both have lengths > 1 beat, but not equal to each other
     ///
     /// Buffers need to either have the same length in beats, or one should have
@@ -180,7 +283,7 @@ pub enum DmacError {
 }
 
 /// Result for DMAC operations
-pub type Result<T> = core::result::Result<T, DmacError>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 #[cfg(all(feature = "samd11", feature = "max-channels"))]
 #[macro_export]
@@ -239,9 +342,12 @@ macro_rules! get {
 /// Number of DMA channels used by the driver
 pub const NUM_CHANNELS: usize = with_num_channels!(get);
 
+// ----- DMAC SRAM registers ----- //
+/// Bitfield representing the BTCTRL SRAM DMAC register
 #[bitfield]
 #[derive(Clone, Copy)]
 #[repr(u16)]
+#[doc(hidden)]
 pub struct BlockTransferControl {
     #[allow(dead_code)]
     valid: bool,
@@ -264,7 +370,6 @@ pub struct BlockTransferControl {
     stepsize: B3,
 }
 
-// ----- DMAC SRAM registers ----- //
 /// Descriptor representing a SRAM register. Datasheet section 19.8.2
 #[derive(Clone, Copy)]
 #[repr(C, align(16))]

--- a/hal/src/dmac/transfer.rs
+++ b/hal/src/dmac/transfer.rs
@@ -89,7 +89,7 @@
 //! transaction, that will now run uninterrupted until it is stopped.
 
 use super::{
-    channel::{AnyChannel, Busy, Channel, ChannelId, Ready},
+    channel::{AnyChannel, Busy, CallbackStatus, Channel, ChannelId, Ready},
     dma_controller::{ChId, TriggerAction, TriggerSource},
     BlockTransferControl, DmacDescriptor, DESCRIPTOR_SECTION,
 };
@@ -110,7 +110,8 @@ pub enum BeatSize {
     HalfWord = 0x01,
     /// Word = [`u32`](core::u32)
     Word = 0x02,
-    _RESERVED = 0x03,
+    #[doc(hidden)]
+    _Reserved = 0x03,
 }
 /// Convert 8, 16 and 32 bit types
 /// into [`BeatSize`](BeatSize)
@@ -300,6 +301,7 @@ where
     buffers: Buf,
     payload: Pld,
     waker: Option<W>,
+    complete: bool,
 }
 
 /// These methods are available to an [`Transfer`] holding a `Ready` `Channel`,
@@ -432,6 +434,7 @@ where
             chan,
             payload: (),
             waker: None,
+            complete: false,
         }
     }
 }
@@ -452,6 +455,7 @@ where
             chan: self.chan,
             waker: self.waker,
             payload,
+            complete: self.complete,
         }
     }
 }
@@ -466,7 +470,7 @@ where
 {
     /// Append a waker to the transfer. This will be called when the DMAC
     /// interrupt is called.
-    pub fn with_waker<W: FnOnce() + 'static>(
+    pub fn with_waker<W: FnOnce(CallbackStatus) + 'static>(
         self,
         waker: W,
     ) -> Transfer<C, BufferPair<S, D>, P, W> {
@@ -474,6 +478,7 @@ where
             buffers: self.buffers,
             chan: self.chan,
             payload: self.payload,
+            complete: self.complete,
             waker: Some(waker),
         }
     }
@@ -492,10 +497,15 @@ where
     /// launch the transfer. Is is therefore not necessary, in most cases,
     /// to manually issue a software trigger to the channel.
     pub fn begin(
-        self,
+        mut self,
         trig_src: TriggerSource,
         trig_act: TriggerAction,
     ) -> Transfer<Channel<ChannelId<C>, Busy>, BufferPair<S, D>, P, W> {
+        // Reset the complete flag before triggering the transfer.
+        // This way an interrupt handler could set complete to true
+        // before this function returns.
+        self.complete = false;
+
         // Memory barrier to prevent the compiler/CPU from re-ordering read/write
         // operations beyond this fence.
         // (see https://docs.rust-embedded.org/embedonomicon/dma.html#compiler-misoptimizations)
@@ -507,6 +517,7 @@ where
             chan,
             payload: self.payload,
             waker: self.waker,
+            complete: self.complete,
         }
     }
 }
@@ -547,33 +558,29 @@ where
     pub fn software_trigger(&mut self) {
         self.chan.as_mut().software_trigger();
     }
-    /// Blocking; Wait for the DMA transfer to complete and release all owned
+    /// Wait for the DMA transfer to complete and release all owned
     /// resources
-    pub fn wait(self) -> (Channel<ChannelId<C>, Ready>, S, D, P) {
-        let chan = self.chan.into().free();
-
-        // Memory barrier to prevent the compiler/CPU from re-ordering read/write
-        // operations beyond this fence.
-        // (see https://docs.rust-embedded.org/embedonomicon/dma.html#compiler-misoptimizations)
-        atomic::fence(atomic::Ordering::Acquire); // ▼
-
-        (
-            chan,
-            self.buffers.source,
-            self.buffers.destination,
-            self.payload,
-        )
+    ///
+    /// # Blocking: This method may block
+    pub fn wait(mut self) -> (Channel<ChannelId<C>, Ready>, S, D, P) {
+        // Wait for transfer to complete
+        while !self.complete() {}
+        self.stop()
     }
 
-    pub fn complete(&self) -> bool {
-        let chan = self.chan.as_ref();
-        chan.xfer_complete()
+    pub fn complete(&mut self) -> bool {
+        if !self.complete {
+            let chan = self.chan.as_ref();
+            let complete = chan.xfer_complete();
+            self.complete = complete;
+        }
+        self.complete
     }
 
     /// Non-blocking; Immediately stop the DMA transfer and release all owned
     /// resources
     pub fn stop(self) -> (Channel<ChannelId<C>, Ready>, S, D, P) {
-        let chan = self.chan.into().stop();
+        let chan = self.chan.into().free();
 
         // Memory barrier to prevent the compiler/CPU from re-ordering read/write
         // operations beyond this fence.
@@ -594,14 +601,19 @@ where
     S: Buffer,
     D: Buffer<Beat = S::Beat>,
     C: AnyChannel<Status = Busy>,
-    W: FnOnce() + 'static,
+    W: FnOnce(CallbackStatus) + 'static,
 {
     /// This function should be put inside the DMAC interrupt handler.
     /// It will take care of calling the [`Transfer`]'s waker (if it exists).
     pub fn callback(&mut self) {
-        self.chan.as_mut().callback();
+        let status = self.chan.as_mut().callback();
+
+        if let CallbackStatus::TransferComplete = status {
+            self.complete = true;
+        }
+
         if let Some(w) = self.waker.take() {
-            w()
+            w(status)
         }
     }
 }

--- a/hal/src/dmac/transfer.rs
+++ b/hal/src/dmac/transfer.rs
@@ -619,10 +619,12 @@ where
             .tcmpl()
     }
 
-    /// Modify a completed transfer with new `source` and `destination`, restart
+    /// Modify a completed transfer with new `source` and `destination`, thern
+    /// restart.
     ///
     /// Returns a Result containing the source and destination from the
-    /// completed transfer.
+    /// completed transfer. Returns `Err(_)` if the buffer lengths are
+    /// mismatched or if the previous transfer has not yet completed.
     pub fn recycle(&mut self, mut source: S, mut destination: D) -> Result<(S, D)> {
         Self::check_buffer_pair(&source, &destination)?;
 

--- a/hal/src/dmac/transfer.rs
+++ b/hal/src/dmac/transfer.rs
@@ -91,7 +91,7 @@
 use super::{
     channel::{AnyChannel, Busy, CallbackStatus, Channel, ChannelId, InterruptFlags, Ready},
     dma_controller::{ChId, TriggerAction, TriggerSource},
-    BlockTransferControl, DmacDescriptor, DmacError, Result, DESCRIPTOR_SECTION,
+    BlockTransferControl, DmacDescriptor, Error, Result, DESCRIPTOR_SECTION,
 };
 use crate::typelevel::{Is, Sealed};
 use core::{ptr::null_mut, sync::atomic};
@@ -147,6 +147,7 @@ impl_beat!(
 
 /// Buffer useable by the DMAC.
 pub unsafe trait Buffer {
+    /// DMAC beat size
     type Beat: Beat;
     /// Pointer to the buffer. If the buffer is incrementing, the address should
     /// point to one past the last beat transfer in the block.
@@ -232,7 +233,9 @@ where
     S: Buffer,
     D: Buffer<Beat = S::Beat>,
 {
+    /// Source buffer
     pub source: S,
+    /// Destination buffer
     pub destination: D,
 }
 
@@ -351,7 +354,7 @@ where
         let dst_len = destination.buffer_len();
 
         if src_len > 1 && dst_len > 1 && src_len != dst_len {
-            Err(DmacError::LengthMismatch)
+            Err(Error::LengthMismatch)
         } else {
             Ok(())
         }
@@ -624,7 +627,7 @@ where
         Self::check_buffer_pair(&source, &destination)?;
 
         if !self.complete() {
-            return Err(DmacError::InvalidState);
+            return Err(Error::InvalidState);
         }
 
         // Circular transfers won't ever complete, so never re-fill as one

--- a/hal/src/dmac/transfer.rs
+++ b/hal/src/dmac/transfer.rs
@@ -94,7 +94,7 @@ use super::{
     BlockTransferControl, DmacDescriptor, DmacError, Result, DESCRIPTOR_SECTION,
 };
 use crate::typelevel::{Is, Sealed};
-use core::{mem, ptr::null_mut, sync::atomic};
+use core::{ptr::null_mut, sync::atomic};
 use modular_bitfield::prelude::*;
 
 //==============================================================================

--- a/hal/src/dmac/transfer.rs
+++ b/hal/src/dmac/transfer.rs
@@ -291,11 +291,10 @@ where
 // TODO change source and dest types to Pin? (see https://docs.rust-embedded.org/embedonomicon/dma.html#immovable-buffers)
 /// DMA transfer, owning the resources until the transfer is done and
 /// [`Transfer::wait`] is called.
-pub struct Transfer<Chan, Buf, Pld = (), W = fn()>
+pub struct Transfer<Chan, Buf, Pld = (), W = ()>
 where
     Buf: AnyBufferPair,
     Chan: AnyChannel,
-    W: FnMut() + 'static,
 {
     chan: Chan,
     buffers: Buf,
@@ -444,7 +443,6 @@ where
     S: Buffer,
     D: Buffer<Beat = S::Beat>,
     C: AnyChannel<Status = Ready>,
-    W: FnMut() + 'static,
 {
     /// Append a payload to the transfer. This guarantees that it cannot safely
     /// be accessed while the transfer is ongoing.
@@ -468,7 +466,10 @@ where
 {
     /// Append a waker to the transfer. This will be called when the DMAC
     /// interrupt is called.
-    pub fn with_waker<W: FnMut() + 'static>(self, waker: W) -> Transfer<C, BufferPair<S, D>, P, W> {
+    pub fn with_waker<W: FnOnce() + 'static>(
+        self,
+        waker: W,
+    ) -> Transfer<C, BufferPair<S, D>, P, W> {
         Transfer {
             buffers: self.buffers,
             chan: self.chan,
@@ -485,7 +486,6 @@ where
     S: Buffer,
     D: Buffer<Beat = S::Beat>,
     C: AnyChannel<Status = Ready>,
-    W: FnMut() + 'static,
 {
     /// Begin DMA transfer. If [TriggerSource::DISABLE](TriggerSource::DISABLE)
     /// is used, a sowftware trigger will be issued to the DMA channel to
@@ -539,7 +539,6 @@ where
     S: Buffer,
     D: Buffer<Beat = S::Beat>,
     C: AnyChannel<Status = Busy>,
-    W: FnMut() + 'static,
 {
     /// Issue a software trigger request to the corresponding channel.
     /// Note that is not guaranteed that the trigger request will register,
@@ -588,10 +587,20 @@ where
             self.payload,
         )
     }
+}
 
+impl<S, D, C, P, W> Transfer<C, BufferPair<S, D>, P, W>
+where
+    S: Buffer,
+    D: Buffer<Beat = S::Beat>,
+    C: AnyChannel<Status = Busy>,
+    W: FnOnce() + 'static,
+{
+    /// This function should be put inside the DMAC interrupt handler.
+    /// It will take care of calling the [`Transfer`]'s waker (if it exists).
     pub fn callback(&mut self) {
         self.chan.as_mut().callback();
-        if let Some(mut w) = self.waker.take() {
+        if let Some(w) = self.waker.take() {
             w()
         }
     }

--- a/hal/src/dmac/transfer.rs
+++ b/hal/src/dmac/transfer.rs
@@ -614,7 +614,7 @@ where
     #[inline]
     pub fn complete(&mut self) -> bool {
         if !self.complete {
-            let chan = self.chan.as_ref();
+            let chan = self.chan.as_mut();
             let complete = chan.xfer_complete();
             self.complete = complete;
         }

--- a/hal/src/dmac/transfer.rs
+++ b/hal/src/dmac/transfer.rs
@@ -115,7 +115,7 @@ pub enum BeatSize {
 }
 /// Convert 8, 16 and 32 bit types
 /// into [`BeatSize`](BeatSize)
-pub trait Beat: Sealed {
+pub unsafe trait Beat: Sealed {
     /// Convert to BeatSize enum
     const BEATSIZE: BeatSize;
 }
@@ -124,7 +124,7 @@ macro_rules! impl_beat {
     ( $( ($Type:ty, $Size:ident) ),+ ) => {
         $(
             impl Sealed for $Type {}
-            impl Beat for $Type {
+            unsafe impl Beat for $Type {
                 const BEATSIZE: BeatSize = BeatSize::$Size;
             }
         )+

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -96,7 +96,6 @@ pub mod timer_params;
 pub mod timer_traits;
 
 #[cfg(all(feature = "unproven", feature = "dma"))]
-#[macro_use]
 pub mod dmac;
 
 #[cfg(any(feature = "samd11", feature = "samd21"))]

--- a/hal/src/sercom/v2.rs
+++ b/hal/src/sercom/v2.rs
@@ -48,8 +48,10 @@ pub trait Sercom: Sealed + Deref<Target = sercom0::RegisterBlock> {
     /// SERCOM number
     const NUM: usize;
     /// RX Trigger source for DMA transactions
+    #[cfg(feature = "dma")]
     const DMA_RX_TRIGGER: TriggerSource;
     /// TX trigger source for DMA transactions
+    #[cfg(feature = "dma")]
     const DMA_TX_TRIGGER: TriggerSource;
     /// Enable the corresponding APB clock
     fn enable_apb_clock(&mut self, ctrl: &APB_CLK_CTRL);
@@ -64,7 +66,9 @@ macro_rules! sercom {
                 impl Sealed for Sercom#N {}
                 impl Sercom for Sercom#N {
                     const NUM: usize = N;
+                    #[cfg(feature = "dma")]
                     const DMA_RX_TRIGGER: TriggerSource = TriggerSource::[<SERCOM#N _RX>];
+                    #[cfg(feature = "dma")]
                     const DMA_TX_TRIGGER: TriggerSource = TriggerSource::[<SERCOM#N _TX>];
                     #[inline]
                     fn enable_apb_clock(&mut self, ctrl: &APB_CLK_CTRL) {

--- a/hal/src/sercom/v2.rs
+++ b/hal/src/sercom/v2.rs
@@ -30,6 +30,8 @@ pub use crate::common::thumbv6m::sercom::v2::*;
 #[cfg(feature = "min-samd51g")]
 pub use crate::common::thumbv7em::sercom::v2::*;
 
+#[cfg(feature = "dma")]
+use crate::common::dmac::TriggerSource;
 use crate::typelevel::Sealed;
 
 pub mod pad;
@@ -45,6 +47,10 @@ pub mod spi_future;
 pub trait Sercom: Sealed + Deref<Target = sercom0::RegisterBlock> {
     /// SERCOM number
     const NUM: usize;
+    /// RX Trigger source for DMA transactions
+    const DMA_RX_TRIGGER: TriggerSource;
+    /// TX trigger source for DMA transactions
+    const DMA_TX_TRIGGER: TriggerSource;
     /// Enable the corresponding APB clock
     fn enable_apb_clock(&mut self, ctrl: &APB_CLK_CTRL);
 }
@@ -58,6 +64,8 @@ macro_rules! sercom {
                 impl Sealed for Sercom#N {}
                 impl Sercom for Sercom#N {
                     const NUM: usize = N;
+                    const DMA_RX_TRIGGER: TriggerSource = TriggerSource::[<SERCOM#N _RX>];
+                    const DMA_TX_TRIGGER: TriggerSource = TriggerSource::[<SERCOM#N _TX>];
                     #[inline]
                     fn enable_apb_clock(&mut self, ctrl: &APB_CLK_CTRL) {
                         ctrl.$apbmask.modify(|_, w| w.[<sercom#N _>]().set_bit());

--- a/hal/src/thumbv6m/sercom/v2/spi.rs
+++ b/hal/src/thumbv6m/sercom/v2/spi.rs
@@ -139,6 +139,30 @@
 //! let rcvd: u16 = block!(spi.read());
 //! ```
 //!
+//! # Using SPI with DMA
+//!
+//! This HAL includes support for DMA-enabled SPI transfers. An enabled `Spi`
+//! struct implements the DMAC [`Buffer`](crate::dmac::transfer::Buffer)
+//! trait. The provided [`send_with_dma`](Spi::send_with_dma) and
+//! [`receive_with_dma`](Spi::receive_with_dma) build and begin a
+//! [`dmac::Transfer`](crate::dmac::Transfer), thus starting the SPI in a
+//! non-blocking way. Optionally, interrupts can be enabled on the provided
+//! [`Channel`](crate::dmac::channel::Channel). Note that the `dma` feature must
+//! be enabled. Please refer to the [`dmac`](crate::dmac) module-level
+//! documentation for more information. ```
+//! // Assume channel is a configured `dmac::Channel`, and spi a
+//! fully-configured `Spi`
+//!
+//! // Create data to send
+//! let buffer: [u8; 50] = [0xff; 50]
+//!
+//! // Launch transfer
+//! let dma_transfer = spi.send_with_dma(&mut buffer, channel, ());
+//!
+//! // Wait for transfer to complete and reclaim resources
+//! let (chan0, _, spi, _) = dma_transfer.wait();
+//! ```
+//! 
 //! [`enable`]: Config::enable
 //! [`Pin`]: crate::gpio::v2::pin::Pin
 //! [`PinId`]: crate::gpio::v2::pin::PinId

--- a/hal/src/thumbv6m/sercom/v2/spi.rs
+++ b/hal/src/thumbv6m/sercom/v2/spi.rs
@@ -1637,22 +1637,17 @@ mod spi_dma {
     {
         type Beat = C::Word;
 
-        #[cfg(feature = "min-samd51g")]
         #[inline]
-        fn dma_ptr(&mut self) -> *mut Self::Beat {
-            unsafe { self.sercom().spim().data.as_ptr() as *mut _ }
-        }
-
-        #[inline]
-        #[cfg(any(feature = "samd11", feature = "samd21"))]
         fn dma_ptr(&mut self) -> *mut Self::Beat {
             unsafe { self.sercom().spi().data.as_ptr() as *mut _ }
         }
 
+        #[inline]
         fn incrementing(&self) -> bool {
             false
         }
 
+        #[inline]
         fn buffer_len(&self) -> usize {
             1
         }
@@ -1662,7 +1657,7 @@ mod spi_dma {
     where
         Self: dmac::transfer::Buffer<Beat = C::Word>,
         Config<P, M, C>: ValidConfig,
-        P: DipoDopo + Tx,
+        P: Tx,
         M: MasterMode,
         C: CharSize,
         C::Word: dmac::transfer::Beat,
@@ -1684,6 +1679,7 @@ mod spi_dma {
             channel
                 .as_mut()
                 .enable_interrupts(dmac::channel::InterruptFlags::new().with_tcmpl(true));
+
             // SAFETY: We use new_unchecked to avoid having to pass a 'static self as the
             // destination buffer. This is safe as long as we guarantee the source buffer is
             // static.
@@ -1700,7 +1696,7 @@ mod spi_dma {
     where
         Self: dmac::transfer::Buffer<Beat = C::Word>,
         Config<P, M, C>: ValidConfig,
-        P: DipoDopo + Rx,
+        P: Rx,
         M: MasterMode,
         C: CharSize,
         C::Word: dmac::transfer::Beat,
@@ -1722,6 +1718,7 @@ mod spi_dma {
             channel
                 .as_mut()
                 .enable_interrupts(dmac::channel::InterruptFlags::new().with_tcmpl(true));
+
             // SAFETY: We use new_unchecked to avoid having to pass a 'static self as the
             // destination buffer. This is safe as long as we guarantee the source buffer is
             // static.

--- a/hal/src/thumbv6m/sercom/v2/spi.rs
+++ b/hal/src/thumbv6m/sercom/v2/spi.rs
@@ -1630,7 +1630,7 @@ mod spi_dma {
     unsafe impl<P, M, C> dmac::transfer::Buffer for Spi<Config<P, M, C>>
     where
         Config<P, M, C>: ValidConfig,
-        P: DipoDopo,
+        P: ValidPads,
         M: MasterMode,
         C: CharSize,
         C::Word: dmac::transfer::Beat,
@@ -1690,7 +1690,7 @@ mod spi_dma {
             unsafe { dmac::Transfer::new_unchecked(channel, buf, self, false) }
                 .with_waker(waker)
                 .begin(
-                    SpiSercom::<Config<P, M, C>>::DMA_TX_TRIGGER,
+                    <Self as AnySpi>::Sercom::DMA_TX_TRIGGER,
                     dmac::TriggerAction::BEAT,
                 )
         }
@@ -1728,7 +1728,7 @@ mod spi_dma {
             unsafe { dmac::Transfer::new_unchecked(channel, self, buf, false) }
                 .with_waker(waker)
                 .begin(
-                    SpiSercom::<Config<P, M, C>>::DMA_RX_TRIGGER,
+                    <Self as AnySpi>::Sercom::DMA_RX_TRIGGER,
                     dmac::TriggerAction::BEAT,
                 )
         }

--- a/hal/src/thumbv7em/sercom/v2/spi.rs
+++ b/hal/src/thumbv7em/sercom/v2/spi.rs
@@ -143,6 +143,30 @@
 //! let rcvd: u16 = block!(spi.read());
 //! ```
 //!
+//! # Using SPI with DMA
+//!
+//! This HAL includes support for DMA-enabled SPI transfers. An enabled `Spi`
+//! struct implements the DMAC [`Buffer`](crate::dmac::transfer::Buffer)
+//! trait. The provided [`send_with_dma`](Spi::send_with_dma) and
+//! [`receive_with_dma`](Spi::receive_with_dma) build and begin a
+//! [`dmac::Transfer`](crate::dmac::Transfer), thus starting the SPI in a
+//! non-blocking way. Optionally, interrupts can be enabled on the provided
+//! [`Channel`](crate::dmac::channel::Channel). Note that the `dma` feature must
+//! be enabled. Please refer to the [`dmac`](crate::dmac) module-level
+//! documentation for more information. ```
+//! // Assume channel is a configured `dmac::Channel`, and spi a
+//! fully-configured `Spi`
+//!
+//! // Create data to send
+//! let buffer: [u8; 50] = [0xff; 50]
+//!
+//! // Launch transfer
+//! let dma_transfer = spi.send_with_dma(&mut buffer, channel, ());
+//!
+//! // Wait for transfer to complete and reclaim resources
+//! let (chan0, _, spi, _) = dma_transfer.wait();
+//! ```
+//! 
 //! [`enable`]: Config::enable
 //! [`Pin`]: crate::gpio::v2::pin::Pin
 //! [`OptionalPinId`]: crate::gpio::v2::pin::OptionalPinId

--- a/hal/src/thumbv7em/sercom/v2/spi.rs
+++ b/hal/src/thumbv7em/sercom/v2/spi.rs
@@ -1672,6 +1672,126 @@ impl<C: ValidConfig> AnySpi for Spi<C> {
 }
 
 //=============================================================================
+// SPI DMA transfers
+//=============================================================================
+#[cfg(feature = "dma")]
+pub use spi_dma::*;
+
+#[cfg(feature = "dma")]
+mod spi_dma {
+    use super::*;
+    use crate::dmac::{
+        self,
+        channel::{self, Busy, Channel, ChannelId, Ready},
+        transfer, Transfer,
+    };
+
+    unsafe impl<P, M, L> dmac::transfer::Buffer for Spi<Config<P, M, L>>
+    where
+        Config<P, M, L>: ValidConfig,
+        P: ValidPads,
+        M: MasterMode,
+        L: Length,
+        L::Word: dmac::transfer::Beat,
+    {
+        type Beat = L::Word;
+
+        #[inline]
+        fn dma_ptr(&mut self) -> *mut Self::Beat {
+            unsafe { self.sercom().spim().data.as_ptr() as *mut _ }
+        }
+
+        #[inline]
+        fn incrementing(&self) -> bool {
+            false
+        }
+
+        #[inline]
+        fn buffer_len(&self) -> usize {
+            1
+        }
+    }
+
+    impl<P, M, L> Spi<Config<P, M, L>>
+    where
+        Self: dmac::transfer::Buffer<Beat = L::Word>,
+        Config<P, M, L>: ValidConfig,
+        P: Tx,
+        M: MasterMode,
+        L: Length,
+        L::Word: dmac::transfer::Beat,
+    {
+        /// Transform an [`Spi`] into a DMA [`Transfer`]) and
+        /// start a send transaction.
+        #[inline]
+        pub fn send_with_dma<Chan, B, W>(
+            self,
+            buf: B,
+            mut channel: Chan,
+            waker: W,
+        ) -> Transfer<Channel<ChannelId<Chan>, Busy>, transfer::BufferPair<B, Self>, (), W>
+        where
+            Chan: channel::AnyChannel<Status = Ready>,
+            B: dmac::Buffer<Beat = L::Word> + 'static,
+            W: FnOnce(crate::dmac::channel::CallbackStatus) + 'static,
+        {
+            channel
+                .as_mut()
+                .enable_interrupts(dmac::channel::InterruptFlags::new().with_tcmpl(true));
+
+            // SAFETY: We use new_unchecked to avoid having to pass a 'static self as the
+            // destination buffer. This is safe as long as we guarantee the source buffer is
+            // static.
+            unsafe { dmac::Transfer::new_unchecked(channel, buf, self, false) }
+                .with_waker(waker)
+                .begin(
+                    <Self as AnySpi>::Sercom::DMA_TX_TRIGGER,
+                    dmac::TriggerAction::BURST,
+                )
+        }
+    }
+
+    impl<P, M, L> Spi<Config<P, M, L>>
+    where
+        Self: dmac::transfer::Buffer<Beat = L::Word>,
+        Config<P, M, L>: ValidConfig,
+        P: Rx,
+        M: MasterMode,
+        L: Length,
+        L::Word: dmac::transfer::Beat,
+    {
+        /// Transform an [`Spi`] into a DMA [`Transfer`]) and
+        /// start a receive transaction.
+        #[inline]
+        pub fn receive_with_dma<Chan, B, W>(
+            self,
+            buf: B,
+            mut channel: Chan,
+            waker: W,
+        ) -> Transfer<Channel<ChannelId<Chan>, Busy>, transfer::BufferPair<Self, B>, (), W>
+        where
+            Chan: channel::AnyChannel<Status = Ready>,
+            B: dmac::Buffer<Beat = L::Word> + 'static,
+            W: FnOnce(crate::dmac::channel::CallbackStatus) + 'static,
+        {
+            channel
+                .as_mut()
+                .enable_interrupts(dmac::channel::InterruptFlags::new().with_tcmpl(true));
+
+            // SAFETY: We use new_unchecked to avoid having to pass a 'static self as the
+            // destination buffer. This is safe as long as we guarantee the source buffer is
+            // static.
+            unsafe { dmac::Transfer::new_unchecked(channel, self, buf, false) }
+                .with_waker(waker)
+                .begin(
+                    <Self as AnySpi>::Sercom::DMA_RX_TRIGGER,
+                    dmac::TriggerAction::BURST,
+                )
+        }
+    }
+}
+
+//=============================================================================
 // Embedded HAL traits
 //=============================================================================
 


### PR DESCRIPTION
# DMAC peripherals

This is a tracking PR to add DMA support for some peripherals. It is also meant to be an example for other contributors showing how to integrate DMA transfers into other peripheral implementations.

## API changes

There are some breaking API changes in the PR. Recognizing the fact that individual DMA `Channel`s should be moveable, and should be able to control themselves in a standalone way, the API was modified such that each `Channel` can access the `DMAC` PAC peripheral via `Peripherals::steal().DMAC`. This avoids neesing to pass an `&mut DmaController` reference every time we want to mutate or read a `Channel`'s configuration. The contract is as follows: each individual `Channel` may only access registers pertaining to itself. It may not modify or read registers controlling other channels, or general DMAC configuration registers. This is mostly done through the `Channel::with_chid` method.

## To-Do

- [x] thumbv7em SPI DMA-enabled transfers
- [x] Document all the things! + Add RTIC waker example

## async?

I want to start off this section by mentioning I don't know how contributors of this HAL feel about supporting `async/await`, so any comments are appreciated. 

Given that the entire point of DMA transfers is to free up the CPU while the hardware does the transfer, I think it makes sense to support a standard asynchronous model. Right now, DMA `Transfer`s have the option of adding a `waker` closure, which will get called when the transfer is complete, à la `sercom::v2::spi_future`.

This works very well on the application side of things, but it does make developing device driver libraries really hard, without resorting to the blocking peripheral implementations. The defacto traits in [embedded-hal](https://github.com/rust-embedded/embedded-hal) only support a small subset of non-blocking operations. Notably, I2C only has blocking support. I'd like to propose that we start supporting async traits, maybe from [embassy](https://github.com/embassy-rs/embassy)? These could be feature-gated behind an `async` feature.

Asynchronous DMA/Peripheral transfers seem to fit perfectly within the scope of usefulness of `async/await`. This is a personal opinion, but I'd really like seeing more asynchronous device drivers within the Rust embedded ecosystem.