### PR TITLE
WIP: add xiao_m0 sck/miso/mosi pin aliases

### DIFF
--- a/boards/xiao_m0/src/lib.rs
+++ b/boards/xiao_m0/src/lib.rs
@@ -55,6 +55,13 @@ define_pins!(
     /// Pin A10/D10/MOSI
     pin a10 = a6,
 
+    /// The SPI SCK
+    pin sck = a7,
+    /// The SPI MOSI
+    pin mosi = a6,
+    /// The SPI MISO
+    pin miso = a5,
+
     /// On-board yellow 'L' LED.
     pin led0 = a17,
     /// On-board blue 'RX' LED.


### PR DESCRIPTION
When using `<Pin>` type, this now allows the `xiao_m0` to use `<Pin>.sck`, `<Pin>.miso`, and `<Pin>.mosi` in the same way as other BSP's.

corresponding datasheet pinout here: https://files.seeedstudio.com/wiki/Seeeduino-XIAO/res/Seeeduino-XIAO-v1.0-SCH-191112.pdf