### PR TITLE
Allow wider range of USB maxPacketSize values

### DIFF
--- a/hal/src/thumbv6m/usb/bus.rs
+++ b/hal/src/thumbv6m/usb/bus.rs
@@ -805,7 +805,20 @@ impl Inner {
         max_packet_size: u16,
         interval: u8,
     ) -> UsbResult<EndpointAddress> {
-        let allocated_size = max_packet_size.max(64);
+        // The USB hardware encodes the maximum packet size in 3 bits, so
+        // reserve enough buffer that the hardware won't overwrite it even if
+        // the other side issues an overly-long transfer.
+        let allocated_size = match max_packet_size {
+            1..=8 => 8,
+            9..=16 => 16,
+            17..=32 => 32,
+            33..=64 => 64,
+            65..=128 => 128,
+            129..=256 => 256,
+            257..=512 => 512,
+            513..=1023 => 1024,
+            _ => return Err(UsbError::Unsupported),
+        };
 
         let buffer = self.buffers.borrow_mut().allocate_buffer(allocated_size)?;
 

--- a/hal/src/thumbv6m/usb/devicedesc.rs
+++ b/hal/src/thumbv6m/usb/devicedesc.rs
@@ -63,16 +63,20 @@ impl DeviceDescBank {
     }
 
     /// These bits contains the maximum packet size of the endpoint.
+    ///
+    /// The maximum packet size is encoded in 3 bits; this method takes any u16
+    /// below 1024B and rounds up to the lowest endpoint size value which will
+    /// accommodate `size`.  Panics if a `size` > 1023 is supplied.
     pub fn set_endpoint_size(&mut self, size: u16) {
         let size = match size {
-            8 => 0u32,
-            16 => 1,
-            32 => 2,
-            64 => 3,
-            128 => 4,
-            256 => 5,
-            512 => 6,
-            1023 => 7,
+            1..=8 => 0u32,
+            9..=16 => 1,
+            17..=32 => 2,
+            33..=64 => 3,
+            65..=128 => 4,
+            129..=256 => 5,
+            257..=512 => 6,
+            513..=1023 => 7,
             _ => unreachable!(),
         };
         self.pcksize.set_size(size);

--- a/hal/src/thumbv7em/usb/devicedesc.rs
+++ b/hal/src/thumbv7em/usb/devicedesc.rs
@@ -64,16 +64,20 @@ impl DeviceDescBank {
     }
 
     /// These bits contains the maximum packet size of the endpoint.
+    ///
+    /// The maximum packet size is encoded in 3 bits; this method takes any u16
+    /// below 1024B and rounds up to the lowest endpoint size value which will
+    /// accommodate `size`.  Panics if a `size` > 1023 is supplied.
     pub fn set_endpoint_size(&mut self, size: u16) {
         let size = match size {
-            8 => 0u32,
-            16 => 1,
-            32 => 2,
-            64 => 3,
-            128 => 4,
-            256 => 5,
-            512 => 6,
-            1023 => 7,
+            1..=8 => 0u32,
+            9..=16 => 1,
+            17..=32 => 2,
+            33..=64 => 3,
+            65..=128 => 4,
+            129..=256 => 5,
+            257..=512 => 6,
+            513..=1023 => 7,
             _ => unreachable!(),
         };
         self.pcksize.set_size(size);


### PR DESCRIPTION
This is important for isochronous endpoints, which reserve bandwidth on the USB as opposed to bulk endpoints which use whatever bandwidth is available.  Isochronous transfers on full-speed USB can have maximum packet sizes anywhere between 1B and 1023B (not just powers of 2), but for instance bulk ones need to be either 1B, 2B, ... 32B, or 64B.

I've opened https://github.com/mvirkkunen/usb-device/issues/71 in usb-device to propose checking for valid endpoint sizes there, since that code will be the same across all implementations.

(note the old `alloc_ep()` code made buffers at least 64B - I couldn't find a reason for that, and it seems to work fine for smaller ones)