### PR TITLE
Add support for pullup/pulldown of EIC pins

### DIFF
--- a/boards/trinket_m0/examples/eic.rs
+++ b/boards/trinket_m0/examples/eic.rs
@@ -1,9 +1,13 @@
 #![no_std]
 #![no_main]
 
+/// This example is intended to be used with a pushbutton connected between D0
+/// and ground.  The LED should toggle when the button is pressed (perhaps more
+/// than once due to the lack of debouncing).
 use panic_halt as _;
 use trinket_m0 as hal;
 
+use cortex_m::asm::delay as cycle_delay;
 use hal::clock::GenericClockController;
 use hal::eic::{pin::Sense, EIC};
 use hal::entry;
@@ -30,7 +34,7 @@ fn main() -> ! {
     let clock = clocks.eic(&gclk0).unwrap();
     let mut eic = EIC::init(&mut peripherals.PM, clock, peripherals.EIC);
 
-    let mut d3 = pins.d3.into_ei(&mut pins.port);
+    let mut d3 = pins.d3.into_pull_up_ei(&mut pins.port);
     d3.sense(&mut eic, Sense::FALL);
     d3.enable_interrupt(&mut eic);
 

--- a/boards/wio_terminal/src/buttons.rs
+++ b/boards/wio_terminal/src/buttons.rs
@@ -52,14 +52,14 @@ impl ButtonPins {
         // ExtInt line as up on the joystick. As such, we don't
         // support B1.
 
-        // let mut b1 = self.button1.into_ei(port);
-        let mut b2 = self.button2.into_ei(port);
-        let mut b3 = self.button3.into_ei(port);
-        let mut x = self.switch_x.into_ei(port);
-        let mut y = self.switch_y.into_ei(port);
-        let mut z = self.switch_z.into_ei(port);
-        let mut u = self.switch_u.into_ei(port);
-        let mut b = self.switch_b.into_ei(port);
+        // let mut b1 = self.button1.into_floating_ei(port);
+        let mut b2 = self.button2.into_floating_ei(port);
+        let mut b3 = self.button3.into_floating_ei(port);
+        let mut x = self.switch_x.into_floating_ei(port);
+        let mut y = self.switch_y.into_floating_ei(port);
+        let mut z = self.switch_z.into_floating_ei(port);
+        let mut u = self.switch_u.into_floating_ei(port);
+        let mut b = self.switch_b.into_floating_ei(port);
 
         // b1.sense(&mut eic, Sense::BOTH);
         b2.sense(&mut eic, Sense::BOTH);
@@ -113,15 +113,15 @@ pub struct ButtonEvent {
 
 pub struct ButtonController {
     _eic: eic::EIC,
-    // b1: ExtInt10<Pc26<PfA>>,
-    b2: ExtInt11<Pc27<PfA>>,
-    b3: ExtInt12<Pc28<PfA>>,
+    // b1: ExtInt10<Pc26<Interrupt<Floating>>>,
+    b2: ExtInt11<Pc27<Interrupt<Floating>>>,
+    b3: ExtInt12<Pc28<Interrupt<Floating>>>,
 
-    x: ExtInt3<Pd8<PfA>>,
-    y: ExtInt4<Pd9<PfA>>,
-    z: ExtInt5<Pd10<PfA>>,
-    u: ExtInt10<Pd20<PfA>>,
-    b: ExtInt7<Pd12<PfA>>,
+    x: ExtInt3<Pd8<Interrupt<Floating>>>,
+    y: ExtInt4<Pd9<Interrupt<Floating>>>,
+    z: ExtInt5<Pd10<Interrupt<Floating>>>,
+    u: ExtInt10<Pd20<Interrupt<Floating>>>,
+    b: ExtInt7<Pd12<Interrupt<Floating>>>,
 }
 
 macro_rules! isr {

--- a/hal/src/gpio/v1.rs
+++ b/hal/src/gpio/v1.rs
@@ -33,6 +33,10 @@ use crate::typelevel::Sealed;
 /// `PullUp`.
 pub type Input<MODE> = v2::Input<MODE>;
 
+/// Represents a pin configured for interrupt.
+/// The MODE type is one of `Floating`, `PullDown` or `PullUp`.
+pub type Interrupt<MODE> = v2::Interrupt<MODE>;
+
 /// Represents a pin configured for output.
 /// The MODE type is typically one of `PushPull`, or
 /// `OpenDrain`.
@@ -59,8 +63,6 @@ pub type OpenDrain = v2::PushPull;
 /// This option actually represents a readable `PushPull` output
 pub type ReadableOpenDrain = v2::Readable;
 
-/// Peripheral Function A
-pub type PfA = v2::AlternateA;
 /// Peripheral Function B
 pub type PfB = v2::AlternateB;
 /// Peripheral Function C
@@ -155,6 +157,33 @@ where
         }
     }
 
+    /// Configures the pin to operate as a floating interrupt
+    #[allow(unused_variables)]
+    #[inline]
+    pub fn into_floating_interrupt(self, port: &mut Port) -> Pin<I, Interrupt<Floating>> {
+        Pin {
+            pin: self.pin.into_floating_interrupt(),
+        }
+    }
+
+    /// Configures the pin to operate as a pulled down interrupt pin
+    #[allow(unused_variables)]
+    #[inline]
+    pub fn into_pull_down_interrupt(self, port: &mut Port) -> Pin<I, Interrupt<PullDown>> {
+        Pin {
+            pin: self.pin.into_pull_down_interrupt(),
+        }
+    }
+
+    /// Configures the pin to operate as a pulled up interrupt pin
+    #[allow(unused_variables)]
+    #[inline]
+    pub fn into_pull_up_interrupt(self, port: &mut Port) -> Pin<I, Interrupt<PullUp>> {
+        Pin {
+            pin: self.pin.into_pull_up_interrupt(),
+        }
+    }
+
     /// Configures the pin to operate as an open drain output
     #[allow(unused_variables)]
     #[inline]
@@ -190,13 +219,6 @@ where
         Pin {
             pin: self.pin.into_alternate(),
         }
-    }
-
-    /// Configures the pin to operate with a peripheral
-    #[allow(unused_variables)]
-    #[inline]
-    pub fn into_function_a(self, port: &mut Port) -> Pin<I, PfA> {
-        self.into_alternate()
     }
 
     /// Configures the pin to operate with a peripheral

--- a/hal/src/gpio/v2/dynpin.rs
+++ b/hal/src/gpio/v2/dynpin.rs
@@ -88,6 +88,14 @@ pub enum DynInput {
     PullUp,
 }
 
+/// Value-level `enum` for interrupt configurations
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum DynInterrupt {
+    Floating,
+    PullDown,
+    PullUp,
+}
+
 /// Value-level `enum` for output configurations
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum DynOutput {
@@ -98,7 +106,6 @@ pub enum DynOutput {
 /// Value-level `enum` for alternate peripheral function configurations
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum DynAlternate {
-    A,
     B,
     C,
     D,
@@ -130,6 +137,7 @@ pub enum DynAlternate {
 pub enum DynPinMode {
     Disabled(DynDisabled),
     Input(DynInput),
+    Interrupt(DynInterrupt),
     Output(DynOutput),
     Alternate(DynAlternate),
 }
@@ -147,6 +155,13 @@ pub const DYN_FLOATING_INPUT: DynPinMode = DynPinMode::Input(DynInput::Floating)
 pub const DYN_PULL_DOWN_INPUT: DynPinMode = DynPinMode::Input(DynInput::PullDown);
 /// Value-level variant of [`DynPinMode`] for pull-up input mode
 pub const DYN_PULL_UP_INPUT: DynPinMode = DynPinMode::Input(DynInput::PullUp);
+
+/// Value-level variant of [`DynPinMode`] for floating interrupt mode
+pub const DYN_FLOATING_INTERRUPT: DynPinMode = DynPinMode::Interrupt(DynInterrupt::Floating);
+/// Value-level variant of [`DynPinMode`] for pull-down interrupt mode
+pub const DYN_PULL_DOWN_INTERRUPT: DynPinMode = DynPinMode::Interrupt(DynInterrupt::PullDown);
+/// Value-level variant of [`DynPinMode`] for pull-up interrupt mode
+pub const DYN_PULL_UP_INTERRUPT: DynPinMode = DynPinMode::Interrupt(DynInterrupt::PullUp);
 
 /// Value-level variant of [`DynPinMode`] for push-pull output mode
 pub const DYN_PUSH_PULL_OUTPUT: DynPinMode = DynPinMode::Output(DynOutput::PushPull);
@@ -168,7 +183,7 @@ macro_rules! dyn_alternate {
     };
 }
 
-dyn_alternate!(A, B, C, D, E, F, G);
+dyn_alternate!(B, C, D, E, F, G);
 #[cfg(any(feature = "samd21", feature = "min-samd51g"))]
 dyn_alternate!(H);
 #[cfg(feature = "min-samd51g")]
@@ -329,6 +344,24 @@ impl DynPin {
     #[inline]
     pub fn into_pull_up_input(&mut self) {
         self.into_mode(DYN_PULL_UP_INPUT);
+    }
+
+    /// Configure the pin to operate as a floating interrupt
+    #[inline]
+    pub fn into_floating_interrupt(&mut self) {
+        self.into_mode(DYN_FLOATING_INTERRUPT);
+    }
+
+    /// Configure the pin to operate as a pulled down interrupt
+    #[inline]
+    pub fn into_pull_down_interrupt(&mut self) {
+        self.into_mode(DYN_PULL_DOWN_INTERRUPT);
+    }
+
+    /// Configure the pin to operate as a pulled up interrupt
+    #[inline]
+    pub fn into_pull_up_interrupt(&mut self) {
+        self.into_mode(DYN_PULL_UP_INTERRUPT);
     }
 
     /// Configure the pin to operate as a push-pull output

--- a/hal/src/gpio/v2/reg.rs
+++ b/hal/src/gpio/v2/reg.rs
@@ -70,6 +70,25 @@ impl From<DynPinMode> for ModeFields {
                     }
                 }
             }
+            Interrupt(config) => {
+                fields.pmuxen = true;
+                fields.pmux = 0;
+                use DynInterrupt::*;
+                match config {
+                    Floating => {
+                        fields.pullen = false;
+                        fields.out = false;
+                    }
+                    PullDown => {
+                        fields.pullen = true;
+                        fields.out = false;
+                    }
+                    PullUp => {
+                        fields.pullen = true;
+                        fields.out = true;
+                    }
+                }
+            }
             Output(config) => {
                 fields.dir = true;
                 use DynOutput::*;
@@ -86,9 +105,6 @@ impl From<DynPinMode> for ModeFields {
                 fields.pmuxen = true;
                 use DynAlternate::*;
                 match config {
-                    A => {
-                        fields.pmux = 0;
-                    }
                     B => {
                         fields.pmux = 1;
                     }

--- a/hal/src/thumbv7em/eic/pin.rs
+++ b/hal/src/thumbv7em/eic/pin.rs
@@ -1,12 +1,27 @@
-use crate::gpio::v2::{self, AlternateA, AnyPin, PinId, PinMode};
-use crate::gpio::{self, IntoFunction, Pin, Port};
+use crate::gpio::{
+    self, v2::AnyPin, v2::FloatingInterrupt, v2::Pin, v2::PinId, v2::PinMode,
+    v2::PullDownInterrupt, v2::PullUpInterrupt, Port,
+};
 use crate::target_device;
 
 /// The EicPin trait makes it more ergonomic to convert a gpio pin into an EIC
 /// pin. You should not implement this trait for yourself; only the
 /// implementations in the EIC module make sense.
-pub trait EicPin<T> {
-    fn into_ei(self, port: &mut Port) -> T;
+// This is more complicated than it needs to be, due to the ExtInt structs being
+// defined through macros below.
+pub trait EicPin {
+    type Floating;
+    type PullUp;
+    type PullDown;
+
+    /// Configure a pin as a floating external interrupt
+    fn into_floating_ei(self, port: &mut Port) -> Self::Floating;
+
+    /// Configure a pin as pulled-up external interrupt
+    fn into_pull_up_ei(self, port: &mut Port) -> Self::PullUp;
+
+    /// Configure a pin as pulled-down external interrupt
+    fn into_pull_down_ei(self, port: &mut Port) -> Self::PullDown;
 }
 
 pub type Sense = target_device::eic::config::SENSE0_A;
@@ -39,7 +54,7 @@ crate::paste::item! {
     where
         GPIO: AnyPin,
     {
-        _pin: v2::Pin<GPIO::Id, AlternateA>,
+        _pin: Pin<GPIO::Id, GPIO::Mode>,
     }
 
     // impl !Send for [<$PadType $num>]<GPIO> {};
@@ -50,8 +65,9 @@ crate::paste::item! {
         /// You may find it more convenient to use the `into_pad` trait
         /// and avoid referencing the pad type.
         pub fn new(pin: GPIO) -> Self {
-            let _pin = pin.into().into_alternate();
-            [<$PadType $num>]{ _pin }
+            [<$PadType $num>]{
+                _pin: pin.into()
+            }
         }
 
         pub fn enable_event(&mut self, eic: &mut super::ConfigurableEIC) {
@@ -135,13 +151,26 @@ crate::paste::item! {
 
     $(
         $(#[$attr])*
-        impl<MODE: gpio::PinMode> EicPin<[<$PadType $num>]<gpio::$PinType<gpio::PfA>>> for gpio::$PinType<MODE> {
-            fn into_ei(self, port: &mut Port) -> [<$PadType $num>]<gpio::$PinType<gpio::PfA>> {
-                [<$PadType $num>]::new(self.into_function(port))
+        impl<MODE: PinMode> EicPin for gpio::$PinType<MODE> {
+            type Floating = [<$PadType $num>]<gpio::$PinType<FloatingInterrupt>>;
+            type PullUp = [<$PadType $num>]<gpio::$PinType<PullUpInterrupt>>;
+            type PullDown = [<$PadType $num>]<gpio::$PinType<PullDownInterrupt>>;
+
+            fn into_floating_ei(self, port: &mut Port) -> Self::Floating {
+                [<$PadType $num>]::new(self.into_floating_interrupt(port))
+            }
+
+            fn into_pull_up_ei(self, port: &mut Port) -> Self::PullUp {
+                [<$PadType $num>]::new(self.into_pull_up_interrupt(port))
+            }
+
+            fn into_pull_down_ei(self, port: &mut Port) -> Self::PullDown {
+                [<$PadType $num>]::new(self.into_pull_down_interrupt(port))
             }
         }
+
         $(#[$attr])*
-        impl<MODE: gpio::PinMode> ExternalInterrupt for gpio::$PinType<MODE> {
+        impl<MODE: PinMode> ExternalInterrupt for gpio::$PinType<MODE> {
             fn id(&self) -> ExternalInterruptID {
                 $num
             }
@@ -152,7 +181,7 @@ crate::paste::item! {
     };
 }
 
-impl<I, M> ExternalInterrupt for v2::Pin<I, M>
+impl<I, M> ExternalInterrupt for Pin<I, M>
 where
     I: PinId,
     M: PinMode,


### PR DESCRIPTION
This change replaces the GPIO AlternateA with an `Interrupt<Mode>` akin to the existing `Input<Mode>`, where `Mode` is one of `Floating`, `PullUp`, or `PullDown`.  This allows the EIC module to instantiate external interrupts with pullup or pulldown resistors enabled, previously external interrupts were always floating.

According to http://misfittech.net/blog/samd21-pull-up-resistors/ , the pullup and pulldown resistors can only be used when pins are configured as GPIO or EIC, so it doesn't seem like we need to make the pull resistors available to other functions.

Parts of this change feel a little bit copypasta, but as far as I can tell there's not a nice way to accomplish the same goals with less code.

The Wio Terminal example was updated to use the equivalent floating input; I don't have one, and couldn't find a schematic in a few minutes of looking, so it would be helpful if someone could confirm whether it's got external pullup resistors.