### PR TITLE
Added Vdiv (A6) as pin b1

### DIFF
--- a/boards/feather_m4/src/lib.rs
+++ b/boards/feather_m4/src/lib.rs
@@ -48,7 +48,9 @@ define_pins!(
     pin a4 = a4,
     /// Analog Pin 5
     pin a5 = a6,
-
+	/// Analog Vdiv
+	pin a6 = b1,
+	
     /// Pin 0, rx
     pin d0 = b17,
     /// Pin 1, tx


### PR DESCRIPTION
The Feather-M4 has a 1:2 resistor divider from VBat to what anrduino
considers A6 (mapped to port b 1).  This permits the battery voltage
to be monitored using the ADC.