### PR TITLE
Remove the sercom::v2::Pad type and redefine the v2::spi::Pads type

### DIFF
--- a/boards/feather_m0/src/lib.rs
+++ b/boards/feather_m0/src/lib.rs
@@ -8,10 +8,8 @@ pub use embedded_hal as ehal;
 pub use hal::pac;
 
 use hal::clock::GenericClockController;
-use hal::sercom::v2::pad::PinToPad;
-use hal::sercom::v2::spi;
+use hal::sercom::v2::{spi, Sercom4};
 use hal::sercom::{I2CMaster3, UART0};
-use hal::spi_pads_from_pins;
 use hal::time::Hertz;
 
 #[cfg(feature = "usb")]
@@ -105,14 +103,14 @@ hal::bsp_pins!(
         /// The I2C data line
         name: sda
         aliases: {
-            AlternateD: Sda
+            AlternateC: Sda
         }
     }
     PA23 {
         /// The I2C clock line
         name: scl
         aliases: {
-            AlternateD: Scl
+            AlternateC: Scl
         }
     }
 
@@ -207,7 +205,10 @@ hal::bsp_pins!(
     },
 );
 
-type SpiPads = spi_pads_from_pins!(Sercom4, DI = Miso, DO = Mosi, CK = Sclk);
+/// SPI pads for the labelled SPI peripheral
+///
+/// You can use these pads with other, user-defined [`spi::Config`]urations.
+pub type SpiPads = spi::Pads<Sercom4, Miso, Mosi, Sclk>;
 
 /// SPI master for the labelled SPI peripheral
 ///
@@ -238,7 +239,7 @@ pub fn spi_master(
 }
 
 /// I2C master for the labelled SDA & SCL pins
-pub type I2C = I2CMaster3<PinToPad<Sda>, PinToPad<Scl>>;
+pub type I2C = I2CMaster3<Sda, Scl>;
 
 /// Convenience for setting up the labelled SDA, SCL pins to
 /// operate as an I2C master running at the specified frequency.
@@ -253,13 +254,13 @@ pub fn i2c_master(
     let gclk0 = clocks.gclk0();
     let clock = &clocks.sercom3_core(&gclk0).unwrap();
     let baud = baud.into();
-    let sda = sda.into().into();
-    let scl = scl.into().into();
+    let sda = sda.into();
+    let scl = scl.into();
     I2CMaster3::new(clock, baud, sercom3, pm, sda, scl)
 }
 
 /// UART device for the labelled RX & TX pins
-pub type Uart = UART0<PinToPad<UartRx>, PinToPad<UartTx>, (), ()>;
+pub type Uart = UART0<UartRx, UartTx, (), ()>;
 
 /// Convenience for setting up the labelled RX, TX pins to
 /// operate as a UART device running at the specified baud.
@@ -274,7 +275,7 @@ pub fn uart(
     let gclk0 = clocks.gclk0();
     let clock = &clocks.sercom0_core(&gclk0).unwrap();
     let baud = baud.into();
-    let pads = (uart_rx.into().into(), uart_tx.into().into());
+    let pads = (uart_rx.into(), uart_tx.into());
     UART0::new(clock, baud, sercom0, pm, pads)
 }
 

--- a/boards/wio_terminal/src/display.rs
+++ b/boards/wio_terminal/src/display.rs
@@ -36,7 +36,7 @@ pub struct Display {
     pub backlight: Pc5<Input<Floating>>,
 }
 
-pub type SpiPads = spi::Pads<Sercom7, IoSet4, NoneT, PB19, PB20>;
+pub type SpiPads = spi::PadsFromIds<Sercom7, IoSet4, NoneT, PB19, PB20>;
 
 /// Type alias for the ILI9341 LCD display.
 pub type LCD = Ili9341<

--- a/hal/src/gpio/v2/pin.rs
+++ b/hal/src/gpio/v2/pin.rs
@@ -815,22 +815,6 @@ where
 /// [`AnyKind`]: crate::typelevel#anykind-trait-pattern
 pub type SpecificPin<P> = Pin<<P as AnyPin>::Id, <P as AnyPin>::Mode>;
 
-/// Type alias to recover the [`PinId`] type from an implementation of
-/// [`AnyPin`]
-///
-/// See the [`AnyKind`] documentation for more details on the pattern.
-///
-/// [`AnyKind`]: crate::typelevel#anykind-trait-pattern
-pub type SpecificPinId<P> = <P as AnyPin>::Id;
-
-/// Type alias to recover the [`PinMode`] type from an implementation of
-/// [`AnyPin`]
-///
-/// See the [`AnyKind`] documentation for more details on the pattern.
-///
-/// [`AnyKind`]: crate::typelevel#anykind-trait-pattern
-pub type SpecificPinMode<P> = <P as AnyPin>::Mode;
-
 impl<P: AnyPin> AsRef<P> for SpecificPin<P> {
     #[inline]
     fn as_ref(&self) -> &P {
@@ -862,17 +846,25 @@ impl<P: AnyPin> AsMut<P> for SpecificPin<P> {
 /// See the [`OptionalKind`] documentation for more details on the pattern.
 ///
 /// [`OptionalKind`]: crate::typelevel#optionalkind-trait-pattern
-pub trait OptionalPin: Sealed {}
-impl OptionalPin for NoneT {}
-impl<P: AnyPin> OptionalPin for P {}
+pub trait OptionalPin: Sealed {
+    type Id: OptionalPinId;
+}
+
+impl OptionalPin for NoneT {
+    type Id = NoneT;
+}
+
+impl<P: AnyPin> OptionalPin for P {
+    type Id = P::Id;
+}
 
 /// Type-level equivalent of `Some(PinId)`
 ///
 /// See the [`OptionalKind`] documentation for more details on the pattern.
 ///
 /// [`OptionalKind`]: crate::typelevel#optionalkind-trait-pattern
-pub trait SomePin: OptionalPin + AnyPin {}
-impl<P: OptionalPin + AnyPin> SomePin for P {}
+pub trait SomePin: AnyPin {}
+impl<P: AnyPin> SomePin for P {}
 
 //==============================================================================
 //  Embedded HAL traits

--- a/hal/src/sercom/v2/pad.rs
+++ b/hal/src/sercom/v2/pad.rs
@@ -1,46 +1,30 @@
 //! Define a SERCOM pad type
 //!
-//! This module defines the [`Pad`] type, which represents a [`Pin`] configured
-//! to act as a SERCOM pad.
+//! This module helps configure [`Pin`]s as SERCOM pads. It provides type-level
+//! tools to convert `Pin`s to the correct [`PinMode`] and to enforce type-level
+//! constraints at compile-time.
 //!
 //! # Overview
 //!
-//! Because each SERCOM pad can usually be mapped to several possible GPIO pins,
-//! a `Pad` is parameterized by three [type-level enums]: [`Sercom`], [`PadNum`]
-//! and [`PinId`]. For instance, pin PA11 configured to act as pad 3 for SERCOM
-//! 0 would be specified as `Pad<Sercom0, Pad3, PA11>`.
+//! A SERCOM pad is defined by two types, its corresponding [`Sercom`] instance
+//! and its [`PadNum`], from [`Pad0`] to [`Pad3`]. However, a given SERCOM pad
+//! can usually be mapped to several possible [`PinId`]s.
 //!
-//! When a `Pad` is created, it takes ownership of the corresponding `Pin` and
-//! correctly configures the [`PinMode`] automatically. Users usually don't need
-//! to create `Pad`s directly. The downstream consumers of `Pad` types, like
-//! [`v2::spi`](super::spi), often take care of that conversion. However, if
-//! necessary, `Pad`s can be created in two different ways. They can be created
-//! manually, using the [`Pad::new()`] method, or they can be converted [`From`]
-//! `Pin`s. The conversion from `Pin` to `Pad` is generally many-valued, so the
-//! types usually can't be inferred.
+//! There are two primary traits defined in this module:
+//! - The [`IsPad`] trait is implemented on `Pin` types that are properly
+//!   configured as SERCOM pads, with `PinMode` [`AlternateC`] or
+//!   [`AlternateD`]. It acts as both a [type class] for SERCOM pads and as a
+//!   [type-level function] to recover the corresponding [`Sercom`] and
+//!   [`PadNum`] types from the `Pin`.
+//! - The [`GetPad`] trait maps each [`PinId`] to its corresponding, pad-related
+//!   types. The [`PadMode`] alias uses `GetPad` to recover the corresponding
+//!   `PinMode` for a given SERCOM pad, while the [`Pad`] alias recovers the
+//!   configured [`Pin`] type.
 //!
-//! ```
-//! use atsamd_hal::pac::Peripherals;
-//! use atsamd_hal::gpio::v2::Pins;
-//! use atsamd_hal::sercom::v2::{Pad, Sercom0, Pad0, Pad1};
-//!
-//! let peripherals = Peripherals::take();
-//! let pins = Pins::new(peripherals.PORT);
-//! let pad0 = Pad::<Sercom0, Pad0, _>::new(pins.pa08);
-//! let pad1: Pad<Sercom0, Pad1, _> = pins.pa09.into();
-//! ```
-//!
-//! On the other hand, the conversion from `Pad` to `Pin` is always unique,
-//! because the `Pad` always knows which `Pin` it contains. Conversion in this
-//! direction can be accomplished with the [`free`] method or the
-//! [`From`]/[`Into`] traits.
-//!
-//! ```
-//! use atsamd_hal::gpio::v2::Pin;
-//!
-//! let pa08 = pad0.free();
-//! let pa09: Pin<_, _> = pad1.into();
-//! ```
+//! [`AlternateC`]: crate::gpio::v2::AlternateC
+//! [`AlternateD`]: crate::gpio::v2::AlternateD
+//! [type class]: crate::typelevel#type-classes
+//! [type-level function]: crate::typelevel#type-level-functions
 #![cfg_attr(
     feature = "min-samd51g",
     doc = "
@@ -48,68 +32,21 @@
 \n
 SAMx5x chips do not allow arbitrary combinations of `PinId` for a given
 SERCOM. Instead, all `PinId`s must belong to the same IOSET. This module
-defines a [type-level enum], [`IoSet`], to enforce this restriction. The
-[`InIoSet`] [type class] is responsible for labeling each `Pad` type with
+defines a [type-level enum], [`IoSet`], to enforce this restriction, and the
+[`InIoSet`] [type class] is responsible for labeling each `IsPad` type with
 its corresponding, valid `IoSet`\\(s).\n
 \n
 "
 )]
-//! # Type-level enforcement
-//!
-//! This module also provides additional, type-level tools to enforce the
-//! restrictions imposed by the corresponding datasheets.
-//!
-//! The [`PadInfo`] trait forms the core of type-level encoding for `Pad`
-//! types. All other traits are derived from `PadInfo` in some way. It acts as
-//! a [type-level function] mapping `PinId`s to other `Pad`-related types.
-//!
-//! For a given `Sercom` and `PadNum`, the type-level function
-//! [`GetPadMode`] maps a `PinId` to its corresponding `PinMode`, either
-//! [`AlternateC`] or [`AlternateD`], and [`PadMode`] acts a type alias for the
-//! output of this function. This trait is used to automatically convert a
-//! `Pin` to the correct `PinMode` for the given `Pad`.
-//!
-//! The [`GetPad<S>`] trait is a type-level function mapping an input type to
-//! a corresponding `Pad` type for the given `Sercom`. For SAMD21 and SAMx5x
-//! chips, `GetPad` is implemented on `PinId`s, while for SAMD11 chips, `GetPad`
-//! is implemented on (`PadNum`, `PinId`) tuples, marked by the
-#![cfg_attr(feature = "samd11", doc = "[`NITuple`]")]
-#![cfg_attr(not(feature = "samd11"), doc = "`NITuple`")]
-//! [type class].
-//!
-//! `GetPad` serves to improve the ergonomics of specifying downstream, `Pad`
-//! types. With knowledge of a desired `Sercom`, `GetPad<S>` allows users to
-//! specify a unique `Pad` with the minimum amount of information for the given
-//! chip.
-//!
-//! The [`ConvertPinToPad`] trait is a type-level function theat makes it easier
-//! to convert a `Pin` type to its corresponding `Sercom` and `PadNum` types.
-//!
-//! The [`OptionalPadNum`] and [`OptionalPad`] traits use the [`OptionalKind`]
-//! pattern to act as type-level versions of [`Option`] for `PadNum` and `Pad`
-//! respectively. And the [`GetOptionalPad`] trait acts as a type-level function
-//! to retreive an `OptionalPad`.
-//!
-//! Finally, the [`AnyPad`] trait defines an [`AnyKind`] type class for all
-//! `Pad` types.
-//!
-//! [`AlternateC`]: crate::gpio::v2::AlternateC
-//! [`AlternateD`]: crate::gpio::v2::AlternateD
-//! [type-level enum]: crate::typelevel#type-level-enums
-//! [type-level enums]: crate::typelevel#type-level-enums
-//! [type class]: crate::typelevel#type-classes
-//! [type-level function]: crate::typelevel#type-level-functions
-//! [`OptionalKind`]: crate::typelevel#optionalkind-trait-pattern
-//! [`AnyKind`]: crate::typelevel#anykind-trait-pattern
-//! [`new`]: Pad::new
-//! [`free`]: Pad::free
 
 use paste::paste;
 use seq_macro::seq;
 
 use super::Sercom;
-use crate::gpio::v2::{AnyPin, OptionalPinId, Pin, PinId, PinMode, SpecificPinId};
-use crate::typelevel::{Is, NoneT, Sealed};
+#[cfg(not(feature = "samd11"))]
+use crate::gpio::v2::OptionalPinId;
+use crate::gpio::v2::{AnyPin, OptionalPin, Pin, PinId, PinMode};
+use crate::typelevel::{NoneT, Sealed};
 
 //==============================================================================
 // PadNum
@@ -152,307 +89,21 @@ impl OptionalPadNum for NoneT {}
 
 impl<N: PadNum> OptionalPadNum for N {}
 
-/// Type-level equivalent of `Some(PadNum)`
-///
-/// See the [`OptionalKind`] documentation for more details on the pattern.
-///
-/// [`OptionalKind`]: crate::typelevel#optionalkind-trait-pattern
-pub trait SomePadNum: OptionalPadNum + PadNum {}
-
-impl<N: PadNum> SomePadNum for N {}
-
 //==============================================================================
-// PadInfo
+// IsPad
 //==============================================================================
 
-/// Type-level function mapping [`PinId`]s to other [`Pad`]-related types
+/// Type class for [`Pin`]s configured as SERCOM pads
 ///
-/// This trait forms the basis of all type-level enforcement in this module. Its
-/// implementations are defined by macros in the [`pad_info`](super::pad_info)
-/// module.
+/// This trait serves as both a [type class] for `Pin`s configured as SERCOM
+/// pads and as a [type-level function] mapping each `Pin` type to its
+/// corresponding [`Sercom`] and [`PadNum`].
 ///
-/// For SAMD21 and SAMx5x chips, a [`Sercom`] and a [`PinId`] is enough
-/// information to uniquely identify a [`Pad`], so this trait returns the
-/// corresponding [`PadNum`] and [`PinMode`].
-///
-/// For SAMD11 chips, on the other hand, some `PinId`s can serve as two
-/// different `PadNum`s for the *same* `Sercom`. For these chips, `PadInfo`
-/// requires a second type parameter to specify the `PadNum` and only returns
-/// the `PinMode`.
-#[cfg(feature = "samd11")]
-pub trait PadInfo<S, N>
-where
-    S: Sercom,
-    Self: PinId,
-{
-    /// Corresponding [`PinMode`] for `Pad<S, N, Self>`
-    type PinMode: PinMode;
-}
-
-/// Type-level function mapping [`PinId`]s to other [`Pad`]-related types
-///
-/// This trait forms the basis of all type-level enforcement in this module. Its
-/// implementations are defined by macros in the [`pad_info`](super::pad_info)
-/// module.
-///
-/// For SAMD21 and SAMx5x chips, a [`Sercom`] and a [`PinId`] is enough
-/// information to uniquely identify a [`Pad`], so this trait returns the
-/// corresponding [`PadNum`] and [`PinMode`].
-///
-/// For SAMD11 chips, on the other hand, some `PinId`s can serve as two
-/// different `PadNum`s for the *same* `Sercom`. For these chips, `PadInfo`
-/// requires a second type parameter to specify the `PadNum` and only returns
-/// the `PinMode`.
-#[cfg(not(feature = "samd11"))]
-pub trait PadInfo<S>
-where
-    S: Sercom,
-    Self: PinId,
-{
-    /// Corresponding [`PadNum`] for the combination of `S` and `Self`
-    type PadNum: PadNum;
-    /// Corresponding [`PinMode`] for `Pad<S, Self::PadNum, Self>`
-    type PinMode: PinMode;
-}
-
-//==============================================================================
-// ConvertPinToPad
-//==============================================================================
-
-/// Type-level function mapping a configured [`Pin`] to its corresponding
-/// [`Sercom`] and [`PadNum`]
-///
-/// This trait is a [type-level function] theat makes it easier to convert a
-/// [`Pin`] type in a [`PinMode`] of [`AlternateC`] or [`AlternateD`] to its
-/// corresponding [`Sercom`] and [`PadNum`] types.
-///
-/// The type aliases [`PinToSercom`], [`PinToPadNum`],
-#[cfg_attr(feature = "samd11", doc = "[`PinToNITuple`]")]
-#[cfg_attr(not(feature = "samd11"), doc = "`PinToNITuple`")]
-/// and [`PinToPad`] use this trait to recover their respective types.
-///
-/// [type-level function]: crate::typelevel#type-level-functions
-pub trait ConvertPinToPad: AnyPin {
-    type Sercom: Sercom;
-    type PadNum: PadNum;
-}
-
-/// Type alias to recover the corresponding [`Sercom`] type from a [`Pin`] using
-/// the [`ConvertPinToPad`] trait.
-pub type PinToSercom<P> = <P as ConvertPinToPad>::Sercom;
-
-/// Type alias to recover the corresponding [`PadNum`] type from a [`Pin`] using
-/// the [`ConvertPinToPad`] trait.
-pub type PinToPadNum<P> = <P as ConvertPinToPad>::PadNum;
-
-/// Type alias to recover the corresponding [`Pad`] type from a [`Pin`] using
-/// the [`ConvertPinToPad`] trait.
-pub type PinToPad<P> = Pad<PinToSercom<P>, PinToPadNum<P>, SpecificPinId<P>>;
-
-/// Type alias to recover the corresponding [`NITuple`] type from a [`Pin`]
-/// using the [`ConvertPinToPad`] trait.
-#[cfg(feature = "samd11")]
-pub type PinToNITuple<P> = (PinToPadNum<P>, SpecificPinId<P>);
-
-//==============================================================================
-// GetPadMode
-//==============================================================================
-
-/// Type-level function mapping [`PinId`]s to [`PinMode`]s for a given
-/// [`Sercom`] and [`PadNum`]
-///
-/// This trait acts as a [type-level function]. It is implemented on [`PinId`]s
-/// and it takes two additional types as arguments, a [`Sercom`] and a
-/// [`PadNum`]. It returns the correct [`PinMode`] for the corresponding [`Pin`]
-/// configured as a [`Pad`].
-///
-/// [type-level function]: crate::typelevel#type-level-functions
-pub trait GetPadMode<S, N>
-where
-    Self: PinId,
-    S: Sercom,
-    N: PadNum,
-{
-    /// Corresponding [`PinMode`] for `Pad<S, N, Self>`
-    type Mode: PinMode;
-}
-
-/// Alias for the return type of [`GetPadMode`]
-///
-/// See the documentation on [type-level functions] for an explanation of the
-/// pattern.
-///
-/// [type-level functions]: crate::typelevel#type-level-functions
-pub type PadMode<S, N, I> = <I as GetPadMode<S, N>>::Mode;
-
-#[cfg(feature = "samd11")]
-impl<S, N, I> GetPadMode<S, N> for I
-where
-    S: Sercom,
-    N: PadNum,
-    I: PadInfo<S, N>,
-{
-    type Mode = I::PinMode;
-}
-
-#[cfg(not(feature = "samd11"))]
-impl<S, I> GetPadMode<S, I::PadNum> for I
-where
-    S: Sercom,
-    I: PadInfo<S>,
-{
-    type Mode = I::PinMode;
-}
-
-//==============================================================================
-// Pad
-//==============================================================================
-
-/// A GPIO pin configured as a SERCOM pad
-///
-/// Each `Pad` is parameterized by three [type-level enums], [`Sercom`],
-/// [`PadNum`], and [`PinId`]. When created, a `Pad` takes ownership of the
-/// corresponding [`Pin`]. `Pad`s usually don't need to be created by users
-/// directly. But if required, they can be created with the [`new`](Self::new())
-/// function or converted [`From`] `Pin`s. The corresponding `Pin` can be
-/// recovered with the [`free`](Self::free()) function or again with
-/// [`From`]/[`Into`].
-///
-/// See the [module-level documentation](self) for examples.
-///
-/// [type-level enums]: crate::typelevel#type-level-enum
-/// [type-level function]: crate::typelevel#type-level-functions
-pub struct Pad<S, N, I>
-where
-    S: Sercom,
-    N: PadNum,
-    I: GetPadMode<S, N>,
-{
-    pin: Pin<I, I::Mode>,
-}
-
-impl<S, N, I> Pad<S, N, I>
-where
-    S: Sercom,
-    N: PadNum,
-    I: GetPadMode<S, N>,
-{
-    /// Create a new SERCOM [`Pad`] from a [`Pin`]
-    #[inline]
-    pub fn new(pin: impl AnyPin<Id = I>) -> Self {
-        let pin = pin.into().into_mode();
-        Pad { pin }
-    }
-
-    /// Consume the [`Pad`] and release the corresponding [`Pin`]
-    #[inline]
-    pub fn free(self) -> Pin<I, I::Mode> {
-        self.pin
-    }
-}
-
-//==============================================================================
-// Convert between Pin and Pad
-//==============================================================================
-
-impl<S, N, P> From<P> for Pad<S, N, P::Id>
-where
-    S: Sercom,
-    N: PadNum,
-    P: AnyPin,
-    P::Id: GetPadMode<S, N>,
-{
-    /// Convert from a [`Pin`] to its corresponding [`Pad`]
-    ///
-    /// This conversion is not necessarily unique for a given [`Pin`].
-    #[inline]
-    fn from(pin: P) -> Self {
-        Pad::new(pin)
-    }
-}
-
-impl<S, N, I> From<Pad<S, N, I>> for Pin<I, I::Mode>
-where
-    S: Sercom,
-    N: PadNum,
-    I: GetPadMode<S, N>,
-{
-    /// Convert from a [`Pad`] to its corresponding [`Pin`]
-    ///
-    /// This transformation is unique for a given [`Pad`].
-    #[inline]
-    fn from(pad: Pad<S, N, I>) -> Self {
-        pad.pin
-    }
-}
-
-//==============================================================================
-// AnyPad
-//==============================================================================
-
-/// Type class for [`Pad`] types
-///
-/// This trait uses the [`AnyKind`] trait pattern to create a [type class] for
-/// [`Pad`] types. See the `AnyKind` documentation for more details on the
-/// pattern.
-///
-/// [`AnyKind`]: crate::typelevel#anykind-trait-pattern
 /// [type class]: crate::typelevel#type-classes
-pub trait AnyPad: Is<Type = SpecificPad<Self>> {
+/// [type-level function]: crate::typelevel#type-level-functions
+pub trait IsPad: AnyPin {
     type Sercom: Sercom;
     type PadNum: PadNum;
-    type PinId: GetPadMode<Self::Sercom, Self::PadNum>;
-}
-
-/// Type constructor to recover the specific [`Pad`] from an implementation of
-/// [`AnyPad`]
-///
-/// See the [`AnyKind`] documentation for more details on the pattern.
-///
-/// [`AnyKind`]: crate::typelevel#anykind-trait-pattern
-pub type SpecificPad<P> = Pad<<P as AnyPad>::Sercom, <P as AnyPad>::PadNum, <P as AnyPad>::PinId>;
-
-impl<S, N, I> AsRef<Self> for Pad<S, N, I>
-where
-    S: Sercom,
-    N: PadNum,
-    I: GetPadMode<S, N>,
-{
-    #[inline]
-    fn as_ref(&self) -> &Self {
-        self
-    }
-}
-
-impl<S, N, I> AsMut<Self> for Pad<S, N, I>
-where
-    S: Sercom,
-    N: PadNum,
-    I: GetPadMode<S, N>,
-{
-    #[inline]
-    fn as_mut(&mut self) -> &mut Self {
-        self
-    }
-}
-
-impl<S, N, I> Sealed for Pad<S, N, I>
-where
-    S: Sercom,
-    N: PadNum,
-    I: GetPadMode<S, N>,
-{
-}
-
-impl<S, N, I> AnyPad for Pad<S, N, I>
-where
-    S: Sercom,
-    N: PadNum,
-    I: GetPadMode<S, N>,
-{
-    type Sercom = S;
-    type PadNum = N;
-    type PinId = I;
 }
 
 //==============================================================================
@@ -464,177 +115,137 @@ where
 /// See the [`OptionalKind`] documentation for more details on the pattern.
 ///
 /// [`OptionalKind`]: crate::typelevel#optionalkind-trait-pattern
-pub trait OptionalPad: Sealed {}
-impl OptionalPad for NoneT {}
-impl<P: AnyPad> OptionalPad for P {}
+pub trait OptionalPad: OptionalPin {
+    type PadNum: OptionalPadNum;
+}
+
+impl OptionalPad for NoneT {
+    type PadNum = NoneT;
+}
+
+impl<P: IsPad> OptionalPad for P {
+    type PadNum = P::PadNum;
+}
 
 /// Type-level equivalent of `Some(Pad)`
 ///
 /// See the [`OptionalKind`] documentation for more details on the pattern.
 ///
 /// [`OptionalKind`]: crate::typelevel#optionalkind-trait-pattern
-pub trait SomePad: OptionalPad + AnyPad {}
-impl<P: AnyPad> SomePad for P {}
+pub trait SomePad: IsPad {}
 
-//==============================================================================
-// NITuple
-//==============================================================================
-
-/// Type-class for (`PadNum`, `PinId`) tuples
-///
-/// This trait forms a type-class for all (`PadNum`, `PinId`) tuples, and it
-/// allows you to recover the constituate types from a generic type implementing
-/// `NITuple`.
-///
-/// This type is used by the [type-level function] [`GetPad`], through the
-/// [`GetPadMarker`] trait. It allows the implementation of [`GetPad`] to be
-/// fully generic, which helps type inference in downstream modules.
-///
-/// [type-level function]: crate::typelevel#type-level-functions
-#[cfg(feature = "samd11")]
-pub trait NITuple: Sealed {
-    type Num: PadNum;
-    type Id: PinId;
-}
-
-#[cfg(feature = "samd11")]
-impl<N: PadNum, I: PinId> Sealed for (N, I) {}
-
-#[cfg(feature = "samd11")]
-impl<N: PadNum, I: PinId> NITuple for (N, I) {
-    type Num = N;
-    type Id = I;
-}
-
-//==============================================================================
-// GetPadMarker
-//==============================================================================
-
-/// Marker trait for [`GetPad`]
-///
-/// This trait has two purposes. First, it papers over differences between the
-/// SAMD11 chips and all other chips. And second, it acts to prevent
-/// conflicting-implementation errors.
-///
-/// The latter purpose is a limitation of the Rust trait system. For some
-/// reason, when a local trait takes type parameters, the compiler stops
-/// understanding that a local trait can never be implemented for a local type
-/// in some other crate. As a workaround, you can use a marker trait like this
-/// one to make it possible.
-#[cfg(feature = "samd11")]
-pub trait GetPadMarker: NITuple {}
-
-#[cfg(feature = "samd11")]
-impl<P: NITuple> GetPadMarker for P {}
-
-/// Marker trait for [`GetPad`]
-///
-/// This trait has two purposes. First, it papers over differences between the
-/// SAMD11 chips and all other chips. And second, it acts to prevent
-/// conflicting-implementation errors.
-///
-/// The latter purpose is a limitation of the Rust trait system. For some
-/// reason, when a local trait takes type parameters, the compiler stops
-/// understanding that a local trait can never be implemented for a local type
-/// in some other crate. As a workaround, you can use a marker trait like this
-/// one to make it possible.
-#[cfg(not(feature = "samd11"))]
-pub trait GetPadMarker: PinId {}
-
-#[cfg(not(feature = "samd11"))]
-impl<I: PinId> GetPadMarker for I {}
+impl<P: IsPad> SomePad for P {}
 
 //==============================================================================
 // GetPad
 //==============================================================================
 
-/// Type-level function to uniquely specify a [`Pad`] type
+/// Type-level function mapping [`PinId`]s to SERCOM-pad-related types
 ///
-/// This trait acts as a [type-level function] to uniquely specify a [`Pad`]
-/// type with as little information as possible.
+/// For SAMD21 and SAMx5x chips, a [`Sercom`] and a [`PinId`] is enough
+/// information to uniquely identify a pad, so this trait returns the
+/// corresponding [`PadNum`] and [`PinMode`].
 ///
-/// SAMD21 and SAMx5x chips only ever map a given [`PinId`] to a single
-/// [`PadNum`] for a given [`Sercom`]. SAMD11 chips, on the other hand,
-/// sometimes have the same `PinId` mapped to two different `PadNum`s for the
-/// *same* `Sercom`. As a result, a `Sercom` and a `PinId` is enough information
-/// to uniquely specify a `Pad` for SAMD21 and SAMDx5x chips, but you need to
-/// know the `PadNum` for SAMD11 chips.
+/// For SAMD11 chips, on the other hand, some `PinId`s can serve as two
+/// different `PadNum`s for the *same* `Sercom`. For these chips, `GetPad`
+/// requires a second type parameter to specify the `PadNum` and only returns
+/// the `PinMode`.
 ///
-/// For SAMD21 and SAMx5x chips, this trait is implemented on `PinId`s directly.
-/// For SAMD11 chips, it is implemented on (`PadNum`, `PinId`) tupes, also known
-/// as
-#[cfg_attr(feature = "samd11", doc = "[`NITuple`]s")]
-#[cfg_attr(not(feature = "samd11"), doc = "`NITuple`s")]
+/// See the documentation on [type-level functions] for more details.
 ///
-/// This trait improves the ergonomics of fully specifying a `Pad` in downstream
-/// modules, like the [`spi::Pads`](super::spi::Pads) type.
+/// [type-level functions]: crate::typelevel#type-level-functions
+#[cfg(feature = "samd11")]
+pub trait GetPad<S, N>
+where
+    S: Sercom,
+    N: PadNum,
+    Self: PinId,
+{
+    type PinMode: PinMode;
+}
+
+/// Type-level function mapping [`PinId`]s to SERCOM-pad-related types
 ///
-/// [type-level function]: crate::typelevel#type-level-functions
+/// For SAMD21 and SAMx5x chips, a [`Sercom`] and a [`PinId`] is enough
+/// information to uniquely identify a pad, so this trait returns the
+/// corresponding [`PadNum`] and [`PinMode`].
+///
+/// For SAMD11 chips, on the other hand, some `PinId`s can serve as two
+/// different `PadNum`s for the *same* `Sercom`. For these chips, `GetPad`
+/// requires a second type parameter to specify the `PadNum` and only returns
+/// the `PinMode`.
+///
+/// See the documentation on [type-level functions] for more details.
+///
+/// [type-level functions]: crate::typelevel#type-level-functions
+#[cfg(not(feature = "samd11"))]
 pub trait GetPad<S>
 where
     S: Sercom,
-    Self: GetPadMarker,
+    Self: PinId,
 {
     type PadNum: PadNum;
-    type PinId: GetPadMode<S, Self::PadNum>;
-    type Pad: AnyPad<Sercom = S, PadNum = Self::PadNum, PinId = Self::PinId>;
+    type PinMode: PinMode;
 }
 
+//==============================================================================
+// GetPad aliases
+//==============================================================================
+
+/// Type alias using [`GetPad`] to recover the [`PinMode`] for a given SERCOM
+/// pad
 #[cfg(feature = "samd11")]
-impl<S, T> GetPad<S> for T
-where
-    S: Sercom,
-    T: NITuple,
-    T::Id: PadInfo<S, T::Num>,
-{
-    type PadNum = T::Num;
-    type PinId = T::Id;
-    type Pad = Pad<S, T::Num, T::Id>;
-}
+pub type PadMode<S, N, I> = <I as GetPad<S, N>>::PinMode;
 
+/// Type alias using [`GetPad`] to recover the [`PinMode`] for a given SERCOM
+/// pad
 #[cfg(not(feature = "samd11"))]
-impl<S, I> GetPad<S> for I
-where
-    S: Sercom,
-    I: PadInfo<S>,
-{
-    type PadNum = I::PadNum;
-    type PinId = I;
-    type Pad = Pad<S, I::PadNum, I>;
-}
+pub type PadMode<S, I> = <I as GetPad<S>>::PinMode;
+
+/// Type alias to recover a [`Pin`] configured as a SERCOM pad in the correct
+/// [`PadMode`]
+#[cfg(feature = "samd11")]
+pub type Pad<S, N, I> = Pin<I, PadMode<S, N, I>>;
+
+/// Type alias to recover a [`Pin`] configured as a SERCOM pad in the correct
+/// [`PadMode`]
+#[cfg(not(feature = "samd11"))]
+pub type Pad<S, I> = Pin<I, PadMode<S, I>>;
 
 //==============================================================================
 // GetOptionalPad
 //==============================================================================
 
-/// Type-level function to recover an [`OptionalPad`] from an optional
-/// implementor of [`GetPad`]
+/// Type-level function mapping [`OptionalPinId`]s to their corresponding
+/// [`OptionalPad`]s
 ///
-/// This trait acts as a [type-level function]. In pseudo-Rust, it is the
-/// type-level equivalent of starting with an `Option<GetPadMarker>` and calling
-/// `.map(GetPad)` to recover an `Option<Pad>`.
+/// This trait acts as a [type-level function] mapping `OptionalPinId`s to their
+/// corresponding `OptionalPad`. In pseudo-Rust, it is the type-level equivalent
+/// of starting with `Option<PinId>` and calling `.map(GetPad)` to recover an
+/// `Option<Pad>`.
 ///
-/// [type-level function]: crate::typelevel#type-level-functions
-pub trait GetOptionalPad<S: Sercom>: Sealed {
+/// [type-level functions]: crate::typelevel#type-level-functions
+#[cfg(not(feature = "samd11"))]
+pub trait GetOptionalPad<S: Sercom>: OptionalPinId {
     type PadNum: OptionalPadNum;
-    type PinId: OptionalPinId;
     type Pad: OptionalPad;
 }
 
+#[cfg(not(feature = "samd11"))]
 impl<S: Sercom> GetOptionalPad<S> for NoneT {
     type PadNum = NoneT;
-    type PinId = NoneT;
     type Pad = NoneT;
 }
 
-impl<S, T> GetOptionalPad<S> for T
+#[cfg(not(feature = "samd11"))]
+impl<S, I> GetOptionalPad<S> for I
 where
     S: Sercom,
-    T: GetPad<S> + GetPadMarker,
+    I: PinId + GetPad<S>,
+    Pad<S, I>: IsPad,
 {
-    type PadNum = T::PadNum;
-    type PinId = T::PinId;
-    type Pad = T::Pad;
+    type PadNum = I::PadNum;
+    type Pad = Pad<S, I>;
 }
 
 //==============================================================================
@@ -664,18 +275,18 @@ seq!(N in 1..=6 {
     }
 });
 
-/// Type class for [`Pad`]s in a given [`IoSet`]
+/// Type class for SERCOM pads in a given [`IoSet`]
 ///
-/// This trait is used to label each [`Pad`] with its corresponding
-/// [`IoSet`]\(s). Downstream types can use this trait as a [type class] to
-/// restrict [`Pad`]s to a given [`IoSet`]. See the [type class] documentation
-/// for more details on the pattern.
+/// This trait is used to label each [`Pin`] implementing [`IsPad`] with its
+/// corresponding [`IoSet`]\(s). Downstream types can use this trait as a
+/// [type class] to restrict [`Pin`]s to a given [`IoSet`]. See the [type class]
+/// documentation for more details on the pattern.
 ///
 /// [type class]: crate::typelevel#type-classes
 #[cfg(feature = "min-samd51g")]
 pub trait InIoSet<I>
 where
-    Self: AnyPad,
+    Self: IsPad,
     I: IoSet,
 {
 }

--- a/hal/src/thumbv6m/sercom/v1/i2c.rs
+++ b/hal/src/thumbv6m/sercom/v1/i2c.rs
@@ -2,6 +2,8 @@
 
 use crate::clock;
 use crate::hal::blocking::i2c::{Read, Write, WriteRead};
+use crate::sercom::v1::pads::CompatiblePad;
+use crate::sercom::v2::pad::{Pad0, Pad1};
 use crate::target_device::sercom0::I2CM;
 use crate::target_device::{PM, SERCOM0, SERCOM1};
 #[cfg(feature = "samd21")]
@@ -20,18 +22,36 @@ const MASTER_ACT_STOP: u8 = 3;
 /// Define an I2C master type for the given SERCOM and pad pair.
 macro_rules! i2c {
     ([
-        $($Type:ident: ($pad0:ident, $pad1:ident, $SERCOM:ident, $powermask:ident, $clock:ident),)+
+        $($Type:ident:
+            (
+                $pad0:ident,  // No longer used
+                $pad1:ident,  // No longer used
+                $SERCOM:ident,
+                $powermask:ident,
+                $clock:ident
+            ),
+        )+
     ]) => {
+
         $(
+
 /// Represents the Sercom instance configured to act as an I2C Master.
 /// The embedded_hal blocking I2C traits are implemented by this instance.
-pub struct $Type<$pad0, $pad1> {
-    sda: $pad0,
-    scl: $pad1,
+pub struct $Type<P0, P1>
+where
+    P0: CompatiblePad<Sercom = $SERCOM, PadNum = Pad0>,
+    P1: CompatiblePad<Sercom = $SERCOM, PadNum = Pad1>,
+{
+    sda: P0,
+    scl: P1,
     sercom: $SERCOM,
 }
 
-impl<$pad0, $pad1> $Type<$pad0, $pad1> {
+impl<P0, P1> $Type<P0, P1>
+where
+    P0: CompatiblePad<Sercom = $SERCOM, PadNum = Pad0>,
+    P1: CompatiblePad<Sercom = $SERCOM, PadNum = Pad1>,
+{
     /// Configures the sercom instance to work as an I2C Master.
     /// The clock is obtained via the `GenericClockGenerator` type.
     /// `freq` specifies the bus frequency to use for I2C communication.
@@ -58,8 +78,8 @@ impl<$pad0, $pad1> $Type<$pad0, $pad1> {
         freq: F,
         sercom: $SERCOM,
         pm: &mut PM,
-        sda: $pad0,
-        scl: $pad1,
+        sda: P0,
+        scl: P1,
     ) -> Self {
         // Power up the peripheral bus clock.
         // safe because we're exclusively owning SERCOM
@@ -101,7 +121,7 @@ impl<$pad0, $pad1> $Type<$pad0, $pad1> {
 
     /// Breaks the sercom device up into its constituent pins and the SERCOM
     /// instance.  Does not make any changes to power management.
-    pub fn free(self) -> ($pad0, $pad1, $SERCOM) {
+    pub fn free(self) -> (P0, P1, $SERCOM) {
         (self.sda, self.scl, self.sercom)
     }
 
@@ -273,7 +293,12 @@ impl<$pad0, $pad1> $Type<$pad0, $pad1> {
         self.fill_buffer(buffer)
     }
 }
-impl<$pad0, $pad1> Write for $Type<$pad0, $pad1> {
+
+impl<P0, P1> Write for $Type<P0, P1>
+where
+    P0: CompatiblePad<Sercom = $SERCOM, PadNum = Pad0>,
+    P1: CompatiblePad<Sercom = $SERCOM, PadNum = Pad1>,
+{
     type Error = I2CError;
 
     /// Sends bytes to slave with address `addr`
@@ -284,7 +309,11 @@ impl<$pad0, $pad1> Write for $Type<$pad0, $pad1> {
     }
 }
 
-impl<$pad0, $pad1> Read for $Type<$pad0, $pad1> {
+impl<P0, P1> Read for $Type<P0, P1>
+where
+    P0: CompatiblePad<Sercom = $SERCOM, PadNum = Pad0>,
+    P1: CompatiblePad<Sercom = $SERCOM, PadNum = Pad1>,
+{
     type Error = I2CError;
 
     fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
@@ -294,7 +323,11 @@ impl<$pad0, $pad1> Read for $Type<$pad0, $pad1> {
     }
 }
 
-impl<$pad0, $pad1> WriteRead for $Type<$pad0, $pad1> {
+impl<P0, P1> WriteRead for $Type<P0, P1>
+where
+    P0: CompatiblePad<Sercom = $SERCOM, PadNum = Pad0>,
+    P1: CompatiblePad<Sercom = $SERCOM, PadNum = Pad1>,
+{
     type Error = I2CError;
 
     fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {

--- a/hal/src/thumbv6m/sercom/v1/spi.rs
+++ b/hal/src/thumbv6m/sercom/v1/spi.rs
@@ -1,8 +1,9 @@
+use core::marker::PhantomData;
+
 use crate::clock;
-use crate::gpio::v2::pin::AnyPin;
 use crate::hal::spi::{FullDuplex, Mode, Phase, Polarity};
-use crate::sercom::pads::*;
-use crate::sercom::v2;
+use crate::sercom::v1::pads::CompatiblePad;
+use crate::sercom::v2::*;
 use crate::spi_common::CommonSpi;
 use crate::target_device::sercom0::SPI;
 use crate::target_device::{PM, SERCOM0, SERCOM1};
@@ -22,7 +23,79 @@ pub enum Error {
 /// this trait for yourself; only the implementations in the sercom module make
 /// sense.
 pub trait DipoDopo {
-    fn dipo_dopo(&self) -> (u8, u8);
+    const DIPO: u8;
+    const DOPO: u8;
+    fn dipo_dopo(&self) -> (u8, u8) {
+        (Self::DIPO, Self::DOPO)
+    }
+}
+
+macro_rules! padout {
+    ( ($dipo:literal, $dopo:literal) => $pad0:ident, $pad1:ident, $pad2:ident) => {
+        impl DipoDopo for ($pad0, $pad1, $pad2) {
+            const DIPO: u8 = $dipo;
+            const DOPO: u8 = $dopo;
+        }
+    };
+}
+
+padout!((0, 1) => Pad0, Pad2, Pad3);
+padout!((0, 2) => Pad0, Pad3, Pad1);
+
+padout!((1, 1) => Pad1, Pad2, Pad3);
+padout!((1, 3) => Pad1, Pad0, Pad3);
+
+padout!((2, 0) => Pad2, Pad0, Pad1);
+padout!((2, 2) => Pad2, Pad3, Pad1);
+padout!((2, 3) => Pad2, Pad0, Pad3);
+
+padout!((3, 0) => Pad3, Pad0, Pad1);
+
+/// A pad mapping configuration for the SERCOM in SPI master mode.
+///
+/// This type can only be constructed using the From implementations
+/// in this module, which are restricted to valid configurations.
+///
+/// Defines which sercom pad is mapped to which SPI function.
+pub struct Padout<S, MISO, MOSI, SCLK>
+where
+    S: Sercom,
+{
+    sercom: PhantomData<S>,
+    _miso: MISO,
+    _mosi: MOSI,
+    _sclk: SCLK,
+}
+
+/// Convert from a tuple of (MISO, MOSI, SCK) to SPIMasterXPadout
+impl<S, PAD0, PAD1, PAD2> From<(PAD0, PAD1, PAD2)> for Padout<S, PAD0, PAD1, PAD2>
+where
+    S: Sercom,
+    PAD0: CompatiblePad<Sercom = S>,
+    PAD1: CompatiblePad<Sercom = S>,
+    PAD2: CompatiblePad<Sercom = S>,
+    (PAD0::PadNum, PAD1::PadNum, PAD2::PadNum): DipoDopo,
+{
+    fn from(pads: (PAD0, PAD1, PAD2)) -> Padout<S, PAD0, PAD1, PAD2> {
+        Padout {
+            sercom: PhantomData,
+            _miso: pads.0,
+            _mosi: pads.1,
+            _sclk: pads.2,
+        }
+    }
+}
+
+impl<S, PAD0, PAD1, PAD2> DipoDopo for Padout<S, PAD0, PAD1, PAD2>
+where
+    S: Sercom,
+    PAD0: CompatiblePad<Sercom = S>,
+    PAD1: CompatiblePad<Sercom = S>,
+    PAD2: CompatiblePad<Sercom = S>,
+    (PAD0::PadNum, PAD1::PadNum, PAD2::PadNum): DipoDopo,
+{
+    const DIPO: u8 = <(PAD0::PadNum, PAD1::PadNum, PAD2::PadNum)>::DIPO;
+    const DOPO: u8 = <(PAD0::PadNum, PAD1::PadNum, PAD2::PadNum)>::DOPO;
 }
 
 /// Define an SPIMasterX type for the given Sercom number.
@@ -32,212 +105,124 @@ pub trait DipoDopo {
 macro_rules! spi_master {
     ($Type:ident: ($Sercom:ident, $SERCOM:ident, $powermask:ident, $clock:ident)) => {
         $crate::paste::item! {
-            /// A pad mapping configuration for the SERCOM in SPI master mode.
-            ///
-            /// This type can only be constructed using the From implementations
-            /// in this module, which are restricted to valid configurations.
-            ///
-            /// Defines which sercom pad is mapped to which SPI function.
-            pub struct [<$Type Padout>]<MISO, MOSI, SCK> {
-                _miso: MISO,
-                _mosi: MOSI,
-                _sck: SCK,
-            }
+            pub type [<$Type Padout>]<MISO, MOSI, SCLK> = Padout<$Sercom, MISO, MOSI, SCLK>;
         }
 
-        /// Define a From instance for a tuple of SercomXPadX instances that
-        /// converts them into an SPIMasterXPadout instance.
+        /// SPIMasterX represents the corresponding SERCOMX instance
+        /// configured to act in the role of an SPI Master.
+        /// Objects of this type implement the HAL `FullDuplex` and blocking
+        /// SPI traits.
         ///
-        /// Also defines a DipoDopo instance for the constructed padout instance
-        /// that returns the values used to configure the sercom pads for the
-        /// appropriate function in the sercom register file.
-        macro_rules! padout {
-            ($dipo_dopo:expr => $pad0:ident, $pad1:ident, $pad2:ident) => {
-                $crate::paste::item! {
-                    /// Convert from a tuple of (MISO, MOSI, SCK) to SPIMasterXPadout
-                    impl<PIN0, PIN1, PIN2> From<([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>)> for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>>
-                    where
-                        PIN0: AnyPin,
-                        PIN1: AnyPin,
-                        PIN2: AnyPin,
-                        PIN0::Id: GetPadMode<$Sercom, $pad0>,
-                        PIN1::Id: GetPadMode<$Sercom, $pad1>,
-                        PIN2::Id: GetPadMode<$Sercom, $pad2>,
-                    {
-                        fn from(pads: ([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>)) -> [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>> {
-                            [<$Type Padout>] { _miso: pads.0, _mosi: pads.1, _sck: pads.2 }
-                        }
-                    }
-
-                    impl<PIN0, PIN1, PIN2> DipoDopo for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>>
-                    where
-                        PIN0: AnyPin,
-                        PIN1: AnyPin,
-                        PIN2: AnyPin,
-                        PIN0::Id: GetPadMode<$Sercom, $pad0>,
-                        PIN1::Id: GetPadMode<$Sercom, $pad1>,
-                        PIN2::Id: GetPadMode<$Sercom, $pad2>,
-                    {
-                        fn dipo_dopo(&self) -> (u8, u8) {
-                            $dipo_dopo
-                        }
-                    }
-
-                    impl<Id0, Id1, Id2> From<(v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>)> for [<$Type Padout>]<v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>>
-                    where
-                        Id0: v2::GetPadMode<$Sercom, $pad0>,
-                        Id1: v2::GetPadMode<$Sercom, $pad1>,
-                        Id2: v2::GetPadMode<$Sercom, $pad2>,
-                    {
-                        fn from(pads: (v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>)) -> Self {
-                            [<$Type Padout>] { _miso: pads.0, _mosi: pads.1, _sck: pads.2 }
-                        }
-                    }
-
-                    impl<Id0, Id1, Id2> DipoDopo for [<$Type Padout>]<v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>>
-                    where
-                        Id0: v2::GetPadMode<$Sercom, $pad0>,
-                        Id1: v2::GetPadMode<$Sercom, $pad1>,
-                        Id2: v2::GetPadMode<$Sercom, $pad2>,
-                    {
-                        fn dipo_dopo(&self) -> (u8, u8) {
-                            $dipo_dopo
-                        }
-                    }
-                }
-            };
+        /// This type is generic over any valid pad mapping where there is
+        /// a defined "data in pin out data out pin out" implementation.
+        pub struct $Type<MISO, MOSI, SCK> {
+            padout: Padout<$Sercom, MISO, MOSI, SCK>,
+            sercom: $SERCOM,
         }
 
-        padout!((0, 1) => Pad0, Pad2, Pad3);
-        padout!((0, 2) => Pad0, Pad3, Pad1);
+        impl<MISO, MOSI, SCK> CommonSpi for $Type<MISO, MOSI, SCK> {
+            /// Helper for accessing the spi member of the sercom instance
+            fn spi(&self) -> &SPI {
+                &self.sercom.spi()
+            }
 
-        padout!((1, 1) => Pad1, Pad2, Pad3);
-        padout!((1, 3) => Pad1, Pad0, Pad3);
+            /// Helper for accessing the spi member of the sercom instance
+            fn spi_mut(&mut self) -> &SPI {
+                &self.sercom.spi()
+            }
+        }
 
-        padout!((2, 0) => Pad2, Pad0, Pad1);
-        padout!((2, 2) => Pad2, Pad3, Pad1);
-        padout!((2, 3) => Pad2, Pad0, Pad3);
-
-        padout!((3, 0) => Pad3, Pad0, Pad1);
-
-        $crate::paste::item! {
-            /// SPIMasterX represents the corresponding SERCOMX instance
-            /// configured to act in the role of an SPI Master.
-            /// Objects of this type implement the HAL `FullDuplex` and blocking
-            /// SPI traits.
+        impl<MISO, MOSI, SCK> $Type<MISO, MOSI, SCK> {
+            /// Power on and configure SERCOMX to work as an SPI Master operating
+            /// with the specified frequency and SPI Mode. The padout specifies
+            /// which pins are bound to the MISO, MOSI, SCK functions.
             ///
-            /// This type is generic over any valid pad mapping where there is
-            /// a defined "data in pin out data out pin out" implementation.
-            pub struct $Type<MISO, MOSI, SCK> {
-                padout: [<$Type Padout>]<MISO, MOSI, SCK>,
+            /// You can use a tuple of three SercomXPadY instances for which
+            /// there exists a From implementation for SPIMasterXPadout.
+            pub fn new<F: Into<Hertz>, T: Into<Padout<$Sercom, MISO, MOSI, SCK>>>(
+                clock: &clock::$clock,
+                freq: F,
+                mode: Mode,
                 sercom: $SERCOM,
+                pm: &mut PM,
+                padout: T,
+            ) -> Self
+            where
+                Padout<$Sercom, MISO, MOSI, SCK>: DipoDopo,
+            {
+                let padout = padout.into();
+
+                // Power up the peripheral bus clock.
+                // safe because we're exclusively owning SERCOM
+                pm.apbcmask.modify(|_, w| w.$powermask().set_bit());
+
+                // reset the sercom instance
+                sercom.spi().ctrla.modify(|_, w| w.swrst().set_bit());
+                // wait for reset to complete
+                while sercom.spi().syncbusy.read().swrst().bit_is_set()
+                    || sercom.spi().ctrla.read().swrst().bit_is_set()
+                {}
+
+                // Put the hardware into spi master mode
+                sercom.spi().ctrla.modify(|_, w| w.mode().spi_master());
+                // wait for configuration to take effect
+                while sercom.spi().syncbusy.read().enable().bit_is_set() {}
+
+                // 8 bit data size and enable the receiver
+                unsafe {
+                    sercom.spi().ctrlb.modify(|_, w| {
+                        w.chsize().bits(0);
+                        w.rxen().set_bit()
+                    });
+                }
+
+                // set the baud rate
+                let baud = Self::calculate_baud(freq, clock.freq());
+
+                unsafe {
+                    sercom.spi().baud.modify(|_, w| w.baud().bits(baud));
+
+                    sercom.spi().ctrla.modify(|_, w| {
+                        match mode.polarity {
+                            Polarity::IdleLow => w.cpol().clear_bit(),
+                            Polarity::IdleHigh => w.cpol().set_bit(),
+                        };
+
+                        match mode.phase {
+                            Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
+                            Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
+                        };
+
+                        let (dipo, dopo) = padout.dipo_dopo();
+                        w.dipo().bits(dipo);
+                        w.dopo().bits(dopo);
+
+                        // MSB first
+                        w.dord().clear_bit()
+                    });
+                }
+
+                sercom.spi().ctrla.modify(|_, w| w.enable().set_bit());
+                // wait for configuration to take effect
+                while sercom.spi().syncbusy.read().enable().bit_is_set() {}
+
+                Self { padout, sercom }
             }
 
-            impl<MISO, MOSI, SCK> CommonSpi for $Type<MISO, MOSI, SCK> {
-                /// Helper for accessing the spi member of the sercom instance
-                fn spi(&self) -> &SPI {
-                    &self.sercom.spi()
+            /// Set the baud rate
+            pub fn set_baud<F: Into<Hertz>>(&mut self, freq: F, clock: &clock::$clock) {
+                self.disable();
+                let baud = Self::calculate_baud(freq, clock.freq());
+                unsafe {
+                    self.spi_mut().baud.modify(|_, w| w.baud().bits(baud));
                 }
-
-                /// Helper for accessing the spi member of the sercom instance
-                fn spi_mut(&mut self) -> &SPI {
-                    &self.sercom.spi()
-                }
+                self.enable();
             }
 
-            impl<MISO, MOSI, SCK> $Type<MISO, MOSI, SCK> {
-                /// Power on and configure SERCOMX to work as an SPI Master operating
-                /// with the specified frequency and SPI Mode. The padout specifies
-                /// which pins are bound to the MISO, MOSI, SCK functions.
-                ///
-                /// You can use a tuple of three SercomXPadY instances for which
-                /// there exists a From implementation for SPIMasterXPadout.
-                pub fn new<F: Into<Hertz>, T: Into<[<$Type Padout>]<MISO, MOSI, SCK>>>(
-                    clock:&clock::$clock,
-                    freq: F,
-                    mode: Mode,
-                    sercom: $SERCOM,
-                    pm: &mut PM,
-                    padout: T,
-                ) -> Self where
-                    [<$Type Padout>]<MISO, MOSI, SCK>: DipoDopo {
-                    let padout = padout.into();
-
-                    // Power up the peripheral bus clock.
-                    // safe because we're exclusively owning SERCOM
-                    pm.apbcmask.modify(|_, w| w.$powermask().set_bit());
-
-                    // reset the sercom instance
-                    sercom.spi().ctrla.modify(|_, w| w.swrst().set_bit());
-                    // wait for reset to complete
-                    while sercom.spi().syncbusy.read().swrst().bit_is_set()
-                        || sercom.spi().ctrla.read().swrst().bit_is_set()
-                    {}
-
-                    // Put the hardware into spi master mode
-                    sercom.spi().ctrla.modify(|_, w| w.mode().spi_master());
-                    // wait for configuration to take effect
-                    while sercom.spi().syncbusy.read().enable().bit_is_set() {}
-
-                    // 8 bit data size and enable the receiver
-                    unsafe {
-                        sercom.spi().ctrlb.modify(|_, w|{
-                            w.chsize().bits(0);
-                            w.rxen().set_bit()
-                        });
-                    }
-
-                    // set the baud rate
-                    let baud = Self::calculate_baud(freq, clock.freq());
-
-                    unsafe {
-                        sercom.spi().baud.modify(|_, w| w.baud().bits(baud));
-
-                        sercom.spi().ctrla.modify(|_, w| {
-                            match mode.polarity {
-                                Polarity::IdleLow => w.cpol().clear_bit(),
-                                Polarity::IdleHigh => w.cpol().set_bit(),
-                            };
-
-                            match mode.phase {
-                                Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
-                                Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
-                            };
-
-                            let (dipo, dopo) = padout.dipo_dopo();
-                            w.dipo().bits(dipo);
-                            w.dopo().bits(dopo);
-
-                            // MSB first
-                            w.dord().clear_bit()
-                        });
-                    }
-
-                    sercom.spi().ctrla.modify(|_, w| w.enable().set_bit());
-                    // wait for configuration to take effect
-                    while sercom.spi().syncbusy.read().enable().bit_is_set() {}
-
-                    Self {
-                        padout,
-                        sercom,
-                    }
-                }
-
-                /// Set the baud rate
-                pub fn set_baud<F: Into<Hertz>>(&mut self, freq: F, clock: &clock::$clock) {
-                    self.disable();
-                    let baud = Self::calculate_baud(freq, clock.freq());
-                    unsafe {
-                        self.spi_mut().baud.modify(|_, w| w.baud().bits(baud));
-                    }
-                    self.enable();
-                }
-
-                /// Tear down the SPI instance and yield the constituent pins and
-                /// SERCOM instance.  No explicit de-initialization is performed.
-                pub fn free(self) -> ([<$Type Padout>]<MISO, MOSI, SCK>, $SERCOM) {
-                    (self.padout, self.sercom)
-                }
+            /// Tear down the SPI instance and yield the constituent pins and
+            /// SERCOM instance.  No explicit de-initialization is performed.
+            pub fn free(self) -> (Padout<$Sercom, MISO, MOSI, SCK>, $SERCOM) {
+                (self.padout, self.sercom)
             }
         }
 
@@ -263,7 +248,9 @@ macro_rules! spi_master {
                 let intflag = self.spi().intflag.read();
                 // dre is data register empty
                 if intflag.dre().bit_is_set() {
-                    self.spi_mut().data.write(|w| unsafe{w.data().bits(byte as u16)});
+                    self.spi_mut()
+                        .data
+                        .write(|w| unsafe { w.data().bits(byte as u16) });
                     Ok(())
                 } else {
                     Err(nb::Error::WouldBlock)
@@ -271,13 +258,17 @@ macro_rules! spi_master {
             }
         }
 
-        impl<MISO, MOSI, SCK> ::hal::blocking::spi::transfer::Default<u8> for $Type<MISO, MOSI, SCK> {}
+        impl<MISO, MOSI, SCK> ::hal::blocking::spi::transfer::Default<u8>
+            for $Type<MISO, MOSI, SCK>
+        {
+        }
         impl<MISO, MOSI, SCK> ::hal::blocking::spi::write::Default<u8> for $Type<MISO, MOSI, SCK> {}
         #[cfg(feature = "unproven")]
-        impl<MISO, MOSI, SCK> ::hal::blocking::spi::write_iter::Default<u8> for $Type<MISO, MOSI, SCK> {}
-
+        impl<MISO, MOSI, SCK> ::hal::blocking::spi::write_iter::Default<u8>
+            for $Type<MISO, MOSI, SCK>
+        {
+        }
     };
-
 }
 
 spi_master!(SPIMaster0: (Sercom0, SERCOM0, sercom0_, Sercom0CoreClock));

--- a/hal/src/thumbv6m/sercom/v1/uart.rs
+++ b/hal/src/thumbv6m/sercom/v1/uart.rs
@@ -1,9 +1,8 @@
 use crate::clock;
-use crate::gpio::v2::pin::AnyPin;
 use crate::hal::blocking::serial::{write::Default, Write};
 use crate::hal::serial;
-use crate::sercom::pads::*;
-use crate::sercom::v2;
+use crate::sercom::v1::pads::CompatiblePad;
+use crate::sercom::v2::*;
 use crate::target_device::sercom0::USART;
 use crate::target_device::{PM, SERCOM0, SERCOM1};
 #[cfg(feature = "samd21")]
@@ -19,7 +18,172 @@ use core::marker::PhantomData;
 /// this trait for yourself; only the implementations in the sercom module make
 /// sense.
 pub trait RxpoTxpo {
-    fn rxpo_txpo(&self) -> (u8, u8);
+    const RXPO: u8;
+    const TXPO: u8;
+    fn rxpo_txpo(&self) -> (u8, u8) {
+        (Self::RXPO, Self::TXPO)
+    }
+}
+
+macro_rules! padout {
+    ( ($rxpo:literal, $txpo:literal) => $pad0:ident, $pad1:ident) => {
+        impl RxpoTxpo for ($pad0, $pad1) {
+            const RXPO: u8 = $rxpo;
+            const TXPO: u8 = $txpo;
+        }
+    };
+    ( ($rxpo:literal, $txpo:literal) => $pad0:ident, $pad1:ident, $pad2:ident, $pad3:ident) => {
+        impl RxpoTxpo for ($pad0, $pad1, $pad2, $pad3) {
+            const RXPO: u8 = $rxpo;
+            const TXPO: u8 = $txpo;
+        }
+    };
+}
+
+padout!((0, 1) => Pad0, Pad2);
+
+padout!((1, 0) => Pad1, Pad0);
+padout!((1, 2) => Pad1, Pad0, Pad2, Pad3);
+padout!((1, 1) => Pad1, Pad2);
+
+padout!((2, 0) => Pad2, Pad0);
+
+padout!((3, 0) => Pad3, Pad0);
+padout!((3, 1) => Pad3, Pad2);
+
+/// A pad mapping configuration for the SERCOM in UART mode.
+///
+/// This type can only be constructed using the From implementations
+/// in this module, which are restricted to valid configurations.
+///
+/// Defines which sercom pad is mapped to which UART function.
+pub struct Padout<S, RX, TX, RTS, CTS>
+where
+    S: Sercom,
+{
+    sercom: PhantomData<S>,
+    rx: RX,
+    tx: TX,
+    rts: RTS,
+    cts: CTS,
+}
+
+/// A pad mapping configuration for the receiving half of the SERCOM in UART
+/// mode.
+pub struct RxPadout<S, RX, CTS>
+where
+    S: Sercom,
+{
+    sercom: PhantomData<S>,
+    rx: RX,
+    cts: CTS,
+}
+
+/// A pad mapping configuration for the transmitting half of the SERCOM in UART
+/// mode.
+pub struct TxPadout<S, TX, RTS>
+where
+    S: Sercom,
+{
+    sercom: PhantomData<S>,
+    tx: TX,
+    rts: RTS,
+}
+
+impl<S, RX, TX, RTS, CTS> Padout<S, RX, TX, RTS, CTS>
+where
+    S: Sercom,
+{
+    /// Splits the padout into transmit and receive halves
+    pub fn split(self) -> (TxPadout<S, TX, RTS>, RxPadout<S, RX, CTS>) {
+        (
+            TxPadout {
+                sercom: PhantomData,
+                tx: self.tx,
+                rts: self.rts,
+            },
+            RxPadout {
+                sercom: PhantomData,
+                rx: self.rx,
+                cts: self.cts,
+            },
+        )
+    }
+
+    /// Combines transmit and receive halves back into a duplex padout
+    pub fn join(tx: TxPadout<S, TX, RTS>, rx: RxPadout<S, RX, CTS>) -> Self {
+        Self {
+            sercom: PhantomData,
+            rx: rx.rx,
+            tx: tx.tx,
+            rts: tx.rts,
+            cts: rx.cts,
+        }
+    }
+}
+
+/// Convert from a tuple of (RX, TX) to UARTXPadout
+impl<S, PAD0, PAD1> From<(PAD0, PAD1)> for Padout<S, PAD0, PAD1, (), ()>
+where
+    S: Sercom,
+    PAD0: CompatiblePad<Sercom = S>,
+    PAD1: CompatiblePad<Sercom = S>,
+    (PAD0::PadNum, PAD1::PadNum): RxpoTxpo,
+{
+    fn from(pads: (PAD0, PAD1)) -> Padout<S, PAD0, PAD1, (), ()> {
+        Padout {
+            sercom: PhantomData,
+            rx: pads.0,
+            tx: pads.1,
+            rts: (),
+            cts: (),
+        }
+    }
+}
+
+impl<S, PAD0, PAD1> RxpoTxpo for Padout<S, PAD0, PAD1, (), ()>
+where
+    S: Sercom,
+    PAD0: CompatiblePad<Sercom = S>,
+    PAD1: CompatiblePad<Sercom = S>,
+    (PAD0::PadNum, PAD1::PadNum): RxpoTxpo,
+{
+    const RXPO: u8 = <(PAD0::PadNum, PAD1::PadNum)>::RXPO;
+    const TXPO: u8 = <(PAD0::PadNum, PAD1::PadNum)>::TXPO;
+}
+
+/// Convert from a tuple of (RX, TX, RTS, CTS) to UARTXPadout
+impl<S, PAD0, PAD1, PAD2, PAD3> From<(PAD0, PAD1, PAD2, PAD3)> for Padout<S, PAD0, PAD1, PAD2, PAD3>
+where
+    S: Sercom,
+    PAD0: CompatiblePad<Sercom = S>,
+    PAD1: CompatiblePad<Sercom = S>,
+    PAD2: CompatiblePad<Sercom = S>,
+    PAD3: CompatiblePad<Sercom = S>,
+    (PAD0::PadNum, PAD1::PadNum, PAD2::PadNum, PAD3::PadNum): RxpoTxpo,
+{
+    fn from(pads: (PAD0, PAD1, PAD2, PAD3)) -> Padout<S, PAD0, PAD1, PAD2, PAD3> {
+        Padout {
+            sercom: PhantomData,
+            rx: pads.0,
+            tx: pads.1,
+            rts: pads.2,
+            cts: pads.3,
+        }
+    }
+}
+
+impl<S, PAD0, PAD1, PAD2, PAD3> RxpoTxpo for Padout<S, PAD0, PAD1, PAD2, PAD3>
+where
+    S: Sercom,
+    PAD0: CompatiblePad<Sercom = S>,
+    PAD1: CompatiblePad<Sercom = S>,
+    PAD2: CompatiblePad<Sercom = S>,
+    PAD3: CompatiblePad<Sercom = S>,
+    (PAD0::PadNum, PAD1::PadNum, PAD2::PadNum, PAD3::PadNum): RxpoTxpo,
+{
+    const RXPO: u8 = <(PAD0::PadNum, PAD1::PadNum, PAD2::PadNum, PAD3::PadNum)>::RXPO;
+    const TXPO: u8 = <(PAD0::PadNum, PAD1::PadNum, PAD2::PadNum, PAD3::PadNum)>::TXPO;
 }
 
 /// Define a UARTX type for the given Sercom.
@@ -29,188 +193,10 @@ pub trait RxpoTxpo {
 macro_rules! uart {
     ($Type:ident: ($Sercom:ident, $SERCOM:ident, $powermask:ident, $clock:ident)) => {
         $crate::paste::item! {
-            /// A pad mapping configuration for the SERCOM in UART mode.
-            ///
-            /// This type can only be constructed using the From implementations
-            /// in this module, which are restricted to valid configurations.
-            ///
-            /// Defines which sercom pad is mapped to which UART function.
-            pub struct [<$Type Padout>]<RX, TX, RTS, CTS> {
-                rx: RX,
-                tx: TX,
-                rts: RTS,
-                cts: CTS,
-            }
-
-            /// A pad mapping configuration for the receiving half of the SERCOM in UART mode.
-            pub struct [<$Type RxPadout>]<RX, CTS> {
-                rx: RX,
-                cts: CTS,
-            }
-
-            /// A pad mapping configuration for the transmitting half of the SERCOM in UART mode.
-            pub struct [<$Type TxPadout>]<TX, RTS> {
-                tx: TX,
-                rts: RTS,
-            }
-
-            impl<RX, TX, RTS, CTS> [<$Type Padout>]<RX, TX, RTS, CTS> {
-                /// Splits the padout into transmit and receive halves
-                pub fn split(self) -> ([<$Type TxPadout>]<TX, RTS>, [<$Type RxPadout>]<RX, CTS>) {
-                    (
-                        [<$Type TxPadout>] {
-                            tx: self.tx,
-                            rts: self.rts,
-                        },
-                        [<$Type RxPadout>] {
-                            rx: self.rx,
-                            cts: self.cts,
-                        },
-                    )
-                }
-
-                /// Combines transmit and receive halves back into a duplex padout
-                pub fn join(tx: [<$Type TxPadout>]<TX, RTS>, rx: [<$Type RxPadout>]<RX, CTS>) -> Self {
-                    Self {
-                        rx: rx.rx,
-                        tx: tx.tx,
-                        rts: tx.rts,
-                        cts: rx.cts,
-                    }
-                }
-            }
+            pub type [<$Type Padout>]<RX, TX, RTS, CTS> = Padout<$Sercom, RX, TX, RTS, CTS>;
+            pub type [<$Type TxPadout>]<TX, RTS> = TxPadout<$Sercom, TX, RTS>;
+            pub type [<$Type RxPadout>]<RX, CTS> = RxPadout<$Sercom, RX, CTS>;
         }
-
-        /// Define a From instance for either a tuple of two SercomXPadX
-        /// instances, or a tuple of four SercomXPadX instances that converts
-        /// them into an UARTXPadout instance.
-        ///
-        /// Also defines a RxpoTxpo instance for the constructed padout instance
-        /// that returns the values used to configure the sercom pads for the
-        /// appropriate function in the sercom register file.
-        macro_rules! padout {
-            ($rxpo_txpo:expr => $pad0:ident, $pad1:ident) => {
-                $crate::paste::item! {
-                    /// Convert from a tuple of (RX, TX) to UARTXPadout
-                    impl<PIN0, PIN1> From<([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>)> for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, (), ()>
-                    where
-                        PIN0: AnyPin,
-                        PIN1: AnyPin,
-                        PIN0::Id: GetPadMode<$Sercom, $pad0>,
-                        PIN1::Id: GetPadMode<$Sercom, $pad1>,
-                    {
-                        fn from(pads: ([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>)) -> [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, (), ()> {
-                            [<$Type Padout>] { rx: pads.0, tx: pads.1, rts: (), cts: () }
-                        }
-                    }
-
-                    impl<PIN0, PIN1> RxpoTxpo for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, (), ()>
-                    where
-                        PIN0: AnyPin,
-                        PIN1: AnyPin,
-                        PIN0::Id: GetPadMode<$Sercom, $pad0>,
-                        PIN1::Id: GetPadMode<$Sercom, $pad1>,
-                    {
-                        fn rxpo_txpo(&self) -> (u8, u8) {
-                            $rxpo_txpo
-                        }
-                    }
-
-                    /// Convert from a tuple of (RX, TX, RTS, CTS) to UARTXPadout
-                    impl<Id0, Id1> From<(v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>)> for [<$Type Padout>]<v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, (), ()>
-                    where
-                        Id0: v2::GetPadMode<$Sercom, $pad0>,
-                        Id1: v2::GetPadMode<$Sercom, $pad1>,
-                    {
-                        fn from(pads: (v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>)) -> Self {
-                            [<$Type Padout>] { rx: pads.0, tx: pads.1, rts: (), cts: () }
-                        }
-                    }
-
-                    impl<Id0, Id1> RxpoTxpo for [<$Type Padout>]<v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, (), ()>
-                    where
-                        Id0: v2::GetPadMode<$Sercom, $pad0>,
-                        Id1: v2::GetPadMode<$Sercom, $pad1>,
-                    {
-                        fn rxpo_txpo(&self) -> (u8, u8) {
-                            $rxpo_txpo
-                        }
-                    }
-                }
-            };
-            ($rxpo_txpo:expr => $pad0:ident, $pad1:ident, $pad2:ident, $pad3:ident) => {
-                $crate::paste::item! {
-                    /// Convert from a tuple of (RX, TX, RTS, CTS) to UARTXPadout
-                    impl<PIN0, PIN1, PIN2, PIN3> From<([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>, [<$Sercom $pad3>]<PIN3>)> for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>, [<$Sercom $pad3>]<PIN3>>
-                    where
-                        PIN0: AnyPin,
-                        PIN1: AnyPin,
-                        PIN2: AnyPin,
-                        PIN3: AnyPin,
-                        PIN0::Id: GetPadMode<$Sercom, $pad0>,
-                        PIN1::Id: GetPadMode<$Sercom, $pad1>,
-                        PIN2::Id: GetPadMode<$Sercom, $pad2>,
-                        PIN3::Id: GetPadMode<$Sercom, $pad3>,
-                    {
-                        fn from(pads: ([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>, [<$Sercom $pad3>]<PIN3>)) -> [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>, [<$Sercom $pad3>]<PIN3>> {
-                            [<$Type Padout>] { rx: pads.0, tx: pads.1, rts: pads.2, cts: pads.3 }
-                        }
-                    }
-
-                    impl<PIN0, PIN1, PIN2, PIN3> RxpoTxpo for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>, [<$Sercom $pad3>]<PIN3>>
-                    where
-                        PIN0: AnyPin,
-                        PIN1: AnyPin,
-                        PIN2: AnyPin,
-                        PIN3: AnyPin,
-                        PIN0::Id: GetPadMode<$Sercom, $pad0>,
-                        PIN1::Id: GetPadMode<$Sercom, $pad1>,
-                        PIN2::Id: GetPadMode<$Sercom, $pad2>,
-                        PIN3::Id: GetPadMode<$Sercom, $pad3>,
-                    {
-                        fn rxpo_txpo(&self) -> (u8, u8) {
-                            $rxpo_txpo
-                        }
-                    }
-
-                    /// Convert from a tuple of (RX, TX, RTS, CTS) to UARTXPadout
-                    impl<Id0, Id1, Id2, Id3> From<(v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>, v2::Pad<$Sercom, $pad3, Id3>)> for [<$Type Padout>]<v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>, v2::Pad<$Sercom, $pad3, Id3>>
-                    where
-                        Id0: v2::GetPadMode<$Sercom, $pad0>,
-                        Id1: v2::GetPadMode<$Sercom, $pad1>,
-                        Id2: v2::GetPadMode<$Sercom, $pad2>,
-                        Id3: v2::GetPadMode<$Sercom, $pad3>,
-                    {
-                        fn from(pads: (v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>, v2::Pad<$Sercom, $pad3, Id3>)) -> Self {
-                            [<$Type Padout>] { rx: pads.0, tx: pads.1, rts: pads.2, cts: pads.3 }
-                        }
-                    }
-
-                    impl<Id0, Id1, Id2, Id3> RxpoTxpo for [<$Type Padout>]<v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>, v2::Pad<$Sercom, $pad3, Id3>>
-                    where
-                        Id0: v2::GetPadMode<$Sercom, $pad0>,
-                        Id1: v2::GetPadMode<$Sercom, $pad1>,
-                        Id2: v2::GetPadMode<$Sercom, $pad2>,
-                        Id3: v2::GetPadMode<$Sercom, $pad3>,
-                    {
-                        fn rxpo_txpo(&self) -> (u8, u8) {
-                            $rxpo_txpo
-                        }
-                    }
-                }
-            };
-        }
-
-        padout!((0, 1) => Pad0, Pad2);
-
-        padout!((1, 0) => Pad1, Pad0);
-        padout!((1, 2) => Pad1, Pad0, Pad2, Pad3);
-        padout!((1, 1) => Pad1, Pad2);
-
-        padout!((2, 0) => Pad2, Pad0);
-
-        padout!((3, 0) => Pad3, Pad0);
-        padout!((3, 1) => Pad3, Pad2);
 
         $crate::paste::item! {
             /// UARTX represents the corresponding SERCOMX instance
@@ -221,7 +207,7 @@ macro_rules! uart {
             /// This type is generic over any valid pad mapping where there is
             /// a defined "receive pin out transmit pin out" implementation.
             pub struct $Type<RX, TX, RTS, CTS> {
-                padout: [<$Type Padout>]<RX, TX, RTS, CTS>,
+                padout: Padout<$Sercom, RX, TX, RTS, CTS>,
                 sercom: $SERCOM,
             }
 
@@ -234,14 +220,14 @@ macro_rules! uart {
                 /// You can use any tuple of two or four SercomXPadY instances
                 /// for which there exists a From implementation for
                 /// UARTXPadout.
-                pub fn new<F: Into<Hertz>, T: Into<[<$Type Padout>]<RX, TX, RTS, CTS>>>(
+                pub fn new<F: Into<Hertz>, T: Into<Padout<$Sercom, RX, TX, RTS, CTS>>>(
                     clock: &clock::$clock,
                     freq: F,
                     sercom: $SERCOM,
                     pm: &mut PM,
                     padout: T
                 ) -> $Type<RX, TX, RTS, CTS> where
-                    [<$Type Padout>]<RX, TX, RTS, CTS>: RxpoTxpo {
+                    Padout<$Sercom, RX, TX, RTS, CTS>: RxpoTxpo {
                     let padout = padout.into();
 
                     pm.apbcmask.modify(|_, w| w.$powermask().set_bit());
@@ -313,7 +299,7 @@ macro_rules! uart {
                     }
                 }
 
-                pub fn free(self) -> ([<$Type Padout>]<RX, TX, RTS, CTS>, $SERCOM) {
+                pub fn free(self) -> (Padout<$Sercom, RX, TX, RTS, CTS>, $SERCOM) {
                     (self.padout, self.sercom)
                 }
 
@@ -378,7 +364,7 @@ macro_rules! uart {
 
             /// The transmitting half of the corresponding UARTX instance (as returned by `UARTX::split`)
             pub struct [<$Type Tx>]<TX, RTS> {
-                padout: [<$Type TxPadout>]<TX, RTS>,
+                padout: TxPadout<$Sercom, TX, RTS>,
                 /// We store the SERCOM object here so we can retrieve it later,
                 /// but conceptually, ownership is shared between the Rx and Tx halves.
                 sercom: $SERCOM,
@@ -442,7 +428,7 @@ macro_rules! uart {
 
             /// The receiving half of the corresponding UARTX instance (as returned by `UARTX::split`)
             pub struct [<$Type Rx>]<RX, CTS> {
-                padout: [<$Type RxPadout>]<RX, CTS>,
+                padout: RxPadout<$Sercom, RX, CTS>,
                 sercom: PhantomData<$SERCOM>,
             }
 
@@ -499,7 +485,7 @@ macro_rules! uart {
                 }
             }
         }
-    }
+    };
 }
 
 uart!(UART0: (Sercom0, SERCOM0, sercom0_, Sercom0CoreClock));

--- a/hal/src/thumbv6m/sercom/v2.rs
+++ b/hal/src/thumbv6m/sercom/v2.rs
@@ -1,2 +1,2 @@
-pub mod pad_info;
+pub mod impl_pad;
 pub mod spi;

--- a/hal/src/thumbv6m/sercom/v2/impl_pad.rs
+++ b/hal/src/thumbv6m/sercom/v2/impl_pad.rs
@@ -1,4 +1,5 @@
-//! Implementations of the [`PadInfo`] trait
+//! Implementations of the [`IsPad`] and [`GetPad`] traits
+
 use crate::gpio::v2::*;
 use crate::sercom::v2::*;
 
@@ -14,17 +15,17 @@ macro_rules! pad_info {
         $PadNum:ident
     ) => {
         #[cfg(feature = "samd11")]
-        impl PadInfo<$Sercom, $PadNum> for $PinId {
+        impl GetPad<$Sercom, $PadNum> for $PinId {
             type PinMode = Alternate<$Cfg>;
         }
 
         #[cfg(feature = "samd21")]
-        impl PadInfo<$Sercom> for $PinId {
+        impl GetPad<$Sercom> for $PinId {
             type PadNum = $PadNum;
             type PinMode = Alternate<$Cfg>;
         }
 
-        impl ConvertPinToPad for Pin<$PinId, Alternate<$Cfg>> {
+        impl IsPad for Pin<$PinId, Alternate<$Cfg>> {
             type Sercom = $Sercom;
             type PadNum = $PadNum;
         }

--- a/hal/src/thumbv7em/sercom/v1/i2c.rs
+++ b/hal/src/thumbv7em/sercom/v1/i2c.rs
@@ -2,6 +2,8 @@
 
 use crate::clock;
 use crate::hal::blocking::i2c::{Read, Write, WriteRead};
+use crate::sercom::v1::pads::CompatiblePad;
+use crate::sercom::v2::{Pad0, Pad1};
 use crate::target_device::sercom0::I2CM;
 use crate::target_device::{MCLK, SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5};
 #[cfg(feature = "min-samd51n")]
@@ -19,8 +21,8 @@ macro_rules! i2c {
     ([
         $($Type:ident:
             (
-                $pad0:ident,
-                $pad1:ident,
+                $pad0:ident,  // No longer used
+                $pad1:ident,  // No longer used
                 $SERCOM:ident,
                 $powermask:ident,
                 $clock:ident,
@@ -33,13 +35,21 @@ macro_rules! i2c {
 
 /// Represents the Sercom instance configured to act as an I2C Master.
 /// The embedded_hal blocking I2C traits are implemented by this instance.
-pub struct $Type<$pad0, $pad1> {
-    sda: $pad0,
-    scl: $pad1,
+pub struct $Type<P0, P1>
+where
+    P0: CompatiblePad<Sercom = $SERCOM, PadNum = Pad0>,
+    P1: CompatiblePad<Sercom = $SERCOM, PadNum = Pad1>,
+{
+    sda: P0,
+    scl: P1,
     sercom: $SERCOM,
 }
 
-impl<$pad0, $pad1> $Type<$pad0, $pad1> {
+impl<P0, P1> $Type<P0, P1>
+where
+    P0: CompatiblePad<Sercom = $SERCOM, PadNum = Pad0>,
+    P1: CompatiblePad<Sercom = $SERCOM, PadNum = Pad1>,
+{
     /// Configures the sercom instance to work as an I2C Master.
     /// The clock is obtained via the `GenericClockGenerator` type.
     /// `freq` specifies the bus frequency to use for I2C communication.
@@ -66,8 +76,8 @@ impl<$pad0, $pad1> $Type<$pad0, $pad1> {
         freq: F,
         sercom: $SERCOM,
         mclk: &mut MCLK,
-        sda: $pad0,
-        scl: $pad1,
+        sda: P0,
+        scl: P1,
     ) -> Self {
         // Power up the peripheral bus clock.
         // safe because we're exclusively owning SERCOM
@@ -109,7 +119,7 @@ impl<$pad0, $pad1> $Type<$pad0, $pad1> {
 
     /// Breaks the sercom device up into its constituent pins and the SERCOM
     /// instance.  Does not make any changes to power management.
-    pub fn free(self) -> ($pad0, $pad1, $SERCOM) {
+    pub fn free(self) -> (P0, P1, $SERCOM) {
         (self.sda, self.scl, self.sercom)
     }
 
@@ -280,7 +290,11 @@ impl<$pad0, $pad1> $Type<$pad0, $pad1> {
     }
 }
 
-impl<$pad0, $pad1> Write for $Type<$pad0, $pad1> {
+impl<P0, P1> Write for $Type<P0, P1>
+where
+    P0: CompatiblePad<Sercom = $SERCOM, PadNum = Pad0>,
+    P1: CompatiblePad<Sercom = $SERCOM, PadNum = Pad1>,
+{
     type Error = I2CError;
 
     /// Sends bytes to slave with address `addr`
@@ -291,7 +305,11 @@ impl<$pad0, $pad1> Write for $Type<$pad0, $pad1> {
     }
 }
 
-impl<$pad0, $pad1> Read for $Type<$pad0, $pad1> {
+impl<P0, P1> Read for $Type<P0, P1>
+where
+    P0: CompatiblePad<Sercom = $SERCOM, PadNum = Pad0>,
+    P1: CompatiblePad<Sercom = $SERCOM, PadNum = Pad1>,
+{
     type Error = I2CError;
 
     fn read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
@@ -301,7 +319,11 @@ impl<$pad0, $pad1> Read for $Type<$pad0, $pad1> {
     }
 }
 
-impl<$pad0, $pad1> WriteRead for $Type<$pad0, $pad1> {
+impl<P0, P1> WriteRead for $Type<P0, P1>
+where
+    P0: CompatiblePad<Sercom = $SERCOM, PadNum = Pad0>,
+    P1: CompatiblePad<Sercom = $SERCOM, PadNum = Pad1>,
+{
     type Error = I2CError;
 
     fn write_read(&mut self, addr: u8, bytes: &[u8], buffer: &mut [u8]) -> Result<(), Self::Error> {

--- a/hal/src/thumbv7em/sercom/v1/spi.rs
+++ b/hal/src/thumbv7em/sercom/v1/spi.rs
@@ -1,8 +1,9 @@
+use core::marker::PhantomData;
+
 use crate::clock;
-use crate::gpio::v2::pin::AnyPin;
 use crate::hal::spi::{FullDuplex, Mode, Phase, Polarity};
-use crate::sercom::pads::*;
-use crate::sercom::v2;
+use crate::sercom::v1::pads::CompatiblePad;
+use crate::sercom::v2::*;
 use crate::spi_common::CommonSpi;
 use crate::target_device::sercom0::SPIM;
 use crate::target_device::{MCLK, SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5};
@@ -20,7 +21,80 @@ pub enum Error {
 /// this trait for yourself; only the implementations in the sercom module make
 /// sense.
 pub trait DipoDopo {
-    fn dipo_dopo(&self) -> (u8, u8);
+    const DIPO: u8;
+    const DOPO: u8;
+    fn dipo_dopo(&self) -> (u8, u8) {
+        (Self::DIPO, Self::DOPO)
+    }
+}
+
+/// Defines a DipoDopo instance for the constructed padout instance
+/// that returns the values used to configure the sercom pads for the
+/// appropriate function in the sercom register file.
+macro_rules! padout {
+    ( ($dipo:literal, $dopo:literal) => $pad0:ident, $pad1:ident, $pad2:ident) => {
+        impl DipoDopo for ($pad0, $pad1, $pad2) {
+            const DIPO: u8 = $dipo;
+            const DOPO: u8 = $dopo;
+        }
+    };
+}
+
+// dipo In master operation, DI is MISO Pad number 0-3
+// dopo 0 MOSI PAD 0
+// dopo 2 MOSI PAD 3
+// SCK can only be on PAD 1
+// (dipo,dopo) => (MISO, MOSI, SCK)
+padout!((0, 2) => Pad0, Pad3, Pad1);
+padout!((2, 0) => Pad2, Pad0, Pad1);
+padout!((2, 2) => Pad2, Pad3, Pad1);
+padout!((3, 0) => Pad3, Pad0, Pad1);
+
+/// A pad mapping configuration for the SERCOM in SPI master mode.
+///
+/// This type can only be constructed using the From implementations
+/// in this module, which are restricted to valid configurations.
+///
+/// Defines which sercom pad is mapped to which SPI function.
+pub struct Padout<S, MISO, MOSI, SCLK>
+where
+    S: Sercom,
+{
+    sercom: PhantomData<S>,
+    _miso: MISO,
+    _mosi: MOSI,
+    _sclk: SCLK,
+}
+
+/// Convert from a tuple of (MISO, MOSI, SCK) to SPIMasterXPadout
+impl<S, PAD0, PAD1, PAD2> From<(PAD0, PAD1, PAD2)> for Padout<S, PAD0, PAD1, PAD2>
+where
+    S: Sercom,
+    PAD0: CompatiblePad<Sercom = S>,
+    PAD1: CompatiblePad<Sercom = S>,
+    PAD2: CompatiblePad<Sercom = S>,
+    (PAD0::PadNum, PAD1::PadNum, PAD2::PadNum): DipoDopo,
+{
+    fn from(pads: (PAD0, PAD1, PAD2)) -> Padout<S, PAD0, PAD1, PAD2> {
+        Padout {
+            sercom: PhantomData,
+            _miso: pads.0,
+            _mosi: pads.1,
+            _sclk: pads.2,
+        }
+    }
+}
+
+impl<S, PAD0, PAD1, PAD2> DipoDopo for Padout<S, PAD0, PAD1, PAD2>
+where
+    S: Sercom,
+    PAD0: CompatiblePad<Sercom = S>,
+    PAD1: CompatiblePad<Sercom = S>,
+    PAD2: CompatiblePad<Sercom = S>,
+    (PAD0::PadNum, PAD1::PadNum, PAD2::PadNum): DipoDopo,
+{
+    const DIPO: u8 = <(PAD0::PadNum, PAD1::PadNum, PAD2::PadNum)>::DIPO;
+    const DOPO: u8 = <(PAD0::PadNum, PAD1::PadNum, PAD2::PadNum)>::DOPO;
 }
 
 /// Define an SPIMasterX type for the given Sercom number.
@@ -31,249 +105,165 @@ macro_rules! spi_master {
     (
         $Type:ident: ($Sercom:ident, $SERCOM:ident, $powermask:ident, $clock:ident, $apmask:ident)
     ) => {
-
         $crate::paste::item! {
-            /// A pad mapping configuration for the SERCOM in SPI master mode.
-            ///
-            /// This type can only be constructed using the From implementations
-            /// in this module, which are restricted to valid configurations.
-            ///
-            /// Defines which sercom pad is mapped to which SPI function.
-            pub struct [<$Type Padout>]<MISO, MOSI, SCK> {
-                _miso: MISO,
-                _mosi: MOSI,
-                _sck: SCK,
-            }
+            pub type [<$Type Padout>]<MISO, MOSI, SCLK> = Padout<$Sercom, MISO, MOSI, SCLK>;
         }
 
-        /// Define a From instance for a tuple of SercomXPadX instances that
-        /// converts them into an SPIMasterXPadout instance.
+        /// SPIMasterX represents the corresponding SERCOMX instance
+        /// configured to act in the role of an SPI Master.
+        /// Objects of this type implement the HAL `FullDuplex` and blocking
+        /// SPI traits.
         ///
-        /// Also defines a DipoDopo instance for the constructed padout instance
-        /// that returns the values used to configure the sercom pads for the
-        /// appropriate function in the sercom register file.
-        macro_rules! padout {
-            ($dipo_dopo:expr => $pad0:ident, $pad1:ident, $pad2:ident) => {
-                $crate::paste::item! {
-                    /// Convert from a tuple of (MISO, MOSI, SCK) to SPIMasterXPadout
-                    impl<PIN0, PIN1, PIN2> From<([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>)> for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>>
-                    where
-                        PIN0: AnyPin,
-                        PIN1: AnyPin,
-                        PIN2: AnyPin,
-                        PIN0::Id: GetPadMode<$Sercom, $pad0>,
-                        PIN1::Id: GetPadMode<$Sercom, $pad1>,
-                        PIN2::Id: GetPadMode<$Sercom, $pad2>,
-                    {
-                        fn from(pads: ([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>)) -> [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>> {
-                            [<$Type Padout>] { _miso: pads.0, _mosi: pads.1, _sck: pads.2 }
-                        }
-                    }
-
-                    impl<PIN0, PIN1, PIN2> DipoDopo for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>>
-                    where
-                        PIN0: AnyPin,
-                        PIN1: AnyPin,
-                        PIN2: AnyPin,
-                        PIN0::Id: GetPadMode<$Sercom, $pad0>,
-                        PIN1::Id: GetPadMode<$Sercom, $pad1>,
-                        PIN2::Id: GetPadMode<$Sercom, $pad2>,
-                    {
-                        fn dipo_dopo(&self) -> (u8, u8) {
-                            $dipo_dopo
-                        }
-                    }
-
-                    impl<Id0, Id1, Id2> From<(v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>)> for [<$Type Padout>]<v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>>
-                    where
-                        Id0: v2::GetPadMode<$Sercom, $pad0>,
-                        Id1: v2::GetPadMode<$Sercom, $pad1>,
-                        Id2: v2::GetPadMode<$Sercom, $pad2>,
-                    {
-                        fn from(pads: (v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>)) -> Self {
-                            [<$Type Padout>] { _miso: pads.0, _mosi: pads.1, _sck: pads.2 }
-                        }
-                    }
-
-                    impl<Id0, Id1, Id2> DipoDopo for [<$Type Padout>]<v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>>
-                    where
-                        Id0: v2::GetPadMode<$Sercom, $pad0>,
-                        Id1: v2::GetPadMode<$Sercom, $pad1>,
-                        Id2: v2::GetPadMode<$Sercom, $pad2>,
-                    {
-                        fn dipo_dopo(&self) -> (u8, u8) {
-                            $dipo_dopo
-                        }
-                    }
-                }
-            };
+        /// This type is generic over any valid pad mapping where there is
+        /// a defined "data in pin out data out pin out" implementation.
+        pub struct $Type<MISO, MOSI, SCK> {
+            padout: Padout<$Sercom, MISO, MOSI, SCK>,
+            sercom: $SERCOM,
         }
 
-        // dipo In master operation, DI is MISO Pad number 0-3
-        // dopo 0 MOSI PAD 0
-        // dopo 2 MOSI PAD 3
-        // SCK can only be on PAD 1
-        // (dipo,dopo) => (MISO, MOSI, SCK)
-        padout!((0, 2) => Pad0, Pad3, Pad1);
-        padout!((2, 0) => Pad2, Pad0, Pad1);
-        padout!((2, 2) => Pad2, Pad3, Pad1);
-        padout!((3, 0) => Pad3, Pad0, Pad1);
+        impl<MISO, MOSI, SCK> CommonSpi for $Type<MISO, MOSI, SCK> {
+            /// Helper for accessing the spi member of the sercom instance
+            fn spi(&self) -> &SPIM {
+                &self.sercom.spim()
+            }
 
-        $crate::paste::item! {
-            /// SPIMasterX represents the corresponding SERCOMX instance
-            /// configured to act in the role of an SPI Master.
-            /// Objects of this type implement the HAL `FullDuplex` and blocking
-            /// SPI traits.
-            ///
-            /// This type is generic over any valid pad mapping where there is
-            /// a defined "data in pin out data out pin out" implementation.
-            pub struct $Type<MISO, MOSI, SCK> {
-                padout: [<$Type Padout>]<MISO, MOSI, SCK>,
+            /// Helper for accessing the spi member of the sercom instance
+            fn spi_mut(&mut self) -> &SPIM {
+                &self.sercom.spim()
+            }
+        }
+
+        impl<MISO, MOSI, SCK> $Type<MISO, MOSI, SCK> {
+            /// Power on and configure SERCOMX to work as an SPI Master operating
+            /// with the specified frequency and SPI Mode.  The pinout specifies
+            /// which pins are bound to the MISO, MOSI, SCK functions.
+            pub fn new<F: Into<Hertz>, T: Into<Padout<$Sercom, MISO, MOSI, SCK>>>(
+                clock: &clock::$clock,
+                freq: F,
+                mode: Mode,
                 sercom: $SERCOM,
+                mclk: &mut MCLK,
+                padout: T,
+            ) -> Self
+            where
+                Padout<$Sercom, MISO, MOSI, SCK>: DipoDopo,
+            {
+                let padout = padout.into();
+
+                // Power up the peripheral bus clock.
+                // safe because we're exclusively owning SERCOM
+                mclk.$apmask.modify(|_, w| w.$powermask().set_bit());
+
+                // reset the sercom instance
+                sercom.spim().ctrla.modify(|_, w| w.swrst().set_bit());
+                // wait for reset to complete
+                while sercom.spim().syncbusy.read().swrst().bit_is_set()
+                    || sercom.spim().ctrla.read().swrst().bit_is_set()
+                {}
+
+                // Put the hardware into spi master mode
+                sercom.spim().ctrla.modify(|_, w| w.mode().spi_master());
+                // wait for configuration to take effect
+                while sercom.spim().syncbusy.read().enable().bit_is_set() {}
+
+                // 8 bit data size and enable the receiver
+                unsafe {
+                    sercom.spim().ctrlb.modify(|_, w| {
+                        w.chsize().bits(0);
+                        w.rxen().set_bit()
+                    });
+                }
+
+                // set the baud rate
+                let baud = Self::calculate_baud(freq, clock.freq());
+                unsafe {
+                    sercom.spim().baud.modify(|_, w| w.baud().bits(baud));
+
+                    sercom.spim().ctrla.modify(|_, w| {
+                        match mode.polarity {
+                            Polarity::IdleLow => w.cpol().clear_bit(),
+                            Polarity::IdleHigh => w.cpol().set_bit(),
+                        };
+
+                        match mode.phase {
+                            Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
+                            Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
+                        };
+
+                        let (dipo, dopo) = padout.dipo_dopo();
+                        w.dipo().bits(dipo);
+                        w.dopo().bits(dopo);
+
+                        // MSB first
+                        w.dord().clear_bit()
+                    });
+                }
+
+                sercom.spim().ctrla.modify(|_, w| w.enable().set_bit());
+                // wait for configuration to take effect
+                while sercom.spim().syncbusy.read().enable().bit_is_set() {}
+
+                Self { padout, sercom }
             }
 
-            impl<MISO, MOSI, SCK> CommonSpi for $Type<MISO, MOSI, SCK> {
-                /// Helper for accessing the spi member of the sercom instance
-                fn spi(&self) -> &SPIM {
-                    &self.sercom.spim()
+            /// Set the baud rate
+            pub fn set_baud<F: Into<Hertz>>(&mut self, freq: F, clock: &clock::$clock) {
+                self.disable();
+                let baud = Self::calculate_baud(freq, clock.freq());
+                unsafe {
+                    self.spi_mut().baud.modify(|_, w| w.baud().bits(baud));
                 }
-
-                /// Helper for accessing the spi member of the sercom instance
-                fn spi_mut(&mut self) -> &SPIM {
-                    &self.sercom.spim()
-                }
+                self.enable();
             }
 
-            impl<MISO, MOSI, SCK> $Type<MISO, MOSI, SCK> {
-                /// Power on and configure SERCOMX to work as an SPI Master operating
-                /// with the specified frequency and SPI Mode.  The pinout specifies
-                /// which pins are bound to the MISO, MOSI, SCK functions.
-                pub fn new<F: Into<Hertz>, T: Into<[<$Type Padout>]<MISO, MOSI, SCK>>>(
-                    clock:&clock::$clock,
-                    freq: F,
-                    mode: Mode,
-                    sercom: $SERCOM,
-                    mclk: &mut MCLK,
-                    padout: T,
-                ) -> Self where
-                    [<$Type Padout>]<MISO, MOSI, SCK>: DipoDopo {
-                    let padout = padout.into();
+            /// Tear down the SPI instance and yield the constituent pins and
+            /// SERCOM instance.  No explicit de-initialization is performed.
+            pub fn free(self) -> (Padout<$Sercom, MISO, MOSI, SCK>, $SERCOM) {
+                (self.padout, self.sercom)
+            }
+        }
 
-                    // Power up the peripheral bus clock.
-                    // safe because we're exclusively owning SERCOM
-                    mclk.$apmask.modify(|_, w| w.$powermask().set_bit());
+        impl<MISO, MOSI, SCK> FullDuplex<u8> for $Type<MISO, MOSI, SCK> {
+            type Error = Error;
 
-                    // reset the sercom instance
-                    sercom.spim().ctrla.modify(|_, w| w.swrst().set_bit());
-                    // wait for reset to complete
-                    while sercom.spim().syncbusy.read().swrst().bit_is_set()
-                        || sercom.spim().ctrla.read().swrst().bit_is_set()
-                    {}
-
-                    // Put the hardware into spi master mode
-                    sercom.spim().ctrla.modify(|_, w| w.mode().spi_master());
-                    // wait for configuration to take effect
-                    while sercom.spim().syncbusy.read().enable().bit_is_set() {}
-
-                    // 8 bit data size and enable the receiver
-                    unsafe {
-                        sercom.spim().ctrlb.modify(|_, w|{
-                            w.chsize().bits(0);
-                            w.rxen().set_bit()
-                        });
-                    }
-
-                    // set the baud rate
-                    let baud = Self::calculate_baud(freq, clock.freq());
-                    unsafe {
-                        sercom.spim().baud.modify(|_, w| w.baud().bits(baud));
-
-                        sercom.spim().ctrla.modify(|_, w| {
-                            match mode.polarity {
-                                Polarity::IdleLow => w.cpol().clear_bit(),
-                                Polarity::IdleHigh => w.cpol().set_bit(),
-                            };
-
-                            match mode.phase {
-                                Phase::CaptureOnFirstTransition => w.cpha().clear_bit(),
-                                Phase::CaptureOnSecondTransition => w.cpha().set_bit(),
-                            };
-
-                            let (dipo, dopo) = padout.dipo_dopo();
-                            w.dipo().bits(dipo);
-                            w.dopo().bits(dopo);
-
-                            // MSB first
-                            w.dord().clear_bit()
-                        });
-                    }
-
-
-                    sercom.spim().ctrla.modify(|_, w| w.enable().set_bit());
-                    // wait for configuration to take effect
-                    while sercom.spim().syncbusy.read().enable().bit_is_set() {}
-
-                    Self {
-                        padout,
-                        sercom,
-                    }
+            fn read(&mut self) -> nb::Result<u8, Error> {
+                let status = self.spi().status.read();
+                if status.bufovf().bit_is_set() {
+                    return Err(nb::Error::Other(Error::Overrun));
                 }
 
-                /// Set the baud rate
-                pub fn set_baud<F: Into<Hertz>>(
-                    &mut self,
-                    freq: F,
-                    clock:&clock::$clock
-                ) {
-                    self.disable();
-                    let baud = Self::calculate_baud(freq, clock.freq());
-                    unsafe {
-                        self.spi_mut().baud.modify(|_, w| w.baud().bits(baud));
-                    }
-                    self.enable();
-                }
-
-                /// Tear down the SPI instance and yield the constituent pins and
-                /// SERCOM instance.  No explicit de-initialization is performed.
-                pub fn free(self) -> ([<$Type Padout>]<MISO, MOSI, SCK>, $SERCOM) {
-                    (self.padout, self.sercom)
+                let intflag = self.spi().intflag.read();
+                // rxc is receive complete
+                if intflag.rxc().bit_is_set() {
+                    Ok(self.spi().data.read().data().bits() as u8)
+                } else {
+                    Err(nb::Error::WouldBlock)
                 }
             }
 
-            impl<MISO, MOSI, SCK> FullDuplex<u8> for $Type<MISO, MOSI, SCK> {
-                type Error = Error;
-
-                fn read(&mut self) -> nb::Result<u8, Error> {
-                    let status = self.spi().status.read();
-                    if status.bufovf().bit_is_set() {
-                        return Err(nb::Error::Other(Error::Overrun));
-                    }
-
-                    let intflag = self.spi().intflag.read();
-                    // rxc is receive complete
-                    if intflag.rxc().bit_is_set() {
-                        Ok(self.spi().data.read().data().bits() as u8)
-                    } else {
-                        Err(nb::Error::WouldBlock)
-                    }
-                }
-
-                fn send(&mut self, byte: u8) -> nb::Result<(), Error> {
-                    let intflag = self.spi().intflag.read();
-                    // dre is data register empty
-                    if intflag.dre().bit_is_set() {
-                        self.spi_mut().data.write(|w| unsafe{w.data().bits(byte as u32)});
-                        Ok(())
-                    } else {
-                        Err(nb::Error::WouldBlock)
-                    }
+            fn send(&mut self, byte: u8) -> nb::Result<(), Error> {
+                let intflag = self.spi().intflag.read();
+                // dre is data register empty
+                if intflag.dre().bit_is_set() {
+                    self.spi_mut()
+                        .data
+                        .write(|w| unsafe { w.data().bits(byte as u32) });
+                    Ok(())
+                } else {
+                    Err(nb::Error::WouldBlock)
                 }
             }
+        }
 
-            impl<MISO, MOSI, SCK> ::hal::blocking::spi::transfer::Default<u8> for $Type<MISO, MOSI, SCK> {}
-            impl<MISO, MOSI, SCK> ::hal::blocking::spi::write::Default<u8> for $Type<MISO, MOSI, SCK> {}
-            #[cfg(feature = "unproven")]
-            impl<MISO, MOSI, SCK> ::hal::blocking::spi::write_iter::Default<u8> for $Type<MISO, MOSI, SCK> {}
+        impl<MISO, MOSI, SCK> ::hal::blocking::spi::transfer::Default<u8>
+            for $Type<MISO, MOSI, SCK>
+        {
+        }
+        impl<MISO, MOSI, SCK> ::hal::blocking::spi::write::Default<u8> for $Type<MISO, MOSI, SCK> {}
+        #[cfg(feature = "unproven")]
+        impl<MISO, MOSI, SCK> ::hal::blocking::spi::write_iter::Default<u8>
+            for $Type<MISO, MOSI, SCK>
+        {
         }
     };
 }

--- a/hal/src/thumbv7em/sercom/v1/uart.rs
+++ b/hal/src/thumbv7em/sercom/v1/uart.rs
@@ -1,9 +1,8 @@
 use crate::clock;
-use crate::gpio::v2::pin::AnyPin;
 use crate::hal::blocking::serial::{write::Default, Write};
 use crate::hal::serial;
-use crate::sercom::pads::*;
-use crate::sercom::v2;
+use crate::sercom::v1::pads::CompatiblePad;
+use crate::sercom::v2::*;
 use crate::target_device::sercom0::USART_INT;
 use crate::target_device::{MCLK, SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5};
 #[cfg(feature = "min-samd51n")]
@@ -17,7 +16,180 @@ use core::marker::PhantomData;
 /// this trait for yourself; only the implementations in the sercom module make
 /// sense.
 pub trait RxpoTxpo {
-    fn rxpo_txpo(&self) -> (u8, u8);
+    const RXPO: u8;
+    const TXPO: u8;
+    fn rxpo_txpo(&self) -> (u8, u8) {
+        (Self::RXPO, Self::TXPO)
+    }
+}
+
+macro_rules! padout {
+    ( ($rxpo:literal, $txpo:literal) => $pad0:ident, $pad1:ident) => {
+        impl RxpoTxpo for ($pad0, $pad1) {
+            const RXPO: u8 = $rxpo;
+            const TXPO: u8 = $txpo;
+        }
+    };
+    ( ($rxpo:literal, $txpo:literal) => $pad0:ident, $pad1:ident, $pad2:ident, $pad3:ident) => {
+        impl RxpoTxpo for ($pad0, $pad1, $pad2, $pad3) {
+            const RXPO: u8 = $rxpo;
+            const TXPO: u8 = $txpo;
+        }
+    };
+}
+
+// rxpo 0-3 RX on PAD 0-3
+// TX always PAD 0
+// txpo 0 no RTS/CTS
+// txpo 1 reserved and can't be used
+// txpo 2 RTS PAD 2, CTS PAD 3
+// txpo 3 RTS PAD 2, no CTS
+// (rxpo_txpo) => (RX, TX, RTS, CTS)
+padout!((1, 0) => Pad1, Pad0);
+padout!((1, 2) => Pad1, Pad0, Pad2, Pad3);
+
+// todo we could support an RTS without a CTS
+// padout!((1, 3) => Pad1, Pad0, Pad2);
+
+padout!((2, 0) => Pad2, Pad0);
+padout!((3, 0) => Pad3, Pad0);
+
+// todo we could support an RTS without a CTS
+// padout!((3, 3) => Pad3, Pad0, Pad2);
+
+/// A pad mapping configuration for the SERCOM in UART mode.
+///
+/// This type can only be constructed using the From implementations
+/// in this module, which are restricted to valid configurations.
+///
+/// Defines which sercom pad is mapped to which UART function.
+pub struct Padout<S, RX, TX, RTS, CTS>
+where
+    S: Sercom,
+{
+    sercom: PhantomData<S>,
+    rx: RX,
+    tx: TX,
+    rts: RTS,
+    cts: CTS,
+}
+
+/// A pad mapping configuration for the receiving half of the SERCOM in UART
+/// mode.
+pub struct RxPadout<S, RX, CTS>
+where
+    S: Sercom,
+{
+    sercom: PhantomData<S>,
+    rx: RX,
+    cts: CTS,
+}
+
+/// A pad mapping configuration for the transmitting half of the SERCOM in UART
+/// mode.
+pub struct TxPadout<S, TX, RTS>
+where
+    S: Sercom,
+{
+    sercom: PhantomData<S>,
+    tx: TX,
+    rts: RTS,
+}
+
+impl<S, RX, TX, RTS, CTS> Padout<S, RX, TX, RTS, CTS>
+where
+    S: Sercom,
+{
+    /// Splits the padout into transmit and receive halves
+    pub fn split(self) -> (TxPadout<S, TX, RTS>, RxPadout<S, RX, CTS>) {
+        (
+            TxPadout {
+                sercom: PhantomData,
+                tx: self.tx,
+                rts: self.rts,
+            },
+            RxPadout {
+                sercom: PhantomData,
+                rx: self.rx,
+                cts: self.cts,
+            },
+        )
+    }
+
+    /// Combines transmit and receive halves back into a duplex padout
+    pub fn join(tx: TxPadout<S, TX, RTS>, rx: RxPadout<S, RX, CTS>) -> Self {
+        Self {
+            sercom: PhantomData,
+            rx: rx.rx,
+            tx: tx.tx,
+            rts: tx.rts,
+            cts: rx.cts,
+        }
+    }
+}
+
+/// Convert from a tuple of (RX, TX) to UARTXPadout
+impl<S, PAD0, PAD1> From<(PAD0, PAD1)> for Padout<S, PAD0, PAD1, (), ()>
+where
+    S: Sercom,
+    PAD0: CompatiblePad<Sercom = S>,
+    PAD1: CompatiblePad<Sercom = S>,
+    (PAD0::PadNum, PAD1::PadNum): RxpoTxpo,
+{
+    fn from(pads: (PAD0, PAD1)) -> Padout<S, PAD0, PAD1, (), ()> {
+        Padout {
+            sercom: PhantomData,
+            rx: pads.0,
+            tx: pads.1,
+            rts: (),
+            cts: (),
+        }
+    }
+}
+
+impl<S, PAD0, PAD1> RxpoTxpo for Padout<S, PAD0, PAD1, (), ()>
+where
+    S: Sercom,
+    PAD0: CompatiblePad<Sercom = S>,
+    PAD1: CompatiblePad<Sercom = S>,
+    (PAD0::PadNum, PAD1::PadNum): RxpoTxpo,
+{
+    const RXPO: u8 = <(PAD0::PadNum, PAD1::PadNum)>::RXPO;
+    const TXPO: u8 = <(PAD0::PadNum, PAD1::PadNum)>::TXPO;
+}
+
+/// Convert from a tuple of (RX, TX, RTS, CTS) to UARTXPadout
+impl<S, PAD0, PAD1, PAD2, PAD3> From<(PAD0, PAD1, PAD2, PAD3)> for Padout<S, PAD0, PAD1, PAD2, PAD3>
+where
+    S: Sercom,
+    PAD0: CompatiblePad<Sercom = S>,
+    PAD1: CompatiblePad<Sercom = S>,
+    PAD2: CompatiblePad<Sercom = S>,
+    PAD3: CompatiblePad<Sercom = S>,
+    (PAD0::PadNum, PAD1::PadNum, PAD2::PadNum, PAD3::PadNum): RxpoTxpo,
+{
+    fn from(pads: (PAD0, PAD1, PAD2, PAD3)) -> Padout<S, PAD0, PAD1, PAD2, PAD3> {
+        Padout {
+            sercom: PhantomData,
+            rx: pads.0,
+            tx: pads.1,
+            rts: pads.2,
+            cts: pads.3,
+        }
+    }
+}
+
+impl<S, PAD0, PAD1, PAD2, PAD3> RxpoTxpo for Padout<S, PAD0, PAD1, PAD2, PAD3>
+where
+    S: Sercom,
+    PAD0: CompatiblePad<Sercom = S>,
+    PAD1: CompatiblePad<Sercom = S>,
+    PAD2: CompatiblePad<Sercom = S>,
+    PAD3: CompatiblePad<Sercom = S>,
+    (PAD0::PadNum, PAD1::PadNum, PAD2::PadNum, PAD3::PadNum): RxpoTxpo,
+{
+    const RXPO: u8 = <(PAD0::PadNum, PAD1::PadNum, PAD2::PadNum, PAD3::PadNum)>::RXPO;
+    const TXPO: u8 = <(PAD0::PadNum, PAD1::PadNum, PAD2::PadNum, PAD3::PadNum)>::TXPO;
 }
 
 /// Define a UARTX type for the given Sercom.
@@ -36,196 +208,10 @@ macro_rules! uart {
         $int2: ident)
     ) => {
         $crate::paste::item! {
-            /// A pad mapping configuration for the SERCOM in UART mode.
-            ///
-            /// This type can only be constructed using the From implementations
-            /// in this module, which are restricted to valid configurations.
-            ///
-            /// Defines which sercom pad is mapped to which UART function.
-            pub struct [<$Type Padout>]<RX, TX, RTS, CTS> {
-                rx: RX,
-                tx: TX,
-                rts: RTS,
-                cts: CTS,
-            }
-
-            /// A pad mapping configuration for the receiving half of the SERCOM in UART mode.
-            pub struct [<$Type RxPadout>]<RX, CTS> {
-                rx: RX,
-                cts: CTS,
-            }
-
-            /// A pad mapping configuration for the transmitting half of the SERCOM in UART mode.
-            pub struct [<$Type TxPadout>]<TX, RTS> {
-                tx: TX,
-                rts: RTS,
-            }
-
-            impl<RX, TX, RTS, CTS> [<$Type Padout>]<RX, TX, RTS, CTS> {
-                /// Splits the padout into transmit and receive halves
-                pub fn split(self) -> ([<$Type TxPadout>]<TX, RTS>, [<$Type RxPadout>]<RX, CTS>) {
-                    (
-                        [<$Type TxPadout>] {
-                            tx: self.tx,
-                            rts: self.rts,
-                        },
-                        [<$Type RxPadout>] {
-                            rx: self.rx,
-                            cts: self.cts,
-                        },
-                    )
-                }
-
-                /// Combines transmit and receive halves back into a duplex padout
-                pub fn join(tx: [<$Type TxPadout>]<TX, RTS>, rx: [<$Type RxPadout>]<RX, CTS>) -> Self {
-                    Self {
-                        rx: rx.rx,
-                        tx: tx.tx,
-                        rts: tx.rts,
-                        cts: rx.cts,
-                    }
-                }
-            }
+            pub type [<$Type Padout>]<RX, TX, RTS, CTS> = Padout<$Sercom, RX, TX, RTS, CTS>;
+            pub type [<$Type TxPadout>]<TX, RTS> = TxPadout<$Sercom, TX, RTS>;
+            pub type [<$Type RxPadout>]<RX, CTS> = RxPadout<$Sercom, RX, CTS>;
         }
-
-        /// Define a From instance for either a tuple of two SercomXPadX
-        /// instances, or a tuple of four SercomXPadX instances that converts
-        /// them into an UARTXPadout instance.
-        ///
-        /// Also defines a RxpoTxpo instance for the constructed padout instance
-        /// that returns the values used to configure the sercom pads for the
-        /// appropriate function in the sercom register file.
-        macro_rules! padout {
-            ($rxpo_txpo:expr => $pad0:ident, $pad1:ident) => {
-                $crate::paste::item! {
-                    /// Convert from a tuple of (RX, TX) to UARTXPadout
-                    impl<PIN0, PIN1> From<([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>)> for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, (), ()>
-                    where
-                        PIN0: AnyPin,
-                        PIN1: AnyPin,
-                        PIN0::Id: GetPadMode<$Sercom, $pad0>,
-                        PIN1::Id: GetPadMode<$Sercom, $pad1>,
-                    {
-                        fn from(pads: ([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>)) -> [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, (), ()> {
-                            [<$Type Padout>] { rx: pads.0, tx: pads.1, rts: (), cts: () }
-                        }
-                    }
-
-                    impl<PIN0, PIN1> RxpoTxpo for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, (), ()>
-                    where
-                        PIN0: AnyPin,
-                        PIN1: AnyPin,
-                        PIN0::Id: GetPadMode<$Sercom, $pad0>,
-                        PIN1::Id: GetPadMode<$Sercom, $pad1>,
-                    {
-                        fn rxpo_txpo(&self) -> (u8, u8) {
-                            $rxpo_txpo
-                        }
-                    }
-
-                    /// Convert from a tuple of (RX, TX, RTS, CTS) to UARTXPadout
-                    impl<Id0, Id1> From<(v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>)> for [<$Type Padout>]<v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, (), ()>
-                    where
-                        Id0: v2::GetPadMode<$Sercom, $pad0>,
-                        Id1: v2::GetPadMode<$Sercom, $pad1>,
-                    {
-                        fn from(pads: (v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>)) -> Self {
-                            [<$Type Padout>] { rx: pads.0, tx: pads.1, rts: (), cts: () }
-                        }
-                    }
-
-                    impl<Id0, Id1> RxpoTxpo for [<$Type Padout>]<v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, (), ()>
-                    where
-                        Id0: v2::GetPadMode<$Sercom, $pad0>,
-                        Id1: v2::GetPadMode<$Sercom, $pad1>,
-                    {
-                        fn rxpo_txpo(&self) -> (u8, u8) {
-                            $rxpo_txpo
-                        }
-                    }
-                }
-            };
-            ($rxpo_txpo:expr => $pad0:ident, $pad1:ident, $pad2:ident, $pad3:ident) => {
-                $crate::paste::item! {
-                    /// Convert from a tuple of (RX, TX, RTS, CTS) to UARTXPadout
-                    impl<PIN0, PIN1, PIN2, PIN3> From<([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>, [<$Sercom $pad3>]<PIN3>)> for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>, [<$Sercom $pad3>]<PIN3>>
-                    where
-                        PIN0: AnyPin,
-                        PIN1: AnyPin,
-                        PIN2: AnyPin,
-                        PIN3: AnyPin,
-                        PIN0::Id: GetPadMode<$Sercom, $pad0>,
-                        PIN1::Id: GetPadMode<$Sercom, $pad1>,
-                        PIN2::Id: GetPadMode<$Sercom, $pad2>,
-                        PIN3::Id: GetPadMode<$Sercom, $pad3>,
-                    {
-                        fn from(pads: ([<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>, [<$Sercom $pad3>]<PIN3>)) -> [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>, [<$Sercom $pad3>]<PIN3>> {
-                            [<$Type Padout>] { rx: pads.0, tx: pads.1, rts: pads.2, cts: pads.3 }
-                        }
-                    }
-
-                    impl<PIN0, PIN1, PIN2, PIN3> RxpoTxpo for [<$Type Padout>]<[<$Sercom $pad0>]<PIN0>, [<$Sercom $pad1>]<PIN1>, [<$Sercom $pad2>]<PIN2>, [<$Sercom $pad3>]<PIN3>>
-                    where
-                        PIN0: AnyPin,
-                        PIN1: AnyPin,
-                        PIN2: AnyPin,
-                        PIN3: AnyPin,
-                        PIN0::Id: GetPadMode<$Sercom, $pad0>,
-                        PIN1::Id: GetPadMode<$Sercom, $pad1>,
-                        PIN2::Id: GetPadMode<$Sercom, $pad2>,
-                        PIN3::Id: GetPadMode<$Sercom, $pad3>,
-                    {
-                        fn rxpo_txpo(&self) -> (u8, u8) {
-                            $rxpo_txpo
-                        }
-                    }
-
-                    /// Convert from a tuple of (RX, TX, RTS, CTS) to UARTXPadout
-                    impl<Id0, Id1, Id2, Id3> From<(v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>, v2::Pad<$Sercom, $pad3, Id3>)> for [<$Type Padout>]<v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>, v2::Pad<$Sercom, $pad3, Id3>>
-                    where
-                        Id0: v2::GetPadMode<$Sercom, $pad0>,
-                        Id1: v2::GetPadMode<$Sercom, $pad1>,
-                        Id2: v2::GetPadMode<$Sercom, $pad2>,
-                        Id3: v2::GetPadMode<$Sercom, $pad3>,
-                    {
-                        fn from(pads: (v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>, v2::Pad<$Sercom, $pad3, Id3>)) -> Self {
-                            [<$Type Padout>] { rx: pads.0, tx: pads.1, rts: pads.2, cts: pads.3 }
-                        }
-                    }
-
-                    impl<Id0, Id1, Id2, Id3> RxpoTxpo for [<$Type Padout>]<v2::Pad<$Sercom, $pad0, Id0>, v2::Pad<$Sercom, $pad1, Id1>, v2::Pad<$Sercom, $pad2, Id2>, v2::Pad<$Sercom, $pad3, Id3>>
-                    where
-                        Id0: v2::GetPadMode<$Sercom, $pad0>,
-                        Id1: v2::GetPadMode<$Sercom, $pad1>,
-                        Id2: v2::GetPadMode<$Sercom, $pad2>,
-                        Id3: v2::GetPadMode<$Sercom, $pad3>,
-                    {
-                        fn rxpo_txpo(&self) -> (u8, u8) {
-                            $rxpo_txpo
-                        }
-                    }
-                }
-            };
-        }
-
-        // rxpo 0-3 RX on PAD 0-3
-        // TX always PAD 0
-        // txpo 0 no RTS/CTS
-        // txpo 1 reserved and can't be used
-        // txpo 2 RTS PAD 2, CTS PAD 3
-        // txpo 3 RTS PAD 2, no CTS
-        // (rxpo_txpo) => (RX, TX, RTS, CTS)
-        padout!((1, 0) => Pad1, Pad0);
-        padout!((1, 2) => Pad1, Pad0, Pad2, Pad3);
-
-        // todo we could support an RTS without a CTS
-        // padout!((1, 3) => Pad1, Pad0, Pad2);
-
-        padout!((2, 0) => Pad2, Pad0);
-        padout!((3, 0) => Pad3, Pad0);
-
-        // todo we could support an RTS without a CTS
-        // padout!((3, 3) => Pad3, Pad0, Pad2);
 
         $crate::paste::item! {
             /// UARTX represents the corresponding SERCOMX instance
@@ -236,19 +222,19 @@ macro_rules! uart {
             /// This type is generic over any valid pad mapping where there is
             /// a defined "receive pin out transmit pin out" implementation.
             pub struct $Type<RX, TX, RTS, CTS> {
-                padout: [<$Type Padout>]<RX, TX, RTS, CTS>,
+                padout: Padout<$Sercom, RX, TX, RTS, CTS>,
                 sercom: $SERCOM,
             }
 
             impl<RX, TX, RTS, CTS> $Type<RX, TX, RTS, CTS> {
-                pub fn new<F: Into<Hertz>, T: Into<[<$Type Padout>]<RX, TX, RTS, CTS>>>(
+                pub fn new<F: Into<Hertz>, T: Into<Padout<$Sercom, RX, TX, RTS, CTS>>>(
                     clock: &clock::$clock,
                     freq: F,
                     sercom: $SERCOM,
                     mclk: &mut MCLK,
                     padout: T,
                 ) -> Self where
-                    [<$Type Padout>]<RX, TX, RTS, CTS>: RxpoTxpo {
+                    Padout<$Sercom, RX, TX, RTS, CTS>: RxpoTxpo {
                     let padout = padout.into();
 
                     mclk.$apmask.modify(|_, w| w.$powermask().set_bit());
@@ -326,7 +312,7 @@ macro_rules! uart {
                     }
                 }
 
-                pub fn free(self) -> ([<$Type Padout>]<RX, TX, RTS, CTS>, $SERCOM) {
+                pub fn free(self) -> (Padout<$Sercom, RX, TX, RTS, CTS>, $SERCOM) {
                     (self.padout, self.sercom)
                 }
 
@@ -348,7 +334,7 @@ macro_rules! uart {
                 /// Combines transmit and receive halves back into a duplex UART
                 pub fn join(tx: [<$Type Tx>]<TX, RTS>, rx: [<$Type Rx>]<RX, CTS>) -> Self {
                     Self {
-                        padout: [<$Type Padout>]::join(tx.padout, rx.padout),
+                        padout: Padout::join(tx.padout, rx.padout),
                         sercom: tx.sercom,
                     }
                 }
@@ -382,7 +368,7 @@ macro_rules! uart {
 
             /// The transmitting half of the corresponding UARTX instance (as returned by `UARTX::split`)
             pub struct [<$Type Tx>]<TX, RTS> {
-                padout: [<$Type TxPadout>]<TX, RTS>,
+                padout: TxPadout<$Sercom, TX, RTS>,
                 /// We store the SERCOM object here so we can retrieve it later,
                 /// but conceptually, ownership is shared between the Rx and Tx halves.
                 sercom: $SERCOM,
@@ -446,7 +432,7 @@ macro_rules! uart {
 
             /// The receiving half of the corresponding UARTX instance (as returned by `UARTX::split`)
             pub struct [<$Type Rx>]<RX, CTS> {
-                padout: [<$Type RxPadout>]<RX, CTS>,
+                padout: RxPadout<$Sercom, RX, CTS>,
                 sercom: PhantomData<$SERCOM>,
             }
 
@@ -507,7 +493,7 @@ macro_rules! uart {
                 }
             }
         }
-    }
+    };
 }
 
 uart!(

--- a/hal/src/thumbv7em/sercom/v2.rs
+++ b/hal/src/thumbv7em/sercom/v2.rs
@@ -1,2 +1,2 @@
-pub mod pad_info;
+pub mod impl_pad;
 pub mod spi;

--- a/hal/src/thumbv7em/sercom/v2/impl_pad.rs
+++ b/hal/src/thumbv7em/sercom/v2/impl_pad.rs
@@ -1,4 +1,4 @@
-//! Implementations of the [`PadInfo`] and [`InIoSet`] traits
+//! Implementations of the [`IsPad`], [`GetPad`] and [`InIoSet`] traits
 
 use crate::gpio::v2::*;
 use crate::sercom::v2::*;
@@ -15,14 +15,14 @@ macro_rules! pad_info {
         $PadNum:ident,
         $( $IoSet:ident ),+
     ) => {
-        impl PadInfo<$Sercom> for $PinId {
+        impl GetPad<$Sercom> for $PinId {
             type PadNum = $PadNum;
             type PinMode = Alternate<$Cfg>;
         }
         $(
-            impl InIoSet<$IoSet> for Pad<$Sercom, $PadNum, $PinId> {}
+            impl InIoSet<$IoSet> for Pin<$PinId, Alternate<$Cfg>> {}
         )+
-        impl ConvertPinToPad for Pin<$PinId, Alternate<$Cfg>> {
+        impl IsPad for Pin<$PinId, Alternate<$Cfg>> {
             type Sercom = $Sercom;
             type PadNum = $PadNum;
         }

--- a/hal/src/typelevel.rs
+++ b/hal/src/typelevel.rs
@@ -332,6 +332,12 @@
 //! readers understand that a particular type parameter is restricted to an
 //! instances of `Class` when an `OptionalClass` could be accepted.
 //!
+//! Note that when `Class` and `OptionalClass` contain associated types, name
+//! clashes may occur when using `SomeClass` as a trait bound. This can be
+//! avoided by removing the `OptionalClass` super trait from `SomeClass`.
+//! Ultimately, it is redundant anyway, because any implementer of `Class` also
+//! implements `OptionalClass`.
+//!
 //! # `AnyKind` trait pattern
 //!
 //! The `AnyKind` trait pattern allows you to encapsulate types with multiple
@@ -634,6 +640,7 @@ mod private {
 pub(crate) use private::Sealed;
 
 /// Type-level version of the [None] variant
+#[derive(Default)]
 pub struct NoneT;
 impl Sealed for NoneT {}
 
@@ -684,15 +691,4 @@ where
     T: Sealed + AsRef<T> + AsMut<T>,
 {
     type Type = T;
-}
-
-#[macro_export]
-#[doc(hidden)]
-macro_rules! __opt_type {
-    () => {
-        $crate::typelevel::NoneT
-    };
-    ($Type:ty) => {
-        $Type
-    };
 }


### PR DESCRIPTION
The `sercom::v2::Pad` type was a simple wrapper around a `gpio::v2::Pin`
type. Its purpose was to ensure that each `Pin` was properly configured
to act as the corresponding SERCOM `Pad`. However, one of my goals in
designing the `v2::spi` API was to avoid the need for users to manually
convert `Pin` types to `Pad` types. As that module progressed, it became
clear that the `v2::Pad` type served no real purpose. All the same
constraints could be imposed using a slightly different approach to
type-level programming.

Remove the `v2::Pad` type and modify the `sercom::v2::pad` module
accordingly. Update the `v1::Pad` type as well. Rename some of the
type-level items in the `v2::pad` module and improve the documentation.
Update the `sercom::v1` peripheral APIs to accept both `v1::Pad` types
and the equivalent of a `v2::Pad`, which is simply a properly configured
`v2::Pin`.

Finally, redefine the type parameters of `v2::spi::Pads` to be
`OptionalPad`s rather than `OptionalPinId`s, and provide a new
`PadsFromIds` to make up for it. This change increases consistency in
the definition of the `spi::Pads` type, and it allows me to remove a
significant amount of trait boilerplate needed to make it all work.