### PR TITLE
Remove DMAC Transfer payloads

### DIFF
--- a/boards/feather_m0/examples/dmac.rs
+++ b/boards/feather_m0/examples/dmac.rs
@@ -50,7 +50,7 @@ fn main() -> ! {
         .with_waker(|_status| asm::nop())
         .begin(TriggerSource::DISABLE, TriggerAction::BLOCK);
     // Wait for transfer to complete and grab resulting buffers
-    let (chan0, buf_src, buf_dest, _) = xfer.wait();
+    let (chan0, buf_src, buf_dest) = xfer.wait();
 
     // Read the returned buffers
     let _a = buf_src[LENGTH - 1];
@@ -61,13 +61,12 @@ fn main() -> ! {
         cortex_m::singleton!(:[u16; LENGTH] = [0x0000; LENGTH]).unwrap();
 
     // Setup a DMA transfer (memory-to-memory -> fixed source, incrementing
-    // destination) with a 16-bit beat size. Demonstrate payload management.
+    // destination) with a 16-bit beat size.
     let xfer = Transfer::new(chan0, const_16, buf_16, false)
         .unwrap()
-        .with_payload(pm)
         .begin(TriggerSource::DISABLE, TriggerAction::BLOCK);
 
-    let (chan0, const_16, buf_16, mut pm) = xfer.wait();
+    let (chan0, const_16, buf_16) = xfer.wait();
 
     // Read the returned buffers
     let _a = *const_16;
@@ -84,7 +83,7 @@ fn main() -> ! {
         .unwrap()
         .begin(TriggerSource::DISABLE, TriggerAction::BLOCK);
 
-    let (chan0, buf_16, const_16, _) = xfer.wait();
+    let (chan0, buf_16, const_16) = xfer.wait();
 
     // Read the returned buffers
     let _a = *const_16; // We expect the value "LENGTH - 1" to end up here

--- a/boards/feather_m4/examples/dmac.rs
+++ b/boards/feather_m4/examples/dmac.rs
@@ -14,10 +14,7 @@ use hal::{
     pac::{CorePeripherals, Peripherals},
 };
 
-use hal::dmac::{
-    BurstLength, DmaController, FifoThreshold, PriorityLevel, Transfer, TriggerAction,
-    TriggerSource,
-};
+use hal::dmac::{DmaController, PriorityLevel, Transfer, TriggerAction, TriggerSource};
 
 #[entry]
 fn main() -> ! {
@@ -56,7 +53,7 @@ fn main() -> ! {
         .begin(TriggerSource::DISABLE, TriggerAction::BLOCK);
 
     // Wait for transfer to complete and grab resulting buffers
-    let (chan0, buf_src, buf_dest, _) = xfer.wait();
+    let (chan0, buf_src, buf_dest) = xfer.wait();
 
     // Read the returned buffers
     let _a = buf_src[LENGTH - 1];
@@ -67,13 +64,12 @@ fn main() -> ! {
         cortex_m::singleton!(:[u16; LENGTH] = [0x0000; LENGTH]).unwrap();
 
     // Setup a DMA transfer (memory-to-memory -> fixed source, incrementing
-    // destination) with a 16-bit beat size. Demonstrate payload management.
+    // destination) with a 16-bit beat size.
     let xfer = Transfer::new(chan0, const_16, buf_16, false)
         .unwrap()
-        .with_payload(pm)
         .begin(TriggerSource::DISABLE, TriggerAction::BLOCK);
 
-    let (chan0, const_16, buf_16, mut pm) = xfer.wait();
+    let (chan0, const_16, buf_16) = xfer.wait();
 
     // Read the returned buffers
     let _a = *const_16;
@@ -90,7 +86,7 @@ fn main() -> ! {
         .unwrap()
         .begin(TriggerSource::DISABLE, TriggerAction::BLOCK);
 
-    let (chan0, buf_16, const_16, _) = xfer.wait();
+    let (chan0, buf_16, const_16) = xfer.wait();
 
     // Read the returned buffers
     let _a = *const_16; // We expect the value "LENGTH - 1" to end up here

--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -8,16 +8,19 @@
 //! requires setting a priority level, as well as enabling or disabling
 //! interrupt requests (only for the specific channel being initialized).
 //!
-//! # Burst Length and FIFO Threshold (SAMD51/SAME5x only)
-//!
-//! The transfer burst length can be configured through the
-//! [`Channel::burst_length`] method. A burst is an atomic,
-//! uninterruptible transfer which length corresponds to a number of beats. See
-//! SAMD5x/E5x datasheet section 22.6.1.1 for more information. The FIFO
-//! threshold can be configured through the
-//! [`Channel::fifo_threshold`] method. This enables the channel
-//! to wait for multiple Beats before sending a Burst. See SAMD5x/E5x datasheet
-//! section 22.6.2.8 for more information.
+#![cfg_attr(
+    not(any(feature = "samd11", feature = "samd21")),
+    doc = "# Burst Length and FIFO Threshold (SAMD51/SAME5x only)
+
+The transfer burst length can be configured through the
+[`Channel::burst_length`] method. A burst is an atomic,
+uninterruptible transfer which length corresponds to a number of beats. See
+SAMD5x/E5x datasheet section 22.6.1.1 for more information. The FIFO
+threshold can be configured through the
+[`Channel::fifo_threshold`] method. This enables the channel
+to wait for multiple Beats before sending a Burst. See SAMD5x/E5x datasheet
+section 22.6.2.8 for more information."
+)]
 //!
 //! # Channel status
 //!

--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -7,7 +7,6 @@
 //! use by a [`Transfer`](super::transfer::Transfer). Initializing a channel
 //! requires setting a priority level, as well as enabling or disabling
 //! interrupt requests (only for the specific channel being initialized).
-//!
 #![cfg_attr(
     not(any(feature = "samd11", feature = "samd21")),
     doc = "# Burst Length and FIFO Threshold (SAMD51/SAME5x only)

--- a/hal/src/dmac/channel/reg.rs
+++ b/hal/src/dmac/channel/reg.rs
@@ -1,14 +1,14 @@
 //! # Channel registers
 //!
 //! This module adds a [`RegisterBlock`] struct, which acts as a proxy for the
-//! registers a single DMAC [`Channel`](super::Channel) can read/write. Its purpose is to
-//! remediate the inadequacies of the PAC. In particular, for SAMD11/SAMD21, the
-//! CHID register must be written with the correct channel ID before accessing
-//! the channel specific registers. There is a provided `with_chid` method that
-//! takes a closure with the register read/write proxies to ensure any
-//! read/write to these registers are done in an interrupt-safe way. For
-//! SAMD51+, `with_chid` returns the register block which contains the registers
-//! owned by a specific channel.
+//! registers a single DMAC [`Channel`](super::Channel) can read/write. Its
+//! purpose is to remediate the inadequacies of the PAC. In particular, for
+//! SAMD11/SAMD21, the CHID register must be written with the correct channel ID
+//! before accessing the channel specific registers. There is a provided
+//! `with_chid` method that takes a closure with the register read/write proxies
+//! to ensure any read/write to these registers are done in an interrupt-safe
+//! way. For SAMD51+, `with_chid` returns the register block which contains the
+//! registers owned by a specific channel.
 
 use super::super::dma_controller::ChId;
 use core::marker::PhantomData;

--- a/hal/src/dmac/channel/reg.rs
+++ b/hal/src/dmac/channel/reg.rs
@@ -1,7 +1,7 @@
 //! # Channel registers
 //!
 //! This module adds a [`RegisterBlock`] struct, which acts as a proxy for the
-//! registers a single DMAC [`Channel`] can read/write. Its purpose is to
+//! registers a single DMAC [`Channel`](super::Channel) can read/write. Its purpose is to
 //! remediate the inadequacies of the PAC. In particular, for SAMD11/SAMD21, the
 //! CHID register must be written with the correct channel ID before accessing
 //! the channel specific registers. There is a provided `with_chid` method that

--- a/hal/src/dmac/mod.rs
+++ b/hal/src/dmac/mod.rs
@@ -170,7 +170,7 @@
 //! # Waker operation
 //!
 //! A [`Transfer`] can also accept a function or closure that will be called on
-//! completion of the transaction, acting like a [`Waker`].
+//! completion of the transaction, acting like a waker.
 //!
 //! ```
 //! fn wake_up() {

--- a/hal/src/dmac/mod.rs
+++ b/hal/src/dmac/mod.rs
@@ -89,14 +89,6 @@
 //! the NVIC. You will be responsible for clearing the interrupt flags in the
 //! ISR.
 //!
-//! # Payloads
-//!
-//! You may choose to append a payload to a `Transfer` by using the
-//! [`Transfer::with_payload`] method. This will take ownership of an aribtrary
-//! type until the transfer is released (`stop`ped or `wait`ed). This is useful,
-//! for instance, to take ownership of a peripheral until the transfer is
-//! complete and prevent data races.
-//!
 //! # About static lifetimes
 //!
 //! The safe API this driver offers requires all buffers (source and

--- a/hal/src/dmac/mod.rs
+++ b/hal/src/dmac/mod.rs
@@ -253,14 +253,9 @@
 
 use modular_bitfield::prelude::*;
 
-pub use channel::CallbackStatus;
-#[cfg(feature = "min-samd51g")]
-pub use dma_controller::{BurstLength, FifoThreshold};
-pub use dma_controller::{
-    DmaController, PriorityLevel, PriorityLevelMask, RoundRobinMask, TriggerAction, TriggerSource,
-};
-use transfer::BeatSize;
-pub use transfer::{Beat, Buffer, Transfer};
+pub use channel::*;
+pub use dma_controller::*;
+pub use transfer::*;
 
 #[derive(Debug)]
 /// Runtime errors that may occur when dealing with DMA transfers.

--- a/hal/src/thumbv6m/sercom/v2/spi.rs
+++ b/hal/src/thumbv6m/sercom/v2/spi.rs
@@ -162,7 +162,7 @@
 //! // Wait for transfer to complete and reclaim resources
 //! let (chan0, _, spi, _) = dma_transfer.wait();
 //! ```
-//! 
+//!
 //! [`enable`]: Config::enable
 //! [`Pin`]: crate::gpio::v2::pin::Pin
 //! [`PinId`]: crate::gpio::v2::pin::PinId
@@ -1694,7 +1694,7 @@ mod spi_dma {
             buf: B,
             mut channel: Chan,
             waker: W,
-        ) -> Transfer<Channel<ChannelId<Chan>, Busy>, transfer::BufferPair<B, Self>, (), W>
+        ) -> Transfer<Channel<ChannelId<Chan>, Busy>, transfer::BufferPair<B, Self>, W>
         where
             Chan: channel::AnyChannel<Status = Ready>,
             B: dmac::Buffer<Beat = C::Word> + 'static,
@@ -1733,7 +1733,7 @@ mod spi_dma {
             buf: B,
             mut channel: Chan,
             waker: W,
-        ) -> Transfer<Channel<ChannelId<Chan>, Busy>, transfer::BufferPair<Self, B>, (), W>
+        ) -> Transfer<Channel<ChannelId<Chan>, Busy>, transfer::BufferPair<Self, B>, W>
         where
             Chan: channel::AnyChannel<Status = Ready>,
             B: dmac::Buffer<Beat = C::Word> + 'static,

--- a/hal/src/thumbv6m/sercom/v2/spi.rs
+++ b/hal/src/thumbv6m/sercom/v2/spi.rs
@@ -162,7 +162,7 @@
 //! // Wait for transfer to complete and reclaim resources
 //! let (chan0, _, spi, _) = dma_transfer.wait();
 //! ```
-//!
+//! 
 //! [`enable`]: Config::enable
 //! [`Pin`]: crate::gpio::v2::pin::Pin
 //! [`PinId`]: crate::gpio::v2::pin::PinId

--- a/hal/src/thumbv7em/sercom/v2/spi.rs
+++ b/hal/src/thumbv7em/sercom/v2/spi.rs
@@ -166,7 +166,7 @@
 //! // Wait for transfer to complete and reclaim resources
 //! let (chan0, _, spi, _) = dma_transfer.wait();
 //! ```
-//! 
+//!
 //! [`enable`]: Config::enable
 //! [`Pin`]: crate::gpio::v2::pin::Pin
 //! [`OptionalPinId`]: crate::gpio::v2::pin::OptionalPinId
@@ -1753,7 +1753,7 @@ mod spi_dma {
             buf: B,
             mut channel: Chan,
             waker: W,
-        ) -> Transfer<Channel<ChannelId<Chan>, Busy>, transfer::BufferPair<B, Self>, (), W>
+        ) -> Transfer<Channel<ChannelId<Chan>, Busy>, transfer::BufferPair<B, Self>, W>
         where
             Chan: channel::AnyChannel<Status = Ready>,
             B: dmac::Buffer<Beat = L::Word> + 'static,
@@ -1792,7 +1792,7 @@ mod spi_dma {
             buf: B,
             mut channel: Chan,
             waker: W,
-        ) -> Transfer<Channel<ChannelId<Chan>, Busy>, transfer::BufferPair<Self, B>, (), W>
+        ) -> Transfer<Channel<ChannelId<Chan>, Busy>, transfer::BufferPair<Self, B>, W>
         where
             Chan: channel::AnyChannel<Status = Ready>,
             B: dmac::Buffer<Beat = L::Word> + 'static,

--- a/hal/src/thumbv7em/sercom/v2/spi.rs
+++ b/hal/src/thumbv7em/sercom/v2/spi.rs
@@ -166,7 +166,7 @@
 //! // Wait for transfer to complete and reclaim resources
 //! let (chan0, _, spi, _) = dma_transfer.wait();
 //! ```
-//!
+//! 
 //! [`enable`]: Config::enable
 //! [`Pin`]: crate::gpio::v2::pin::Pin
 //! [`OptionalPinId`]: crate::gpio::v2::pin::OptionalPinId


### PR DESCRIPTION
This PR removes the `payload` concept from DMAC `Transfers`. It was initially intended to tie in a PAC/peripheral struct while a Transfer is ongoing. Since then, the design has evolved, and the peripherals themselves implement `Buffer`. Therefore they're already moved into a `Transfer`, rendering the use of `payload`s redundant.

PR also fixes doc warnings for the `dmac` module, and re-exports all public items from its submodules for slightly better ergonomics.