### PR TITLE
Add methods for the USB Start Of Frame interrupt

### DIFF
--- a/hal/src/thumbv7em/usb/bus.rs
+++ b/hal/src/thumbv7em/usb/bus.rs
@@ -663,6 +663,15 @@ impl Inner {
         usb.ctrlb.modify(|_, w| w.detach().clear_bit());
     }
 
+    /// Enables/disables the Start Of Frame (SOF) interrupt
+    fn sof_interrupt(&self, enable: bool) {
+        if enable {
+            self.usb().intenset.write(|w| w.sof().set_bit());
+        } else {
+            self.usb().intenclr.write(|w| w.sof().set_bit());
+        }
+    }
+
     /// Configures all endpoints based on prior calls to alloc_ep().
     fn flush_eps(&self, mode: FlushConfigMode) {
         for idx in 0..8 {
@@ -804,6 +813,14 @@ impl Inner {
         self.usb()
             .dadd
             .write(|w| unsafe { w.dadd().bits(addr).adden().set_bit() });
+    }
+
+    fn check_sof_interrupt(&self) -> bool {
+        if self.usb().intflag.read().sof().bit() {
+            self.usb().intflag.write(|w| w.sof().set_bit());
+            return true;
+        }
+        false
     }
 
     fn poll(&self) -> PollResult {
@@ -960,6 +977,23 @@ impl Inner {
 
     fn set_stalled(&self, ep: EndpointAddress, stalled: bool) {
         self.set_stall(ep, stalled);
+    }
+}
+
+impl UsbBus {
+    /// Enables the Start Of Frame (SOF) interrupt
+    pub fn enable_sof_interrupt(&self) {
+        disable_interrupts(|cs| self.inner.borrow(cs).borrow_mut().sof_interrupt(true))
+    }
+
+    /// Disables the Start Of Frame (SOF) interrupt
+    pub fn disable_sof_interrupt(&self) {
+        disable_interrupts(|cs| self.inner.borrow(cs).borrow_mut().sof_interrupt(false))
+    }
+
+    /// Checks, and clears if set, the Start Of Frame (SOF) interrupt flag
+    pub fn check_sof_interrupt(&self) -> bool {
+        disable_interrupts(|cs| self.inner.borrow(cs).borrow_mut().check_sof_interrupt())
     }
 }
 


### PR DESCRIPTION
After using https://github.com/atsamd-rs/atsamd/pull/398 a bit, I found that checking the SOF flag in `poll()` was problematic, because from the outside it's not clear whether or not the SOF flag was set.

This functionality is helpful in the context of USB classes which are always accessed in the USB ISR (working around https://github.com/atsamd-rs/atsamd/issues/397).  If the host isn't read/writing to the endpoint, but the device has info it wants to send, then somehow execution needs to get back in to the USB ISR.

Since the PR is so small, and the original one hasn't been updated in a while, I've made a new PR.  If that's problematic, I'd be happy to re-do this as a PR against https://github.com/henrikssn/atsamd/tree/usb-sof