### PR TITLE
Add `pub use nb;` to HAL prelude

### DIFF
--- a/hal/src/prelude.rs
+++ b/hal/src/prelude.rs
@@ -14,3 +14,5 @@ pub use hal::digital::v2::OutputPin as _atsamd_hal_embedded_hal_digital_v2_Outpu
 pub use hal::digital::v2::ToggleableOutputPin as _atsamd_hal_embedded_hal_digital_v2_ToggleableOutputPin;
 
 pub use hal::prelude::*;
+
+pub use nb;


### PR DESCRIPTION
Just a little thing - this means that crates depending on the HAL don't need to explicitly depend on `nb` to handle the `nb::Result`s and such returned by HAL methods.