### PR TITLE
Rework USB OUT endpoint interrupts

### DIFF
--- a/hal/src/thumbv6m/usb/bus.rs
+++ b/hal/src/thumbv6m/usb/bus.rs
@@ -820,18 +820,23 @@ impl Inner {
         let mut ep_in_complete = 0;
         let mut ep_setup = 0;
 
+        let intbits = self.usb().epintsmry.read().bits();
+
         for ep in 0..8u16 {
             let mask = 1 << ep;
 
             let idx = ep as usize;
 
-            if let Ok(bank1) = self.bank1(EndpointAddress::from_parts(idx, UsbDirection::In)) {
-                if bank1.is_transfer_complete() {
-                    bank1.clear_transfer_complete();
-                    ep_in_complete |= mask;
+            if (intbits & mask) != 0 {
+                if let Ok(bank1) = self.bank1(EndpointAddress::from_parts(idx, UsbDirection::In)) {
+                    if bank1.is_transfer_complete() {
+                        bank1.clear_transfer_complete();
+                        ep_in_complete |= mask;
+                    }
                 }
             }
 
+            // Can't test intbits, because bk0rdy doesn't interrupt
             if let Ok(bank0) = self.bank0(EndpointAddress::from_parts(idx, UsbDirection::Out)) {
                 if bank0.received_setup_interrupt() {
                     ep_setup |= mask;

--- a/hal/src/thumbv6m/usb/bus.rs
+++ b/hal/src/thumbv6m/usb/bus.rs
@@ -394,13 +394,6 @@ impl<'a> Bank<'a, OutBank> {
             .write(|w| w.trcpt0().set_bit().trfail0().set_bit());
     }
 
-    /// Checks if data has been received. Returns true for failed transfers
-    /// as well as successful transfers.
-    #[inline]
-    fn is_transfer_complete(&self) -> bool {
-        self.epintflag(self.index()).read().trcpt0().bit()
-    }
-
     /// Returns true if a Received Setup interrupt has occurred.
     /// This indicates that the read buffer holds a SETUP packet.
     #[inline]
@@ -750,6 +743,7 @@ impl Inner {
     }
 
     fn suspend(&self) {}
+
     fn resume(&self) {}
 
     fn alloc_ep(
@@ -822,20 +816,12 @@ impl Inner {
         // unconnected & unsuspended, we do not handle them to avoid spurious
         // transitions.
 
-        let intbits = self.usb().epintsmry.read().bits();
-        if intbits == 0 {
-            return PollResult::None;
-        }
-
         let mut ep_out = 0;
         let mut ep_in_complete = 0;
         let mut ep_setup = 0;
 
         for ep in 0..8u16 {
             let mask = 1 << ep;
-            if (intbits & mask) == 0 {
-                continue;
-            }
 
             let idx = ep as usize;
 
@@ -849,22 +835,45 @@ impl Inner {
             if let Ok(bank0) = self.bank0(EndpointAddress::from_parts(idx, UsbDirection::Out)) {
                 if bank0.received_setup_interrupt() {
                     ep_setup |= mask;
-                    // usb-device crate:
-                    //  "This event should continue to be reported until the
-                    //  packet is read." So we don't clear the flag here,
-                    //  instead it is cleared in the read handler.
+
+                    // The RXSTP interrupt is not cleared here, because doing so
+                    // would allow the USB hardware to overwrite the received
+                    // data, potentially before it is `read()` - see SAMD21
+                    // datasheet "32.6.2.6 Management of SETUP Transactions".
+                    // Setup events are only relevant for control endpoints, and
+                    // in typical USB devices, endpoint 0 is the only control
+                    // endpoint. The usb-device `poll()` method, which calls
+                    // this `poll()`, will immediately `read()` endpoint 0 when
+                    // its setup bit is set.
                 }
 
-                if bank0.is_transfer_complete() {
+                // Clear the transfer complete and transfer failed interrupt flags
+                // so that execution leaves the USB interrupt until the host makes
+                // another transaction.  The transfer failed flag may have been set
+                // if an OUT transaction wasn't read() from the endpoint by the
+                // Class; the hardware will have NAKed (unless the endpoint is
+                // isochronous) and the host may retry.
+                bank0.clear_transfer_complete();
+
+                // Use the bk0rdy flag via is_ready() to indicate that data has been
+                // received successfully, rather than the interrupting trcpt0 via
+                // is_transfer_ready(), because data may have been received on an
+                // earlier poll() which cleared trcpt0.  bk0rdy is cleared in the
+                // endpoint read().
+                if bank0.is_ready() {
                     ep_out |= mask;
                 }
             }
         }
 
-        PollResult::Data {
-            ep_out,
-            ep_in_complete,
-            ep_setup,
+        if ep_out == 0 && ep_in_complete == 0 && ep_setup == 0 {
+            PollResult::None
+        } else {
+            PollResult::Data {
+                ep_out,
+                ep_in_complete,
+                ep_setup,
+            }
         }
     }
 
@@ -897,8 +906,6 @@ impl Inner {
 
             bank.clear_transfer_complete();
             bank.set_ready(false);
-
-            drop(bank);
 
             size
         } else {

--- a/hal/src/thumbv7em/usb/bus.rs
+++ b/hal/src/thumbv7em/usb/bus.rs
@@ -763,18 +763,23 @@ impl Inner {
         let mut ep_in_complete = 0;
         let mut ep_setup = 0;
 
+        let intbits = self.usb().epintsmry.read().bits();
+
         for ep in 0..8u16 {
             let mask = 1 << ep;
 
             let idx = ep as usize;
 
-            if let Ok(bank1) = self.bank1(EndpointAddress::from_parts(idx, UsbDirection::In)) {
-                if bank1.is_transfer_complete() {
-                    bank1.clear_transfer_complete();
-                    ep_in_complete |= mask;
+            if (intbits & mask) != 0 {
+                if let Ok(bank1) = self.bank1(EndpointAddress::from_parts(idx, UsbDirection::In)) {
+                    if bank1.is_transfer_complete() {
+                        bank1.clear_transfer_complete();
+                        ep_in_complete |= mask;
+                    }
                 }
             }
 
+            // Can't test intbits, because bk0rdy doesn't interrupt
             if let Ok(bank0) = self.bank0(EndpointAddress::from_parts(idx, UsbDirection::Out)) {
                 if bank0.received_setup_interrupt() {
                     ep_setup |= mask;

--- a/hal/src/thumbv7em/usb/bus.rs
+++ b/hal/src/thumbv7em/usb/bus.rs
@@ -393,13 +393,6 @@ impl<'a> Bank<'a, OutBank> {
             .write(|w| w.trcpt0().set_bit().trfail0().set_bit());
     }
 
-    /// Checks if data has been received. Returns true for failed transfers
-    /// as well as successful transfers.
-    #[inline]
-    fn is_transfer_complete(&self) -> bool {
-        self.epintflag(self.index()).read().trcpt0().bit()
-    }
-
     /// Returns true if a Received Setup interrupt has occurred.
     /// This indicates that the read buffer holds a SETUP packet.
     #[inline]
@@ -555,7 +548,6 @@ impl Inner {
 
     fn set_stall<EP: Into<EndpointAddress>>(&self, ep: EP, stall: bool) {
         let ep = ep.into();
-
         if ep.is_out() {
             if let Ok(mut bank) = self.bank0(ep) {
                 bank.set_stall(stall);
@@ -767,20 +759,12 @@ impl Inner {
         // unconnected & unsuspended, we do not handle them to avoid spurious
         // transitions.
 
-        let intbits = self.usb().epintsmry.read().bits();
-        if intbits == 0 {
-            return PollResult::None;
-        }
-
         let mut ep_out = 0;
         let mut ep_in_complete = 0;
         let mut ep_setup = 0;
 
         for ep in 0..8u16 {
             let mask = 1 << ep;
-            if (intbits & mask) == 0 {
-                continue;
-            }
 
             let idx = ep as usize;
 
@@ -794,22 +778,45 @@ impl Inner {
             if let Ok(bank0) = self.bank0(EndpointAddress::from_parts(idx, UsbDirection::Out)) {
                 if bank0.received_setup_interrupt() {
                     ep_setup |= mask;
-                    // usb-device crate:
-                    //  "This event should continue to be reported until the
-                    //  packet is read." So we don't clear the flag here,
-                    //  instead it is cleared in the read handler.
+
+                    // The RXSTP interrupt is not cleared here, because doing so
+                    // would allow the USB hardware to overwrite the received
+                    // data, potentially before it is `read()` - see SAMD5x
+                    // datasheet "38.6.2.6 Management of SETUP Transactions".
+                    // Setup events are only relevant for control endpoints, and
+                    // in typical USB devices, endpoint 0 is the only control
+                    // endpoint. The usb-device `poll()` method, which calls
+                    // this `poll()`, will immediately `read()` endpoint 0 when
+                    // its setup bit is set.
                 }
 
-                if bank0.is_transfer_complete() {
+                // Clear the transfer complete and transfer failed interrupt flags
+                // so that execution leaves the USB interrupt until the host makes
+                // another transaction.  The transfer failed flag may have been set
+                // if an OUT transaction wasn't read() from the endpoint by the
+                // Class; the hardware will have NAKed (unless the endpoint is
+                // isochronous) and the host may retry.
+                bank0.clear_transfer_complete();
+
+                // Use the bk0rdy flag via is_ready() to indicate that data has been
+                // received successfully, rather than the interrupting trcpt0 via
+                // is_transfer_ready(), because data may have been received on an
+                // earlier poll() which cleared trcpt0.  bk0rdy is cleared in the
+                // endpoint read().
+                if bank0.is_ready() {
                     ep_out |= mask;
                 }
             }
         }
 
-        PollResult::Data {
-            ep_out,
-            ep_in_complete,
-            ep_setup,
+        if ep_out == 0 && ep_in_complete == 0 && ep_setup == 0 {
+            PollResult::None
+        } else {
+            PollResult::Data {
+                ep_out,
+                ep_in_complete,
+                ep_setup,
+            }
         }
     }
 
@@ -842,8 +849,6 @@ impl Inner {
 
             bank.clear_transfer_complete();
             bank.set_ready(false);
-
-            drop(bank);
 
             size
         } else {


### PR DESCRIPTION
(this PR has been heavily edited from the original - sorry)

Previously, when the USB interrupt was unmasked and a host issued an OUT transfer to an endpoint, the USB interrupt would continually fire until `read()` was called on that endpoint.  This could lead to a hang if the USB class controlling the endpoint was dependent on some lower-priority task before it could successfully read.  For example: if the class received data over USB to feed out to an interrupt-driven serial port, the class might have a full buffer so not call the endpoint `read()`, but the buffer would not drain because the serial port interrupt was lower priority than the USB one.  This behaviour came about because the USB `poll()` method didn't clear the endpoint interrupts for OUT transfers, but relied on the `read()` methods on endpoints to clear them.

The endpoints have a non-interrupting flag that indicates when the endpoint is ready to be read, and this change switches to using that to indicate data is available.

One subtle consequence of this change is that if a USB class doesn't `read()` a successful OUT transfer, the OUT data will sit idle indefinitely, until either it or the host transfers data.  A simple workaround is to enable the SOF interrupts using https://github.com/atsamd-rs/atsamd/pull/456 so that `poll()` gets called within the next millisecond.