### PR TITLE
Moved unproven feature gates to trait impl blocks

### DIFF
--- a/hal/src/thumbv6m/adc.rs
+++ b/hal/src/thumbv6m/adc.rs
@@ -140,6 +140,7 @@ impl Adc<ADC> {
     }
 }
 
+#[cfg(feature = "unproven")]
 impl<WORD, PIN> OneShot<ADC, WORD, PIN> for Adc<ADC>
 where
     WORD: From<u16>,
@@ -179,6 +180,7 @@ macro_rules! adc_pins {
 
 /// Implement [`Channel`] for [`v1::Pin`]s based on the implementations for
 /// `v2` [`Pin`]s
+#[cfg(feature = "unproven")]
 impl<I> Channel<ADC> for v1::Pin<I, v1::PfB>
 where
     I: PinId,

--- a/hal/src/thumbv6m/mod.rs
+++ b/hal/src/thumbv6m/mod.rs
@@ -10,13 +10,10 @@ pub mod calibration;
 pub mod clock;
 pub mod timer;
 
-#[cfg(feature = "unproven")]
 pub mod adc;
 
-#[cfg(feature = "unproven")]
 pub mod pwm;
 
-#[cfg(feature = "unproven")]
 pub mod watchdog;
 
 #[cfg(feature = "usb")]

--- a/hal/src/thumbv6m/pwm.rs
+++ b/hal/src/thumbv6m/pwm.rs
@@ -97,6 +97,7 @@ impl $TYPE {
     }
 }
 
+#[cfg(feature = "unproven")]
 impl PwmPin for $TYPE {
     type Duty = u16;
 
@@ -213,6 +214,7 @@ impl $TYPE {
     }
 }
 
+#[cfg(feature = "unproven")]
 impl Pwm for $TYPE {
     type Channel = Channel;
     type Time = Hertz;

--- a/hal/src/thumbv6m/watchdog.rs
+++ b/hal/src/thumbv6m/watchdog.rs
@@ -30,6 +30,7 @@ impl Watchdog {
     }
 }
 
+#[cfg(feature = "unproven")]
 impl watchdog::Watchdog for Watchdog {
     /// Feeds an existing watchdog to ensure the processor isn't reset.
     /// Sometimes commonly referred to as "kicking" or "refreshing".
@@ -39,6 +40,7 @@ impl watchdog::Watchdog for Watchdog {
 }
 
 /// Disables a running watchdog timer so the processor won't be reset.
+#[cfg(feature = "unproven")]
 impl watchdog::WatchdogDisable for Watchdog {
     fn disable(&mut self) {
         // Disable the watchdog timer.
@@ -48,6 +50,7 @@ impl watchdog::WatchdogDisable for Watchdog {
     }
 }
 
+#[cfg(feature = "unproven")]
 impl watchdog::WatchdogEnable for Watchdog {
     type Time = u8;
 

--- a/hal/src/thumbv7em/adc.rs
+++ b/hal/src/thumbv7em/adc.rs
@@ -247,6 +247,7 @@ impl<C> From<Adc<$ADC>> for InterruptAdc<$ADC, C>
     }
 }
 
+#[cfg(feature = "unproven")]
 impl<WORD, PIN> OneShot<$ADC, WORD, PIN> for Adc<$ADC>
 where
    WORD: From<u16>,
@@ -288,6 +289,7 @@ macro_rules! adc_pins {
 
 /// Implement [`Channel`] for [`v1::Pin`]s based on the implementations for
 /// `v2` [`Pin`]s
+#[cfg(feature = "unproven")]
 impl<I, A> Channel<A> for v1::Pin<I, v1::PfB>
 where
     I: PinId,

--- a/hal/src/thumbv7em/mod.rs
+++ b/hal/src/thumbv7em/mod.rs
@@ -15,11 +15,6 @@ pub use reset_cause::*;
 mod serial_number;
 pub use serial_number::*;
 
-#[cfg(feature = "unproven")]
 pub mod adc;
-
-#[cfg(feature = "unproven")]
 pub mod pwm;
-
-#[cfg(feature = "unproven")]
 pub mod watchdog;

--- a/hal/src/thumbv7em/pwm.rs
+++ b/hal/src/thumbv7em/pwm.rs
@@ -166,6 +166,7 @@ impl<I: PinId> $TYPE<I> {
     }
 }
 
+#[cfg(feature = "unproven")]
 impl<I: PinId> PwmPin for $TYPE<I> {
     type Duty = u16;
 
@@ -486,6 +487,7 @@ impl<I: PinId, M: PinMode> $TYPE<I, M> {
     }
 }
 
+#[cfg(feature = "unproven")]
 impl<I: PinId, M: PinMode> Pwm for $TYPE<I, M> {
     type Channel = Channel;
     type Time = Hertz;

--- a/hal/src/thumbv7em/watchdog.rs
+++ b/hal/src/thumbv7em/watchdog.rs
@@ -30,6 +30,7 @@ impl Watchdog {
     }
 }
 
+#[cfg(feature = "unproven")]
 impl watchdog::Watchdog for Watchdog {
     /// Feeds an existing watchdog to ensure the processor isn't reset.
     /// Sometimes commonly referred to as "kicking" or "refreshing".
@@ -39,6 +40,7 @@ impl watchdog::Watchdog for Watchdog {
 }
 
 /// Disables a running watchdog timer so the processor won't be reset.
+#[cfg(feature = "unproven")]
 impl watchdog::WatchdogDisable for Watchdog {
     fn disable(&mut self) {
         // Disable the watchdog timer.
@@ -48,6 +50,7 @@ impl watchdog::WatchdogDisable for Watchdog {
     }
 }
 
+#[cfg(feature = "unproven")]
 impl watchdog::WatchdogEnable for Watchdog {
     type Time = u8;
 


### PR DESCRIPTION
As suggested in #426, this PR moves the feature gates to the impl blocks. That way, you can still use parts of these modules without `unproven`.

If this is something we want, I would probably add replacement methods in case `unproven` isn't active to make them useful again. And make the e-h trait impls wrappers around those. 

At this state some modules' main functions wouldn't be accessible.