### PR TITLE
Get ready for v0.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Unreleased Changes
+
+---
+
+Changelog tracking started at v0.13

--- a/README.md
+++ b/README.md
@@ -89,6 +89,79 @@ $ cargo build --examples
 
 ## How to use a BSP (i.e. getting started writing your own code)
 
+A BSP (**B**oard **S**upport **P**ackage) is a crate that contains definitions specific to a particular board. These generally contain pin definitions, sometimes helper functions to setup certain peripherals, as well as examples to quickly get up and running with your board. BSPs are separated into 2 tiers:
+
+* Tier 1 boards are guaranteed to be up to date with the latest version of `atsamd-hal`
+
+* Tier 2 boards are tied to a specific version of `atsamd-hal`. They are not guaranteed to be updated when a new version of `atsamd-hal` gets released. 
+
+### Tier 1 BSPs
+
+* `feather_m0`
+
+* `feather_m4`
+
+* `metro_m0`
+
+* `metro_m4`
+
+* `pygamer`
+
+* `samd11_bare`
+
+* `wio_terminal`
+
+
+### Tier 2 BSPs
+
+* `arduino_mkr1000`
+
+* `arduino_mkrvidor4000`
+
+* `arduino_mkrzero`
+
+* `arduino_nano33iot`
+
+* `atsame54_xpro`
+
+* `circuit_playground_express`
+
+* `edgebadge`
+
+* `gemma_m0`
+
+* `grand_central_m4`
+
+* `itsybitsy_m0`
+
+* `itsybitsy_m4`
+
+* `p1am_100`
+
+* `pfza_proto1`
+
+* `pyportal`
+
+* `qt_py_m0`
+
+* `samd21_mini`
+
+* `serpente`
+
+* `sodaq_one`
+
+* `sodaq_sara_aff`
+
+* `trellis_m4`
+
+* `trinket_m0`
+
+* `wio_lite_mg126`
+
+* `wio_lite_w600`
+
+* `xiao_m0`
+
 To bootstrap your own project you should be able to copy/paste the Rust code from the examples folder within the folder of the BSP you've chosen. But you shouldn't copy the `Cargo.toml` file from there, since that's not only used for the examples, but also for the whole BSP itself. You want to make your own `Cargo.toml` file. If you're new to this and have no clue what you're doing then this is probably the line you want in there:
 
 ```rust

--- a/boards/arduino_mkr1000/Cargo.toml
+++ b/boards/arduino_mkr1000/Cargo.toml
@@ -19,7 +19,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/arduino_mkr1000/Cargo.toml
+++ b/boards/arduino_mkr1000/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/arduino_mkr1000/Cargo.toml
+++ b/boards/arduino_mkr1000/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arduino_mkr1000"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Eric Rushing <rushinge@gmail.com>"]
 description = "Board Support crate for the Arduino MKR 1000 WiFi"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/arduino_mkrvidor4000/Cargo.toml
+++ b/boards/arduino_mkrvidor4000/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dev-dependencies]

--- a/boards/arduino_mkrvidor4000/Cargo.toml
+++ b/boards/arduino_mkrvidor4000/Cargo.toml
@@ -19,7 +19,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/arduino_mkrvidor4000/Cargo.toml
+++ b/boards/arduino_mkrvidor4000/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arduino_mkrvidor4000"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Sameer Puri <purisame@spuri.io>"]
 description = "Board Support crate for the Arduino MKR VIDOR 4000"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]

--- a/boards/arduino_mkrzero/Cargo.toml
+++ b/boards/arduino_mkrzero/Cargo.toml
@@ -19,7 +19,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/arduino_mkrzero/Cargo.toml
+++ b/boards/arduino_mkrzero/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arduino_mkrzero"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Wez Furlong <wez@wezfurlong.org>", "David McGillicuddy <contact@djmcgill.co.uk>"]
 description = "Board Support crate for the Arduino MKRZERO"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]

--- a/boards/arduino_mkrzero/Cargo.toml
+++ b/boards/arduino_mkrzero/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/arduino_nano33iot/Cargo.toml
+++ b/boards/arduino_nano33iot/Cargo.toml
@@ -19,7 +19,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/arduino_nano33iot/Cargo.toml
+++ b/boards/arduino_nano33iot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arduino_nano33iot"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Gus Wynn <guswynn@gmail.com>"]
 description = "Board Support crate for the Arduino Nano 33 IOT"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]

--- a/boards/arduino_nano33iot/Cargo.toml
+++ b/boards/arduino_nano33iot/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/atsame54_xpro/Cargo.toml
+++ b/boards/atsame54_xpro/Cargo.toml
@@ -21,7 +21,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/atsame54_xpro/Cargo.toml
+++ b/boards/atsame54_xpro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atsame54_xpro"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     "Karsten Große <karsten.grosse@sympatron.de>"
 ]

--- a/boards/atsame54_xpro/Cargo.toml
+++ b/boards/atsame54_xpro/Cargo.toml
@@ -21,7 +21,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circuit_playground_express"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Paul Sajna <paulsajna@gmail.com>"]
 description = "Board Support crate for the Adafruit Circuit Playground Express"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -15,7 +15,6 @@ embedded-hal = "0.2.3"
 nb = "0.1"
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -15,7 +15,7 @@ embedded-hal = "0.2.3"
 nb = "0.1"
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dev-dependencies]

--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgebadge"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Jacob Rosenthal <@jacobrosenthal>"]
 description = "Board Support crate for the Adafruit EdgeBadge"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -22,7 +22,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -22,7 +22,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.micromath]

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -20,7 +20,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.panic_rtt]

--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -20,7 +20,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feather_m4"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2018"
 authors = ["Theodore DeRego <tderego94@gmail.com>"]
 description = "Board Support crate for the Adafruit Feather M4"

--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/gemma_m0/Cargo.toml
+++ b/boards/gemma_m0/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dev-dependencies]

--- a/boards/gemma_m0/Cargo.toml
+++ b/boards/gemma_m0/Cargo.toml
@@ -19,7 +19,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/gemma_m0/Cargo.toml
+++ b/boards/gemma_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gemma_m0"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Wez Furlong <wez@wezfurlong.org>"]
 description = "Board Support crate for the Adafruit Gemma M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -22,7 +22,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grand_central_m4"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Dustin Little <dlittle@toyatech.net>"
 ]

--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -22,7 +22,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itsybitsy_m0"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit ItsyBitsy M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -22,7 +22,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -22,7 +22,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/itsybitsy_m4/Cargo.toml
+++ b/boards/itsybitsy_m4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itsybitsy_m4"
-version = "0.5.0"
+version = "0.6.0"
 authors = [
     "Nic Hartley <nxh9052@rit.edu>",
     "Tom <twitchyliquid64@ciphersink.net>",

--- a/boards/itsybitsy_m4/Cargo.toml
+++ b/boards/itsybitsy_m4/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/itsybitsy_m4/Cargo.toml
+++ b/boards/itsybitsy_m4/Cargo.toml
@@ -25,7 +25,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -20,7 +20,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.rtic-monotonic]

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -19,7 +19,6 @@ version = "0.6.13"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metro_m4"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Paul Sajna <sajattack@gmail.com>", "Wez Furlong <wez@wezfurlong.org>"]
 description = "Board Support crate for the Adafruit Metro M4"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.6.13"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/p1am_100/Cargo.toml
+++ b/boards/p1am_100/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p1am_100"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Quentin Smith <quentin@mit.edu>"]
 description = "Board Support crate for the Facts Engineering P1AM-100"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/p1am_100/Cargo.toml
+++ b/boards/p1am_100/Cargo.toml
@@ -23,7 +23,6 @@ version = "0.5.1"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/p1am_100/Cargo.toml
+++ b/boards/p1am_100/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.5.1"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.panic_rtt]

--- a/boards/pfza_proto1/Cargo.toml
+++ b/boards/pfza_proto1/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dev-dependencies]

--- a/boards/pfza_proto1/Cargo.toml
+++ b/boards/pfza_proto1/Cargo.toml
@@ -19,7 +19,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/pfza_proto1/Cargo.toml
+++ b/boards/pfza_proto1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pfza_proto1"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Michael van Niekerk <mvniekerk@gmail.com>"]
 description = "Board Support crate for the PathfinderZA Proto1"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.micromath]

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pygamer"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
     "Paul Sajna <sajattack@gmail.com>",
     "Wez Furlong <wez@wezfurlong.org>"

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -25,7 +25,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/pyportal/Cargo.toml
+++ b/boards/pyportal/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dev-dependencies]

--- a/boards/pyportal/Cargo.toml
+++ b/boards/pyportal/Cargo.toml
@@ -23,7 +23,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/pyportal/Cargo.toml
+++ b/boards/pyportal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyportal"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
     "Shella Stephens <shella@infracoven.io",
     "Paul Sajna <sajattack@gmail.com>",

--- a/boards/qt_py_m0/Cargo.toml
+++ b/boards/qt_py_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qt_py_m0"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Garret Kelly <gkelly@gkel.ly>"]
 description = "Board Support crate for the Adafruit QT Py"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/qt_py_m0/Cargo.toml
+++ b/boards/qt_py_m0/Cargo.toml
@@ -14,18 +14,12 @@ cortex-m = "0.6"
 embedded-hal = "0.2.3"
 nb = "0.1"
 cortex-m-rt = { version = "0.6.12", optional = true }
-atsamd-hal = { path = "../../hal", version = "0.12", default-features = false }
 usb-device = { version = "0.2", optional = true }
 usbd-serial = { version = "0.1", optional = true }
 
-# [dependencies.cortex-m-rt]
-# version = "0.6.12"
-# optional = true
-
-# [dependencies.atsamd-hal]
-# path = "../../hal"
-# version = "0.12"
-# default-features = false
+[dependencies.atsamd-hal]
+version = "0.12"
+default-features = false
 
 [dev-dependencies]
 panic-halt = "0.2"

--- a/boards/qt_py_m0/Cargo.toml
+++ b/boards/qt_py_m0/Cargo.toml
@@ -18,7 +18,7 @@ usb-device = { version = "0.2", optional = true }
 usbd-serial = { version = "0.1", optional = true }
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dev-dependencies]

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -23,9 +23,17 @@ path = "../../hal"
 version = "0.12"
 default-features = false
 
+[dependencies.cortex-m-semihosting]
+version = "0.3"
+optional = true
+
+[dependencies.panic-semihosting]
+version = "0.5"
+optional = true
+
 [dev-dependencies]
 panic-halt = "0.2"
-panic-probe = "0.1.0"
+panic-probe = "0.2.0"
 rtt-target = { version = "0.3.0", features = ["cortex-m"] }
 
 [features]
@@ -33,7 +41,7 @@ rtt-target = { version = "0.3.0", features = ["cortex-m"] }
 default = ["rt", "atsamd-hal/samd11c"]
 rt = ["cortex-m-rt", "atsamd-hal/samd11c-rt"]
 unproven = ["atsamd-hal/unproven"]
-use_semihosting = []
+use_semihosting = ["cortex-m-semihosting", "panic-semihosting"]
 
 [profile.release]
 debug = true
@@ -44,7 +52,7 @@ chip = "ATSAMD11C14A"
 
 [[example]]
 name = "adc"
-required-features = ["unproven", "rt"]
+required-features = ["unproven", "rt", "use_semihosting"]
 
 [[example]]
 name = "blinky_basic"

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -20,7 +20,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.cortex-m-semihosting]

--- a/boards/samd11_bare/examples/adc.rs
+++ b/boards/samd11_bare/examples/adc.rs
@@ -14,15 +14,17 @@
 #![no_std]
 #![no_main]
 
+use panic_probe as _;
+
 use bsp::hal;
 use samd11_bare as bsp;
 
 use bsp::entry;
 use hal::adc::Adc;
 use hal::clock::GenericClockController;
+use hal::gpio::v2::*;
 use hal::pac::{CorePeripherals, Peripherals};
 use hal::prelude::*;
-use panic_probe as _;
 use rtt_target::{rprintln, rtt_init_print};
 
 #[entry]
@@ -39,10 +41,10 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let mut delay = hal::delay::Delay::new(core.SYST, &mut clocks);
-    let mut pins = bsp::Pins::new(peripherals.PORT);
+    let pins = bsp::Pins::new(peripherals.PORT);
 
     let mut adc = Adc::adc(peripherals.ADC, &mut peripherals.PM, &mut clocks);
-    let mut a0 = pins.d1.into_function_b(&mut pins.port);
+    let mut a0: Pin<_, AlternateB> = pins.d1.into_mode();
 
     loop {
         let data: u16 = adc.read(&mut a0).unwrap();

--- a/boards/samd11_bare/examples/blinky_basic.rs
+++ b/boards/samd11_bare/examples/blinky_basic.rs
@@ -1,35 +1,34 @@
 #![no_std]
 #![no_main]
 
-use bsp::hal;
 #[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;
 #[cfg(feature = "use_semihosting")]
 use panic_semihosting as _;
+
+use bsp::hal;
+use bsp::pac;
 use samd11_bare as bsp;
 
 use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
-use hal::pac::{CorePeripherals, Peripherals};
 use hal::prelude::*;
+use pac::{CorePeripherals, Peripherals};
 
 #[entry]
 fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
-
     let mut clocks = GenericClockController::with_internal_32kosc(
         peripherals.GCLK,
         &mut peripherals.PM,
         &mut peripherals.SYSCTRL,
         &mut peripherals.NVMCTRL,
     );
-
-    let mut pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led = pins.d2.into_open_drain_output(&mut pins.port);
+    let pins = bsp::Pins::new(peripherals.PORT);
+    let mut red_led: bsp::Led = pins.d2.into();
     let mut delay = Delay::new(core.SYST, &mut clocks);
-
     loop {
         delay.delay_ms(200u8);
         red_led.set_high().unwrap();

--- a/boards/samd11_bare/examples/pwm.rs
+++ b/boards/samd11_bare/examples/pwm.rs
@@ -1,19 +1,22 @@
 #![no_std]
 #![no_main]
 
-use bsp::hal;
 #[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;
 #[cfg(feature = "use_semihosting")]
 use panic_semihosting as _;
+
 use samd11_bare as bsp;
 
-use cortex_m_rt::entry;
+use bsp::{hal, pac};
+
+use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
-use hal::pac::{CorePeripherals, Peripherals};
+use hal::gpio::v2::*;
 use hal::prelude::*;
 use hal::pwm::{Channel, Pwm0};
+use pac::{CorePeripherals, Peripherals};
 
 #[entry]
 fn main() -> ! {
@@ -27,10 +30,10 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let mut delay = Delay::new(core.SYST, &mut clocks);
-    let mut pins = bsp::Pins::new(peripherals.PORT);
+    let pins = bsp::Pins::new(peripherals.PORT);
 
-    let _d1 = pins.d1.into_function_f(&mut pins.port);
-    let _d14 = pins.d14.into_function_f(&mut pins.port);
+    let _d1: Pin<_, AlternateF> = pins.d1.into_mode();
+    let _d14: Pin<_, AlternateF> = pins.d14.into_mode();
 
     let gclk0 = clocks.gclk0();
     let mut pwm0 = Pwm0::new(

--- a/boards/samd11_bare/examples/timer.rs
+++ b/boards/samd11_bare/examples/timer.rs
@@ -1,18 +1,21 @@
 #![no_std]
 #![no_main]
 
-use bsp::hal;
 #[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;
 #[cfg(feature = "use_semihosting")]
 use panic_semihosting as _;
+
 use samd11_bare as bsp;
+
+use bsp::hal;
+use bsp::pac;
 
 use bsp::entry;
 use hal::clock::GenericClockController;
-use hal::pac::Peripherals;
 use hal::prelude::*;
 use hal::timer::TimerCounter;
+use pac::Peripherals;
 
 #[entry]
 fn main() -> ! {
@@ -30,8 +33,8 @@ fn main() -> ! {
     let mut timer = TimerCounter::tc1_(&timer_clock, peripherals.TC1, &mut peripherals.PM);
     timer.start(1u32.hz());
 
-    let mut pins = bsp::Pins::new(peripherals.PORT);
-    let mut d2 = pins.d2.into_open_drain_output(&mut pins.port);
+    let pins = bsp::Pins::new(peripherals.PORT);
+    let mut d2: bsp::Led = pins.d2.into();
 
     loop {
         d2.set_high().unwrap();

--- a/boards/samd11_bare/src/lib.rs
+++ b/boards/samd11_bare/src/lib.rs
@@ -1,85 +1,116 @@
 #![no_std]
 
-pub use atsamd_hal as hal;
-
 #[cfg(feature = "rt")]
 extern crate cortex_m_rt;
 #[cfg(feature = "rt")]
 pub use cortex_m_rt::entry;
 
-use hal::prelude::*;
-use hal::*;
-
-pub use hal::common::*;
-
+pub use atsamd_hal as hal;
+pub use embedded_hal as ehal;
 pub use hal::pac;
 
-use gpio::{Floating, Input, PfC, Port};
-
 use hal::clock::GenericClockController;
-use hal::sercom::{I2CMaster0, PadPin, UART0};
+use hal::sercom::{
+    v2::{
+        uart::{self, BaudMode, Oversampling},
+        Sercom0,
+    },
+    I2CMaster0,
+};
 use hal::time::Hertz;
 
-define_pins!(
-    /// Maps the pins to their physical pins.
-    struct Pins,
-    pac: pac,
+hal::bsp_pins! {
+    PA05 {
+        name: d1
+        aliases: {
+            AlternateC: UartRx
+        }
+    }
+    PA08 {
+        name: d2
+        aliases: {
+            PushPullOutput: Led
+        }
+    }
+    PA09 {
+        name: d3
+    }
+    PA14 {
+        name: d4
+        aliases: {
+            AlternateC: Sda
+        }
+    }
+    PA15 {
+        name: d5
+        aliases: {
+            AlternateC: Scl
+        }
+    }
+    PA28 {
+        /// RST pin
+        name: d6
+    }
+    PA30 {
+        name: d7
+    }
+    PA31 {
+        name: d8
+    }
+    PA24 {
+        name: d9
+    }
+    PA25 {
+        name: d10
+    }
+    PA02 {
+        name: d13
+    }
+    PA04 {
+        name: d14
+        aliases: {
+            AlternateC: UartTx
+        }
+    }
+}
 
-    pin d1 = a5,
-    pin d2 = a8,
-    pin d3 = a9,
-    pin d4 = a14,
-    pin d5 = a15,
-    pin d6 = a28, // RST
-    pin d7 = a30,
+pub type UartPads = uart::Pads<Sercom0, UartRx, UartTx>;
 
-    pin d8 = a31,
-    pin d9 = a24,
-    pin d10 = a25,
-
-    // 11 & 12 are GND/VCC
-
-    pin d13 = a2,
-    pin d14 = a4,
-);
+/// UART device for the labelled RX & TX pins
+pub type Uart = uart::Uart<uart::Config<UartPads>, uart::Duplex>;
 
 /// Convenience for setting up the D1 and D14 pins to
 /// operate as UART RX/TX (respectively) running at the specified baud.
-pub fn uart<F: Into<Hertz>>(
+pub fn uart(
     clocks: &mut GenericClockController,
-    baud: F,
+    baud: impl Into<Hertz>,
     sercom0: pac::SERCOM0,
     pm: &mut pac::PM,
-    d1: gpio::Pa5<Input<Floating>>,
-    d14: gpio::Pa4<Input<Floating>>,
-    port: &mut Port,
-) -> UART0<hal::sercom::Sercom0Pad3<gpio::Pa5<PfC>>, hal::sercom::Sercom0Pad2<gpio::Pa4<PfC>>, (), ()>
-{
+    rx: impl Into<UartRx>,
+    tx: impl Into<UartTx>,
+) -> Uart {
     let gclk0 = clocks.gclk0();
-
-    UART0::new(
-        &clocks.sercom0_core(&gclk0).unwrap(),
-        baud.into(),
-        sercom0,
-        pm,
-        (d1.into_pad(port), d14.into_pad(port)),
-    )
+    let clock = &clocks.sercom0_core(&gclk0).unwrap();
+    let baud = baud.into();
+    let pads = uart::Pads::default().rx(rx.into()).tx(tx.into());
+    uart::Config::new(pm, sercom0, pads, clock.freq())
+        .baud(baud, BaudMode::Fractional(Oversampling::Bits16))
+        .enable()
 }
+
+/// I2C master for the labelled SDA & SCL pins
+pub type I2C = I2CMaster0<Sda, Scl>;
 
 /// Convenience for setting up the D4 and D5 pins to operate as I²C
 /// SDA/SDL (respectively) running at the specified baud.
-pub fn i2c_master<F: Into<Hertz>>(
+pub fn i2c_master(
     clocks: &mut GenericClockController,
-    bus_speed: F,
+    bus_speed: impl Into<Hertz>,
     sercom0: pac::SERCOM0,
     pm: &mut pac::PM,
-    sda: gpio::Pa14<Input<Floating>>,
-    scl: gpio::Pa15<Input<Floating>>,
-    port: &mut Port,
-) -> I2CMaster0<
-    hal::sercom::Sercom0Pad0<gpio::Pa14<gpio::PfC>>,
-    hal::sercom::Sercom0Pad1<gpio::Pa15<gpio::PfC>>,
-> {
+    sda: impl Into<Sda>,
+    scl: impl Into<Scl>,
+) -> I2C {
     let gclk0 = clocks.gclk0();
 
     I2CMaster0::new(
@@ -87,7 +118,7 @@ pub fn i2c_master<F: Into<Hertz>>(
         bus_speed.into(),
         sercom0,
         pm,
-        sda.into_pad(port),
-        scl.into_pad(port),
+        sda.into(),
+        scl.into(),
     )
 }

--- a/boards/samd21_mini/Cargo.toml
+++ b/boards/samd21_mini/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dev-dependencies]

--- a/boards/samd21_mini/Cargo.toml
+++ b/boards/samd21_mini/Cargo.toml
@@ -19,7 +19,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/samd21_mini/Cargo.toml
+++ b/boards/samd21_mini/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samd21_mini"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Ze'ev Klapow <zklapow@gmail.com>"]
 description = "Board Support crate for the Sparkfun SAMD21 Mini Breakout"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/serpente/Cargo.toml
+++ b/boards/serpente/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dev-dependencies]

--- a/boards/serpente/Cargo.toml
+++ b/boards/serpente/Cargo.toml
@@ -19,7 +19,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/serpente/Cargo.toml
+++ b/boards/serpente/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serpente"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Jens Andersen <jens.andersen@gmail.com>"]
 description = "Board Support crate for the Serpente board"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/sodaq_one/Cargo.toml
+++ b/boards/sodaq_one/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dev-dependencies]

--- a/boards/sodaq_one/Cargo.toml
+++ b/boards/sodaq_one/Cargo.toml
@@ -19,7 +19,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/sodaq_one/Cargo.toml
+++ b/boards/sodaq_one/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sodaq_one"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Robert Hennig <robert.hennig@freylax.de>"]
 description = "Board Support crate for the SODAQ ONE"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/sodaq_sara_aff/Cargo.toml
+++ b/boards/sodaq_sara_aff/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dev-dependencies]

--- a/boards/sodaq_sara_aff/Cargo.toml
+++ b/boards/sodaq_sara_aff/Cargo.toml
@@ -19,7 +19,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/sodaq_sara_aff/Cargo.toml
+++ b/boards/sodaq_sara_aff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sodaq_sara_aff"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Stefan de Lange <langestefan@msn.com>"]
 description = "Board Support crate for the Sodaq SARA AFF"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -30,7 +30,7 @@ version = "0.4"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.keypad]

--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -30,7 +30,6 @@ version = "0.4"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trellis_m4"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "Tony Arcieri <bascule@gmail.com>",
     "Paul Sajna <sajattack@gmail.com>",

--- a/boards/trinket_m0/Cargo.toml
+++ b/boards/trinket_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trinket_m0"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit Trinket M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/trinket_m0/Cargo.toml
+++ b/boards/trinket_m0/Cargo.toml
@@ -22,7 +22,6 @@ version = "~0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/trinket_m0/Cargo.toml
+++ b/boards/trinket_m0/Cargo.toml
@@ -22,7 +22,7 @@ version = "~0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/wio_lite_mg126/Cargo.toml
+++ b/boards/wio_lite_mg126/Cargo.toml
@@ -24,7 +24,6 @@ version = "0.1"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/wio_lite_mg126/Cargo.toml
+++ b/boards/wio_lite_mg126/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wio_lite_mg126"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Max Khardin <max.khardin@gmail.com"]
 description = "Board Support crate for the Wio Lite MG126"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]

--- a/boards/wio_lite_mg126/Cargo.toml
+++ b/boards/wio_lite_mg126/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.1"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -43,7 +43,7 @@ generic-array = { version = "0.14", optional = true }
 seeed-erpc = { version = "0.1.1", optional = true }
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dev-dependencies]

--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wio_terminal"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Tom <twitchyliquid64@ciphersink.net>"

--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -43,7 +43,6 @@ generic-array = { version = "0.14", optional = true }
 seeed-erpc = { version = "0.1.1", optional = true }
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/xiao_m0/Cargo.toml
+++ b/boards/xiao_m0/Cargo.toml
@@ -19,7 +19,6 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.12"
 default-features = false
 

--- a/boards/xiao_m0/Cargo.toml
+++ b/boards/xiao_m0/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.6.12"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.12"
+version = "0.13"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/xiao_m0/Cargo.toml
+++ b/boards/xiao_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xiao_m0"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Garret Kelly <gdk@google.com>"]
 description = "Board support crate for the Seeed Studio Seeeduino XIAO"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/crates.json
+++ b/crates.json
@@ -33,7 +33,7 @@
       "build": "cargo build --examples --features=unproven,usb,dma,rtic"
     },
     "feather_m4": {
-	  "tier": 1,
+	  "tier": 2,
       "build": "cargo build --examples --features=unproven,usb"
     },
     "gemma_m0": {

--- a/crates.json
+++ b/crates.json
@@ -78,7 +78,7 @@
     },
     "samd11_bare": {
 	  "tier": 1,
-      "build": "cargo build --release --examples --features=unproven"
+      "build": "cargo build --release --examples --features=unproven,rt,use-semihosting"
     },
     "samd21_mini": {
 	  "tier": 2,

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atsamd-hal"
-version = "0.12.0"
+version = "0.13.0"
 authors = [
     "Wez Furlong <wez@wezfurlong.org>",
     "Paul Sajna <sajattack@gmail.com>",

--- a/hal/src/delay.rs
+++ b/hal/src/delay.rs
@@ -4,8 +4,8 @@ use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m::peripheral::SYST;
 
 use crate::clock::GenericClockController;
+use crate::ehal::blocking::delay::{DelayMs, DelayUs};
 use crate::time::Hertz;
-use hal::blocking::delay::{DelayMs, DelayUs};
 
 /// System timer (SysTick) as a delay provider
 pub struct Delay {

--- a/hal/src/gpio/mod.rs
+++ b/hal/src/gpio/mod.rs
@@ -97,6 +97,8 @@
 //! [`bsp_pins`]: crate::bsp_pins
 
 pub mod v1;
+
+#[allow(deprecated)]
 pub use v1::*;
 
 pub mod v2;

--- a/hal/src/gpio/v1.rs
+++ b/hal/src/gpio/v1.rs
@@ -19,11 +19,10 @@
     Please use the gpio::v2 module instead."
 )]
 
-use crate::pac::PORT;
-use hal::digital::v2::OutputPin;
-
+use crate::ehal::digital::v2::OutputPin;
 #[cfg(feature = "unproven")]
-use hal::digital::v2::{InputPin, StatefulOutputPin, ToggleableOutputPin};
+use crate::ehal::digital::v2::{InputPin, StatefulOutputPin, ToggleableOutputPin};
+use crate::pac::PORT;
 
 use crate::gpio::v2::{self, Alternate, AlternateConfig, AnyPin, OutputConfig};
 pub use crate::gpio::v2::{PinId, PinMode};

--- a/hal/src/gpio/v1.rs
+++ b/hal/src/gpio/v1.rs
@@ -13,8 +13,13 @@
 //! use of type states to make the interface (ideally, or at least practically)
 //! impossible to misuse.
 
-use crate::pac::PORT;
+#![deprecated(
+    since = "0.13.0",
+    note = "The gpio::v1 module is deprecated, and will be removed in a subsequent release.
+    Please use the gpio::v2 module instead."
+)]
 
+use crate::pac::PORT;
 use hal::digital::v2::OutputPin;
 
 #[cfg(feature = "unproven")]

--- a/hal/src/gpio/v2/dynpin.rs
+++ b/hal/src/gpio/v2/dynpin.rs
@@ -61,9 +61,9 @@ use core::convert::TryFrom;
 
 use paste::paste;
 
-use hal::digital::v2::OutputPin;
+use crate::ehal::digital::v2::OutputPin;
 #[cfg(feature = "unproven")]
-use hal::digital::v2::{InputPin, StatefulOutputPin, ToggleableOutputPin};
+use crate::ehal::digital::v2::{InputPin, StatefulOutputPin, ToggleableOutputPin};
 
 use super::pin::*;
 use super::reg::RegisterInterface;

--- a/hal/src/gpio/v2/pin.rs
+++ b/hal/src/gpio/v2/pin.rs
@@ -99,9 +99,9 @@ use core::convert::Infallible;
 use core::marker::PhantomData;
 use core::mem::transmute;
 
-use hal::digital::v2::OutputPin;
+use crate::ehal::digital::v2::OutputPin;
 #[cfg(feature = "unproven")]
-use hal::digital::v2::{InputPin, StatefulOutputPin, ToggleableOutputPin};
+use crate::ehal::digital::v2::{InputPin, StatefulOutputPin, ToggleableOutputPin};
 use paste::paste;
 
 use crate::pac::PORT;

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -72,6 +72,7 @@ pub use atsame54p as pac;
     note = "`atsamd_hal::target_device` is deprecated and will be removed in a future release. \
     Use `atsamd_hal::pac` instead"
 )]
+#[cfg(not(feature = "library"))]
 pub use pac as target_device;
 
 #[cfg(feature = "use_rtt")]

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -147,6 +147,7 @@ pub mod common {
     pub use crate::sercom;
     pub use crate::sleeping_delay;
     #[cfg(feature = "device")]
+    #[allow(deprecated)]
     pub use crate::spi_common;
     pub use crate::time;
     pub use crate::timer_params;

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -128,6 +128,11 @@ pub mod pad {
 }
 
 // This module maintains backwards compatibility within this major release
+#[deprecated(
+    since = "0.13.0",
+    note = "The `common` module is deprecated and will be removed in a future
+    release. Directly use modules from atsamd_hal instead."
+)]
 #[macro_use]
 pub mod common {
     #[cfg(feature = "device")]
@@ -169,23 +174,43 @@ pub mod common {
 // should be removed.
 
 #[cfg(feature = "samd51")]
+#[deprecated(
+    since = "0.13.0",
+    note = "The `samd51` module is deprecated and will be removed in a future
+    release."
+)]
 pub mod samd51 {
     #[cfg(feature = "unproven")]
     pub use crate::pwm;
 }
 
+#[deprecated(
+    since = "0.13.0",
+    note = "The `same51` module is deprecated and will be removed in a future
+    release."
+)]
 #[cfg(feature = "same51")]
 pub mod same51 {
     #[cfg(feature = "unproven")]
     pub use crate::pwm;
 }
 
+#[deprecated(
+    since = "0.13.0",
+    note = "The `same53` module is deprecated and will be removed in a future
+    release."
+)]
 #[cfg(feature = "same53")]
 pub mod same53 {
     #[cfg(feature = "unproven")]
     pub use crate::pwm;
 }
 
+#[deprecated(
+    since = "0.13.0",
+    note = "The `same54` module is deprecated and will be removed in a future
+    release."
+)]
 #[cfg(feature = "same54")]
 pub mod same54 {
     #[cfg(feature = "unproven")]

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -1,6 +1,12 @@
 #![no_std]
 
-pub extern crate embedded_hal as hal;
+#[deprecated(
+    since = "0.13.0",
+    note = "`atsamd_hal::hal` is deprecated and will be removed in a future release. \
+    Use `atsamd_hal::ehal` instead"
+)]
+pub use embedded_hal as hal;
+pub use embedded_hal as ehal;
 
 pub use paste;
 
@@ -60,6 +66,13 @@ pub use atsame54n as pac;
 
 #[cfg(feature = "same54p")]
 pub use atsame54p as pac;
+
+#[deprecated(
+    since = "0.13.0",
+    note = "`atsamd_hal::target_device` is deprecated and will be removed in a future release. \
+    Use `atsamd_hal::pac` instead"
+)]
+pub use pac as target_device;
 
 #[cfg(feature = "use_rtt")]
 pub use jlink_rtt;

--- a/hal/src/prelude.rs
+++ b/hal/src/prelude.rs
@@ -1,6 +1,7 @@
 //! Import the prelude to gain convenient access to helper traits
 pub use crate::eic::pin::EicPin;
-pub use crate::gpio::GpioExt as _atsamd21_hal_gpio_GpioExt;
+#[allow(deprecated)]
+pub use crate::gpio::v1::GpioExt as _atsamd21_hal_gpio_GpioExt;
 pub use crate::spi_common::CommonSpi as _atsamd_hal_spi_common_CommonSpi;
 pub use crate::time::U32Ext as _atsamd21_hal_time_U32Ext;
 pub use crate::timer_traits::InterruptDrivenTimer as _atsamd_hal_timer_traits_InterruptDrivenTimer;

--- a/hal/src/prelude.rs
+++ b/hal/src/prelude.rs
@@ -10,11 +10,11 @@ pub use crate::timer_traits::InterruptDrivenTimer as _atsamd_hal_timer_traits_In
 // embedded-hal doesn’t yet have v2 in its prelude, so we need to
 // export it ourselves
 #[cfg(feature = "unproven")]
-pub use hal::digital::v2::InputPin as _atsamd_hal_embedded_hal_digital_v2_InputPin;
-pub use hal::digital::v2::OutputPin as _atsamd_hal_embedded_hal_digital_v2_OutputPin;
+pub use crate::ehal::digital::v2::InputPin as _atsamd_hal_embedded_hal_digital_v2_InputPin;
+pub use crate::ehal::digital::v2::OutputPin as _atsamd_hal_embedded_hal_digital_v2_OutputPin;
 #[cfg(feature = "unproven")]
-pub use hal::digital::v2::ToggleableOutputPin as _atsamd_hal_embedded_hal_digital_v2_ToggleableOutputPin;
+pub use crate::ehal::digital::v2::ToggleableOutputPin as _atsamd_hal_embedded_hal_digital_v2_ToggleableOutputPin;
 
-pub use hal::prelude::*;
+pub use crate::ehal::prelude::*;
 
 pub use nb;

--- a/hal/src/prelude.rs
+++ b/hal/src/prelude.rs
@@ -2,6 +2,7 @@
 pub use crate::eic::pin::EicPin;
 #[allow(deprecated)]
 pub use crate::gpio::v1::GpioExt as _atsamd21_hal_gpio_GpioExt;
+#[allow(deprecated)]
 pub use crate::spi_common::CommonSpi as _atsamd_hal_spi_common_CommonSpi;
 pub use crate::time::U32Ext as _atsamd21_hal_time_U32Ext;
 pub use crate::timer_traits::InterruptDrivenTimer as _atsamd_hal_timer_traits_InterruptDrivenTimer;

--- a/hal/src/rtc.rs
+++ b/hal/src/rtc.rs
@@ -1,11 +1,11 @@
 //! Real-time clock/counter
+use crate::ehal::timer::{CountDown, Periodic};
 use crate::pac::rtc::{MODE0, MODE2};
 use crate::pac::RTC;
 use crate::time::{Hertz, Nanoseconds};
 use crate::timer_traits::InterruptDrivenTimer;
 use crate::typelevel::Sealed;
 use core::marker::PhantomData;
-use hal::timer::{CountDown, Periodic};
 use void::Void;
 
 #[cfg(feature = "sdmmc")]

--- a/hal/src/sercom/v1/pads.rs
+++ b/hal/src/sercom/v1/pads.rs
@@ -29,6 +29,8 @@
 //!
 //! [`free`]: Pad::free
 
+#![allow(deprecated)]
+
 use core::marker::PhantomData;
 
 use paste::paste;

--- a/hal/src/sleeping_delay.rs
+++ b/hal/src/sleeping_delay.rs
@@ -2,9 +2,9 @@
 use core::sync::atomic;
 use cortex_m::asm;
 
+use crate::ehal::blocking::delay::{DelayMs, DelayUs};
 use crate::time::U32Ext;
 use crate::timer_traits::InterruptDrivenTimer;
-use hal::blocking::delay::{DelayMs, DelayUs};
 
 const NUM_US_IN_S: u32 = 1_000_000;
 

--- a/hal/src/spi_common.rs
+++ b/hal/src/spi_common.rs
@@ -1,4 +1,9 @@
-/// Consolidated common logic for dealing with ATSAMD SPI peripherals.
+#![deprecated(
+    since = "0.13.0",
+    note = "The `spi_common` module is deprecated, and will be removed in a subsequent release.
+    Please use the `sercom::v2::spi::AnySpi` trait instead."
+)]
+
 use crate::hal::spi::{Mode, Phase, Polarity};
 use crate::time::{Hertz, U32Ext};
 
@@ -13,6 +18,7 @@ use crate::pac::sercom0::SPI;
 ))]
 use crate::pac::sercom0::SPIM as SPI;
 
+/// Consolidated common logic for dealing with ATSAMD SPI peripherals.
 pub trait CommonSpi {
     /// Helper for accessing the spi member of the sercom instance
     fn spi(&self) -> &SPI;

--- a/hal/src/thumbv6m/adc.rs
+++ b/hal/src/thumbv6m/adc.rs
@@ -1,5 +1,6 @@
 //! Analogue-to-Digital Conversion
 use crate::clock::GenericClockController;
+#[allow(deprecated)]
 use crate::gpio::v1;
 use crate::gpio::v2::*;
 use crate::hal::adc::{Channel, OneShot};
@@ -179,6 +180,7 @@ macro_rules! adc_pins {
 
 /// Implement [`Channel`] for [`v1::Pin`]s based on the implementations for
 /// `v2` [`Pin`]s
+#[allow(deprecated)]
 impl<I> Channel<ADC> for v1::Pin<I, v1::PfB>
 where
     I: PinId,

--- a/hal/src/thumbv6m/eic/pin.rs
+++ b/hal/src/thumbv6m/eic/pin.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::gpio::{
     self, v2::AnyPin, v2::FloatingInterrupt, v2::Pin, v2::PinId, v2::PinMode,
     v2::PullDownInterrupt, v2::PullUpInterrupt, Port,

--- a/hal/src/thumbv6m/sercom/v1.rs
+++ b/hal/src/thumbv6m/sercom/v1.rs
@@ -13,5 +13,9 @@ pub mod spi;
 pub mod uart;
 
 pub use self::i2c::*;
+
+#[allow(deprecated)]
 pub use self::spi::*;
+
+#[allow(deprecated)]
 pub use self::uart::*;

--- a/hal/src/thumbv6m/sercom/v1/spi.rs
+++ b/hal/src/thumbv6m/sercom/v1/spi.rs
@@ -16,6 +16,7 @@ use crate::pac::{SERCOM2, SERCOM3};
 use crate::pac::{SERCOM4, SERCOM5};
 use crate::sercom::v1::pads::CompatiblePad;
 use crate::sercom::v2::*;
+#[allow(deprecated)]
 use crate::spi_common::CommonSpi;
 use crate::time::Hertz;
 
@@ -126,6 +127,7 @@ macro_rules! spi_master {
             sercom: $SERCOM,
         }
 
+        #[allow(deprecated)]
         impl<MISO, MOSI, SCK> CommonSpi for $Type<MISO, MOSI, SCK> {
             /// Helper for accessing the spi member of the sercom instance
             fn spi(&self) -> &SPI {
@@ -138,6 +140,7 @@ macro_rules! spi_master {
             }
         }
 
+        #[allow(deprecated)]
         impl<MISO, MOSI, SCK> $Type<MISO, MOSI, SCK> {
             /// Power on and configure SERCOMX to work as an SPI Master operating
             /// with the specified frequency and SPI Mode. The padout specifies
@@ -232,6 +235,7 @@ macro_rules! spi_master {
             }
         }
 
+        #[allow(deprecated)]
         impl<MISO, MOSI, SCK> FullDuplex<u8> for $Type<MISO, MOSI, SCK> {
             type Error = Error;
 

--- a/hal/src/thumbv6m/sercom/v1/spi.rs
+++ b/hal/src/thumbv6m/sercom/v1/spi.rs
@@ -268,13 +268,16 @@ macro_rules! spi_master {
             }
         }
 
-        impl<MISO, MOSI, SCK> ::hal::blocking::spi::transfer::Default<u8>
+        impl<MISO, MOSI, SCK> ::embedded_hal::blocking::spi::transfer::Default<u8>
             for $Type<MISO, MOSI, SCK>
         {
         }
-        impl<MISO, MOSI, SCK> ::hal::blocking::spi::write::Default<u8> for $Type<MISO, MOSI, SCK> {}
+        impl<MISO, MOSI, SCK> ::embedded_hal::blocking::spi::write::Default<u8>
+            for $Type<MISO, MOSI, SCK>
+        {
+        }
         #[cfg(feature = "unproven")]
-        impl<MISO, MOSI, SCK> ::hal::blocking::spi::write_iter::Default<u8>
+        impl<MISO, MOSI, SCK> ::embedded_hal::blocking::spi::write_iter::Default<u8>
             for $Type<MISO, MOSI, SCK>
         {
         }

--- a/hal/src/thumbv6m/sercom/v1/spi.rs
+++ b/hal/src/thumbv6m/sercom/v1/spi.rs
@@ -1,3 +1,9 @@
+#![deprecated(
+    since = "0.13.0",
+    note = "The `sercom::v1::spi` module is deprecated, and will be removed in a subsequent release.
+    Please use the `sercom::v2::spi` module instead."
+)]
+
 use core::marker::PhantomData;
 
 use crate::clock;

--- a/hal/src/thumbv6m/sercom/v1/uart.rs
+++ b/hal/src/thumbv6m/sercom/v1/uart.rs
@@ -1,3 +1,9 @@
+#![deprecated(
+    since = "0.13.0",
+    note = "The `sercom::v1::uart` module is deprecated, and will be removed in a subsequent release.
+    Please use the `sercom::v2::uart` module instead."
+)]
+
 use crate::clock;
 use crate::hal::blocking::serial::{write::Default, Write};
 use crate::hal::serial;

--- a/hal/src/thumbv6m/timer.rs
+++ b/hal/src/thumbv6m/timer.rs
@@ -188,19 +188,26 @@ tc! {
     TimerCounter5: (TC5, tc5_, Tc4Tc5Clock),
 }
 
+#[deprecated(
+    since = "0.13.0",
+    note = "`SpinTimer` is deprecated, and will be removed in a subsequent release."
+)]
 #[derive(Clone, Copy)]
 pub struct SpinTimer {
     cycles: u32,
 }
 
+#[allow(deprecated)]
 impl SpinTimer {
     pub fn new(cycles: u32) -> SpinTimer {
         SpinTimer { cycles }
     }
 }
 
+#[allow(deprecated)]
 impl Periodic for SpinTimer {}
 
+#[allow(deprecated)]
 impl CountDown for SpinTimer {
     type Time = u32;
 

--- a/hal/src/thumbv6m/timer.rs
+++ b/hal/src/thumbv6m/timer.rs
@@ -1,4 +1,5 @@
 //! Working with timer counter hardware
+use crate::ehal::timer::{CountDown, Periodic};
 #[cfg(feature = "samd11")]
 use crate::pac::tc1::COUNT16;
 #[cfg(feature = "samd21")]
@@ -10,7 +11,6 @@ use crate::pac::{PM, TC1};
 #[cfg(feature = "samd21")]
 use crate::pac::{PM, TC3, TC4, TC5};
 use crate::timer_params::TimerParams;
-use hal::timer::{CountDown, Periodic};
 
 use crate::clock;
 use crate::time::{Hertz, Nanoseconds};

--- a/hal/src/thumbv6m/watchdog.rs
+++ b/hal/src/thumbv6m/watchdog.rs
@@ -1,5 +1,5 @@
+use crate::ehal::watchdog;
 use crate::pac::WDT;
-use hal::watchdog;
 
 /// WatchdogTimeout enumerates usable values for configuring
 /// the timeout of the watchdog peripheral.

--- a/hal/src/thumbv7em/adc.rs
+++ b/hal/src/thumbv7em/adc.rs
@@ -1,6 +1,7 @@
 //! Analogue-to-Digital Conversion
 use crate::clock::GenericClockController;
 #[rustfmt::skip]
+#[allow(deprecated)]
 use crate::gpio::v1;
 use crate::gpio::v2::*;
 use crate::hal::adc::{Channel, OneShot};
@@ -288,6 +289,7 @@ macro_rules! adc_pins {
 
 /// Implement [`Channel`] for [`v1::Pin`]s based on the implementations for
 /// `v2` [`Pin`]s
+#[allow(deprecated)]
 impl<I, A> Channel<A> for v1::Pin<I, v1::PfB>
 where
     I: PinId,

--- a/hal/src/thumbv7em/eic/pin.rs
+++ b/hal/src/thumbv7em/eic/pin.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::gpio::{
     self, v2::AnyPin, v2::FloatingInterrupt, v2::Pin, v2::PinId, v2::PinMode,
     v2::PullDownInterrupt, v2::PullUpInterrupt, Port,

--- a/hal/src/thumbv7em/sercom/v1.rs
+++ b/hal/src/thumbv7em/sercom/v1.rs
@@ -12,5 +12,9 @@ pub mod spi;
 pub mod uart;
 
 pub use self::i2c::*;
+
+#[allow(deprecated)]
 pub use self::spi::*;
+
+#[allow(deprecated)]
 pub use self::uart::*;

--- a/hal/src/thumbv7em/sercom/v1/spi.rs
+++ b/hal/src/thumbv7em/sercom/v1/spi.rs
@@ -14,6 +14,7 @@ use crate::pac::{MCLK, SERCOM0, SERCOM1, SERCOM2, SERCOM3, SERCOM4, SERCOM5};
 use crate::pac::{SERCOM6, SERCOM7};
 use crate::sercom::v1::pads::CompatiblePad;
 use crate::sercom::v2::*;
+#[allow(deprecated)]
 use crate::spi_common::CommonSpi;
 use crate::time::Hertz;
 
@@ -127,6 +128,7 @@ macro_rules! spi_master {
             sercom: $SERCOM,
         }
 
+        #[allow(deprecated)]
         impl<MISO, MOSI, SCK> CommonSpi for $Type<MISO, MOSI, SCK> {
             /// Helper for accessing the spi member of the sercom instance
             fn spi(&self) -> &SPIM {
@@ -139,6 +141,7 @@ macro_rules! spi_master {
             }
         }
 
+        #[allow(deprecated)]
         impl<MISO, MOSI, SCK> $Type<MISO, MOSI, SCK> {
             /// Power on and configure SERCOMX to work as an SPI Master operating
             /// with the specified frequency and SPI Mode.  The pinout specifies
@@ -229,6 +232,7 @@ macro_rules! spi_master {
             }
         }
 
+        #[allow(deprecated)]
         impl<MISO, MOSI, SCK> FullDuplex<u8> for $Type<MISO, MOSI, SCK> {
             type Error = Error;
 

--- a/hal/src/thumbv7em/sercom/v1/spi.rs
+++ b/hal/src/thumbv7em/sercom/v1/spi.rs
@@ -1,3 +1,9 @@
+#![deprecated(
+    since = "0.13.0",
+    note = "The `sercom::v1::spi` module is deprecated, and will be removed in a subsequent release.
+    Please use the `sercom::v2::spi` module instead."
+)]
+
 use core::marker::PhantomData;
 
 use crate::clock;

--- a/hal/src/thumbv7em/sercom/v1/spi.rs
+++ b/hal/src/thumbv7em/sercom/v1/spi.rs
@@ -265,13 +265,16 @@ macro_rules! spi_master {
             }
         }
 
-        impl<MISO, MOSI, SCK> ::hal::blocking::spi::transfer::Default<u8>
+        impl<MISO, MOSI, SCK> ::embedded_hal::blocking::spi::transfer::Default<u8>
             for $Type<MISO, MOSI, SCK>
         {
         }
-        impl<MISO, MOSI, SCK> ::hal::blocking::spi::write::Default<u8> for $Type<MISO, MOSI, SCK> {}
+        impl<MISO, MOSI, SCK> ::embedded_hal::blocking::spi::write::Default<u8>
+            for $Type<MISO, MOSI, SCK>
+        {
+        }
         #[cfg(feature = "unproven")]
-        impl<MISO, MOSI, SCK> ::hal::blocking::spi::write_iter::Default<u8>
+        impl<MISO, MOSI, SCK> ::embedded_hal::blocking::spi::write_iter::Default<u8>
             for $Type<MISO, MOSI, SCK>
         {
         }

--- a/hal/src/thumbv7em/sercom/v1/uart.rs
+++ b/hal/src/thumbv7em/sercom/v1/uart.rs
@@ -1,3 +1,9 @@
+#![deprecated(
+    since = "0.13.0",
+    note = "The `sercom::v1::uart` module is deprecated, and will be removed in a subsequent release.
+    Please use the `sercom::v2::uart` module instead."
+)]
+
 use crate::clock;
 use crate::hal::blocking::serial::{write::Default, Write};
 use crate::hal::serial;

--- a/hal/src/thumbv7em/timer.rs
+++ b/hal/src/thumbv7em/timer.rs
@@ -184,19 +184,26 @@ tc! {
     TimerCounter5: (TC5, tc5_, Tc4Tc5Clock, apbcmask),
 }
 
+#[deprecated(
+    since = "0.13.0",
+    note = "`SpinTimer` is deprecated, and will be removed in a subsequent release."
+)]
 #[derive(Clone, Copy)]
 pub struct SpinTimer {
     cycles: u32,
 }
 
+#[allow(deprecated)]
 impl SpinTimer {
     pub fn new(cycles: u32) -> SpinTimer {
         SpinTimer { cycles }
     }
 }
 
+#[allow(deprecated)]
 impl Periodic for SpinTimer {}
 
+#[allow(deprecated)]
 impl CountDown for SpinTimer {
     type Time = u32;
 

--- a/hal/src/thumbv7em/watchdog.rs
+++ b/hal/src/thumbv7em/watchdog.rs
@@ -1,5 +1,5 @@
+use crate::ehal::watchdog;
 use crate::pac::WDT;
-use hal::watchdog;
 
 /// WatchdogTimeout enumerates usable values for configuring
 /// the timeout of the watchdog peripheral.


### PR DESCRIPTION
This PR aims to tie some loose ends before pushing the v0.13 release:

- [x] Add changelog. This should be updated in the future as individual PRs get merged
- [x] Add deprecation notices to modules that exist solely for backwards compatibility
- [x] Add deprecation notice to `gpio::v1`
- [x] Add deprecation notice to `sercom::v1::{spi, uart}`
- [x] Carry out whatever decision is made regarding Tier 1 vs Tier 2 BSPs and add an explanation to the README
- [ ] Update all Tier 1 BSPs to v2 modules:

* ~~`feather_m0`~~
* ~~`metro_m0`~~
* `feather_m4`
* `metro_m4` (@sajattack - #478)
* ~~`samd11_bare`~~
* `pygamer` (@bradleyharden - #455)
* `wio_terminal`

- [x] Tie all Tier 2 BSPs' `atsamd-hal` dependency to crates.io
- [x] Manually bump T2 BSPs (GHA workflow only bumps T1 boards)
- [ ] Bump T1 BSP and PAC versions using GHA workflow (HAL is already bumped)
- [ ] Release to crates.io and tag commit with v0.13.0