### PR TITLE
Minor `gpio` updates

### DIFF
--- a/hal/src/gpio/v1.rs
+++ b/hal/src/gpio/v1.rs
@@ -130,67 +130,61 @@ where
         }
     }
 
+    #[inline]
+    pub fn into_mode<N: PinMode>(mut self) -> Pin<I, N> {
+        // Change pin mode unconditionally, to match the original `v1` behavior
+        self.pin.regs.change_mode::<N>();
+        // Safe because we drop the existing Pin
+        unsafe { Pin::new() }
+    }
+
     /// Configures the pin to operate as a floating input
     #[allow(unused_variables)]
     #[inline]
     pub fn into_floating_input(self, port: &mut Port) -> Pin<I, Input<Floating>> {
-        Pin {
-            pin: self.pin.into_floating_input(),
-        }
+        self.into_mode()
     }
 
     /// Configures the pin to operate as a pulled down input pin
     #[allow(unused_variables)]
     #[inline]
     pub fn into_pull_down_input(self, port: &mut Port) -> Pin<I, Input<PullDown>> {
-        Pin {
-            pin: self.pin.into_pull_down_input(),
-        }
+        self.into_mode()
     }
 
     /// Configures the pin to operate as a pulled up input pin
     #[allow(unused_variables)]
     #[inline]
     pub fn into_pull_up_input(self, port: &mut Port) -> Pin<I, Input<PullUp>> {
-        Pin {
-            pin: self.pin.into_pull_up_input(),
-        }
+        self.into_mode()
     }
 
     /// Configures the pin to operate as a floating interrupt
     #[allow(unused_variables)]
     #[inline]
     pub fn into_floating_interrupt(self, port: &mut Port) -> Pin<I, Interrupt<Floating>> {
-        Pin {
-            pin: self.pin.into_floating_interrupt(),
-        }
+        self.into_mode()
     }
 
     /// Configures the pin to operate as a pulled down interrupt pin
     #[allow(unused_variables)]
     #[inline]
     pub fn into_pull_down_interrupt(self, port: &mut Port) -> Pin<I, Interrupt<PullDown>> {
-        Pin {
-            pin: self.pin.into_pull_down_interrupt(),
-        }
+        self.into_mode()
     }
 
     /// Configures the pin to operate as a pulled up interrupt pin
     #[allow(unused_variables)]
     #[inline]
     pub fn into_pull_up_interrupt(self, port: &mut Port) -> Pin<I, Interrupt<PullUp>> {
-        Pin {
-            pin: self.pin.into_pull_up_interrupt(),
-        }
+        self.into_mode()
     }
 
     /// Configures the pin to operate as an open drain output
     #[allow(unused_variables)]
     #[inline]
     pub fn into_open_drain_output(self, port: &mut Port) -> Pin<I, Output<OpenDrain>> {
-        Pin {
-            pin: self.pin.into_push_pull_output(),
-        }
+        self.into_mode()
     }
 
     /// Configures the pin to operate as an open drain output which can be read
@@ -200,25 +194,19 @@ where
         self,
         port: &mut Port,
     ) -> Pin<I, Output<ReadableOpenDrain>> {
-        Pin {
-            pin: self.pin.into_readable_output(),
-        }
+        self.into_mode()
     }
 
     /// Configures the pin to operate as a push-pull output
     #[allow(unused_variables)]
     #[inline]
     pub fn into_push_pull_output(self, port: &mut Port) -> Pin<I, Output<PushPull>> {
-        Pin {
-            pin: self.pin.into_push_pull_output(),
-        }
+        self.into_mode()
     }
 
     #[inline]
     fn into_alternate<C: AlternateConfig>(self) -> Pin<I, Alternate<C>> {
-        Pin {
-            pin: self.pin.into_alternate(),
-        }
+        self.into_mode()
     }
 
     /// Configures the pin to operate with a peripheral

--- a/hal/src/gpio/v2/pin.rs
+++ b/hal/src/gpio/v2/pin.rs
@@ -1,26 +1,37 @@
 //! # Type-level module for GPIO pins
 //!
 //! This module provides a type-level API for GPIO pins. It uses the type system
-//! to track the state of pins at compile-time. To do so, it uses traits to
+//! to track the state of pins at compile-time. Representing GPIO pins in this
+//! manner incurs no run-time overhead. Each [`Pin`] struct is zero-sized, so
+//! there is no data to copy around. Instead, real code is generated as a side
+//! effect of type transformations, and the resulting assembly is nearly
+//! identical to the equivalent, hand-written C.
+//!
+//! To track the state of pins at compile-time, this module uses traits to
 //! represent [type classes] and types as instances of those type classes. For
 //! example, the trait [`InputConfig`] acts as a [type-level enum] of the
 //! available input configurations, and the types [`Floating`], [`PullDown`] and
 //! [`PullUp`] are its type-level variants.
 //!
-//! When applied as a trait bound, a type-level enum restricts type parameters
-//! to the corresponding variants. All of the traits in this module are closed,
-//! using the `Sealed` trait pattern, so the type-level instances found in this
-//! module are the only possible variants.
-//!
 //! Type-level [`Pin`]s are parameterized by two type-level enums, [`PinId`] and
 //! [`PinMode`].
+//!
+//! ```
+//! pub struct Pin<I, M>
+//! where
+//!     I: PinId,
+//!     M: PinMode,
+//! {
+//!     // ...
+//! }
+//! ```
 //!
 //! A `PinId` identifies a pin by it's group (A, B, C or D) and pin number. Each
 //! `PinId` instance is named according to its datasheet identifier, e.g.
 //! [`PA02`].
 //!
 //! A `PinMode` represents the various pin modes. The available `PinMode`
-//! variants are [`Disabled`], [`Input`], [`Interrupt`'], [`Output`] and
+//! variants are [`Disabled`], [`Input`], [`Interrupt`], [`Output`] and
 //! [`Alternate`], each with its own corresponding configurations.
 //!
 //! It is not possible for users to create new instances of a [`Pin`]. Singleton

--- a/hal/src/gpio/v2/pin.rs
+++ b/hal/src/gpio/v2/pin.rs
@@ -455,7 +455,7 @@ impl<I: PinId> SomePinId for I {}
 ///
 /// This `struct` takes ownership of a [`PinId`] and provides an API to
 /// access the corresponding regsiters.
-struct Registers<I: PinId> {
+pub(in crate::gpio) struct Registers<I: PinId> {
     id: PhantomData<I>,
 }
 
@@ -483,7 +483,7 @@ impl<I: PinId> Registers<I> {
     /// Provide a type-level equivalent for the
     /// [`RegisterInterface::change_mode`] method.
     #[inline]
-    fn change_mode<M: PinMode>(&mut self) {
+    pub(in crate::gpio) fn change_mode<M: PinMode>(&mut self) {
         RegisterInterface::change_mode(self, M::DYN);
     }
 }
@@ -498,7 +498,7 @@ where
     I: PinId,
     M: PinMode,
 {
-    regs: Registers<I>,
+    pub(in crate::gpio) regs: Registers<I>,
     mode: PhantomData<M>,
 }
 


### PR DESCRIPTION
### Remove some unsafe and improve documentation for gpio::v2

The `RegisterInterface` trait in `gpio::v2` used an approach that
produced an unnecessary amount of `unsafe` code. Because each register
in a PAC struct is wrapped in an `UnsafeCell`, it is safe to mutate them
through shared references. The previous approach used a combination of
raw pointers and unique references. However, raw pointers are
unnecessary and unique references offer no benefits, yet they carry the
risk of UB if not implemented correctly.

Update the `RegisterInterface` trait to use shared references
throughout. Also improve the `pin` module documentation slightly.

### Fix regression in gpio::v1 compatibility

At reset, the `gpio::v1` module gives `Pin`s to users in `FloatingInput`
mode, but this is not correct, because the pins are actually in
`FloatingDisabled` mode. This problem was never discovered, because
users always called a function to change the pin mode before using a
given pin, even when that function was `.into_floating_input()`.

In a recent change to `gpio::v2`, the `into_mode` function was altered
to only update the register settings when actually changing modes. The
goal of this change was to prevent spurious writes to the GPIO
registers.

Combined with the incorrect behavior of `gpio::v1`, this change created
a situation where it was impossible to use a pin as a floating input
without first converting it to some other mode and back. Pins would be
labelled as `FloatingInput`, even though they were actually
`FloatingDisabled`. But calls to `.into_floating_input()` would have no
effect, because there was no change in `PinMode`.

Introduce an `into_mode` method for `v1::Pin`s that mirrors the design
of the corresponding method of `v2::Pin`, but in this case change the
register values unconditionally. This does not fix the fundamental flaw
in `gpio::v1`, but it does return it to the pre-existing behavior.

Closes #464