### PR TITLE
Fix CI for RTIC 0.6.0-alpha.5

### DIFF
--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -52,7 +52,7 @@ version = "0.3"
 optional = true
 
 [dependencies.rtic-monotonic]
-version = "=0.1.0-alpha.1"
+version = "=0.1.0-alpha.2"
 optional = true
 
 [dev-dependencies]
@@ -65,7 +65,7 @@ nom = { version = "5.1", default-features= false }
 heapless = "0.5"
 
 [dev-dependencies.cortex-m-rtic]
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.5"
 
 [features]
 # ask the HAL to enable atsamd21g support

--- a/boards/feather_m0/examples/blinky_rtic.rs
+++ b/boards/feather_m0/examples/blinky_rtic.rs
@@ -24,8 +24,11 @@ mod app {
     use hal::rtc::{Count32Mode, Rtc};
     use rtic_monotonic::Extensions;
 
-    #[resources]
-    struct Resources {
+    #[local]
+    struct Local {}
+
+    #[shared]
+    struct Shared {
         red_led:
             hal::gpio::v2::Pin<hal::gpio::v2::PA17, hal::gpio::v2::Output<hal::gpio::v2::PushPull>>,
     }
@@ -34,7 +37,7 @@ mod app {
     type RtcMonotonic = Rtc<Count32Mode>;
 
     #[init]
-    fn init(cx: init::Context) -> (init::LateResources, init::Monotonics) {
+    fn init(cx: init::Context) -> (Shared, Local, init::Monotonics) {
         let mut peripherals: Peripherals = cx.device;
         let pins = bsp::Pins::new(peripherals.PORT);
         let mut core: rtic::export::Peripherals = cx.core;
@@ -59,12 +62,12 @@ mod app {
         // Start the blink task
         blink::spawn().unwrap();
 
-        (init::LateResources { red_led }, init::Monotonics(rtc))
+        (Shared { red_led }, Local {}, init::Monotonics(rtc))
     }
 
-    #[task(resources = [red_led])]
+    #[task(shared = [red_led])]
     fn blink(mut _cx: blink::Context) {
-        _cx.resources.red_led.lock(|led| led.toggle().unwrap());
+        _cx.shared.red_led.lock(|led| led.toggle().unwrap());
         blink::spawn_after(1_u32.seconds()).ok();
     }
 }

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -46,7 +46,7 @@ optional = true
 
 [dependencies.cortex-m-rtic]
 optional = true
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.5"
 
 [dependencies.rtic-monotonic]
 optional = true

--- a/hal/src/rtc.rs
+++ b/hal/src/rtc.rs
@@ -458,7 +458,7 @@ impl Monotonic for Rtc<Count32Mode> {
     }
 
     fn set_compare(&mut self, instant: &Instant<Rtc<Count32Mode>>) {
-        let value = *instant.duration_since_epoch().integer();
+        let value = instant.duration_since_epoch().integer();
         unsafe { self.mode0().comp[0].write(|w| w.comp().bits(value)) }
     }
 


### PR DESCRIPTION
This is a quick fix to get CI working again. There is currently exacly 1 BSP example using RTIC `0.6.0-alpha.5`: `feather_m0/blinky_rtic`. 