### PR TITLE
eic fix unused borrow that must be used

### DIFF
--- a/hal/src/thumbv6m/eic/pin.rs
+++ b/hal/src/thumbv6m/eic/pin.rs
@@ -95,11 +95,11 @@ crate::paste::item! {
         }
 
         pub fn is_interrupt(&mut self) -> bool {
-            unsafe { (*target_device::EIC::ptr()) }.intflag.read().[<extint $num>]().bit_is_set()
+            unsafe { &(*target_device::EIC::ptr()) }.intflag.read().[<extint $num>]().bit_is_set()
         }
 
         pub fn clear_interrupt(&mut self) {
-            unsafe { (*target_device::EIC::ptr()) }.intflag.modify(|_, w| {
+            unsafe { &(*target_device::EIC::ptr()) }.intflag.modify(|_, w| {
                 w.[<extint $num>]().set_bit()
             });
         }

--- a/hal/src/thumbv6m/eic/pin.rs
+++ b/hal/src/thumbv6m/eic/pin.rs
@@ -95,11 +95,11 @@ crate::paste::item! {
         }
 
         pub fn is_interrupt(&mut self) -> bool {
-            unsafe { &(*target_device::EIC::ptr()) }.intflag.read().[<extint $num>]().bit_is_set()
+            unsafe { (*target_device::EIC::ptr()) }.intflag.read().[<extint $num>]().bit_is_set()
         }
 
         pub fn clear_interrupt(&mut self) {
-            unsafe { &(*target_device::EIC::ptr()) }.intflag.modify(|_, w| {
+            unsafe { (*target_device::EIC::ptr()) }.intflag.modify(|_, w| {
                 w.[<extint $num>]().set_bit()
             });
         }

--- a/hal/src/thumbv7em/eic/pin.rs
+++ b/hal/src/thumbv7em/eic/pin.rs
@@ -100,7 +100,7 @@ crate::paste::item! {
 
         pub fn clear_interrupt(&mut self) {
             unsafe {
-                &(*target_device::EIC::ptr()).intflag.write(|w| {
+                (*target_device::EIC::ptr()).intflag.write(|w| {
                     w.bits(1 << $num)
                 });
             }

--- a/hal/src/thumbv7em/eic/pin.rs
+++ b/hal/src/thumbv7em/eic/pin.rs
@@ -100,9 +100,7 @@ crate::paste::item! {
 
         pub fn clear_interrupt(&mut self) {
             unsafe {
-                (*target_device::EIC::ptr()).intflag.write(|w| {
-                    w.bits(1 << $num)
-                });
+                {&(*target_device::EIC::ptr())}.intflag.write(|w| { w.bits(1 << $num) });
             }
         }
 


### PR DESCRIPTION
Been getting these with 1.55.0

```
warning: 	
   --> /home/jacob/Downloads/atsamd/hal/src/thumbv7em/eic/pin.rs:103:17
    |
103 | /                 &(*target_device::EIC::ptr()).intflag.write(|w| {
104 | |                     w.bits(1 << $num)
105 | |                 });
    | |__________________^
...
388 | / ei!(ExtInt[15] {
389 | |     Pa15,
390 | |     Pa31,
391 | |     #[cfg(feature = "min-samd51j")]
...   |
400 | |     Pc31,
401 | | });
    | |___- in this macro invocation
    |
    = note: this warning originates in the macro `ei` (in Nightly builds, run with -Z macro-backtrace for more info)
 ```