### PR TITLE
Remove unused panic-abort and unnecessary panic-halt feature/dependency

### DIFF
--- a/boards/arduino_mkr1000/Cargo.toml
+++ b/boards/arduino_mkr1000/Cargo.toml
@@ -7,6 +7,7 @@ keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 cortex-m = "0.6"
@@ -32,6 +33,7 @@ optional = true
 
 [dev-dependencies]
 panic-halt = "0.2"
+panic-semihosting = "0.5"
 
 [features]
 # ask the HAL to enable atsamd21g support

--- a/boards/arduino_mkr1000/examples/blinky_basic.rs
+++ b/boards/arduino_mkr1000/examples/blinky_basic.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate arduino_mkr1000 as hal;
+use arduino_mkr1000 as hal;
 
 #[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;

--- a/boards/arduino_mkr1000/examples/blinky_basic.rs
+++ b/boards/arduino_mkr1000/examples/blinky_basic.rs
@@ -2,7 +2,11 @@
 #![no_main]
 
 extern crate arduino_mkr1000 as hal;
-extern crate panic_halt;
+
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use hal::clock::GenericClockController;
 use hal::delay::Delay;

--- a/boards/arduino_mkrvidor4000/Cargo.toml
+++ b/boards/arduino_mkrvidor4000/Cargo.toml
@@ -7,6 +7,7 @@ keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 cortex-m = "0.6"

--- a/boards/arduino_mkrvidor4000/Cargo.toml
+++ b/boards/arduino_mkrvidor4000/Cargo.toml
@@ -17,20 +17,19 @@ nb = "0.1"
 version = "0.6.12"
 optional = true
 
-[dependencies.panic-halt]
-version = "0.2"
-optional = true
-
 [dependencies.atsamd-hal]
 path = "../../hal"
 version = "0.12"
 default-features = false
 
+[dev-dependencies]
+panic-halt = "0.2"
+panic-semihosting = "0.5"
+
 [features]
 # ask the HAL to enable atsamd21g support
-default = ["rt", "panic_halt", "atsamd-hal/samd21g"]
+default = ["rt", "atsamd-hal/samd21g"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
-panic_halt = ["panic-halt"]
 unproven = ["atsamd-hal/unproven"]
 usb = ["atsamd-hal/usb"]
 use_semihosting = []

--- a/boards/arduino_mkrvidor4000/examples/blinky_basic.rs
+++ b/boards/arduino_mkrvidor4000/examples/blinky_basic.rs
@@ -3,6 +3,11 @@
 
 extern crate arduino_mkrvidor4000 as hal;
 
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::entry;

--- a/boards/arduino_mkrvidor4000/examples/blinky_basic.rs
+++ b/boards/arduino_mkrvidor4000/examples/blinky_basic.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate arduino_mkrvidor4000 as hal;
+use arduino_mkrvidor4000 as hal;
 
 #[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;

--- a/boards/arduino_mkrvidor4000/examples/enable_battery_charging.rs
+++ b/boards/arduino_mkrvidor4000/examples/enable_battery_charging.rs
@@ -3,6 +3,11 @@
 
 extern crate arduino_mkrvidor4000 as hal;
 
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
 use hal::clock::GenericClockController;
 use hal::entry;
 use hal::pac::{CorePeripherals, Peripherals};

--- a/boards/arduino_mkrvidor4000/examples/enable_battery_charging.rs
+++ b/boards/arduino_mkrvidor4000/examples/enable_battery_charging.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate arduino_mkrvidor4000 as hal;
+use arduino_mkrvidor4000 as hal;
 
 #[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;

--- a/boards/arduino_mkrvidor4000/examples/run_fpga.rs
+++ b/boards/arduino_mkrvidor4000/examples/run_fpga.rs
@@ -3,6 +3,11 @@
 
 extern crate arduino_mkrvidor4000 as hal;
 
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
 use hal::clock::GenericClockController;
 use hal::entry;
 use hal::pac::{CorePeripherals, Peripherals};

--- a/boards/arduino_mkrvidor4000/examples/run_fpga.rs
+++ b/boards/arduino_mkrvidor4000/examples/run_fpga.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate arduino_mkrvidor4000 as hal;
+use arduino_mkrvidor4000 as hal;
 
 #[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;

--- a/boards/arduino_mkrzero/Cargo.toml
+++ b/boards/arduino_mkrzero/Cargo.toml
@@ -17,10 +17,6 @@ nb = "0.1"
 version = "0.6.12"
 optional = true
 
-[dependencies.panic-halt]
-version = "0.2"
-optional = true
-
 [dependencies.atsamd-hal]
 path = "../../hal"
 version = "0.12"
@@ -34,12 +30,15 @@ optional = true
 version = "0.1"
 optional = true
 
+[dev-dependencies]
+panic-halt = "0.2"
+panic-semihosting = "0.5"
+
 [features]
 # ask the HAL to enable atsamd21g support
-default = ["rt", "panic_halt", "atsamd-hal/samd21g", "usb"]
+default = ["rt", "atsamd-hal/samd21g", "usb"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
 usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
-panic_halt = ["panic-halt"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
 

--- a/boards/arduino_mkrzero/Cargo.toml
+++ b/boards/arduino_mkrzero/Cargo.toml
@@ -7,6 +7,7 @@ keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 cortex-m = "0.6"

--- a/boards/arduino_mkrzero/examples/blinky_basic.rs
+++ b/boards/arduino_mkrzero/examples/blinky_basic.rs
@@ -3,6 +3,11 @@
 
 extern crate arduino_mkrzero as hal;
 
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::entry;

--- a/boards/arduino_mkrzero/examples/blinky_basic.rs
+++ b/boards/arduino_mkrzero/examples/blinky_basic.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate arduino_mkrzero as hal;
+use arduino_mkrzero as hal;
 
 #[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;

--- a/boards/arduino_mkrzero/examples/pwm.rs
+++ b/boards/arduino_mkrzero/examples/pwm.rs
@@ -4,6 +4,11 @@
 extern crate arduino_mkrzero as hal;
 extern crate atsamd_hal;
 
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
 use hal::clock::{GenericClockController, Tcc0Tcc1Clock};
 use hal::delay::Delay;
 use hal::entry;

--- a/boards/arduino_mkrzero/examples/pwm.rs
+++ b/boards/arduino_mkrzero/examples/pwm.rs
@@ -1,8 +1,7 @@
 #![no_std]
 #![no_main]
 
-extern crate arduino_mkrzero as hal;
-extern crate atsamd_hal;
+use arduino_mkrzero as hal;
 
 #[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;

--- a/boards/arduino_mkrzero/examples/usb_logging.rs
+++ b/boards/arduino_mkrzero/examples/usb_logging.rs
@@ -3,9 +3,13 @@
 
 extern crate arduino_mkrzero as hal;
 extern crate cortex_m;
-extern crate panic_halt;
 extern crate usb_device;
 extern crate usbd_serial;
+
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use hal::clock::GenericClockController;
 use hal::delay::Delay;

--- a/boards/arduino_mkrzero/examples/usb_logging.rs
+++ b/boards/arduino_mkrzero/examples/usb_logging.rs
@@ -1,10 +1,10 @@
 #![no_std]
 #![no_main]
 
-extern crate arduino_mkrzero as hal;
-extern crate cortex_m;
-extern crate usb_device;
-extern crate usbd_serial;
+use arduino_mkrzero as hal;
+use cortex_m;
+use usb_device;
+use usbd_serial;
 
 #[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;

--- a/boards/arduino_nano33iot/Cargo.toml
+++ b/boards/arduino_nano33iot/Cargo.toml
@@ -18,10 +18,6 @@ nb = "1.0"
 version = "0.6.12"
 optional = true
 
-[dependencies.panic-halt]
-version = "0.2"
-optional = true
-
 [dependencies.atsamd-hal]
 path = "../../hal"
 version = "0.12"
@@ -41,16 +37,17 @@ default-features = false
 features = ["small_rng"]
 
 [dev-dependencies]
+panic-halt = "0.2"
+panic-semihosting = "0.5"
 embedded-graphics = "0.7.1"
 st7735-lcd = "0.8.1"
 ssd1306 = { version = "0.6", features = ["graphics"] }
 
 [features]
 # ask the HAL to enable atsamd21g support
-default = ["rt", "panic_halt", "atsamd-hal/samd21g"]
+default = ["rt", "atsamd-hal/samd21g"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
 usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
-panic_halt = ["panic-halt"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
 

--- a/boards/arduino_nano33iot/examples/blinky_basic.rs
+++ b/boards/arduino_nano33iot/examples/blinky_basic.rs
@@ -3,6 +3,11 @@
 
 extern crate arduino_nano33iot as hal;
 
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::entry;

--- a/boards/arduino_nano33iot/examples/i2c_ssd1306.rs
+++ b/boards/arduino_nano33iot/examples/i2c_ssd1306.rs
@@ -16,6 +16,11 @@ extern crate arduino_nano33iot as hal;
 extern crate rand;
 extern crate ssd1306;
 
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::entry;

--- a/boards/arduino_nano33iot/examples/serial.rs
+++ b/boards/arduino_nano33iot/examples/serial.rs
@@ -3,6 +3,11 @@
 
 extern crate arduino_nano33iot as hal;
 
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::entry;

--- a/boards/arduino_nano33iot/examples/spi_st7735.rs
+++ b/boards/arduino_nano33iot/examples/spi_st7735.rs
@@ -5,6 +5,11 @@ extern crate arduino_nano33iot as hal;
 extern crate embedded_graphics;
 extern crate st7735_lcd;
 
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::entry;

--- a/boards/arduino_nano33iot/examples/usb_logging.rs
+++ b/boards/arduino_nano33iot/examples/usb_logging.rs
@@ -3,9 +3,13 @@
 
 extern crate arduino_nano33iot as hal;
 extern crate cortex_m;
-extern crate panic_halt;
 extern crate usb_device;
 extern crate usbd_serial;
+
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use hal::clock::GenericClockController;
 use hal::entry;

--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -7,6 +7,7 @@ keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
+edition = "2018"
 
 [dependencies]
 cortex-m = "0.6"
@@ -20,6 +21,7 @@ default-features = false
 
 [dev-dependencies]
 panic-halt = "0.2"
+panic-semihosting = "0.5"
 cortex-m-rt = "0.6.12"
 
 [features]

--- a/boards/circuit_playground_express/examples/blinky_basic.rs
+++ b/boards/circuit_playground_express/examples/blinky_basic.rs
@@ -1,9 +1,13 @@
 #![no_std]
 #![no_main]
 
-extern crate circuit_playground_express as hal;
-extern crate cortex_m_rt;
-extern crate panic_halt;
+use circuit_playground_express as hal;
+use cortex_m_rt;
+
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use hal::clock::GenericClockController;
 use hal::delay::Delay;

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -23,18 +23,6 @@ path = "../../hal"
 version = "0.12"
 default-features = false
 
-[dependencies.panic-abort]
-version = "0.3"
-optional = true
-
-[dependencies.panic-halt]
-version = "0.2"
-optional = true
-
-[dependencies.panic-semihosting]
-version = "0.5"
-optional = true
-
 [dependencies.panic_rtt]
 version = "0.1"
 optional = true
@@ -63,20 +51,19 @@ nb = "0.1"
 drogue-nom-utils = "0.1"
 nom = { version = "5.1", default-features = false }
 heapless = "0.5"
+panic-halt = "0.2"
+panic-semihosting = "0.5"
 
 [dev-dependencies.cortex-m-rtic]
 version = "0.6.0-alpha.5"
 
 [features]
 # ask the HAL to enable atsamd21g support
-default = ["rt", "atsamd-hal/samd21g", "panic_halt"]
+default = ["rt", "atsamd-hal/samd21g"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
 unproven = ["atsamd-hal/unproven"]
 use_rtt = ["atsamd-hal/use_rtt", "panic_rtt"]
 usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
-panic_halt = ["panic-halt"]
-panic_abort = ["panic-abort"]
-panic_semihosting = ["panic-semihosting"]
 # Enable pins for the radio on "RadioFruits" with RFM95, RFM96, RFM69
 rfm = []
 # Enable pins for the flash and neopixel on the Feather M0 Express
@@ -87,6 +74,7 @@ max-channels = ["dma", "atsamd-hal/max-channels"]
 adalogger = []
 sdmmc = ["embedded-sdmmc", "atsamd-hal/sdmmc"]
 rtic = ["atsamd-hal/rtic", "rtic-monotonic"]
+use_semihosting = []
 
 [profile.dev]
 incremental = false

--- a/boards/feather_m0/examples/adalogger.rs
+++ b/boards/feather_m0/examples/adalogger.rs
@@ -1,7 +1,10 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use core::fmt::Write;
 use core::sync::atomic;

--- a/boards/feather_m0/examples/clock.rs
+++ b/boards/feather_m0/examples/clock.rs
@@ -3,7 +3,10 @@
 
 use core::fmt::Write;
 
+#[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use cortex_m::interrupt::free as disable_interrupts;
 use cortex_m::peripheral::NVIC;

--- a/boards/feather_m0/examples/dmac.rs
+++ b/boards/feather_m0/examples/dmac.rs
@@ -5,7 +5,11 @@
 #![no_main]
 
 use cortex_m::asm;
+
+#[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use bsp::hal;
 use bsp::pac;

--- a/boards/feather_m0/examples/pwm.rs
+++ b/boards/feather_m0/examples/pwm.rs
@@ -2,7 +2,11 @@
 #![no_main]
 
 use cortex_m_rt::entry;
+
+#[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use bsp::hal;
 use bsp::pac;

--- a/boards/feather_m0/examples/ssd1306_graphicsmode_128x64_spi.rs
+++ b/boards/feather_m0/examples/ssd1306_graphicsmode_128x64_spi.rs
@@ -51,7 +51,10 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use embedded_graphics::pixelcolor::BinaryColor;
 use embedded_graphics::prelude::*;

--- a/boards/feather_m0/examples/uart.rs
+++ b/boards/feather_m0/examples/uart.rs
@@ -4,7 +4,10 @@
 #![no_main]
 
 use cortex_m::asm;
+#[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use bsp::hal;
 use bsp::pac;

--- a/boards/feather_m0/examples/usb_echo.rs
+++ b/boards/feather_m0/examples/usb_echo.rs
@@ -1,7 +1,10 @@
 #![no_std]
 #![no_main]
 
+#[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use cortex_m::asm::delay as cycle_delay;
 use cortex_m::peripheral::NVIC;

--- a/boards/p1am_100/Cargo.toml
+++ b/boards/p1am_100/Cargo.toml
@@ -27,18 +27,6 @@ path = "../../hal"
 version = "0.12"
 default-features = false
 
-[dependencies.panic-abort]
-version = "0.3"
-optional = true
-
-[dependencies.panic-halt]
-version = "0.2"
-optional = true
-
-[dependencies.panic-semihosting]
-version = "0.5"
-optional = true
-
 [dependencies.panic_rtt]
 version = "0.1"
 optional = true
@@ -58,19 +46,19 @@ drogue-nom-utils = "0.1"
 nom = { version = "5.1", default-features= false }
 heapless = "0.5"
 cortex-m-rtic = "0.5.1"
+panic-halt = "0.2"
+panic-semihosting = "0.5"
 
 [features]
 # ask the HAL to enable atsamd21g support
-default = ["rt", "atsamd-hal/samd21g", "panic_halt"]
+default = ["rt", "atsamd-hal/samd21g"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
 unproven = ["atsamd-hal/unproven"]
 use_rtt = ["atsamd-hal/use_rtt", "panic_rtt"]
 usb = ["atsamd-hal/usb", "usb-device", "usbd-serial"]
-panic_halt = ["panic-halt"]
-panic_abort = ["panic-abort"]
-panic_semihosting = ["panic-semihosting"]
 dma = ["atsamd-hal/dma"]
 max-channels = ["dma", "atsamd-hal/max-channels"]
+use_semihosting = []
 
 [profile.dev]
 incremental = false

--- a/boards/p1am_100/examples/blinky_basic.rs
+++ b/boards/p1am_100/examples/blinky_basic.rs
@@ -5,9 +5,9 @@ extern crate cortex_m;
 extern crate cortex_m_semihosting;
 extern crate p1am_100 as hal;
 #[cfg(not(feature = "use_semihosting"))]
-extern crate panic_halt;
+use panic_halt as _;
 #[cfg(feature = "use_semihosting")]
-extern crate panic_semihosting;
+use panic_semihosting as _;
 
 use hal::clock::GenericClockController;
 use hal::delay::Delay;

--- a/boards/p1am_100/examples/clock.rs
+++ b/boards/p1am_100/examples/clock.rs
@@ -2,7 +2,10 @@
 #![no_main]
 
 extern crate p1am_100 as hal;
+#[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use cortex_m::interrupt::free as disable_interrupts;
 use cortex_m::peripheral::NVIC;

--- a/boards/p1am_100/examples/pwm.rs
+++ b/boards/p1am_100/examples/pwm.rs
@@ -3,7 +3,10 @@
 
 extern crate cortex_m_rt;
 extern crate p1am_100 as hal;
-extern crate panic_halt;
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use core::fmt::Write;
 

--- a/boards/p1am_100/examples/sleeping_timer.rs
+++ b/boards/p1am_100/examples/sleeping_timer.rs
@@ -8,9 +8,9 @@
 extern crate cortex_m;
 extern crate p1am_100 as hal;
 #[cfg(not(feature = "use_semihosting"))]
-extern crate panic_halt;
+use panic_halt as _;
 #[cfg(feature = "use_semihosting")]
-extern crate panic_semihosting;
+use panic_semihosting as _;
 
 use hal::clock::{enable_internal_32kosc, ClockGenId, ClockSource, GenericClockController};
 use hal::entry;

--- a/boards/p1am_100/examples/sleeping_timer_rtc.rs
+++ b/boards/p1am_100/examples/sleeping_timer_rtc.rs
@@ -8,9 +8,9 @@
 extern crate cortex_m;
 extern crate p1am_100 as hal;
 #[cfg(not(feature = "use_semihosting"))]
-extern crate panic_halt;
+use panic_halt as _;
 #[cfg(feature = "use_semihosting")]
-extern crate panic_semihosting;
+use panic_semihosting as _;
 
 use hal::clock::{enable_internal_32kosc, ClockGenId, ClockSource, GenericClockController};
 use hal::entry;

--- a/boards/p1am_100/examples/timers.rs
+++ b/boards/p1am_100/examples/timers.rs
@@ -6,9 +6,9 @@ extern crate cortex_m_semihosting;
 extern crate nb;
 extern crate p1am_100 as hal;
 #[cfg(not(feature = "use_semihosting"))]
-extern crate panic_halt;
+use panic_halt as _;
 #[cfg(feature = "use_semihosting")]
-extern crate panic_semihosting;
+use panic_semihosting as _;
 
 use hal::clock::GenericClockController;
 use hal::entry;

--- a/boards/p1am_100/examples/uart_echo_rtic.rs
+++ b/boards/p1am_100/examples/uart_echo_rtic.rs
@@ -3,7 +3,10 @@
 
 extern crate cortex_m;
 extern crate p1am_100 as hal;
-extern crate panic_halt;
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use hal::clock::GenericClockController;
 use hal::delay::Delay;

--- a/boards/p1am_100/examples/usb_echo.rs
+++ b/boards/p1am_100/examples/usb_echo.rs
@@ -3,7 +3,10 @@
 
 extern crate cortex_m;
 extern crate p1am_100 as hal;
-extern crate panic_halt;
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 extern crate usb_device;
 extern crate usbd_serial;
 

--- a/boards/p1am_100/examples/usb_echo_rtic.rs
+++ b/boards/p1am_100/examples/usb_echo_rtic.rs
@@ -3,7 +3,10 @@
 
 extern crate cortex_m;
 extern crate p1am_100 as hal;
-extern crate panic_halt;
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 extern crate usb_device;
 extern crate usbd_serial;
 

--- a/boards/wio_lite_mg126/Cargo.toml
+++ b/boards/wio_lite_mg126/Cargo.toml
@@ -19,18 +19,6 @@ nb = "0.1"
 version = "0.6.12"
 optional = true
 
-[dependencies.panic-abort]
-version = "0.3"
-optional = true
-
-[dependencies.panic-halt]
-version = "0.2"
-optional = true
-
-[dependencies.panic-semihosting]
-version = "0.5"
-optional = true
-
 [dependencies.panic_rtt]
 version = "0.1"
 optional = true
@@ -54,17 +42,17 @@ optional = true
 
 [dev-dependencies]
 cortex-m-semihosting = "0.3"
+panic-halt = "0.2"
+panic-semihosting = "0.5"
 
 [features]
 # ask the HAL to enable atsamd21g support
-default = ["rt", "panic_halt", "atsamd-hal/samd21g"]
+default = ["rt", "atsamd-hal/samd21g"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
 unproven = ["atsamd-hal/unproven"]
 use_rtt = ["atsamd-hal/use_rtt", "panic_rtt"]
 usb = ["atsamd-hal/usb", "usb-device", "usbd-serial", "numtoa"]
-panic_halt = ["panic-halt"]
-panic_abort = ["panic-abort"]
-panic_semihosting = ["panic-semihosting"]
+use_semihosting = []
 
 # for cargo flash
 [package.metadata]

--- a/boards/wio_lite_mg126/examples/adc.rs
+++ b/boards/wio_lite_mg126/examples/adc.rs
@@ -5,9 +5,9 @@ extern crate cortex_m;
 extern crate cortex_m_semihosting;
 extern crate embedded_hal;
 #[cfg(not(feature = "use_semihosting"))]
-extern crate panic_halt;
+use panic_halt as _;
 #[cfg(feature = "use_semihosting")]
-extern crate panic_semihosting;
+use panic_semihosting as _;
 extern crate wio_lite_mg126 as hal;
 
 use cortex_m_semihosting::hprintln;

--- a/boards/wio_lite_mg126/examples/adc_usb.rs
+++ b/boards/wio_lite_mg126/examples/adc_usb.rs
@@ -5,7 +5,10 @@ extern crate cortex_m;
 extern crate cortex_m_semihosting;
 extern crate embedded_hal;
 extern crate numtoa;
-extern crate panic_halt;
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 extern crate usb_device;
 extern crate usbd_serial;
 extern crate wio_lite_mg126 as hal;

--- a/boards/wio_lite_mg126/examples/blinky_basic.rs
+++ b/boards/wio_lite_mg126/examples/blinky_basic.rs
@@ -2,6 +2,10 @@
 #![no_main]
 
 extern crate wio_lite_mg126 as hal;
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use hal::clock::GenericClockController;
 use hal::delay::Delay;

--- a/boards/wio_lite_mg126/examples/pwm.rs
+++ b/boards/wio_lite_mg126/examples/pwm.rs
@@ -2,8 +2,11 @@
 #![no_main]
 
 extern crate cortex_m_rt;
-extern crate panic_halt;
 extern crate wio_lite_mg126 as hal;
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
 
 use hal::clock::GenericClockController;
 use hal::delay::Delay;


### PR DESCRIPTION
Some boards have default panic-halt feature and dependency, but this doesn't make sense for users of the BSPs. This dependency is a dev-dependency for the examples. Also, consistency around examples using halt or semihosting panic option was varried on the boards that had this issue, so tried to clean that up as well.