### PR TITLE
Add README to atsamd11d PAC

### DIFF
--- a/pac/atsamd11d/README.md
+++ b/pac/atsamd11d/README.md
@@ -1,0 +1,26 @@
+# ATSAMD11D
+
+A peripheral access crate for the ATSAMD11D chip from Microchip (née Atmel) for Rust Embedded projects.
+
+[![Build Status](https://travis-ci.org/atsamd-rs/atsamd.svg?branch=master)](https://travis-ci.org/atsamd-rs/atsamd)
+[![Crates.io](https://img.shields.io/crates/v/atsamd11c.svg)](https://crates.io/crates/atsamd11c)
+
+## [Documentation](https://docs.rs/atsamd11c)
+
+This source was automatically generated using `svd2rust`, split into smaller pieces using `form` and formatted via `rustfmt`.
+
+## License
+
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/atsamd-rs/atsamd/blob/master/LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](https://github.com/atsamd-rs/atsamd/blob/master/LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall
+be dual licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
Add a README to the `atsamd11d` crate to be able to run `cargo publish`.