### PR TITLE
Fix RTIC depencencies in BSPs

### DIFF
--- a/boards/feather_m0/CHANGELOG.md
+++ b/boards/feather_m0/CHANGELOG.md
@@ -1,0 +1,9 @@
+# 10.0.1
+
+* Bump dependencies `rtic-monotonic` to `0.1.0-rc.1` and `cortex-m-rtic` to `0.6.0-rc.2`.
+
+* Change Cargo feature resolver to `resolver = "2"`
+
+---
+
+Changelog tracking started at v0.10.0 

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feather_m0"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit Feather M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 edition = "2018"
+resolver = "2"
 
 [dependencies]
 cortex-m = "0.6"
@@ -40,7 +41,11 @@ version = "0.3"
 optional = true
 
 [dependencies.rtic-monotonic]
-version = "=0.1.0-alpha.2"
+version = "=0.1.0-rc.1"
+optional = true
+
+[dependencies.cortex-m-rtic]
+version = "=0.6.0-rc.2"
 optional = true
 
 [dev-dependencies]
@@ -53,9 +58,6 @@ nom = { version = "5.1", default-features = false }
 heapless = "0.5"
 panic-halt = "0.2"
 panic-semihosting = "0.5"
-
-[dev-dependencies.cortex-m-rtic]
-version = "0.6.0-alpha.5"
 
 [features]
 # ask the HAL to enable atsamd21g support
@@ -73,7 +75,7 @@ max-channels = ["dma", "atsamd-hal/max-channels"]
 # Enable pins for the adalogger SD card reader
 adalogger = []
 sdmmc = ["embedded-sdmmc", "atsamd-hal/sdmmc"]
-rtic = ["atsamd-hal/rtic", "rtic-monotonic"]
+rtic = ["atsamd-hal/rtic", "rtic-monotonic", "cortex-m-rtic"]
 use_semihosting = []
 
 [profile.dev]

--- a/boards/metro_m0/CHANGELOG.md
+++ b/boards/metro_m0/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 10.0.1
+
+* Bump dependencies `rtic-monotonic` to `0.1.0-rc.1` and `cortex-m-rtic` to `0.6.0-rc.2`.
+
+---
+
+Changelog tracking started at v0.10.0 

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.13"
 default-features = false
 
 [dependencies.rtic-monotonic]
-version = "=0.1.0-alpha.2"
+version = "=0.1.0-rc.1"
 optional = true
 
 [dependencies.usb-device]
@@ -40,7 +40,7 @@ panic-halt = "0.2"
 panic_rtt = "0.2"
 panic-semihosting = "0.5"
 cortex-m-semihosting = "0.3"
-cortex-m-rtic = "=0.6.0-alpha.5"
+cortex-m-rtic = "=0.6.0-rc.2"
 sx1509 = "0.2"
 
 [features]

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metro_m0"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Wez Furlong <wez@wezfurlong.org>"]
 description = "Board Support crate for the Adafruit Metro M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/crates.json
+++ b/crates.json
@@ -30,7 +30,7 @@
     },
     "feather_m0": {
 	  "tier": 1,
-      "build": "cargo build --examples --features=unproven,usb,dma,rtic"
+      "build": "cargo build --examples --features=unproven,dma,usb,rtic,sdmmc,adalogger"
     },
     "feather_m4": {
 	  "tier": 2,
@@ -78,7 +78,7 @@
     },
     "samd11_bare": {
 	  "tier": 1,
-      "build": "cargo build --release --examples --features=unproven,rt,use-semihosting"
+      "build": "cargo build --release --examples --features=unproven,rt,use_semihosting"
     },
     "samd21_mini": {
 	  "tier": 2,


### PR DESCRIPTION
This PR fixes compile errors that happen since RTIC got updated to `0.6.0-rc.2`.

When a crate is used as a normal dependency and a build dependency, the default Cargo feature resolver seems to use an union of all enabled features. In this case, `riscv-target` (a build dependency of RTIC) brought in `regex` with the `std` feature enabled, which in turn caused `memchr` to build with the `[default, std]` feature set:
```
$ cargo tree --all-features -p memchr -i --no-dedupe -f "{p}, features: [{f}]"
memchr v2.4.1, features: [default,std]
├── aho-corasick v0.7.18, features: [default,std]
│   └── regex v1.5.4, features: [aho-corasick,default,memchr,perf,perf-cache,perf-dfa,perf-inline,perf-literal,std,unicode,unicode-age,unicode-bool,unicode-case,unicode-gencat,unicode-perl,unicode-script,unicode-segment]
│       └── riscv-target v0.1.2, features: []
│           [build-dependencies]
│           └── atomic-polyfill v0.1.4, features: []
│               └── heapless v0.7.7, features: [atomic-polyfill,cas,default]
│                   └── cortex-m-rtic v0.6.0-rc.2, features: []
│                       ├── atsamd-hal v0.13.0 (/home/wearable-avionics/blackbox-rust/atsamd/hal), features: [atsamd21g,cortex-m-rtic,device,dma,embedded-sdmmc,jlink_rtt,max-channels,min-samd21g,rtic,rtic-monotonic,samd21,samd21g,samd21g-rt,sdmmc,unproven,usb,usb-device,use_rtt]
│                       │   └── feather_m0 v0.10.0 (/home/wearable-avionics/blackbox-rust/atsamd/boards/feather_m0), features: [adalogger,cortex-m-rt,cortex-m-rtic,default,dma,embedded-sdmmc,express,max-channels,panic_rtt,rfm,rt,rtic,rtic-monotonic,sdmmc,unproven,usb,usb-device,usbd-serial,use_rtt,use_semihosting]
│                       └── feather_m0 v0.10.0 (/home/wearable-avionics/blackbox-rust/atsamd/boards/feather_m0), features: [adalogger,cortex-m-rt,cortex-m-rtic,default,dma,embedded-sdmmc,express,max-channels,panic_rtt,rfm,rt,rtic,rtic-monotonic,sdmmc,unproven,usb,usb-device,usbd-serial,use_rtt,use_semihosting]
└── regex v1.5.4, features: [aho-corasick,default,memchr,perf,perf-cache,perf-dfa,perf-inline,perf-literal,std,unicode,unicode-age,unicode-bool,unicode-case,unicode-gencat,unicode-perl,unicode-script,unicode-segment]
    └── riscv-target v0.1.2, features: []
        [build-dependencies]
        └── atomic-polyfill v0.1.4, features: []
            └── heapless v0.7.7, features: [atomic-polyfill,cas,default]
                └── cortex-m-rtic v0.6.0-rc.2, features: []
                    ├── atsamd-hal v0.13.0 (/home/wearable-avionics/blackbox-rust/atsamd/hal), features: [atsamd21g,cortex-m-rtic,device,dma,embedded-sdmmc,jlink_rtt,max-channels,min-samd21g,rtic,rtic-monotonic,samd21,samd21g,samd21g-rt,sdmmc,unproven,usb,usb-device,use_rtt]
                    │   └── feather_m0 v0.10.0 (/home/wearable-avionics/blackbox-rust/atsamd/boards/feather_m0), features: [adalogger,cortex-m-rt,cortex-m-rtic,default,dma,embedded-sdmmc,express,max-channels,panic_rtt,rfm,rt,rtic,rtic-monotonic,sdmmc,unproven,usb,usb-device,usbd-serial,use_rtt,use_semihosting]
                    └── feather_m0 v0.10.0 (/home/wearable-avionics/blackbox-rust/atsamd/boards/feather_m0), features: [adalogger,cortex-m-rt,cortex-m-rtic,default,dma,embedded-sdmmc,express,max-channels,panic_rtt,rfm,rt,rtic,rtic-monotonic,sdmmc,unproven,usb,usb-device,usbd-serial,use_rtt,use_semihosting]

memchr v2.4.1, features: [default,std]
└── nom v5.1.2, features: []
    └── drogue-nom-utils v0.1.0, features: []
        [dev-dependencies]
        └── feather_m0 v0.10.0 (/home/wearable-avionics/blackbox-rust/atsamd/boards/feather_m0), features: [adalogger,cortex-m-rt,cortex-m-rtic,default,dma,embedded-sdmmc,express,max-channels,panic_rtt,rfm,rt,rtic,rtic-monotonic,sdmmc,unproven,usb,usb-device,usbd-serial,use_rtt,use_semihosting]
    [dev-dependencies]
    └── feather_m0 v0.10.0 (/home/wearable-avionics/blackbox-rust/atsamd/boards/feather_m0), features: [adalogger,cortex-m-rt,cortex-m-rtic,default,dma,embedded-sdmmc,express,max-channels,panic_rtt,rfm,rt,rtic,rtic-monotonic,sdmmc,unproven,usb,usb-device,usbd-serial,use_rtt,use_semihosting]
```
Switching to `resolver = "2"` fixes the issue.