### PR TITLE
add issue/PR templates and update the changelog for the thing I forgot to do

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,1 @@
+**NOTE**: Tier 2 BSPs are _expected_ to have deprecation warnings for "v1" HALs. If you would like them fixed, please open a pull request to update your BSP rather than opening an issue for this. See the `README.md` for more information.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+# Summary
+[describe your changes here]
+
+# Checklist
+  - [ ] `CHANGELOG.md` for the BSP or HAL updated
+  - [ ] All new or modified code is well documented, especially public items
+  - [ ] No new warnings or clippy suggestions have been introduced (see CI or check locally)
+
+## If Adding a new Board
+  - [ ] Board CI added to `crates.json`
+  - [ ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased Changes
 
+- Fixed the RTC implementation of embedded-hal timer traits to be periodic again (#490)
+
 ---
 
 Changelog tracking started at v0.13


### PR DESCRIPTION
Hopefully with this PR template, we won't forget to update the changelog again, and with an issue template, hopefully questions about deprecated APIs won't be as frequent