### PR TITLE
Fix cortex-m/cortex-m-rt version selection issues

### DIFF
--- a/boards/feather_m0/CHANGELOG.md
+++ b/boards/feather_m0/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Bump `cortex-m`/`cortex-m-rt` dependencies to fix a build issue
+
 # 10.0.1
 
 * Bump dependencies `rtic-monotonic` to `0.1.0-rc.1` and `cortex-m-rtic` to `0.6.0-rc.2`.
@@ -6,4 +10,4 @@
 
 ---
 
-Changelog tracking started at v0.10.0 
+Changelog tracking started at v0.10.0

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -11,12 +11,12 @@ edition = "2018"
 resolver = "2"
 
 [dependencies]
-cortex-m = "0.6"
+cortex-m = "0.7"
 embedded-hal = "0.2.3"
 nb = "0.1"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]

--- a/pac/atsamd21g/CHANGELOG.md
+++ b/pac/atsamd21g/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Unreleased
+
+* Bump `cortex-m`/`cortex-m-rt` dependencies to fix a build issue
+
+---
+
+Changelog tracking started at v0.10.0

--- a/pac/atsamd21g/Cargo.toml
+++ b/pac/atsamd21g/Cargo.toml
@@ -14,7 +14,7 @@ cortex-m = "0.6"
 vcell = "0.1.2"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [features]


### PR DESCRIPTION
# Summary
CI started failing recently, not being able to select the right version of `cortex-m`/`cortex-m-rt`. Update some of our dependencies to fix this. Unfortunately updating this everywhere resulted in too many errors. I think the embedded ecosystem needs some time to upgrade.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)