### PR TITLE
Add a bsp_peripherals! macro

### DIFF
--- a/boards/feather_m0/CHANGELOG.md
+++ b/boards/feather_m0/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Make use of `bsp_peripherals`, `periph_alias` and `pin_alias` macros
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
 
 # v0.11.0

--- a/boards/feather_m0/examples/adalogger.rs
+++ b/boards/feather_m0/examples/adalogger.rs
@@ -19,7 +19,7 @@ use usbd_serial::{SerialPort, USB_CLASS_CDC};
 use bsp::hal;
 use feather_m0 as bsp;
 
-use bsp::entry;
+use bsp::{entry, periph_alias, pin_alias};
 use hal::clock::{ClockGenId, ClockSource, GenericClockController};
 use hal::delay::Delay;
 use hal::pac::{interrupt, CorePeripherals, Peripherals};
@@ -51,7 +51,7 @@ fn main() -> ! {
     let rtc_clock = clocks.rtc(&timer_clock).unwrap();
     let timer = rtc::Rtc::clock_mode(peripherals.RTC, rtc_clock.freq(), &mut peripherals.PM);
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led = pins.d13.into_push_pull_output();
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
 
     red_led.set_high().unwrap();
     delay.delay_ms(500_u32);
@@ -88,10 +88,11 @@ fn main() -> ! {
     delay.delay_ms(500_u32);
 
     // Now work on the SD peripherals. Slow SPI speed required on init
+    let spi_sercom = periph_alias!(peripherals.spi_sercom);
     let spi = bsp::spi_master(
         &mut clocks,
         400_u32.khz(),
-        peripherals.SERCOM4,
+        spi_sercom,
         &mut peripherals.PM,
         pins.sclk,
         pins.mosi,
@@ -101,8 +102,8 @@ fn main() -> ! {
     red_led.set_high().unwrap();
     delay.delay_ms(500_u32);
 
-    let sd_cd = pins.sd_cd.into_pull_up_input();
-    let mut sd_cs = pins.sd_cs.into_push_pull_output();
+    let sd_cd: bsp::SdCd = pins.sd_cd.into();
+    let mut sd_cs: bsp::SdCs = pins.sd_cs.into();
     sd_cs.set_high().unwrap();
 
     red_led.set_low().unwrap();

--- a/boards/feather_m0/examples/blinky_basic.rs
+++ b/boards/feather_m0/examples/blinky_basic.rs
@@ -10,7 +10,7 @@ use bsp::hal;
 use bsp::pac;
 use feather_m0 as bsp;
 
-use bsp::entry;
+use bsp::{entry, pin_alias};
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -27,7 +27,7 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pins.d13.into();
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
     let mut delay = Delay::new(core.SYST, &mut clocks);
     loop {
         delay.delay_ms(200u8);

--- a/boards/feather_m0/examples/blinky_rtic.rs
+++ b/boards/feather_m0/examples/blinky_rtic.rs
@@ -16,7 +16,7 @@ use rtic;
 #[rtic::app(device = bsp::pac, peripherals = true, dispatchers = [EVSYS])]
 mod app {
     use super::*;
-    use bsp::hal;
+    use bsp::{hal, pin_alias};
     use hal::clock::{ClockGenId, ClockSource, GenericClockController};
     use hal::pac::Peripherals;
     use hal::prelude::*;
@@ -53,7 +53,7 @@ mod app {
         clocks.configure_standby(ClockGenId::GCLK2, true);
         let rtc_clock = clocks.rtc(&rtc_clock_src).unwrap();
         let rtc = Rtc::count32_mode(peripherals.RTC, rtc_clock.freq(), &mut peripherals.PM);
-        let red_led: bsp::RedLed = pins.d13.into();
+        let red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
 
         // We can use the RTC in standby for maximum power savings
         core.SCB.set_sleepdeep();

--- a/boards/feather_m0/examples/clock.rs
+++ b/boards/feather_m0/examples/clock.rs
@@ -19,7 +19,7 @@ use bsp::hal;
 use bsp::pac;
 use feather_m0 as bsp;
 
-use bsp::entry;
+use bsp::{entry, pin_alias};
 use hal::clock::{ClockGenId, ClockSource, GenericClockController};
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -41,7 +41,7 @@ fn main() -> ! {
 
     let mut delay = Delay::new(core.SYST, &mut clocks);
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pins.d13.into();
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
 
     // get the internal 32k running at 1024 Hz for the RTC
     let timer_clock = clocks

--- a/boards/feather_m0/examples/pwm.rs
+++ b/boards/feather_m0/examples/pwm.rs
@@ -12,6 +12,7 @@ use bsp::hal;
 use bsp::pac;
 use feather_m0 as bsp;
 
+use bsp::pin_alias;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -32,7 +33,7 @@ fn main() -> ! {
     let mut delay = Delay::new(core.SYST, &mut clocks);
     let pins = bsp::Pins::new(peripherals.PORT);
 
-    let _d5: bsp::D5Pwm = pins.d5.into();
+    let _d5: bsp::D5Pwm = pin_alias!(pins.d5_pwm).into();
 
     let gclk0 = clocks.gclk0();
     let mut pwm3 = Pwm3::new(

--- a/boards/feather_m0/examples/sleeping_timer.rs
+++ b/boards/feather_m0/examples/sleeping_timer.rs
@@ -25,7 +25,7 @@ use bsp::hal;
 use bsp::pac;
 use feather_m0 as bsp;
 
-use bsp::entry;
+use bsp::{entry, pin_alias};
 use hal::clock::{enable_internal_32kosc, ClockGenId, ClockSource, GenericClockController};
 use hal::prelude::*;
 use hal::sleeping_delay::SleepingDelay;
@@ -95,7 +95,7 @@ fn main() -> ! {
 
     // Configure our red LED and blink forever, sleeping between!
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pins.d13.into();
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
     loop {
         red_led.set_low().unwrap();
         sleeping_delay.delay_ms(1_000u32);

--- a/boards/feather_m0/examples/sleeping_timer_rtc.rs
+++ b/boards/feather_m0/examples/sleeping_timer_rtc.rs
@@ -25,7 +25,7 @@ use bsp::hal;
 use bsp::pac;
 use feather_m0 as bsp;
 
-use bsp::entry;
+use bsp::{entry, pin_alias};
 use hal::clock::{enable_internal_32kosc, ClockGenId, ClockSource, GenericClockController};
 use hal::prelude::*;
 use hal::rtc;
@@ -90,7 +90,7 @@ fn main() -> ! {
 
     // Configure our red LED and blink forever, sleeping between!
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pins.d13.into();
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
     loop {
         red_led.set_low().unwrap();
         sleeping_delay.delay_ms(1_000u32);

--- a/boards/feather_m0/examples/ssd1306_graphicsmode_128x32_i2c.rs
+++ b/boards/feather_m0/examples/ssd1306_graphicsmode_128x32_i2c.rs
@@ -52,7 +52,7 @@ use bsp::hal;
 use bsp::pac;
 use feather_m0 as bsp;
 
-use bsp::entry;
+use bsp::{entry, periph_alias, pin_alias};
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -70,13 +70,14 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pins.d13.into();
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
+    let i2c_sercom = periph_alias!(peripherals.i2c_sercom);
     let i2c = bsp::i2c_master(
         &mut clocks,
         KiloHertz(400),
-        peripherals.SERCOM3,
+        i2c_sercom,
         &mut peripherals.PM,
         pins.sda,
         pins.scl,

--- a/boards/feather_m0/examples/ssd1306_graphicsmode_128x64_i2c.rs
+++ b/boards/feather_m0/examples/ssd1306_graphicsmode_128x64_i2c.rs
@@ -75,7 +75,7 @@ use bsp::hal;
 use bsp::pac;
 use feather_m0 as bsp;
 
-use bsp::entry;
+use bsp::{entry, periph_alias, pin_alias};
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -93,13 +93,14 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pins.d13.into();
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
+    let i2c_sercom = periph_alias!(peripherals.i2c_sercom);
     let i2c = bsp::i2c_master(
         &mut clocks,
         KiloHertz(400),
-        peripherals.SERCOM3,
+        i2c_sercom,
         &mut peripherals.PM,
         pins.sda,
         pins.scl,

--- a/boards/feather_m0/examples/ssd1306_graphicsmode_128x64_spi.rs
+++ b/boards/feather_m0/examples/ssd1306_graphicsmode_128x64_spi.rs
@@ -65,7 +65,7 @@ use bsp::hal;
 use bsp::pac;
 use feather_m0 as bsp;
 
-use bsp::entry;
+use bsp::{entry, periph_alias, pin_alias};
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -83,21 +83,22 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pins.d13.into();
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
+    let spi_sercom = periph_alias!(peripherals.spi_sercom);
     let spi = bsp::spi_master(
         &mut clocks,
         MegaHertz(10),
-        peripherals.SERCOM4,
+        spi_sercom,
         &mut peripherals.PM,
         pins.sclk,
         pins.mosi,
         pins.miso,
     );
 
-    let dc = pins.d6.into_push_pull_output();
-    let mut rst = pins.d9.into_push_pull_output();
+    let dc: bsp::Ssd1306Dc = pin_alias!(pins.ssd1306_dc).into();
+    let mut rst: bsp::Ssd1306Rst = pin_alias!(pins.ssd1306_rst).into();
 
     // default DisplaySize: 128x64 pixels; see the
     // ssd1306::builder::Builder::new() method definition for more info

--- a/boards/feather_m0/examples/ssd1306_terminalmode_128x32_i2c.rs
+++ b/boards/feather_m0/examples/ssd1306_terminalmode_128x32_i2c.rs
@@ -51,7 +51,7 @@ use bsp::hal;
 use bsp::pac;
 use feather_m0 as bsp;
 
-use bsp::entry;
+use bsp::{entry, periph_alias, pin_alias};
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -69,13 +69,14 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pins.d13.into();
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
+    let i2c_sercom = periph_alias!(peripherals.i2c_sercom);
     let i2c = bsp::i2c_master(
         &mut clocks,
         KiloHertz(400),
-        peripherals.SERCOM3,
+        i2c_sercom,
         &mut peripherals.PM,
         pins.sda,
         pins.scl,

--- a/boards/feather_m0/examples/ssd1306_terminalmode_128x64_i2c.rs
+++ b/boards/feather_m0/examples/ssd1306_terminalmode_128x64_i2c.rs
@@ -74,7 +74,7 @@ use bsp::hal;
 use bsp::pac;
 use feather_m0 as bsp;
 
-use bsp::entry;
+use bsp::{entry, periph_alias, pin_alias};
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -92,13 +92,14 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pins.d13.into();
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
+    let i2c_sercom = periph_alias!(peripherals.i2c_sercom);
     let i2c = bsp::i2c_master(
         &mut clocks,
         KiloHertz(400),
-        peripherals.SERCOM3,
+        i2c_sercom,
         &mut peripherals.PM,
         pins.sda,
         pins.scl,

--- a/boards/feather_m0/examples/ssd1306_terminalmode_128x64_spi.rs
+++ b/boards/feather_m0/examples/ssd1306_terminalmode_128x64_spi.rs
@@ -59,7 +59,7 @@ use bsp::hal;
 use bsp::pac;
 use feather_m0 as bsp;
 
-use bsp::entry;
+use bsp::{entry, periph_alias, pin_alias};
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -81,20 +81,21 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pins.d13.into();
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
     let mut delay = Delay::new(core.SYST, &mut clocks);
+    let spi_sercom = periph_alias!(peripherals.spi_sercom);
     let spi = bsp::spi_master(
         &mut clocks,
         MegaHertz(10),
-        peripherals.SERCOM4,
+        spi_sercom,
         &mut peripherals.PM,
         pins.sclk,
         pins.mosi,
         pins.miso,
     );
 
-    let dc = pins.d6.into_push_pull_output();
-    let mut rst = pins.d9.into_push_pull_output();
+    let dc: bsp::Ssd1306Dc = pin_alias!(pins.ssd1306_dc).into();
+    let mut rst: bsp::Ssd1306Rst = pin_alias!(pins.ssd1306_rst).into();
 
     // NOTE the `DisplaySize` enum comes from the ssd1306 package,
     // and currently only supports certain display sizes; see

--- a/boards/feather_m0/examples/timers.rs
+++ b/boards/feather_m0/examples/timers.rs
@@ -10,7 +10,7 @@ use bsp::hal;
 use bsp::pac;
 use feather_m0 as bsp;
 
-use bsp::entry;
+use bsp::{entry, pin_alias};
 use hal::clock::GenericClockController;
 use hal::prelude::*;
 use hal::timer::TimerCounter;
@@ -26,7 +26,7 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led = pins.d13.into_push_pull_output();
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
 
     // gclk0 represents a configured clock using the system 48MHz oscillator
     let gclk0 = clocks.gclk0();

--- a/boards/feather_m0/examples/uart.rs
+++ b/boards/feather_m0/examples/uart.rs
@@ -13,7 +13,7 @@ use bsp::hal;
 use bsp::pac;
 use feather_m0 as bsp;
 
-use bsp::entry;
+use bsp::{entry, periph_alias, pin_alias};
 use hal::clock::GenericClockController;
 use hal::dmac::{DmaController, PriorityLevel};
 use hal::prelude::*;
@@ -34,9 +34,6 @@ fn main() -> ! {
     let dmac = peripherals.DMAC;
     let pins = bsp::Pins::new(peripherals.PORT);
 
-    // Take RX and TX pins
-    let (rx_pin, tx_pin) = (pins.d0, pins.d1);
-
     // Setup DMA channels for later use
     let mut dmac = DmaController::init(dmac, &mut pm);
     let channels = dmac.split();
@@ -44,14 +41,19 @@ fn main() -> ! {
     let chan0 = channels.0.init(PriorityLevel::LVL0);
     let chan1 = channels.1.init(PriorityLevel::LVL0);
 
+    // Take peripheral and pins
+    let uart_sercom = periph_alias!(peripherals.uart_sercom);
+    let uart_rx = pin_alias!(pins.uart_rx);
+    let uart_tx = pin_alias!(pins.uart_tx);
+
     // Setup UART peripheral
     let uart = bsp::uart(
         &mut clocks,
         9600.hz(),
-        peripherals.SERCOM0,
+        uart_sercom,
         &mut pm,
-        rx_pin,
-        tx_pin,
+        uart_rx,
+        uart_tx,
     );
 
     // Split uart in rx + tx halves

--- a/boards/feather_m0/examples/usb_echo.rs
+++ b/boards/feather_m0/examples/usb_echo.rs
@@ -16,7 +16,7 @@ use bsp::hal;
 use bsp::pac;
 use feather_m0 as bsp;
 
-use bsp::entry;
+use bsp::{entry, pin_alias};
 use hal::clock::GenericClockController;
 use hal::prelude::*;
 use hal::usb::UsbBus;
@@ -33,7 +33,7 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pins.d13.into();
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
 
     let bus_allocator = unsafe {
         USB_ALLOCATOR = Some(bsp::usb_allocator(

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased Changes
 
+- Add a `bsp_peripherals!` macro and fix a bug in `bsp_pins!` (#515)
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
 - updated HAL to be compatible with PAC updates due to svd2rust upgrade
 

--- a/hal/src/bsp_peripherals_macro.rs
+++ b/hal/src/bsp_peripherals_macro.rs
@@ -1,0 +1,195 @@
+//==============================================================================
+//  bsp_peripherals
+//==============================================================================
+
+/// # Helper macro to give meaningful names to peripherals
+///
+/// The [`pac::Peripherals`] struct refers to each peripheral by its datasheet
+/// name. However, in the context of a BSP, peripherals can often be given more
+/// meaningful names. This macro gives BSP authors a convenient way to provide
+/// custom names for each peripheral.
+///
+/// ## Calling the macro
+///
+/// The `bsp_peripherals!` macro takes a series of `PERIPHERAL` blocks. Each
+/// block starts with a peripheral name from the `pac::Peripherals` struct and
+/// is delimited by curly brackets. The brackets should contain a
+/// comma-separated list of alternate names for the peripheral, in `PascalCase`.
+/// The example below defines `Uart` as an alias for the `SERCOM2` peripheral
+/// and `DisplaySpi` as an alias for the `SERCOM4` peripheral.
+///
+/// ```
+/// atsamd_hal::bsp_peripherals!(
+///     SERCOM2 { Uart }
+///     SERCOM4 { DisplaySpi }
+/// );
+/// ```
+///
+/// The macro defines a type alias for each name within curly brackets. The
+/// example above would exand to
+///
+/// ```
+/// pub type Uart = pac::SERCOM2;
+/// pub type DisplaySpi = pac::SERCOM4;
+/// ```
+///
+/// While these type aliases are useful, they do not completely separate the
+/// mapping of each peripheral from the corresponding code.
+///
+/// In Rust, each struct field can only have one name. Fields of the
+/// `pac::Peripherals` struct are named according to their datasheet identifier.
+/// Consequently, you must access the peripheral using that name. For example,
+///
+/// ```
+/// let mut peripherals = pac::Peripherals::take().unwrap();
+/// let uart = peripherals.SERCOM2;
+/// ```
+///
+/// To provide access to the same struct field using *different* names, the
+/// `bsp_peripherals!` macro defines another macro, `periph_alias!`. Based on
+/// the example above, we could use the `periph_alias!` macro to access the
+/// `SERCOM2` peripheral without ever referring to it directly.
+///
+/// ```
+/// let mut peripherals = pac::Peripherals::take().unwrap();
+/// let uart = periph_alias!(peripherals.uart);
+/// ```
+///
+/// Note that the `Uart` alias was translated to `snake_case` when accessing
+/// the `pac::Peripherals` field. The same is true for the `DisplaySpi` alias.
+///
+/// ```
+/// let mut peripherals = pac::Peripherals::take().unwrap();
+/// let display_spi = periph_alias!(peripherals.display_spi);
+/// ```
+///
+/// ## Attributes and documentation
+///
+/// BSP authors can also add attributes to various parts of the macro
+/// declaration. Attributes can be added to the entire `PERIPHERAL` block. These
+/// attributes will be propagated to every use of the corresponding
+/// `PERIPHERAL`. Attributes applied to each alias, on the other hand, will only
+/// be propagated to items specific to that alias, like the corresponding type
+/// alias.
+///
+/// ```
+/// atsamd_hal::bsp_peripherals!(
+///     SERCOM2 {
+///         #[cfg(feature = "uart")]
+///         Uart
+///     }
+///     #[cfg(feature = "display")]
+///     SERCOM4 { DisplaySpi }
+/// );
+/// ```
+#[macro_export]
+macro_rules! bsp_peripherals {
+    (
+        $(
+            $( #[$peripheral_cfg:meta] )*
+            $PERIPHERAL:ident {
+                $(
+                    $( #[$alias_cfg:meta] )*
+                    $Alias:ident $(,)?
+                )+
+            } $(,)?
+        )+
+    ) => {
+        $(
+            $( #[$peripheral_cfg] )*
+            $crate::__create_peripheral_aliases!(
+                $PERIPHERAL
+                $(
+                    $( #[$alias_cfg] )*
+                    $Alias
+                )+
+            );
+        )+
+
+        $crate::__define_periph_alias_macro!(
+            $(
+                $(
+                    $( #[$alias_cfg] )*
+                    ($PERIPHERAL, $Alias)
+                )+
+            )+
+        );
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __create_peripheral_aliases {
+    (
+        $PERIPHERAL:ident
+        $(
+            $( #[$attr:meta] )*
+            $Alias:ident
+        )+
+    ) => {
+        $crate::paste::paste! {
+            $(
+                $( #[$attr] )*
+                #[
+                    doc = "Alias for the "
+                    "[`" $PERIPHERAL "`](atsamd_hal::pac::" $PERIPHERAL ") "
+                    "peripheral"
+                ]
+                pub type $Alias = atsamd_hal::pac::$PERIPHERAL;
+            )+
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __define_periph_alias_macro {
+    (
+        $(
+            $( #[$attr:meta] )*
+            ($PERIPHERAL:ident, $Alias:ident)
+        )+
+    ) => {
+        $crate::paste::paste! {
+            /// Refer to fields of the [`Peripherals`](atsamd_hal::pac::Peripherals)
+            /// struct by alternate names
+            ///
+            /// This macro can be used to access fields of the `Peripherals`
+            /// struct by alternate names. The available aliases are:
+            ///
+            #[ doc =
+                $(
+                    "    - [`" $PERIPHERAL "`](atsamd_hal::pac::" $PERIPHERAL ") \
+                    can be refered to with the type alias [`" $Alias "`] and \
+                    accessed as the field name `" $Alias:snake "`\n"
+                )+
+            ]
+            ///
+            /// For example. suppose `display_spi` were an alternate name for
+            /// the `SERCOM4` peripheral. You could use the `periph_alias!`
+            /// macro to access it like this:
+            ///
+            /// ```
+            /// let mut peripherals = pac::Peripherals::take().unwrap();
+            /// // Replace this
+            /// let display_spi = peripherals.SERCOM4;
+            /// // With this
+            /// let display_spi = periph_alias!(peripherals.display_spi);
+            /// ```
+            #[macro_export]
+            macro_rules! periph_alias {
+                $(
+                    ( $peripherals:ident . [<$Alias:snake>] ) => {
+                        {
+                            $( #[$attr] )*
+                            macro_rules! [<peripheral_alias_ $Alias:snake>] {
+                                () => { $peripherals.$PERIPHERAL };
+                            }
+                            [<peripheral_alias_ $Alias:snake>]!()
+                        }
+                    };
+                )+
+            }
+        }
+    }
+}

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -231,3 +231,7 @@ pub mod same54 {
     #[cfg(feature = "unproven")]
     pub use crate::pwm;
 }
+
+#[macro_use]
+mod bsp_peripherals_macro;
+pub use bsp_peripherals_macro::*;


### PR DESCRIPTION
# Summary

Taking inspiration from `bsp_pins!`, this macro abstracts over the names
of peripherals within the Peripherals struct. BSP authors can use the
`bsp_peripherals!` macro to define the aliases, while users can use the
`periph_alias!` macro to refer to the aliased peripherals.

Update the `feather_m0` to use this new approach.

Also fix a bug in `bsp_pins!` discovered while developing the new macro.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)