### PR TITLE
Path dependency for Metro M4

### DIFF
--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -28,7 +28,7 @@ optional = true
 
 [dev-dependencies]
 usbd-serial = "0.1"
-panic-probe = "0.1.0"
+panic-probe = "0.2"
 panic-halt = "0.2"
 panic-semihosting = "0.5"
 panic-rtt-target = { version = "0.1.1", features = ["cortex-m"] }


### PR DESCRIPTION
# Summary
Corrected the hal dependency for Metro M4

# Checklist
  - [ ] `CHANGELOG.md` for the BSP or HAL updated
  - [ ] All new or modified code is well documented, especially public items
  - [ ] No new warnings or clippy suggestions have been introduced (see CI or check locally)

## If Adding a new Board
  - [ ] Board CI added to `crates.json`
  - [ ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"