### PR TITLE
Make SPI Error support defmt::Format

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fixed the RTC implementation of embedded-hal timer traits to be periodic again (#490)
 - Add Integrity Check Monitor (ICM) abstraction (#480)
 - Add Public Key Cryptography Controller (PUKCC) support (#486)
-- Made SPI Error type support `defmt::Format` trait (behind the `defmt` feature)
+- Made SPI/I2C Error types support `defmt::Format` trait (behind the `defmt` feature)
 
 ---
 

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed the RTC implementation of embedded-hal timer traits to be periodic again (#490)
 - Add Integrity Check Monitor (ICM) abstraction (#480)
 - Add Public Key Cryptography Controller (PUKCC) support (#486)
+- Made SPI Error type support `defmt::Format` trait (behind the `defmt` feature)
 
 ---
 

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -56,6 +56,10 @@ version = "0.1.0-alpha.1"
 default-features = false
 version = "1.0"
 
+[dependencies.defmt]
+version = "0.2"
+optional = true
+
 # Each of the supported chips is listed as an optional dependency here.
 # This makes it available when the corresponding feature name is referenced.
 # We use a feature named "samdFOO" to pull in the dependency named "atsamdFOO"

--- a/hal/src/thumbv6m/sercom/v1/i2c.rs
+++ b/hal/src/thumbv6m/sercom/v1/i2c.rs
@@ -400,6 +400,7 @@ i2c!([
 ]);
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum I2CError {
     ArbitrationLost,
     AddressError,

--- a/hal/src/thumbv6m/sercom/v1/spi.rs
+++ b/hal/src/thumbv6m/sercom/v1/spi.rs
@@ -21,6 +21,7 @@ use crate::spi_common::CommonSpi;
 use crate::time::Hertz;
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     Overrun,
 }

--- a/hal/src/thumbv6m/sercom/v2/spi.rs
+++ b/hal/src/thumbv6m/sercom/v2/spi.rs
@@ -909,6 +909,7 @@ bitflags! {
 ///
 /// The SPI peripheral only has one error type: buffer overflow.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     Overflow,
 }

--- a/hal/src/thumbv7em/sercom/v1/i2c.rs
+++ b/hal/src/thumbv7em/sercom/v1/i2c.rs
@@ -418,6 +418,7 @@ i2c!([
 ]);
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum I2CError {
     ArbitrationLost,
     AddressError,

--- a/hal/src/thumbv7em/sercom/v1/spi.rs
+++ b/hal/src/thumbv7em/sercom/v1/spi.rs
@@ -19,6 +19,7 @@ use crate::spi_common::CommonSpi;
 use crate::time::Hertz;
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     Overrun,
 }

--- a/hal/src/thumbv7em/sercom/v2/spi.rs
+++ b/hal/src/thumbv7em/sercom/v2/spi.rs
@@ -886,6 +886,7 @@ bitflags! {
 /// The SPI peripheral only has two error types, buffer overflow and transaction
 /// length error.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     Overflow,
     LengthError,


### PR DESCRIPTION
# Summary
Make SPI Error support the defmt::Format trait (behind the `defmt` feature)

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)