### PR TITLE
fixup unneeded dependencies in wio_lite_w600

### DIFF
--- a/boards/wio_lite_w600/CHANGELOG.md
+++ b/boards/wio_lite_w600/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Unreleased
+
+# v0.2.1
+
+- remove extraneous `embedded-hal` & `nb dependencies
+
+---
+
+Changelog tracking started at v0.2.0

--- a/boards/wio_lite_w600/Cargo.toml
+++ b/boards/wio_lite_w600/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wio_lite_w600"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Daniel Mason <daniel@danielmason.com"]
 description = "Board Support crate for the Wio Lite W600"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
@@ -12,8 +12,6 @@ edition = "2018"
 
 [dependencies]
 cortex-m = "0.6"
-embedded-hal = "0.2.3"
-nb = "0.1"
 cortex-m-rt = { version = "0.6", optional = true }
 usb-device = { version = "0.2", optional = true }
 

--- a/boards/wio_lite_w600/examples/blinky_basic.rs
+++ b/boards/wio_lite_w600/examples/blinky_basic.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-#[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;
 
 use wio_lite_w600 as bsp;


### PR DESCRIPTION
# Summary
Follow-up from #418 to cleanup unneeded dependencies

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)
