### PR TITLE
Move `Sealed` trait implementation to `crate::typelevel`

### DIFF
--- a/hal/src/dmac/transfer.rs
+++ b/hal/src/dmac/transfer.rs
@@ -118,7 +118,6 @@ pub unsafe trait Beat: Sealed {
 macro_rules! impl_beat {
     ( $( ($Type:ty, $Size:ident) ),+ ) => {
         $(
-            impl Sealed for $Type {}
             unsafe impl Beat for $Type {
                 const BEATSIZE: BeatSize = BeatSize::$Size;
             }

--- a/hal/src/typelevel.rs
+++ b/hal/src/typelevel.rs
@@ -635,6 +635,14 @@ mod private {
     /// Super trait used to mark traits with an exhaustive set of
     /// implementations
     pub trait Sealed {}
+
+    impl Sealed for u8 {}
+    impl Sealed for i8 {}
+    impl Sealed for u16 {}
+    impl Sealed for i16 {}
+    impl Sealed for u32 {}
+    impl Sealed for i32 {}
+    impl Sealed for f32 {}
 }
 
 pub(crate) use private::Sealed;


### PR DESCRIPTION
# Summary

Implementations of `crate::typelevel::private::Sealed` for external types
spread all over the HAL might cause unexpected compile time errors (doubled
trait implementation), especially if one is hidden behind a feature gate
(like DMA).

# Checklist
  - [ ] ~`CHANGELOG.md` for the BSP or HAL updated~ Irrelevant: Change transparent for a user
  - [ ] ~All new or modified code is well documented, especially public items~ Irrelevant
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)
