### PR TITLE
Replace deprecated SpinTimer with TimerCounter in neopixel_rainbow example

### DIFF
--- a/boards/feather_m4/CHANGELOG.md
+++ b/boards/feather_m4/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- replace deprecated `SpinTimer` with `TimerCounter` in the `neopixel_rainbow` example
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 - move `usbd-x` crates used only in examples to `[dev-dependencies]`


### PR DESCRIPTION
# Summary

I replaced the deprecated `SpinTimer` with the `TimerCounter` in the `neopixel_rainbow` example.

# Checklist
  - [X] `CHANGELOG.md` for the BSP or HAL updated
  - [X] All new or modified code is well documented, especially public items
  - [X] No new warnings or clippy suggestions have been introduced (see CI or check locally)

