### PR TITLE
Add a NeoPixel Rainbow example for the Circuit Playground Express

### DIFF
--- a/boards/circuit_playground_express/CHANGELOG.md
+++ b/boards/circuit_playground_express/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- added the `neopixel_rainbow` example
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 - removed unnecessary dependency on `nb` (#510)

--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -27,6 +27,11 @@ cortex-m = "0.7"
 panic-halt = "0.2"
 panic-semihosting = "0.5"
 usbd-serial = "0.1"
+smart-leds = "0.3.0"
+
+[dev-dependencies.ws2812-timer-delay]
+features = ["slow"]
+version = "0.3.0"
 
 [features]
 # ask the HAL to enable atsamd21g support

--- a/boards/circuit_playground_express/examples/neopixel_rainbow.rs
+++ b/boards/circuit_playground_express/examples/neopixel_rainbow.rs
@@ -1,0 +1,67 @@
+#![no_std]
+#![no_main]
+
+// Neopixel Rainbow
+// This only functions when the --release version is compiled. Using the debug
+// version leads to slow pulse durations which results in a straight white LED
+// output.
+//
+// // Needs to be compiled with --release for the timing to be correct
+
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
+use bsp::hal;
+use bsp::pac;
+use circuit_playground_express as bsp;
+
+use bsp::entry;
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::prelude::*;
+use hal::timer::TimerCounter;
+use pac::{CorePeripherals, Peripherals};
+
+use smart_leds::{
+    hsv::{hsv2rgb, Hsv},
+    SmartLedsWrite,
+};
+use ws2812_timer_delay as ws2812;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let pins = bsp::Pins::new(peripherals.PORT);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    let gclk0 = clocks.gclk0();
+    let timer_clock = clocks.tcc2_tc3(&gclk0).unwrap();
+    let mut timer = TimerCounter::tc3_(&timer_clock, peripherals.TC3, &mut peripherals.PM);
+    timer.start(3.mhz());
+
+    let neopixel_pin: bsp::NeoPixel = pins.d8.into();
+    let mut neopixel = ws2812::Ws2812::new(timer, neopixel_pin);
+
+    // Loop through all of the available hue values (colors) to make a
+    // rainbow effect from the onboard neopixel
+    loop {
+        for j in 0..255u8 {
+            let colors = [hsv2rgb(Hsv {
+                hue: j,
+                sat: 255,
+                val: 2,
+            }); 10];
+            neopixel.write(colors.iter().cloned()).unwrap();
+            delay.delay_ms(5u8);
+        }
+    }
+}


### PR DESCRIPTION
# Summary

This just adds a simple NeoPixel Rainbow example for the Circuit Playground Express, which is tricky because it requires using the `slow` feature of the `ws2812-spin-timer` crate otherwise its all white LED's.

# Checklist
  - [X] `CHANGELOG.md` for the BSP or HAL updated
  - [X] All new or modified code is well documented, especially public items
  - [X] No new warnings or clippy suggestions have been introduced (see CI or check locally)
