### PR TITLE
Update xiao m0 library to use v2 gpio and sercom

### DIFF
--- a/boards/xiao_m0/CHANGELOG.md
+++ b/boards/xiao_m0/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.11.0
+
+- update gpio and sercom dependencies to v2
+- create shared_i2c example with I2C bus used for SSD1306 OLED screen and accelerometer
+- create ssd1306_i2c example with basic usage of OLED screen for animation with I2C
+- update blink example to be more readable for newcomers
+- clean up usb_echo example (and extend of blinking on data transfer)
+
 # Unreleased
 
 - remove extraneous `embedded-hal` dependencies from BSPs

--- a/boards/xiao_m0/CHANGELOG.md
+++ b/boards/xiao_m0/CHANGELOG.md
@@ -5,9 +5,6 @@
 - create ssd1306_i2c example with basic usage of OLED screen for animation with I2C
 - update blink example to be more readable for newcomers
 - clean up usb_echo example (and extend of blinking on data transfer)
-
-# Unreleased
-
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 - move `usbd-x` crates used only in examples to `[dev-dependencies]`

--- a/boards/xiao_m0/Cargo.toml
+++ b/boards/xiao_m0/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "xiao_m0"
-version = "0.10.0"
-authors = ["Garret Kelly <gdk@google.com>"]
+version = "0.11.0"
+authors = ["Garret Kelly <gdk@google.com>", "Maciej Procyk <macieekprocyk@gmail.com>"]
 description = "Board support crate for the Seeed Studio Seeeduino XIAO"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.6.15"
 optional = true
 
 [dependencies.atsamd-hal]
@@ -25,6 +25,10 @@ optional = true
 cortex-m = "0.7"
 usbd-serial = "0.1"
 panic-halt = "0.2"
+ssd1306 = "0.6.0"
+embedded-graphics = "0.7.1"
+mpu6050 = "0.1.4"
+shared-bus = "0.2.2"
 
 [features]
 default = ["rt", "atsamd-hal/samd21g"]
@@ -34,12 +38,20 @@ usb = ["atsamd-hal/usb", "usb-device"]
 
 [[example]]
 name = "blink"
+required-features = ["unproven"]
 
 [[example]]
-name = "usb_serial"
-required-features = ["usb"]
+name = "shared_i2c"
+
+[[example]]
+name = "ssd1306_i2c"
+
+[[example]]
+name = "usb_echo"
+required-features = ["usb", "unproven"]
 
 [profile.release]
+debug = false
 lto = true
 opt-level = "s"
 

--- a/boards/xiao_m0/README.md
+++ b/boards/xiao_m0/README.md
@@ -17,7 +17,7 @@ for examples.
 * Put your device in bootloader mode by bridging the `RST` pads _twice_ in
   quick succession. The orange LED will pulse when the device is in bootloader
   mode.
-* Build and upload in one step: `cargo hf2 --release --example blink`
+* Build and upload in one step: `cargo hf2 --release --example blink --features="unproven"`
   * Note that if you're using an older `cargo-hf2` that you'll need to specify
     the VID/PID when flashing: `cargo hf2 --vid 0x2886 --pid 0x002f --release
-    --example blink`
+    --example blink --features="unproven"`

--- a/boards/xiao_m0/examples/blink.rs
+++ b/boards/xiao_m0/examples/blink.rs
@@ -1,19 +1,13 @@
 #![no_main]
 #![no_std]
 
-#[cfg(not(feature = "use_semihosting"))]
-use panic_halt as _;
-#[cfg(feature = "use_semihosting")]
-use panic_semihosting as _;
+extern crate panic_halt;
 
-use bsp::hal;
+use hal::{clock::GenericClockController, delay::Delay, prelude::*};
+use pac::{CorePeripherals, Peripherals};
+
+use bsp::{entry, hal, pac, Led0};
 use xiao_m0 as bsp;
-
-use bsp::entry;
-use hal::clock::GenericClockController;
-use hal::delay::Delay;
-use hal::pac::{CorePeripherals, Peripherals};
-use hal::prelude::*;
 
 #[entry]
 fn main() -> ! {
@@ -25,24 +19,13 @@ fn main() -> ! {
         &mut peripherals.SYSCTRL,
         &mut peripherals.NVMCTRL,
     );
-    let mut pins = bsp::Pins::new(peripherals.PORT);
-    let mut led0 = pins.led0.into_open_drain_output(&mut pins.port);
-    let mut led1 = pins.led1.into_open_drain_output(&mut pins.port);
-    let mut led2 = pins.led2.into_open_drain_output(&mut pins.port);
-    let mut delay = Delay::new(core.SYST, &mut clocks);
+    let pins = bsp::Pins::new(peripherals.PORT);
 
-    let mut counter = 0u8;
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+    let mut led0: Led0 = pins.led0.into_push_pull_output();
+
     loop {
-        counter = counter.wrapping_add(1);
-        delay.delay_ms(100u8);
-        if counter & (1 << 0) != 0 {
-            led0.toggle();
-        }
-        if counter & (1 << 1) != 0 {
-            led1.toggle();
-        }
-        if counter & (1 << 2) != 0 {
-            led2.toggle();
-        }
+        delay.delay_ms(200u8);
+        led0.toggle().unwrap();
     }
 }

--- a/boards/xiao_m0/examples/shared_i2c.rs
+++ b/boards/xiao_m0/examples/shared_i2c.rs
@@ -1,0 +1,56 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+
+use core::fmt::Write;
+
+use hal::{clock::GenericClockController, delay::Delay, prelude::*, time::KiloHertz};
+use mpu6050::Mpu6050;
+use pac::{CorePeripherals, Peripherals};
+use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
+
+use bsp::{entry, hal, pac};
+use xiao_m0 as bsp;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let pins = bsp::Pins::new(peripherals.PORT);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+    let i2c = bsp::i2c_master(
+        &mut clocks,
+        KiloHertz(400),
+        peripherals.SERCOM0,
+        &mut peripherals.PM,
+        pins.a4,
+        pins.a5,
+    );
+    let i2c_bus = shared_bus::BusManagerSimple::new(i2c);
+
+    let interface = I2CDisplayInterface::new(i2c_bus.acquire_i2c());
+    let mut display =
+        Ssd1306::new(interface, DisplaySize128x64, DisplayRotation::Rotate180).into_terminal_mode();
+    display.init().unwrap();
+
+    let mut mpu = Mpu6050::new(i2c_bus.acquire_i2c());
+    mpu.init(&mut delay).unwrap();
+
+    loop {
+        display.clear().unwrap();
+
+        let acc = mpu.get_acc().unwrap();
+        display
+            .write_fmt(format_args!("ax={}\nay={}\naz={}\n", acc.x, acc.y, acc.z))
+            .unwrap();
+
+        delay.delay_ms(1_000u32);
+    }
+}

--- a/boards/xiao_m0/examples/ssd1306_i2c.rs
+++ b/boards/xiao_m0/examples/ssd1306_i2c.rs
@@ -1,0 +1,119 @@
+#![no_std]
+#![no_main]
+
+extern crate panic_halt;
+
+use embedded_graphics::{
+    pixelcolor::BinaryColor,
+    prelude::*,
+    primitives::{Circle, PrimitiveStyleBuilder},
+};
+use hal::{clock::GenericClockController, delay::Delay, prelude::*, time::KiloHertz};
+use pac::{CorePeripherals, Peripherals};
+use ssd1306::{prelude::*, I2CDisplayInterface, Ssd1306};
+
+use bsp::{entry, hal, pac};
+use xiao_m0 as bsp;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let pins = bsp::Pins::new(peripherals.PORT);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+    let i2c = bsp::i2c_master(
+        &mut clocks,
+        KiloHertz(400),
+        peripherals.SERCOM0,
+        &mut peripherals.PM,
+        pins.a4,
+        pins.a5,
+    );
+
+    let interface = I2CDisplayInterface::new(i2c);
+    let mut display = Ssd1306::new(interface, DisplaySize128x64, DisplayRotation::Rotate0)
+        .into_buffered_graphics_mode();
+
+    display.init().unwrap();
+    display.flush().unwrap();
+
+    let style = PrimitiveStyleBuilder::new()
+        .fill_color(BinaryColor::On)
+        .build();
+
+    let width = display.size().width as f32;
+    let height = display.size().height as f32;
+    let mut states = [0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.95]
+        .map(|p| State::new(width * p, height / 2. * (1. + p), 0., 0., 0., -5.));
+
+    loop {
+        display.clear();
+        states.iter_mut().for_each(|state| {
+            Circle::new(state.into(), 8)
+                .into_styled(style)
+                .draw(&mut display)
+                .unwrap();
+            state.update(0.1);
+        });
+        display.flush().unwrap();
+        delay.delay_ms(10u8);
+    }
+}
+
+impl From<&mut State> for Point {
+    fn from(s: &mut State) -> Self {
+        Point::new(s.xy.x as i32, s.xy.y as i32)
+    }
+}
+
+impl Vec {
+    pub fn new(x: f32, y: f32) -> Vec {
+        Vec { x, y }
+    }
+}
+
+impl State {
+    pub fn new(x: f32, y: f32, vx: f32, vy: f32, ax: f32, ay: f32) -> State {
+        let xy = Vec::new(x, y);
+        let v = Vec::new(vx, vy);
+        let a = Vec::new(ax, ay);
+        State { xy, v, a }
+    }
+    pub fn update(&mut self, dt: f32) {
+        self.xy.x = self.xy.x + self.v.x * dt + self.a.x * dt * dt * 0.5;
+        self.xy.y = self.xy.y + self.v.y * dt + self.a.y * dt * dt * 0.5;
+
+        self.v.x = self.v.x + self.a.x * dt;
+        self.v.y = self.v.y + self.a.y * dt;
+
+        self.check_bounce();
+    }
+
+    fn check_bounce(&mut self) {
+        if self.xy.x < 0. {
+            self.v.x = -self.v.x;
+            self.xy.x = 0.;
+        }
+        if self.xy.y < 0. {
+            self.v.y = -self.v.y;
+            self.xy.y = 0.;
+        }
+    }
+}
+
+struct Vec {
+    pub x: f32,
+    pub y: f32,
+}
+
+struct State {
+    xy: Vec,
+    v: Vec,
+    a: Vec,
+}

--- a/boards/xiao_m0/src/lib.rs
+++ b/boards/xiao_m0/src/lib.rs
@@ -25,84 +25,100 @@ pub mod pins {
 
     hal::bsp_pins!(
         PA02 {
+            /// Pin A0/D0/DAC
             name: a0
         }
         PA04 {
+            /// Pin A1/D1
             name: a1
         }
         PA10 {
+            /// Pin A2/D2
             name: a2
         }
         PA11 {
+            /// Pin A3/D3
             name: a3
         }
         PA08 {
+            /// Pin A4/D4/SDA
             name: a4
             aliases: {
                 AlternateC: Sda
             }
         }
         PA09 {
+            /// Pin A5/D5/SCL
             name: a5
             aliases: {
                 AlternateC: Scl
             }
         }
         PB08 {
+            /// Pin A6/D6/TX
             name: a6
             aliases: {
                 AlternateD: UartTx
             }
         }
         PB09 {
+            /// Pin A7/D7/RX
             name: a7
             aliases: {
                 AlternateD: UartRx
             }
         }
         PA07 {
+            /// Pin A8/D8/SCK
             name: a8
             aliases: {
                 AlternateD: Sclk
             }
         }
         PA05 {
+            /// Pin A9/D9/MISO
             name: a9
             aliases: {
                 AlternateD: Miso
             }
         }
         PA06 {
+            /// Pin A10/D10/MOSI
             name: a10
             aliases: {
                 AlternateD: Mosi
             }
         }
         PA17 {
+            /// On-board yellow 'L' LED
             name: led0
             aliases: {
                 PushPullOutput: Led0
             }
         }
         PA18 {
+            /// On-board blue 'RX' LED
             name: led1
             aliases: {
                 PushPullOutput: Led1
             }
         }
         PA19 {
+            /// On-board blue 'TX' LED
             name: led2
             aliases: {
                 PushPullOutput: Led2
             }
         }
         PA24 {
+            /// The USB D- pad
             name: usb_dm
             aliases: {
                 AlternateG: UsbDm
             }
         }
         PA25 {
+            /// The USB D+ pad
             name: usb_dp
             aliases: {
                 AlternateG: UsbDp

--- a/boards/xiao_m0/src/lib.rs
+++ b/boards/xiao_m0/src/lib.rs
@@ -1,160 +1,204 @@
 #![no_std]
 
 pub use atsamd_hal as hal;
-pub use hal::common::*;
-pub use hal::pac;
-
 #[cfg(feature = "rt")]
 pub use cortex_m_rt::entry;
-
-use hal::prelude::*;
-use hal::{
-    clock::GenericClockController,
-    define_pins,
-    gpio::PfD,
-    gpio::{Floating, Input, Port},
-    pad::PadPin,
-    sercom::{I2CMaster2, SPIMaster0, UART4},
-    time::Hertz,
+use hal::clock::GenericClockController;
+pub use hal::ehal;
+pub use hal::pac;
+use hal::sercom::{
+    v2::{uart, Sercom0, Sercom4},
+    I2CMaster0,
 };
-
+use hal::time::Hertz;
 #[cfg(feature = "usb")]
-use hal::gpio::v2::{AnyPin, PA24, PA25};
-#[cfg(feature = "usb")]
-use hal::usb::usb_device::bus::UsbBusAllocator;
-#[cfg(feature = "usb")]
-pub use hal::usb::UsbBus;
+use hal::usb::{usb_device::bus::UsbBusAllocator, UsbBus};
+use spi::Pads;
 
-define_pins!(
-    struct Pins,
-    pac: pac,
+use crate::hal::sercom::v2::spi;
+use crate::hal::sercom::v2::uart::{BaudMode, Oversampling};
+pub use pins::*;
 
-    /// Pin A0/D0/DAC
-    pin a0 = a2,
-    /// Pin A1/D1
-    pin a1 = a4,
-    /// Pin A2/D2
-    pin a2 = a10,
-    /// Pin A3/D3
-    pin a3 = a11,
-    /// Pin A4/D4/SDA
-    pin a4 = a8,
-    /// Pin A5/D5/SCL
-    pin a5 = a9,
-    /// Pin A6/D6/TX
-    pin a6 = b8,
-    /// Pin A7/D7/RX
-    pin a7 = b9,
-    /// Pin A8/D8/SCK
-    pin a8 = a7,
-    /// Pin A9/D9/MISO
-    pin a9 = a5,
-    /// Pin A10/D10/MOSI
-    pin a10 = a6,
+/// Definitions related to pins and pin aliases
+pub mod pins {
+    use super::hal;
 
-    /// On-board yellow 'L' LED.
-    pin led0 = a17,
-    /// On-board blue 'RX' LED.
-    pin led1 = a18,
-    /// On-board blue 'TX' LED.
-    pin led2 = a19,
+    hal::bsp_pins!(
+        PA02 {
+            name: a0
+        }
+        PA04 {
+            name: a1
+        }
+        PA10 {
+            name: a2
+        }
+        PA11 {
+            name: a3
+        }
+        PA08 {
+            name: a4
+            aliases: {
+                AlternateC: Sda
+            }
+        }
+        PA09 {
+            name: a5
+            aliases: {
+                AlternateC: Scl
+            }
+        }
+        PB08 {
+            name: a6
+            aliases: {
+                AlternateD: UartTx
+            }
+        }
+        PB09 {
+            name: a7
+            aliases: {
+                AlternateD: UartRx
+            }
+        }
+        PA07 {
+            name: a8
+            aliases: {
+                AlternateD: Sclk
+            }
+        }
+        PA05 {
+            name: a9
+            aliases: {
+                AlternateD: Miso
+            }
+        }
+        PA06 {
+            name: a10
+            aliases: {
+                AlternateD: Mosi
+            }
+        }
+        PA17 {
+            name: led0
+            aliases: {
+                PushPullOutput: Led0
+            }
+        }
+        PA18 {
+            name: led1
+            aliases: {
+                PushPullOutput: Led1
+            }
+        }
+        PA19 {
+            name: led2
+            aliases: {
+                PushPullOutput: Led2
+            }
+        }
+        PA24 {
+            name: usb_dm
+            aliases: {
+                AlternateG: UsbDm
+            }
+        }
+        PA25 {
+            name: usb_dp
+            aliases: {
+                AlternateG: UsbDp
+            }
+        }
+    );
+}
 
-    /// The USB D- pad.
-    pin usb_dm = a24,
-    /// The USB D+ pad.
-    pin usb_dp = a25,
-);
+/// UART pads for the labelled RX & TX pins
+pub type UartPads = uart::Pads<Sercom4, UartRx, UartTx>;
 
-/// Convenience function for setting up the TX (A6/D6) and RX (A7/D7) pins as a
-/// UART operating at `baud`.
-pub fn uart<F: Into<Hertz>>(
+/// UART device for the labelled RX & TX pins
+pub type Uart = uart::Uart<uart::Config<UartPads>, uart::Duplex>;
+
+/// Convenience for setting up the labelled RX, TX pins to
+/// operate as a UART device running at the specified baud.
+pub fn uart(
     clocks: &mut GenericClockController,
-    baud: F,
+    baud: impl Into<Hertz>,
     sercom4: pac::SERCOM4,
     pm: &mut pac::PM,
-    a7: gpio::Pb9<Input<Floating>>,
-    a6: gpio::Pb8<Input<Floating>>,
-    port: &mut Port,
-) -> UART4<hal::sercom::Sercom4Pad1<gpio::Pb9<PfD>>, hal::sercom::Sercom4Pad0<gpio::Pb8<PfD>>, (), ()>
-{
+    uart_rx: impl Into<UartRx>,
+    uart_tx: impl Into<UartTx>,
+) -> Uart {
     let gclk0 = clocks.gclk0();
-
-    UART4::new(
-        &clocks.sercom4_core(&gclk0).unwrap(),
-        baud.into(),
-        sercom4,
-        pm,
-        (a7.into_pad(port), a6.into_pad(port)),
-    )
+    let clock = &clocks.sercom4_core(&gclk0).unwrap();
+    let baud = baud.into();
+    let pads = uart::Pads::default().rx(uart_rx.into()).tx(uart_tx.into());
+    uart::Config::new(pm, sercom4, pads, clock.freq())
+        .baud(baud, BaudMode::Fractional(Oversampling::Bits16))
+        .enable()
 }
 
-/// Convenience function for setting up the A4/D4/SDA and A5/D5/SCL pins as an
-/// I2C master operating at `speed`.
-pub fn i2c_master<F: Into<Hertz>>(
-    clocks: &mut GenericClockController,
-    speed: F,
-    sercom2: pac::SERCOM2,
-    pm: &mut pac::PM,
-    a4: gpio::Pa8<Input<Floating>>,
-    a5: gpio::Pa9<Input<Floating>>,
-    port: &mut Port,
-) -> hal::sercom::I2CMaster2<
-    hal::sercom::Sercom2Pad0<gpio::Pa8<gpio::PfD>>,
-    hal::sercom::Sercom2Pad1<gpio::Pa9<gpio::PfD>>,
-> {
-    let gclk0 = clocks.gclk0();
+/// I2C master for the labelled SDA & SCL pins
+pub type I2C = I2CMaster0<Sda, Scl>;
 
-    I2CMaster2::new(
-        &clocks.sercom2_core(&gclk0).unwrap(),
-        speed.into(),
-        sercom2,
-        pm,
-        a4.into_pad(port),
-        a5.into_pad(port),
-    )
-}
-
-/// Convenience function for setting up the A8/D8/SCK, A10/D10/MOSI, and
-/// A9/D9/MISO pins as an SPI master in SPI mode 0.
-pub fn spi_master<F: Into<Hertz>>(
+/// Convenience for setting up the labelled SDA, SCL pins to
+/// operate as an I2C master running at the specified frequency.
+pub fn i2c_master(
     clocks: &mut GenericClockController,
-    speed: F,
+    baud: impl Into<Hertz>,
     sercom0: pac::SERCOM0,
     pm: &mut pac::PM,
-    sck: gpio::Pa7<Input<Floating>>,
-    mosi: gpio::Pa6<Input<Floating>>,
-    miso: gpio::Pa5<Input<Floating>>,
-    port: &mut Port,
-) -> SPIMaster0<
-    hal::sercom::Sercom0Pad1<gpio::Pa5<gpio::PfD>>,
-    hal::sercom::Sercom0Pad2<gpio::Pa6<gpio::PfD>>,
-    hal::sercom::Sercom0Pad3<gpio::Pa7<gpio::PfD>>,
-> {
+    sda: impl Into<Sda>,
+    scl: impl Into<Scl>,
+) -> I2C {
     let gclk0 = clocks.gclk0();
+    let clock = &clocks.sercom0_core(&gclk0).unwrap();
+    let baud = baud.into();
+    let sda = sda.into();
+    let scl = scl.into();
+    I2CMaster0::new(clock, baud, sercom0, pm, sda, scl)
+}
 
-    SPIMaster0::new(
-        &clocks.sercom0_core(&gclk0).unwrap(),
-        speed.into(),
-        hal::hal::spi::Mode {
-            phase: hal::hal::spi::Phase::CaptureOnFirstTransition,
-            polarity: hal::hal::spi::Polarity::IdleLow,
-        },
-        sercom0,
-        pm,
-        (miso.into_pad(port), mosi.into_pad(port), sck.into_pad(port)),
-    )
+/// SPI pads for the labelled SPI peripheral
+///
+/// You can use these pads with other, user-defined [`spi::Config`]urations.
+pub type SpiPads = Pads<Sercom0, Miso, Mosi, Sclk>;
+
+/// SPI master for the labelled SPI peripheral
+pub type Spi = spi::Spi<spi::Config<SpiPads>>;
+
+/// Convenience for setting up the labelled SPI peripheral.
+/// This powers up SERCOM0 and configures it for use as an
+/// SPI Master in SPI Mode 0.
+pub fn spi_master(
+    clocks: &mut GenericClockController,
+    baud: impl Into<Hertz>,
+    sercom0: pac::SERCOM0,
+    pm: &mut pac::PM,
+    sclk: impl Into<Sclk>,
+    mosi: impl Into<Mosi>,
+    miso: impl Into<Miso>,
+) -> Spi {
+    let gclk0 = clocks.gclk0();
+    let clock = clocks.sercom4_core(&gclk0).unwrap();
+    let freq = clock.freq();
+    let (miso, mosi, sclk) = (miso.into(), mosi.into(), sclk.into());
+    let pads = Pads::default().data_in(miso).data_out(mosi).sclk(sclk);
+    spi::Config::new(pm, sercom0, pads, freq)
+        .baud(baud)
+        .spi_mode(spi::MODE_0)
+        .enable()
 }
 
 #[cfg(feature = "usb")]
+/// Convenience function for setting up USB
 pub fn usb_allocator(
     usb: pac::USB,
     clocks: &mut GenericClockController,
     pm: &mut pac::PM,
-    dm: impl AnyPin<Id = PA24>,
-    dp: impl AnyPin<Id = PA25>,
+    dm: impl Into<UsbDm>,
+    dp: impl Into<UsbDp>,
 ) -> UsbBusAllocator<UsbBus> {
     let gclk0 = clocks.gclk0();
-    let usb_clock = &clocks.usb(&gclk0).unwrap();
-
-    UsbBusAllocator::new(UsbBus::new(usb_clock, pm, dm, dp, usb))
+    let clock = &clocks.usb(&gclk0).unwrap();
+    let (dm, dp) = (dm.into(), dp.into());
+    UsbBusAllocator::new(UsbBus::new(clock, pm, dm, dp, usb))
 }


### PR DESCRIPTION
# Summary
Updated xiao m0 library to use up to date gpio and sercom api and produce no deprecation warnings when compiling. Updated examples to use new code and provide new examples tested with physical screen and accelerometer.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)