### PR TITLE
Implement `rtic::Monotonic` using fugit & bump RTIC dependencies

### DIFF
--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -27,15 +27,8 @@ optional = true
 version = "0.3"
 optional = true
 
-[dependencies.rtic-monotonic]
-version = "=0.1.0-rc.1"
-optional = true
-
-[dependencies.cortex-m-rtic]
-version = "=0.6.0-rc.2"
-optional = true
-
 [dev-dependencies]
+cortex-m-rtic = "=0.6.0-rc.4"
 cortex-m = "0.7"
 usbd-serial = "0.1"
 cortex-m-semihosting = "0.3"
@@ -63,7 +56,7 @@ max-channels = ["dma", "atsamd-hal/max-channels"]
 # Enable pins for the adalogger SD card reader
 adalogger = []
 sdmmc = ["embedded-sdmmc", "atsamd-hal/sdmmc"]
-rtic = ["atsamd-hal/rtic", "rtic-monotonic", "cortex-m-rtic"]
+rtic = ["atsamd-hal/rtic"]
 use_semihosting = []
 
 [profile.dev]

--- a/boards/feather_m0/examples/blinky_rtic.rs
+++ b/boards/feather_m0/examples/blinky_rtic.rs
@@ -15,14 +15,12 @@ use rtic;
 
 #[rtic::app(device = bsp::pac, peripherals = true, dispatchers = [EVSYS])]
 mod app {
-
     use super::*;
     use bsp::hal;
     use hal::clock::{ClockGenId, ClockSource, GenericClockController};
     use hal::pac::Peripherals;
     use hal::prelude::*;
-    use hal::rtc::{Count32Mode, Rtc};
-    use rtic_monotonic::Extensions;
+    use hal::rtc::{Count32Mode, Duration, Rtc};
 
     #[local]
     struct Local {}
@@ -70,6 +68,6 @@ mod app {
     fn blink(mut cx: blink::Context) {
         // If the LED were a local resource, the lock would not be necessary
         cx.shared.red_led.lock(|led| led.toggle().unwrap());
-        blink::spawn_after(1_u32.seconds()).ok();
+        blink::spawn_after(Duration::secs(1)).ok();
     }
 }

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -18,10 +18,6 @@ path = "../../hal"
 version = "0.13"
 default-features = false
 
-[dependencies.rtic-monotonic]
-version = "=0.1.0-rc.1"
-optional = true
-
 [dependencies.usb-device]
 version = "0.2"
 optional = true
@@ -32,14 +28,14 @@ usbd-serial = "0.1"
 panic-halt = "0.2"
 panic-semihosting = "0.5"
 cortex-m-semihosting = "0.3"
-cortex-m-rtic = "=0.6.0-rc.2"
+cortex-m-rtic = "=0.6.0-rc.4"
 sx1509 = "0.2"
 
 [features]
 # ask the HAL to enable atsamd21g support
 default = ["rt", "atsamd-hal/samd21g"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
-rtic = ["atsamd-hal/rtic", "rtic-monotonic"]
+rtic = ["atsamd-hal/rtic"]
 unproven = ["atsamd-hal/unproven"]
 use_rtt = ["atsamd-hal/use_rtt"]
 usb = ["atsamd-hal/usb", "usb-device"]

--- a/boards/metro_m0/examples/blinky_rtic.rs
+++ b/boards/metro_m0/examples/blinky_rtic.rs
@@ -20,8 +20,7 @@ mod app {
     use hal::clock::{ClockGenId, ClockSource, GenericClockController};
     use hal::pac::Peripherals;
     use hal::prelude::*;
-    use hal::rtc::{Count32Mode, Rtc};
-    use rtic_monotonic::Extensions;
+    use hal::rtc::{Count32Mode, Duration, Rtc};
 
     #[local]
     struct Local {}
@@ -69,6 +68,6 @@ mod app {
     fn blink(mut cx: blink::Context) {
         // If the LED were a local resource, the lock would not be necessary
         cx.shared.red_led.lock(|led| led.toggle().unwrap());
-        blink::spawn_after(1_u32.seconds()).ok();
+        blink::spawn_after(Duration::secs(1)).ok();
     }
 }

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -8,7 +8,9 @@
 - Add Public Key Cryptography Controller (PUKCC) support (#486)
 - Refactor the SPI module (#467)
 - Bump Rust edition to 2021 and MSRV to 1.56 (#535)
-
+- Implement `rtic::Monotonic` for `RTC` using `fugit` (#540)
+  - RTIC spawn task API will now require `fugit::Duration<_, _, _>` (aliased
+  at `atsamd_hal::rtc::Duration`) instead of `embedded_time::Duration`
 ---
 
 Changelog tracking started at v0.13

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -45,13 +45,13 @@ version = "0.2.14"
 version = "0.2"
 optional = true
 
-[dependencies.cortex-m-rtic]
-optional = true
-version = "0.6.0-alpha.5"
-
 [dependencies.rtic-monotonic]
 optional = true
-version = "0.1.0-alpha.1"
+version = "0.1.0-rc.2"
+
+[dependencies.fugit]
+optional = true
+version = "0.3"
 
 [dependencies.void]
 default-features = false
@@ -215,4 +215,4 @@ usb = ["usb-device"]
 dma = ["unproven"]
 max-channels = ["dma"]
 sdmmc = ["embedded-sdmmc"]
-rtic = ["cortex-m-rtic", "rtic-monotonic"]
+rtic = ["rtic-monotonic", "fugit"]


### PR DESCRIPTION
# Summary
- Now `Rtc<Count32Mode>` implements `rtic::Monotonic` using `fugit` instead of `embedded_time`.
- RTIC related dependencies are bumped

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - ~All new or modified code is well documented, especially public items~ Irrelevant
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)