### PR TITLE
Pukcc: Remove redundant import & fix example definition

### DIFF
--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -72,3 +72,7 @@ required-features = ["dma"]
 [[example]]
 name = "uart"
 required-features = ["dma"]
+
+[[example]]
+name = "pukcc_test"
+required-features = ["unproven", "usb"]

--- a/hal/src/thumbv7em/pukcc/c_abi.rs
+++ b/hal/src/thumbv7em/pukcc/c_abi.rs
@@ -778,7 +778,6 @@ pub trait CryptoRamSlice: crate::typelevel::Sealed {
 
 impl CryptoRamSlice for &[u8] {
     unsafe fn pukcc_base(&self) -> nu1 {
-        use core::convert::TryInto;
         (self.as_ptr() as usize & 0x0000FFFF).try_into().unwrap()
     }
 }


### PR DESCRIPTION
# Summary
- Lack of proper example definition for `pukcc_test` in Feather M4 BSC
- With Rust 2021 edition, `TryInto` is included in a prelude, rendering the import in `c_abi.rs` redundant.

# Checklist
  - ~`CHANGELOG.md` for the BSP or HAL updated~ Irrelevant; no public API change
  - ~All new or modified code is well documented, especially public items~ Irrelevant
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)