### PR TITLE
Update `wio-terminal` to use v2 APIs

### DIFF
--- a/boards/wio_terminal/CHANGELOG.md
+++ b/boards/wio_terminal/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Unreleased
+# 0.5.0
 
-- moved crates used only in examples to `[dev-dependencies]`
+- Update library and examples to use `atsamd-hal` V2 APIs and upgrade BSP to Tier 1.
+
+- Moved crates used only in examples to `[dev-dependencies]`
 
 ---
 

--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "wio_terminal"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Tom <twitchyliquid64@ciphersink.net>"
 ]
-edition = "2018"
+edition = "2021"
 description = "Board support crate for the Seeed Studio Wio Terminal"
 documentation = "https://docs.rs/wio-terminal/"
 readme = "README.md"
-repository = "https://github.com/jessebraham/wio-terminal"
+repository = "https://github.com/atsamd-rs/atsamd"
 license = "MIT OR Apache-2.0"
 keywords = [
     "arm",
@@ -27,19 +27,20 @@ exclude = ["assets"]
 
 [dependencies]
 bitfield = "0.13"
-cortex-m = "0.6"
-cortex-m-rt = { version = "0.6", optional = true }
+cortex-m = "0.7.3"
+cortex-m-rt = { version = "0.7", optional = true }
 display-interface-spi = "0.4"
 heapless = "0.5"
 ili9341 = "0.5.0"
 lis3dh = "0.3.0"
 embedded-sdmmc = "0.3.0"
 usb-device = { version = "0.2", optional = true }
-bbqueue = { version = "^0.4.11", optional = true }
+bbqueue = { version = "0.5", optional = true }
 generic-array = { version = "0.14", optional = true }
 seeed-erpc = { version = "0.1.1", optional = true }
 
 [dependencies.atsamd-hal]
+path = "../../hal"
 version = "0.13"
 default-features = false
 

--- a/boards/wio_terminal/examples/blinky.rs
+++ b/boards/wio_terminal/examples/blinky.rs
@@ -4,11 +4,11 @@
 use panic_halt as _;
 use wio_terminal as wio;
 
+use wio::entry;
 use wio::hal::clock::GenericClockController;
 use wio::hal::delay::Delay;
 use wio::pac::{CorePeripherals, Peripherals};
 use wio::prelude::*;
-use wio::{entry, Pins, Sets};
 
 #[entry]
 fn main() -> ! {
@@ -24,12 +24,12 @@ fn main() -> ! {
     );
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
-    let mut sets: Sets = Pins::new(peripherals.PORT).split();
-    let mut user_led = sets.user_led.into_open_drain_output(&mut sets.port);
+    let sets = wio::Pins::new(peripherals.PORT).split();
+    let mut user_led = sets.user_led.into_push_pull_output();
     user_led.set_low().unwrap();
 
     loop {
-        user_led.toggle();
+        user_led.toggle().ok();
         delay.delay_ms(200u8);
     }
 }

--- a/boards/wio_terminal/examples/clock.rs
+++ b/boards/wio_terminal/examples/clock.rs
@@ -20,11 +20,11 @@ use eg::text::Text;
 use cortex_m::interrupt::free as disable_interrupts;
 use cortex_m::peripheral::NVIC;
 
+use wio::entry;
 use wio::hal::clock::GenericClockController;
 use wio::hal::delay::Delay;
 use wio::pac::{interrupt, CorePeripherals, Peripherals};
 use wio::prelude::*;
-use wio::{entry, Pins, Sets};
 
 use core::fmt::Write;
 use heapless::consts::U16;
@@ -50,8 +50,7 @@ fn main() -> ! {
     );
 
     let mut delay = Delay::new(core.SYST, &mut clocks);
-    let pins = Pins::new(peripherals.PORT);
-    let mut sets: Sets = pins.split();
+    let sets = wio::Pins::new(peripherals.PORT).split();
 
     // Configure the RTC. a 1024 Hz clock is configured for us when enabling our
     // main clock
@@ -69,7 +68,6 @@ fn main() -> ! {
             &mut clocks,
             peripherals.SERCOM7,
             &mut peripherals.MCLK,
-            &mut sets.port,
             58.mhz(),
             &mut delay,
         )
@@ -94,9 +92,9 @@ fn main() -> ! {
         USB_ALLOCATOR.as_ref().unwrap()
     };
     unsafe {
-        USB_SERIAL = Some(SerialPort::new(&bus_allocator));
+        USB_SERIAL = Some(SerialPort::new(bus_allocator));
         USB_BUS = Some(
-            UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x16c0, 0x27dd))
+            UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x16c0, 0x27dd))
                 .manufacturer("Fake company")
                 .product("Serial port")
                 .serial_number("TEST")
@@ -116,7 +114,7 @@ fn main() -> ! {
     let style = MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE);
 
     loop {
-        delay.delay_ms(1000 as u16);
+        delay.delay_ms(1000_u16);
         let time =
             disable_interrupts(|_| unsafe { RTC.as_mut().map(|rtc| rtc.current_time()) }).unwrap();
 
@@ -153,8 +151,8 @@ static mut RTC: Option<rtc::Rtc<rtc::ClockMode>> = None;
 
 fn poll_usb() {
     unsafe {
-        USB_BUS.as_mut().map(|usb_dev| {
-            USB_SERIAL.as_mut().map(|serial| {
+        if let Some(usb_dev) = USB_BUS.as_mut() {
+            if let Some(serial) = USB_SERIAL.as_mut() {
                 usb_dev.poll(&mut [serial]);
                 let mut buf = [0u8; 32];
 
@@ -166,8 +164,9 @@ fn poll_usb() {
                         match timespec(buffer) {
                             Ok((remaining, time)) => {
                                 buffer = remaining;
+
                                 disable_interrupts(|_| {
-                                    RTC.as_mut().map(|rtc| {
+                                    if let Some(rtc) = RTC.as_mut() {
                                         rtc.set_time(rtc::Datetime {
                                             seconds: time.second as u8,
                                             minutes: time.minute as u8,
@@ -176,15 +175,15 @@ fn poll_usb() {
                                             month: 0,
                                             year: 0,
                                         });
-                                    });
+                                    }
                                 });
                             }
                             _ => break,
                         };
                     }
                 };
-            });
-        });
+            }
+        }
     };
 }
 
@@ -214,7 +213,7 @@ fn atoi(digits: &[u8]) -> u32 {
     let mut num: u32 = 0;
     let len = digits.len();
     for (i, digit) in digits.iter().enumerate() {
-        let digit = (*digit - '0' as u8) as u32;
+        let digit = (*digit - b'0') as u32;
         let mut exp = 1;
         for _ in 0..(len - i - 1) {
             exp *= 10;

--- a/boards/wio_terminal/examples/orientation.rs
+++ b/boards/wio_terminal/examples/orientation.rs
@@ -11,11 +11,11 @@ use eg::prelude::*;
 use embedded_graphics::primitives::{PrimitiveStyleBuilder, Rectangle};
 
 use wio::accelerometer::{self, Tracker};
+use wio::entry;
 use wio::hal::clock::GenericClockController;
 use wio::hal::delay::Delay;
 use wio::pac::{CorePeripherals, Peripherals};
 use wio::prelude::*;
-use wio::{entry, Pins, Sets};
 
 // The height and width of the RAW image of Ferris, which can be found at
 // 'assets/ferris.raw'.
@@ -36,18 +36,14 @@ fn main() -> ! {
     );
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
-    let pins = Pins::new(peripherals.PORT);
-    let mut sets: Sets = pins.split();
+    let sets = wio::Pins::new(peripherals.PORT).split();
 
     // Initialize the LIS3DH accelerometer, and create the orientation tracker.
     // The calibration value for Tracker was obtained experimentally, as directed in
     // the documentation.
-    let mut lis3dh = sets.accelerometer.init(
-        &mut clocks,
-        peripherals.SERCOM4,
-        &mut peripherals.MCLK,
-        &mut sets.port,
-    );
+    let mut lis3dh =
+        sets.accelerometer
+            .init(&mut clocks, peripherals.SERCOM4, &mut peripherals.MCLK);
     let mut tracker = Tracker::new(3700.0);
 
     // Initialize the ILI9341-based LCD display. Create a black backdrop the size of
@@ -60,7 +56,6 @@ fn main() -> ! {
             &mut clocks,
             peripherals.SERCOM7,
             &mut peripherals.MCLK,
-            &mut sets.port,
             58.mhz(),
             &mut delay,
         )

--- a/boards/wio_terminal/examples/sdcard.rs
+++ b/boards/wio_terminal/examples/sdcard.rs
@@ -13,11 +13,11 @@ use eg::prelude::*;
 use eg::primitives::{PrimitiveStyleBuilder, Rectangle};
 use eg::text::Text;
 
+use wio::entry;
 use wio::hal::clock::GenericClockController;
 use wio::hal::delay::Delay;
 use wio::pac::{CorePeripherals, Peripherals};
 use wio::prelude::*;
-use wio::{entry, Pins, Sets};
 
 use core::fmt::Write;
 use heapless::consts::U128;
@@ -40,8 +40,7 @@ fn main() -> ! {
     );
 
     let mut delay = Delay::new(core.SYST, &mut clocks);
-    let pins = Pins::new(peripherals.PORT);
-    let mut sets: Sets = pins.split();
+    let sets = wio::Pins::new(peripherals.PORT).split();
 
     let (mut cont, _sd_present) = sets
         .sd_card
@@ -49,7 +48,6 @@ fn main() -> ! {
             &mut clocks,
             peripherals.SERCOM6,
             &mut peripherals.MCLK,
-            &mut sets.port,
             Clock,
         )
         .unwrap();
@@ -62,7 +60,6 @@ fn main() -> ! {
             &mut clocks,
             peripherals.SERCOM7,
             &mut peripherals.MCLK,
-            &mut sets.port,
             24.mhz(),
             &mut delay,
         )
@@ -107,7 +104,7 @@ fn main() -> ! {
             }
         }
 
-        delay.delay_ms(2500 as u16);
+        delay.delay_ms(2500_u16);
         Rectangle::with_corners(Point::new(0, 0), Point::new(320, 240))
             .into_styled(
                 PrimitiveStyleBuilder::new()

--- a/boards/wio_terminal/examples/wifi_scan.rs
+++ b/boards/wio_terminal/examples/wifi_scan.rs
@@ -11,7 +11,7 @@ use wio::pac::{CorePeripherals, Peripherals};
 use wio::prelude::*;
 use wio::wifi_prelude::*;
 use wio::wifi_rpcs as rpc;
-use wio::{entry, wifi_singleton, Pins, Sets};
+use wio::{entry, wifi_singleton};
 
 use core::fmt::Write;
 use cortex_m::interrupt::free as disable_interrupts;
@@ -36,7 +36,7 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let mut delay = Delay::new(core.SYST, &mut clocks);
-    let mut sets: Sets = Pins::new(peripherals.PORT).split();
+    let sets = wio::Pins::new(peripherals.PORT).split();
 
     // Set up the display so we can print out APs.
     let (mut display, _backlight) = sets
@@ -45,7 +45,6 @@ fn main() -> ! {
             &mut clocks,
             peripherals.SERCOM7,
             &mut peripherals.MCLK,
-            &mut sets.port,
             24.mhz(),
             &mut delay,
         )
@@ -53,24 +52,24 @@ fn main() -> ! {
     clear(&mut display);
     let mut textbuffer = String::<U256>::new();
 
-    let mut user_led = sets.user_led.into_open_drain_output(&mut sets.port);
+    let mut user_led = sets.user_led.into_push_pull_output();
     user_led.set_high().unwrap();
 
     // Initialize the wifi peripheral.
-    let args = (
-        sets.wifi,
-        peripherals.SERCOM0,
-        &mut clocks,
-        &mut peripherals.MCLK,
-        &mut sets.port,
-        &mut delay,
-    );
     let nvic = &mut core.NVIC;
     disable_interrupts(|cs| unsafe {
-        wifi_init(cs, args.0, args.1, args.2, args.3, args.4, args.5).unwrap();
-        WIFI.as_mut().map(|wifi| {
+        wifi_init(
+            cs,
+            sets.wifi,
+            peripherals.SERCOM0,
+            &mut clocks,
+            &mut peripherals.MCLK,
+            &mut delay,
+        );
+
+        if let Some(wifi) = WIFI.as_mut() {
             wifi.enable(cs, nvic);
-        });
+        }
     });
 
     let version = unsafe {

--- a/boards/wio_terminal/src/buttons.rs
+++ b/boards/wio_terminal/src/buttons.rs
@@ -6,25 +6,27 @@ use atsamd_hal::pac::{interrupt, EIC, MCLK};
 
 use cortex_m::peripheral::NVIC;
 
+use super::pins::*;
+
 /// pushbuttons and joystick
 pub struct ButtonPins {
     /// button1 pin
-    pub button1: Pin<PC26, Disabled<Floating>>,
+    pub button1: Button1Reset,
     /// button2 pin
-    pub button2: Pin<PC27, Disabled<Floating>>,
+    pub button2: Button2Reset,
     /// button3 pin
-    pub button3: Pin<PC28, Disabled<Floating>>,
+    pub button3: Button3Reset,
 
     /// Joystick X
-    pub switch_x: Pin<PD08, Disabled<Floating>>,
+    pub switch_x: SwitchXReset,
     /// Joystick Y
-    pub switch_y: Pin<PD09, Disabled<Floating>>,
+    pub switch_y: SwitchYReset,
     /// Joystick Z
-    pub switch_z: Pin<PD10, Disabled<Floating>>,
+    pub switch_z: SwitchZReset,
     /// Joystick U
-    pub switch_u: Pin<PD20, Disabled<Floating>>,
+    pub switch_u: SwitchUReset,
     /// Joystick B
-    pub switch_b: Pin<PD12, Disabled<Floating>>,
+    pub switch_b: SwitchBReset,
 }
 
 impl ButtonPins {
@@ -116,15 +118,15 @@ pub struct ButtonEvent {
 
 pub struct ButtonController {
     _eic: eic::EIC,
-    // b1: ExtInt10<Pc26<Interrupt<Floating>>>,
-    b2: ExtInt11<Pin<PC27, Interrupt<Floating>>>,
-    b3: ExtInt12<Pin<PC28, Interrupt<Floating>>>,
+    // b1: ExtInt10<Button1>,
+    b2: ExtInt11<Button2>,
+    b3: ExtInt12<Button3>,
 
-    x: ExtInt3<Pin<PD08, Interrupt<Floating>>>,
-    y: ExtInt4<Pin<PD09, Interrupt<Floating>>>,
-    z: ExtInt5<Pin<PD10, Interrupt<Floating>>>,
-    u: ExtInt10<Pin<PD20, Interrupt<Floating>>>,
-    b: ExtInt7<Pin<PD12, Interrupt<Floating>>>,
+    x: ExtInt3<SwitchX>,
+    y: ExtInt4<SwitchY>,
+    z: ExtInt5<SwitchZ>,
+    u: ExtInt10<SwitchU>,
+    b: ExtInt7<SwitchB>,
 }
 
 macro_rules! isr {

--- a/boards/wio_terminal/src/buttons.rs
+++ b/boards/wio_terminal/src/buttons.rs
@@ -1,12 +1,13 @@
 use atsamd_hal::clock::GenericClockController;
 use atsamd_hal::common::eic;
-use atsamd_hal::common::eic::pin::*;
-use atsamd_hal::gpio::v2::*;
+use atsamd_hal::common::eic::pin::{
+    ExtInt10, ExtInt11, ExtInt12, ExtInt3, ExtInt4, ExtInt5, ExtInt7, Sense,
+};
 use atsamd_hal::pac::{interrupt, EIC, MCLK};
 
 use cortex_m::peripheral::NVIC;
 
-use super::pins::*;
+use super::pins::aliases::*;
 
 /// pushbuttons and joystick
 pub struct ButtonPins {

--- a/boards/wio_terminal/src/display.rs
+++ b/boards/wio_terminal/src/display.rs
@@ -1,9 +1,8 @@
 use atsamd_hal::clock::GenericClockController;
-use atsamd_hal::gpio::v2::*;
+use atsamd_hal::ehal::digital::v2::OutputPin;
 use atsamd_hal::hal::blocking::delay::DelayMs;
 use atsamd_hal::hal::spi::{Phase, Polarity};
 use atsamd_hal::pac::{MCLK, SERCOM7};
-use atsamd_hal::prelude::*;
 use atsamd_hal::sercom::v2::spi;
 use atsamd_hal::sercom::v2::{IoSet4, Sercom7};
 use atsamd_hal::time::Hertz;
@@ -11,7 +10,7 @@ use atsamd_hal::typelevel::NoneT;
 use display_interface_spi::SPIInterface;
 use ili9341::{DisplaySize240x320, Ili9341, Orientation};
 
-use super::pins::*;
+use super::pins::aliases::*;
 
 /// ILI9341 LCD display pins (uses `SERCOM7`)
 pub struct Display {

--- a/boards/wio_terminal/src/display.rs
+++ b/boards/wio_terminal/src/display.rs
@@ -1,6 +1,5 @@
 use atsamd_hal::clock::GenericClockController;
-use atsamd_hal::gpio::v2::{PB19, PB20};
-use atsamd_hal::gpio::*;
+use atsamd_hal::gpio::v2::*;
 use atsamd_hal::hal::blocking::delay::DelayMs;
 use atsamd_hal::hal::spi::{Phase, Polarity};
 use atsamd_hal::pac::{MCLK, SERCOM7};
@@ -15,34 +14,34 @@ use ili9341::{DisplaySize240x320, Ili9341, Orientation};
 /// ILI9341 LCD display pins (uses `SERCOM7`)
 pub struct Display {
     /// LCD MISO pin
-    pub miso: Pb18<Input<Floating>>,
+    pub miso: Pin<PB18, Disabled<Floating>>,
 
     /// LCD MOSI pin
-    pub mosi: Pb19<Input<Floating>>,
+    pub mosi: Pin<PB19, Disabled<Floating>>,
 
     /// LCD SCK pin
-    pub sck: Pb20<Input<Floating>>,
+    pub sck: Pin<PB20, Disabled<Floating>>,
 
     /// LCD chip select pin
-    pub cs: Pb21<Input<Floating>>,
+    pub cs: Pin<PB21, Disabled<Floating>>,
 
     /// LCD data/command pin
-    pub dc: Pc6<Input<Floating>>,
+    pub dc: Pin<PC06, Disabled<Floating>>,
 
     /// LCD reset pin
-    pub reset: Pc7<Input<Floating>>,
+    pub reset: Pin<PC07, Disabled<Floating>>,
 
     /// LCD backlight pin
-    pub backlight: Pc5<Input<Floating>>,
+    pub backlight: Pin<PC05, Disabled<Floating>>,
 }
 
 pub type LcdPads = spi::PadsFromIds<Sercom7, IoSet4, NoneT, PB19, PB20>;
-pub type LcdSpi = spi::Spi<spi::Config<LcdPads>>;
+pub type LcdSpi = spi::Spi<spi::Config<LcdPads>, spi::Tx>;
 
 /// Type alias for the ILI9341 LCD display.
 pub type LCD = Ili9341<
-    SPIInterface<LcdSpi, Pc6<Output<PushPull>>, Pb21<Output<PushPull>>>,
-    Pc7<Output<PushPull>>,
+    SPIInterface<LcdSpi, Pin<PC06, Output<PushPull>>, Pin<PB21, Output<PushPull>>>,
+    Pin<PC07, Output<PushPull>>,
 >;
 
 pub use ili9341::Scroller;
@@ -56,10 +55,9 @@ impl Display {
         clocks: &mut GenericClockController,
         sercom7: SERCOM7,
         mclk: &mut MCLK,
-        port: &mut Port,
         baud: F,
         delay: &mut D,
-    ) -> Result<(LCD, Pc5<Output<PushPull>>), ()> {
+    ) -> Result<(LCD, Pin<PC05, Output<PushPull>>), ()> {
         // Initialize the SPI peripherial on the configured pins, using SERCOM7.
         let gclk0 = clocks.gclk0();
         let clock = &clocks.sercom7_core(&gclk0).ok_or(())?;
@@ -71,9 +69,9 @@ impl Display {
             .enable();
 
         // Configure the chip select, data/command, and reset pins as push-pull outputs.
-        let cs = self.cs.into_push_pull_output(port);
-        let dc = self.dc.into_push_pull_output(port);
-        let reset = self.reset.into_push_pull_output(port);
+        let cs = self.cs.into_push_pull_output();
+        let dc = self.dc.into_push_pull_output();
+        let reset = self.reset.into_push_pull_output();
 
         // Create a SPIInterface over the peripheral, then create the ILI9341 driver
         // using said interface and set its default orientation.
@@ -91,8 +89,8 @@ impl Display {
         // does not appear to support PWM.
         //   HIGH - backlight enabled
         //   LOW  - backlight disabled
-        let mut backlight = self.backlight.into_push_pull_output(port);
-        backlight.set_high()?;
+        let mut backlight = self.backlight.into_push_pull_output();
+        backlight.set_high().ok();
 
         // Return a result consisting of a Tuple containing the display driver and
         // backlight pin.

--- a/boards/wio_terminal/src/lib.rs
+++ b/boards/wio_terminal/src/lib.rs
@@ -8,13 +8,14 @@
 //! [atsamd-hal]: https://github.com/atsamd-rs/atsamd
 
 #![no_std]
+#![allow(warnings)]
+
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::entry;
 
 // Re-export the HAL and the PAC to give the user lower-level access to the
 // device should they need it.
 pub use atsamd_hal::{self as hal, pac};
-
-#[cfg(feature = "rt")]
-pub use cortex_m_rt::entry;
 
 // The accelerometer crate contains a number of traits and types which may be
 // useful to the user.
@@ -34,6 +35,7 @@ mod storage;
 
 pub use buttons::*;
 pub use display::*;
+pub use pins::Pins;
 pub use pins::*;
 pub use sensors::*;
 pub use serial::*;

--- a/boards/wio_terminal/src/pins.rs
+++ b/boards/wio_terminal/src/pins.rs
@@ -13,43 +13,78 @@ hal::bsp_pins!(
     /// User LED
         name: user_led,
         aliases: {
-            PushPullOutput: UserLed
+            PushPullOutput: UserLed,
+            Reset: UserLedReset
         }
     }
     PC26 {
         name: button1
+        aliases: {
+            FloatingInterrupt: Button1,
+            Reset: Button1Reset
+        }
     }
     PC27 {
         name: button2
+        aliases: {
+            FloatingInterrupt: Button2,
+            Reset: Button2Reset
+        }
     }
     PC28 {
         name: button3
+        aliases: {
+            FloatingInterrupt: Button3,
+            Reset: Button3Reset
+        }
     }
     PD08 {
         name: switch_x
+        aliases: {
+            FloatingInterrupt: SwitchX,
+            Reset: SwitchXReset
+        }
     }
     PD09 {
         name: switch_y
+        aliases: {
+            FloatingInterrupt: SwitchY,
+            Reset: SwitchYReset
+        }
     }
     PD10 {
         name: switch_z
+        aliases: {
+            FloatingInterrupt: SwitchZ,
+            Reset: SwitchZReset
+        }
     }
     PD12 {
         name: switch_b
+        aliases: {
+            FloatingInterrupt: SwitchB,
+            Reset: SwitchBReset
+        }
     }
     PD20 {
         name: switch_u
+        aliases: {
+            FloatingInterrupt: SwitchU,
+            Reset: SwitchUReset
+        }
     }
     PA12 {
         name: i2c0_scl,
         aliases: {
-            AlternateD: I2c0Scl
+            AlternateD: I2c0Scl,
+            Reset: I2c0SclReset
         }
     }
     PA13 {
         name: i2c0_sda,
         aliases: {
-            AlternateD: I2c0Sda
+            AlternateD: I2c0Sda,
+            Reset: I2c0SdaReset
         }
     }
     PA16 {
@@ -73,44 +108,82 @@ hal::bsp_pins!(
     PB26 {
         name: uart_tx,
         aliases: {
-            AlternateC: UartTx
+            AlternateC: UartTx,
+            Reset: UartTxReset
         }
     }
     PB27 {
         name: uart_rx,
         aliases: {
-            AlternateC: UartRx
+            AlternateC: UartRx,
+            Reset: UartRxReset
         }
     }
     PA24 {
         name: usb_dm
+        aliases: {
+            AlternateH: UsbDm,
+            Reset: UsbDmReset
+        }
     }
     PA25 {
         name: usb_dp
+        aliases: {
+            AlternateH: UsbDp,
+            Reset: UsbDpReset
+        }
     }
     PA27 {
         name: usb_host_en
     }
     PB18 {
         name: lcd_miso
+        aliases: {
+            AlternateD: LcdMiso,
+            Reset: LcdMisoReset
+        }
     }
     PB19 {
         name: lcd_mosi
+        aliases: {
+            AlternateD: LcdMosi,
+            Reset: LcdMosiReset
+        }
     }
     PB20 {
         name: lcd_sck
+        aliases: {
+            AlternateD: LcdSck,
+            Reset: LcdSckReset
+        }
     }
     PB21 {
         name: lcd_cs
+        aliases: {
+            PushPullOutput: LcdCs,
+            Reset: LcdCsReset
+        }
     }
     PC05 {
         name: lcd_backlight
+        aliases: {
+            PushPullOutput: LcdBacklight,
+            Reset: LcdBacklightReset
+        }
     }
     PC06 {
         name: lcd_dc
+        aliases: {
+            PushPullOutput: LcdDc,
+            Reset: LcdDcReset
+        }
     }
     PC07 {
         name: lcd_reset
+        aliases: {
+            PushPullOutput: LcdReset,
+            Reset: LcdResetReset
+        }
     }
     PC10 {
         name: lcd_xl
@@ -140,120 +213,208 @@ hal::bsp_pins!(
         name: i2s_blck
     }
     PD11 {
-    /// BUZZER
+        /// BUZZER
         name: buzzer_ctr
+        aliases: {
+            AlternateF: BuzzerCtrl,
+            Reset: BuzzerCtrlReset
+        }
     }
     PC30 {
-    /// MICROPHONE
+        /// MICROPHONE
         name: mic_output,
         aliases: {
             AlternateB: MicOutput,
+            Reset: MicOutputReset
         }
     }
     PA08 {
         name: mcu_flash_qspi_io0
+        aliases: {
+            AlternateH: QspiD0,
+            Reset: QspiD0Reset
+        }
     }
     PA09 {
         name: mcu_flash_qspi_io1
+        aliases: {
+            AlternateH: QspiD1,
+            Reset: QspiD1Reset
+        }
     }
     PA10 {
         name: mcu_flash_qspi_io2
+        aliases: {
+            AlternateH: QspiD2,
+            Reset: QspiD2Reset
+        }
     }
     PA11 {
         name: mcu_flash_qspi_io3
+        aliases: {
+            AlternateH: QspiD3,
+            Reset: QspiD3Reset
+        }
     }
     PB10 {
         name: mcu_flash_qspi_clk
+        aliases: {
+            AlternateH: QspiSck,
+            Reset: QspiSckReset
+        }
     }
     PB11 {
         name: mcu_flash_qspi_cs
+        aliases: {
+            AlternateH: QspiCs,
+            Reset: QspiCsReset
+        }
     }
     PC16 {
         name: sd_mosi,
         aliases: {
-            AlternateC: SdMosi
+            AlternateC: SdMosi,
+            Reset: SdMosiReset
         }
     }
     PC17 {
         name: sd_sck,
         aliases: {
-            AlternateC: SdSck
+            AlternateC: SdSck,
+            Reset: SdSckReset
         }
     }
     PC18 {
         name: sd_miso,
         aliases: {
-            AlternateC: SdMiso
+            AlternateC: SdMiso,
+            Reset: SdMisoReset
         }
     }
     PC19 {
         name: sd_cs,
         aliases: {
-            PushPullOutput: SdCs
+            PushPullOutput: SdCs,
+            Reset: SdCsReset
         }
     }
     PD21 {
         name: sd_det,
+        aliases: {
+            FloatingInput: SdDet,
+            Reset: SdDetReset
+        }
     }
     PA18 {
         name: rtl8720d_chip_pu
+        aliases: {
+            PushPullOutput: WifiPwr,
+            Reset: WifiPwrReset,
+        }
     }
     PB24 {
         name: rtl8720d_hspi_mosi,
         aliases: {
-            AlternateC: WifiTx
+            AlternateC: WifiTx,
+            Reset: WifiTxReset
         }
     }
     PB25 {
         name: rtl8720d_hspi_clk
+        aliases: {
+            Reset: WifiClkReset
+        }
     }
     PC22 {
         name: rtl8720d_rxd
+        aliases: {
+            Reset: WifiRxdReset
+        }
     }
     PC23 {
         name: rtl8720d_txd
+        aliases: {
+            Reset: WifiTxdReset
+        }
     }
     PC24 {
         name: rtl8720d_hspi_miso,
         aliases: {
-            AlternateC: WifiRx
+            AlternateC: WifiRx,
+            Reset: WifiRxReset
         }
     }
     PC25 {
         name: rtl8720d_hspi_cs
+        aliases: {
+            Reset: WifiCsReset
+        }
     }
     PC20 {
         name: rtl8720d_data_ready
+        aliases: {
+            Reset: WifiReadyReset
+        }
     }
     PA19 {
         name: rtl8720d_dir
+        aliases: {
+            Reset: WifiDirReset
+        }
     }
     PB08 {
         name: a0_d0
+        aliases: {
+            Reset: A0D0Reset
+        }
     }
     PB09 {
         name: a1_d1
+        aliases: {
+            Reset: A1D1Reset
+        }
     }
     PA07 {
         name: a2_d2
+        aliases: {
+            Reset: A2D2Reset
+        }
     }
     PB04 {
         name: a3_d3
+        aliases: {
+            Reset: A3D3Reset
+        }
     }
     PB05 {
         name: a4_d4
+        aliases: {
+            Reset: A4D4Reset
+        }
     }
     PB06 {
         name: a5_d5
+        aliases: {
+            Reset: A5D5Reset
+        }
     }
     PA04 {
         name: a6_d6
+        aliases: {
+            Reset: A6D6Reset
+        }
     }
     PB07 {
         name: a7_d7
+        aliases: {
+            Reset: A7D7Reset
+        }
     }
     PA06 {
         name: a8_d8
+        aliases: {
+            Reset: A8D8Reset
+        }
     }
     PB28 {
         name: fpc_d3_pwm3
@@ -288,7 +449,8 @@ hal::bsp_pins!(
     PD01 {
         name: fpc_d13_a13,
         aliases: {
-            AlternateB: LightSensorAdc
+            AlternateB: LightSensorAdc,
+            Reset: LightSensorAdcReset
         }
     }
     PA02 {
@@ -335,10 +497,10 @@ hal::bsp_pins!(
 /// Sets of pins split apart by category
 pub struct Sets {
     /// Accelerometer I2C pins
-    pub accelerometer: Accelerometer<Pin<PA12, Disabled<Floating>>, Pin<PA13, Disabled<Floating>>>,
+    pub accelerometer: Accelerometer,
 
     /// Buzzer pins
-    pub buzzer: Buzzer<Pin<PD11, Disabled<Floating>>>,
+    pub buzzer: Buzzer,
 
     /// LCD display pins
     pub display: Display,
@@ -347,36 +509,26 @@ pub struct Sets {
     pub flash: QSPIFlash,
 
     /// Analog Light Sensor pins
-    pub light_sensor: LightSensor<Pin<PD01, Disabled<Floating>>>,
+    pub light_sensor: LightSensor,
 
     /// Microphone output pins
-    pub microphone: Microphone<Pin<PC30, Disabled<Floating>>>,
+    pub microphone: Microphone,
 
     /// SD Card pins
     pub sd_card: SDCard,
 
     /// UART (external pinout) pins
-    pub uart: Uart<Pin<PB27, Disabled<Floating>>, Pin<PB26, Disabled<Floating>>>,
+    pub uart: Uart,
 
     /// USB pins
-    pub usb: Usb<Pin<PA24, Disabled<Floating>>, Pin<PA25, Disabled<Floating>>>,
+    pub usb: Usb,
 
     /// LED pin
-    pub user_led: Pin<PA15, PushPullOutput>,
+    pub user_led: UserLedReset,
 
     pub buttons: ButtonPins,
     // WiFi pins
-    pub wifi: WifiPins<
-        Pin<PA18, Disabled<Floating>>,
-        Pin<PC22, Disabled<Floating>>,
-        Pin<PC23, Disabled<Floating>>,
-        Pin<PB24, Disabled<Floating>>,
-        Pin<PB25, Disabled<Floating>>,
-        Pin<PC24, Disabled<Floating>>,
-        Pin<PC25, Disabled<Floating>>,
-        Pin<PC20, Disabled<Floating>>,
-        Pin<PA19, Disabled<Floating>>,
-    >,
+    pub wifi: WifiPins,
 
     pub header_pins: HeaderPins,
 }
@@ -494,13 +646,13 @@ impl Pins {
 
 /// Other pins broken out to the RPi-compatible header.
 pub struct HeaderPins {
-    pub a0_d0: Pin<PB08, Disabled<Floating>>,
-    pub a1_d1: Pin<PB09, Disabled<Floating>>,
-    pub a2_d2: Pin<PA07, Disabled<Floating>>,
-    pub a3_d3: Pin<PB04, Disabled<Floating>>,
-    pub a4_d4: Pin<PB05, Disabled<Floating>>,
-    pub a5_d5: Pin<PB06, Disabled<Floating>>,
-    pub a6_d6: Pin<PA04, Disabled<Floating>>,
-    pub a7_d7: Pin<PB07, Disabled<Floating>>,
-    pub a8_d8: Pin<PA06, Disabled<Floating>>,
+    pub a0_d0: A0D0Reset,
+    pub a1_d1: A1D1Reset,
+    pub a2_d2: A2D2Reset,
+    pub a3_d3: A3D3Reset,
+    pub a4_d4: A4D4Reset,
+    pub a5_d5: A5D5Reset,
+    pub a6_d6: A6D6Reset,
+    pub a7_d7: A7D7Reset,
+    pub a8_d8: A8D8Reset,
 }

--- a/boards/wio_terminal/src/pins.rs
+++ b/boards/wio_terminal/src/pins.rs
@@ -1,5 +1,3 @@
-use atsamd_hal::{self as hal, gpio::v2::*};
-
 use super::buttons::ButtonPins;
 use super::display::Display;
 use super::sensors::{Accelerometer, LightSensor};
@@ -8,491 +6,497 @@ use super::sound::{Buzzer, Microphone};
 use super::storage::{QSPIFlash, SDCard};
 use super::wifi::WifiPins;
 
-hal::bsp_pins!(
-    PA15 {
-    /// User LED
-        name: user_led,
-        aliases: {
-            PushPullOutput: UserLed,
-            Reset: UserLedReset
+/// [`Pin`](atsamd_hal::gpio::v2::Pin) aliases defined by the
+/// [`bsp_pins!`](atsamd_hal::bsp_pins) macro
+pub mod aliases {
+    atsamd_hal::bsp_pins!(
+        PA15 {
+        /// User LED
+            name: user_led,
+            aliases: {
+                PushPullOutput: UserLed,
+                Reset: UserLedReset
+            }
         }
-    }
-    PC26 {
-        name: button1
-        aliases: {
-            FloatingInterrupt: Button1,
-            Reset: Button1Reset
+        PC26 {
+            name: button1
+            aliases: {
+                FloatingInterrupt: Button1,
+                Reset: Button1Reset
+            }
         }
-    }
-    PC27 {
-        name: button2
-        aliases: {
-            FloatingInterrupt: Button2,
-            Reset: Button2Reset
+        PC27 {
+            name: button2
+            aliases: {
+                FloatingInterrupt: Button2,
+                Reset: Button2Reset
+            }
         }
-    }
-    PC28 {
-        name: button3
-        aliases: {
-            FloatingInterrupt: Button3,
-            Reset: Button3Reset
+        PC28 {
+            name: button3
+            aliases: {
+                FloatingInterrupt: Button3,
+                Reset: Button3Reset
+            }
         }
-    }
-    PD08 {
-        name: switch_x
-        aliases: {
-            FloatingInterrupt: SwitchX,
-            Reset: SwitchXReset
+        PD08 {
+            name: switch_x
+            aliases: {
+                FloatingInterrupt: SwitchX,
+                Reset: SwitchXReset
+            }
         }
-    }
-    PD09 {
-        name: switch_y
-        aliases: {
-            FloatingInterrupt: SwitchY,
-            Reset: SwitchYReset
+        PD09 {
+            name: switch_y
+            aliases: {
+                FloatingInterrupt: SwitchY,
+                Reset: SwitchYReset
+            }
         }
-    }
-    PD10 {
-        name: switch_z
-        aliases: {
-            FloatingInterrupt: SwitchZ,
-            Reset: SwitchZReset
+        PD10 {
+            name: switch_z
+            aliases: {
+                FloatingInterrupt: SwitchZ,
+                Reset: SwitchZReset
+            }
         }
-    }
-    PD12 {
-        name: switch_b
-        aliases: {
-            FloatingInterrupt: SwitchB,
-            Reset: SwitchBReset
+        PD12 {
+            name: switch_b
+            aliases: {
+                FloatingInterrupt: SwitchB,
+                Reset: SwitchBReset
+            }
         }
-    }
-    PD20 {
-        name: switch_u
-        aliases: {
-            FloatingInterrupt: SwitchU,
-            Reset: SwitchUReset
+        PD20 {
+            name: switch_u
+            aliases: {
+                FloatingInterrupt: SwitchU,
+                Reset: SwitchUReset
+            }
         }
-    }
-    PA12 {
-        name: i2c0_scl,
-        aliases: {
-            AlternateD: I2c0Scl,
-            Reset: I2c0SclReset
+        PA12 {
+            name: i2c0_scl,
+            aliases: {
+                AlternateD: I2c0Scl,
+                Reset: I2c0SclReset
+            }
         }
-    }
-    PA13 {
-        name: i2c0_sda,
-        aliases: {
-            AlternateD: I2c0Sda,
-            Reset: I2c0SdaReset
+        PA13 {
+            name: i2c0_sda,
+            aliases: {
+                AlternateD: I2c0Sda,
+                Reset: I2c0SdaReset
+            }
         }
-    }
-    PA16 {
-        name: i2c1_scl
-    }
-    PA17 {
-        name: i2c1_sda
-    }
-    PB00 {
-        name: spi_miso
-    }
-    PB01 {
-        name: spi_cs
-    }
-    PB02 {
-        name: spi_mosi
-    }
-    PB03 {
-        name: spi_sck
-    }
-    PB26 {
-        name: uart_tx,
-        aliases: {
-            AlternateC: UartTx,
-            Reset: UartTxReset
+        PA16 {
+            name: i2c1_scl
         }
-    }
-    PB27 {
-        name: uart_rx,
-        aliases: {
-            AlternateC: UartRx,
-            Reset: UartRxReset
+        PA17 {
+            name: i2c1_sda
         }
-    }
-    PA24 {
-        name: usb_dm
-        aliases: {
-            AlternateH: UsbDm,
-            Reset: UsbDmReset
+        PB00 {
+            name: spi_miso
         }
-    }
-    PA25 {
-        name: usb_dp
-        aliases: {
-            AlternateH: UsbDp,
-            Reset: UsbDpReset
+        PB01 {
+            name: spi_cs
         }
-    }
-    PA27 {
-        name: usb_host_en
-    }
-    PB18 {
-        name: lcd_miso
-        aliases: {
-            AlternateD: LcdMiso,
-            Reset: LcdMisoReset
+        PB02 {
+            name: spi_mosi
         }
-    }
-    PB19 {
-        name: lcd_mosi
-        aliases: {
-            AlternateD: LcdMosi,
-            Reset: LcdMosiReset
+        PB03 {
+            name: spi_sck
         }
-    }
-    PB20 {
-        name: lcd_sck
-        aliases: {
-            AlternateD: LcdSck,
-            Reset: LcdSckReset
+        PB26 {
+            name: uart_tx,
+            aliases: {
+                AlternateC: UartTx,
+                Reset: UartTxReset
+            }
         }
-    }
-    PB21 {
-        name: lcd_cs
-        aliases: {
-            PushPullOutput: LcdCs,
-            Reset: LcdCsReset
+        PB27 {
+            name: uart_rx,
+            aliases: {
+                AlternateC: UartRx,
+                Reset: UartRxReset
+            }
         }
-    }
-    PC05 {
-        name: lcd_backlight
-        aliases: {
-            PushPullOutput: LcdBacklight,
-            Reset: LcdBacklightReset
+        PA24 {
+            name: usb_dm
+            aliases: {
+                AlternateH: UsbDm,
+                Reset: UsbDmReset
+            }
         }
-    }
-    PC06 {
-        name: lcd_dc
-        aliases: {
-            PushPullOutput: LcdDc,
-            Reset: LcdDcReset
+        PA25 {
+            name: usb_dp
+            aliases: {
+                AlternateH: UsbDp,
+                Reset: UsbDpReset
+            }
         }
-    }
-    PC07 {
-        name: lcd_reset
-        aliases: {
-            PushPullOutput: LcdReset,
-            Reset: LcdResetReset
+        PA27 {
+            name: usb_host_en
         }
-    }
-    PC10 {
-        name: lcd_xl
-    }
-    PC11 {
-        name: lcd_yu
-    }
-    PC12 {
-        name: lcd_xr
-    }
-    PC13 {
-        name: lcd_yd
-    }
-    PC21 {
-        name: gyroscope_int1
-    }
-    PA20 {
-        name: i2s_lrclk
-    }
-    PA21 {
-        name: i2s_sdin
-    }
-    PA22 {
-        name: i2s_sdout
-    }
-    PB16 {
-        name: i2s_blck
-    }
-    PD11 {
-        /// BUZZER
-        name: buzzer_ctr
-        aliases: {
-            AlternateF: BuzzerCtrl,
-            Reset: BuzzerCtrlReset
+        PB18 {
+            name: lcd_miso
+            aliases: {
+                AlternateD: LcdMiso,
+                Reset: LcdMisoReset
+            }
         }
-    }
-    PC30 {
-        /// MICROPHONE
-        name: mic_output,
-        aliases: {
-            AlternateB: MicOutput,
-            Reset: MicOutputReset
+        PB19 {
+            name: lcd_mosi
+            aliases: {
+                AlternateD: LcdMosi,
+                Reset: LcdMosiReset
+            }
         }
-    }
-    PA08 {
-        name: mcu_flash_qspi_io0
-        aliases: {
-            AlternateH: QspiD0,
-            Reset: QspiD0Reset
+        PB20 {
+            name: lcd_sck
+            aliases: {
+                AlternateD: LcdSck,
+                Reset: LcdSckReset
+            }
         }
-    }
-    PA09 {
-        name: mcu_flash_qspi_io1
-        aliases: {
-            AlternateH: QspiD1,
-            Reset: QspiD1Reset
+        PB21 {
+            name: lcd_cs
+            aliases: {
+                PushPullOutput: LcdCs,
+                Reset: LcdCsReset
+            }
         }
-    }
-    PA10 {
-        name: mcu_flash_qspi_io2
-        aliases: {
-            AlternateH: QspiD2,
-            Reset: QspiD2Reset
+        PC05 {
+            name: lcd_backlight
+            aliases: {
+                PushPullOutput: LcdBacklight,
+                Reset: LcdBacklightReset
+            }
         }
-    }
-    PA11 {
-        name: mcu_flash_qspi_io3
-        aliases: {
-            AlternateH: QspiD3,
-            Reset: QspiD3Reset
+        PC06 {
+            name: lcd_dc
+            aliases: {
+                PushPullOutput: LcdDc,
+                Reset: LcdDcReset
+            }
         }
-    }
-    PB10 {
-        name: mcu_flash_qspi_clk
-        aliases: {
-            AlternateH: QspiSck,
-            Reset: QspiSckReset
+        PC07 {
+            name: lcd_reset
+            aliases: {
+                PushPullOutput: LcdReset,
+                Reset: LcdResetReset
+            }
         }
-    }
-    PB11 {
-        name: mcu_flash_qspi_cs
-        aliases: {
-            AlternateH: QspiCs,
-            Reset: QspiCsReset
+        PC10 {
+            name: lcd_xl
         }
-    }
-    PC16 {
-        name: sd_mosi,
-        aliases: {
-            AlternateC: SdMosi,
-            Reset: SdMosiReset
+        PC11 {
+            name: lcd_yu
         }
-    }
-    PC17 {
-        name: sd_sck,
-        aliases: {
-            AlternateC: SdSck,
-            Reset: SdSckReset
+        PC12 {
+            name: lcd_xr
         }
-    }
-    PC18 {
-        name: sd_miso,
-        aliases: {
-            AlternateC: SdMiso,
-            Reset: SdMisoReset
+        PC13 {
+            name: lcd_yd
         }
-    }
-    PC19 {
-        name: sd_cs,
-        aliases: {
-            PushPullOutput: SdCs,
-            Reset: SdCsReset
+        PC21 {
+            name: gyroscope_int1
         }
-    }
-    PD21 {
-        name: sd_det,
-        aliases: {
-            FloatingInput: SdDet,
-            Reset: SdDetReset
+        PA20 {
+            name: i2s_lrclk
         }
-    }
-    PA18 {
-        name: rtl8720d_chip_pu
-        aliases: {
-            PushPullOutput: WifiPwr,
-            Reset: WifiPwrReset,
+        PA21 {
+            name: i2s_sdin
         }
-    }
-    PB24 {
-        name: rtl8720d_hspi_mosi,
-        aliases: {
-            AlternateC: WifiTx,
-            Reset: WifiTxReset
+        PA22 {
+            name: i2s_sdout
         }
-    }
-    PB25 {
-        name: rtl8720d_hspi_clk
-        aliases: {
-            Reset: WifiClkReset
+        PB16 {
+            name: i2s_blck
         }
-    }
-    PC22 {
-        name: rtl8720d_rxd
-        aliases: {
-            Reset: WifiRxdReset
+        PD11 {
+            /// BUZZER
+            name: buzzer_ctr
+            aliases: {
+                AlternateF: BuzzerCtrl,
+                Reset: BuzzerCtrlReset
+            }
         }
-    }
-    PC23 {
-        name: rtl8720d_txd
-        aliases: {
-            Reset: WifiTxdReset
+        PC30 {
+            /// MICROPHONE
+            name: mic_output,
+            aliases: {
+                AlternateB: MicOutput,
+                Reset: MicOutputReset
+            }
         }
-    }
-    PC24 {
-        name: rtl8720d_hspi_miso,
-        aliases: {
-            AlternateC: WifiRx,
-            Reset: WifiRxReset
+        PA08 {
+            name: mcu_flash_qspi_io0
+            aliases: {
+                AlternateH: QspiD0,
+                Reset: QspiD0Reset
+            }
         }
-    }
-    PC25 {
-        name: rtl8720d_hspi_cs
-        aliases: {
-            Reset: WifiCsReset
+        PA09 {
+            name: mcu_flash_qspi_io1
+            aliases: {
+                AlternateH: QspiD1,
+                Reset: QspiD1Reset
+            }
         }
-    }
-    PC20 {
-        name: rtl8720d_data_ready
-        aliases: {
-            Reset: WifiReadyReset
+        PA10 {
+            name: mcu_flash_qspi_io2
+            aliases: {
+                AlternateH: QspiD2,
+                Reset: QspiD2Reset
+            }
         }
-    }
-    PA19 {
-        name: rtl8720d_dir
-        aliases: {
-            Reset: WifiDirReset
+        PA11 {
+            name: mcu_flash_qspi_io3
+            aliases: {
+                AlternateH: QspiD3,
+                Reset: QspiD3Reset
+            }
         }
-    }
-    PB08 {
-        name: a0_d0
-        aliases: {
-            Reset: A0D0Reset
+        PB10 {
+            name: mcu_flash_qspi_clk
+            aliases: {
+                AlternateH: QspiSck,
+                Reset: QspiSckReset
+            }
         }
-    }
-    PB09 {
-        name: a1_d1
-        aliases: {
-            Reset: A1D1Reset
+        PB11 {
+            name: mcu_flash_qspi_cs
+            aliases: {
+                AlternateH: QspiCs,
+                Reset: QspiCsReset
+            }
         }
-    }
-    PA07 {
-        name: a2_d2
-        aliases: {
-            Reset: A2D2Reset
+        PC16 {
+            name: sd_mosi,
+            aliases: {
+                AlternateC: SdMosi,
+                Reset: SdMosiReset
+            }
         }
-    }
-    PB04 {
-        name: a3_d3
-        aliases: {
-            Reset: A3D3Reset
+        PC17 {
+            name: sd_sck,
+            aliases: {
+                AlternateC: SdSck,
+                Reset: SdSckReset
+            }
         }
-    }
-    PB05 {
-        name: a4_d4
-        aliases: {
-            Reset: A4D4Reset
+        PC18 {
+            name: sd_miso,
+            aliases: {
+                AlternateC: SdMiso,
+                Reset: SdMisoReset
+            }
         }
-    }
-    PB06 {
-        name: a5_d5
-        aliases: {
-            Reset: A5D5Reset
+        PC19 {
+            name: sd_cs,
+            aliases: {
+                PushPullOutput: SdCs,
+                Reset: SdCsReset
+            }
         }
-    }
-    PA04 {
-        name: a6_d6
-        aliases: {
-            Reset: A6D6Reset
+        PD21 {
+            name: sd_det,
+            aliases: {
+                FloatingInput: SdDet,
+                Reset: SdDetReset
+            }
         }
-    }
-    PB07 {
-        name: a7_d7
-        aliases: {
-            Reset: A7D7Reset
+        PA18 {
+            name: rtl8720d_chip_pu
+            aliases: {
+                PushPullOutput: WifiPwr,
+                Reset: WifiPwrReset,
+            }
         }
-    }
-    PA06 {
-        name: a8_d8
-        aliases: {
-            Reset: A8D8Reset
+        PB24 {
+            name: rtl8720d_hspi_mosi,
+            aliases: {
+                AlternateC: WifiTx,
+                Reset: WifiTxReset
+            }
         }
-    }
-    PB28 {
-        name: fpc_d3_pwm3
-    }
-    PB17 {
-        name: fpc_d4_pwm4
-    }
-    PB29 {
-        name: fpc_d5_pwm5
-    }
-    PA14 {
-        name: fpc_d6_pwm6
-    }
-    PC01 {
-        name: fpc_d7_a7
-    }
-    PC02 {
-        name: fpc_d8_a8
-    }
-    PC03 {
-        name: fpc_d9_a9
-    }
-    PC04 {
-        name: fpc_d10_pwm10
-    }
-    PC31 {
-        name: fpc_d11_a11
-    }
-    PD00 {
-        name: fpc_d12_a12
-    }
-    PD01 {
-        name: fpc_d13_a13,
-        aliases: {
-            AlternateB: LightSensorAdc,
-            Reset: LightSensorAdcReset
+        PB25 {
+            name: rtl8720d_hspi_clk
+            aliases: {
+                Reset: WifiClkReset
+            }
         }
-    }
-    PA02 {
-        name: dac0
-    }
-    PA05 {
-        name: dac1
-    }
-    PB14 {
-        name: gpclk0
-    }
-    PB12 {
-        name: gpclk1
-    }
-    PB13 {
-        name: gpclk2
-    }
-    PA30 {
-        name: swdclk
-    }
-    PA31 {
-        name: swdio
-    }
-    PB22 {
-        name: xin
-    }
-    PB23 {
-        name: xout
-    }
-    PB30 {
-        name: swo
-    }
-    PB31 {
-        name: ir_ctl
-    }
-    PC14 {
-        name: output_ctr_5v
-    }
-    PC15 {
-        name: output_ctr_3v3
-    },
-);
+        PC22 {
+            name: rtl8720d_rxd
+            aliases: {
+                Reset: WifiRxdReset
+            }
+        }
+        PC23 {
+            name: rtl8720d_txd
+            aliases: {
+                Reset: WifiTxdReset
+            }
+        }
+        PC24 {
+            name: rtl8720d_hspi_miso,
+            aliases: {
+                AlternateC: WifiRx,
+                Reset: WifiRxReset
+            }
+        }
+        PC25 {
+            name: rtl8720d_hspi_cs
+            aliases: {
+                Reset: WifiCsReset
+            }
+        }
+        PC20 {
+            name: rtl8720d_data_ready
+            aliases: {
+                Reset: WifiReadyReset
+            }
+        }
+        PA19 {
+            name: rtl8720d_dir
+            aliases: {
+                Reset: WifiDirReset
+            }
+        }
+        PB08 {
+            name: a0_d0
+            aliases: {
+                Reset: A0D0Reset
+            }
+        }
+        PB09 {
+            name: a1_d1
+            aliases: {
+                Reset: A1D1Reset
+            }
+        }
+        PA07 {
+            name: a2_d2
+            aliases: {
+                Reset: A2D2Reset
+            }
+        }
+        PB04 {
+            name: a3_d3
+            aliases: {
+                Reset: A3D3Reset
+            }
+        }
+        PB05 {
+            name: a4_d4
+            aliases: {
+                Reset: A4D4Reset
+            }
+        }
+        PB06 {
+            name: a5_d5
+            aliases: {
+                Reset: A5D5Reset
+            }
+        }
+        PA04 {
+            name: a6_d6
+            aliases: {
+                Reset: A6D6Reset
+            }
+        }
+        PB07 {
+            name: a7_d7
+            aliases: {
+                Reset: A7D7Reset
+            }
+        }
+        PA06 {
+            name: a8_d8
+            aliases: {
+                Reset: A8D8Reset
+            }
+        }
+        PB28 {
+            name: fpc_d3_pwm3
+        }
+        PB17 {
+            name: fpc_d4_pwm4
+        }
+        PB29 {
+            name: fpc_d5_pwm5
+        }
+        PA14 {
+            name: fpc_d6_pwm6
+        }
+        PC01 {
+            name: fpc_d7_a7
+        }
+        PC02 {
+            name: fpc_d8_a8
+        }
+        PC03 {
+            name: fpc_d9_a9
+        }
+        PC04 {
+            name: fpc_d10_pwm10
+        }
+        PC31 {
+            name: fpc_d11_a11
+        }
+        PD00 {
+            name: fpc_d12_a12
+        }
+        PD01 {
+            name: fpc_d13_a13,
+            aliases: {
+                AlternateB: LightSensorAdc,
+                Reset: LightSensorAdcReset
+            }
+        }
+        PA02 {
+            name: dac0
+        }
+        PA05 {
+            name: dac1
+        }
+        PB14 {
+            name: gpclk0
+        }
+        PB12 {
+            name: gpclk1
+        }
+        PB13 {
+            name: gpclk2
+        }
+        PA30 {
+            name: swdclk
+        }
+        PA31 {
+            name: swdio
+        }
+        PB22 {
+            name: xin
+        }
+        PB23 {
+            name: xout
+        }
+        PB30 {
+            name: swo
+        }
+        PB31 {
+            name: ir_ctl
+        }
+        PC14 {
+            name: output_ctr_5v
+        }
+        PC15 {
+            name: output_ctr_3v3
+        },
+    );
+}
+pub use aliases::Pins;
+use aliases::*;
 
 /// Sets of pins split apart by category
 pub struct Sets {
@@ -590,7 +594,8 @@ impl Pins {
             dp: self.usb_dp,
         };
 
-        let user_led = self.user_led.into();
+        let user_led = self.user_led;
+
         let header_pins = HeaderPins {
             a0_d0: self.a0_d0,
             a1_d1: self.a1_d1,

--- a/boards/wio_terminal/src/sensors.rs
+++ b/boards/wio_terminal/src/sensors.rs
@@ -1,15 +1,13 @@
-use crate::pins::{I2c0Scl, I2c0Sda, LightSensorAdc};
 use atsamd_hal::adc::Adc;
 use atsamd_hal::clock::GenericClockController;
-use atsamd_hal::gpio::v2::*;
 use atsamd_hal::pac::gclk::pchctrl::GEN_A::GCLK11;
 use atsamd_hal::pac::{ADC1, MCLK, SERCOM4};
-use atsamd_hal::prelude::*;
 use atsamd_hal::sercom::{I2CMaster4, PadPin, Sercom4Pad0, Sercom4Pad1};
+use atsamd_hal::time::U32Ext;
 
 use lis3dh::{Lis3dh, SlaveAddr};
 
-use super::pins::*;
+use super::pins::aliases::*;
 
 /// I2C Accelerometer pins (uses `SERCOM4`)
 pub struct Accelerometer {

--- a/boards/wio_terminal/src/sensors.rs
+++ b/boards/wio_terminal/src/sensors.rs
@@ -9,24 +9,18 @@ use atsamd_hal::sercom::{I2CMaster4, PadPin, Sercom4Pad0, Sercom4Pad1};
 
 use lis3dh::{Lis3dh, SlaveAddr};
 
+use super::pins::*;
+
 /// I2C Accelerometer pins (uses `SERCOM4`)
-pub struct Accelerometer<C, D>
-where
-    C: Into<I2c0Scl>,
-    D: Into<I2c0Sda>,
-{
+pub struct Accelerometer {
     /// `I2C0` bus clock pin
-    pub scl: C,
+    pub scl: I2c0SclReset,
 
     /// `I2C0` bus data pin
-    pub sda: D,
+    pub sda: I2c0SdaReset,
 }
 
-impl<C, D> Accelerometer<C, D>
-where
-    C: Into<I2c0Scl>,
-    D: Into<I2c0Sda>,
-{
+impl Accelerometer {
     /// Initialize the LIS3DH accelerometer using the correct pins and
     // peripherals. Use the driver's default settings.
     pub fn init(
@@ -55,18 +49,12 @@ where
 }
 
 /// Analog Light Sensor
-pub struct LightSensor<P>
-where
-    P: Into<LightSensorAdc>,
-{
+pub struct LightSensor {
     /// Analog Light Sensor input pin
-    pub pd1: P,
+    pub pd1: LightSensorAdcReset,
 }
 
-impl<P> LightSensor<P>
-where
-    P: Into<LightSensorAdc>,
-{
+impl LightSensor {
     /// Initialize Pd1 as an ADC input, and return a Tuple containing the ADC
     /// peripheral and the configured pin.
     pub fn init(
@@ -74,9 +62,9 @@ where
         adc: ADC1,
         clocks: &mut GenericClockController,
         mclk: &mut MCLK,
-    ) -> (Adc<ADC1>, Pin<PD01, Alternate<B>>) {
+    ) -> (Adc<ADC1>, LightSensorAdc) {
         let adc1 = Adc::adc1(adc, mclk, clocks, GCLK11);
 
-        (adc1, self.pd1.into().into())
+        (adc1, self.pd1.into())
     }
 }

--- a/boards/wio_terminal/src/serial.rs
+++ b/boards/wio_terminal/src/serial.rs
@@ -10,17 +10,15 @@ use atsamd_hal::usb::{usb_device::bus::UsbBusAllocator, UsbBus};
 #[cfg(feature = "usb")]
 use pac::gclk::{genctrl::SRC_A, pchctrl::GEN_A};
 
+use super::pins::*;
+
 /// Uart pins (uses `SERCOM2`)
-pub struct Uart<Rx, Tx>
-where
-    Rx: AnyPin<Id = PB27>,
-    Tx: AnyPin<Id = PB26>,
-{
+pub struct Uart {
     /// UART transmit pin
-    pub tx: Tx,
+    pub tx: UartTxReset,
 
     /// UART receive pin
-    pub rx: Rx,
+    pub rx: UartRxReset,
 }
 
 /// UART pads for the labelled RX & TX pins
@@ -29,11 +27,7 @@ pub type UartPads = uart::Pads<Sercom2, IoSet2, UartRx, UartTx>;
 /// UART device for the labelled RX & TX pins
 pub type HalUart = uart::Uart<uart::Config<UartPads>, uart::Duplex>;
 
-impl<Rx, Tx> Uart<Rx, Tx>
-where
-    Rx: AnyPin<Id = PB27>,
-    Tx: AnyPin<Id = PB26>,
-{
+impl Uart {
     /// Set up the labelled TX/RX pins to operate as a UART device at the
     /// specified baud rate.
     pub fn init<F: Into<Hertz>>(
@@ -44,7 +38,7 @@ where
         mclk: &mut MCLK,
     ) -> HalUart {
         let gclk0 = clocks.gclk0();
-        let pads = uart::Pads::default().rx(self.rx.into()).tx(self.tx.into());
+        let pads = uart::Pads::default().rx(self.rx).tx(self.tx);
         uart::Config::new(
             mclk,
             sercom2,
@@ -60,23 +54,15 @@ where
 }
 
 /// USB pins
-pub struct Usb<Dm, Dp>
-where
-    Dm: AnyPin<Id = PA24>,
-    Dp: AnyPin<Id = PA25>,
-{
+pub struct Usb {
     /// USB data-minus pin
-    pub dm: Dm,
+    pub dm: UsbDmReset,
 
     /// USB data-plus pin
-    pub dp: Dp,
+    pub dp: UsbDpReset,
 }
 
-impl<Dm, Dp> Usb<Dm, Dp>
-where
-    Dm: AnyPin<Id = PA24>,
-    Dp: AnyPin<Id = PA25>,
-{
+impl Usb {
     #[cfg(feature = "usb")]
     /// Create a USB allocator.
     pub fn usb_allocator(

--- a/boards/wio_terminal/src/serial.rs
+++ b/boards/wio_terminal/src/serial.rs
@@ -1,6 +1,4 @@
-use crate::pins::{UartRx, UartTx};
 use atsamd_hal::clock::GenericClockController;
-use atsamd_hal::gpio::v2::*;
 use atsamd_hal::pac::{self, MCLK, SERCOM2};
 use atsamd_hal::sercom::v2::{uart, IoSet2, Sercom2};
 use atsamd_hal::time::Hertz;
@@ -10,7 +8,7 @@ use atsamd_hal::usb::{usb_device::bus::UsbBusAllocator, UsbBus};
 #[cfg(feature = "usb")]
 use pac::gclk::{genctrl::SRC_A, pchctrl::GEN_A};
 
-use super::pins::*;
+use super::pins::aliases::*;
 
 /// Uart pins (uses `SERCOM2`)
 pub struct Uart {

--- a/boards/wio_terminal/src/sound.rs
+++ b/boards/wio_terminal/src/sound.rs
@@ -1,13 +1,11 @@
-use crate::pins::MicOutput;
 use atsamd_hal::adc::Adc;
 use atsamd_hal::clock::GenericClockController;
-use atsamd_hal::gpio::v2::*;
 use atsamd_hal::pac::gclk::pchctrl::GEN_A::GCLK11;
 use atsamd_hal::pac::{ADC1, MCLK, TCC0};
-use atsamd_hal::prelude::*;
 use atsamd_hal::pwm::{TCC0Pinout, Tcc0Pwm};
+use atsamd_hal::time::U32Ext;
 
-use super::pins::*;
+use super::pins::aliases::*;
 
 /// Buzzer pins
 pub struct Buzzer {
@@ -23,7 +21,7 @@ impl Buzzer {
         clocks: &mut GenericClockController,
         tcc0: TCC0,
         mclk: &mut MCLK,
-    ) -> Tcc0Pwm<PD11, BuzzerCtrlMode> {
+    ) -> Tcc0Pwm<BuzzerCtrlId, BuzzerCtrlMode> {
         let pinout = TCC0Pinout::Pd11(self.ctr);
 
         let gclk0 = clocks.gclk0();

--- a/boards/wio_terminal/src/sound.rs
+++ b/boards/wio_terminal/src/sound.rs
@@ -7,19 +7,15 @@ use atsamd_hal::pac::{ADC1, MCLK, TCC0};
 use atsamd_hal::prelude::*;
 use atsamd_hal::pwm::{TCC0Pinout, Tcc0Pwm};
 
+use super::pins::*;
+
 /// Buzzer pins
-pub struct Buzzer<C>
-where
-    C: AnyPin<Id = PD11>,
-{
+pub struct Buzzer {
     /// Buzzer control pin
-    pub ctr: C,
+    pub ctr: BuzzerCtrlReset,
 }
 
-impl<C> Buzzer<C>
-where
-    C: AnyPin<Id = PD11>,
-{
+impl Buzzer {
     /// Initialize the pin connected to the piezo buzzer. Configure the pin as a
     /// PWM output using TCC0, and return the Pwm instance.
     pub fn init(
@@ -27,8 +23,8 @@ where
         clocks: &mut GenericClockController,
         tcc0: TCC0,
         mclk: &mut MCLK,
-    ) -> Tcc0Pwm<PD11, AlternateF> {
-        let pinout = TCC0Pinout::Pd11(self.ctr.into());
+    ) -> Tcc0Pwm<PD11, BuzzerCtrlMode> {
+        let pinout = TCC0Pinout::Pd11(self.ctr);
 
         let gclk0 = clocks.gclk0();
         let pwm0 = Tcc0Pwm::new(
@@ -44,18 +40,12 @@ where
 }
 
 /// Microphone pins
-pub struct Microphone<M>
-where
-    M: Into<MicOutput>,
-{
+pub struct Microphone {
     /// Microphone output (analog input) pin
-    pub mic: M,
+    pub mic: MicOutputReset,
 }
 
-impl<M> Microphone<M>
-where
-    M: Into<MicOutput>,
-{
+impl Microphone {
     /// Initialize Pd1 as an ADC input, and return a Tuple containing the ADC
     /// peripheral and the configured pin.
     pub fn init(

--- a/boards/wio_terminal/src/storage.rs
+++ b/boards/wio_terminal/src/storage.rs
@@ -1,17 +1,14 @@
-use crate::pins::{SdCs, SdMiso, SdMosi, SdSck};
 use atsamd_hal::{
     clock::{GenericClockController, Sercom6CoreClock},
-    gpio::v2::*,
     pac::{MCLK, QSPI, SERCOM6},
-    prelude::*,
     qspi,
     sercom::v2::{spi, IoSet1, Sercom6},
-    time::Hertz,
+    time::{Hertz, U32Ext},
     typelevel::NoneT,
 };
 use embedded_sdmmc::{SdMmcSpi, TimeSource};
 
-use super::pins::*;
+use super::pins::aliases::*;
 
 /// QSPI Flash pins (uses `SERCOM4`)
 pub struct QSPIFlash {

--- a/boards/wio_terminal/src/storage.rs
+++ b/boards/wio_terminal/src/storage.rs
@@ -1,40 +1,42 @@
-#[rustfmt::skip]
-use atsamd_hal::clock::{GenericClockController, Sercom6CoreClock};
-use atsamd_hal::gpio::{
-    Floating, Input, Output, Pa10, Pa11, Pa8, Pa9, Pb10, Pb11, Pc16, Pc17, Pc18, Pc19, Pd21, PfC,
-    Port, PushPull,
+use crate::pins::{SdCs, SdMiso, SdMosi, SdSck};
+use atsamd_hal::{
+    clock::{GenericClockController, Sercom6CoreClock},
+    gpio::v2::*,
+    pac::{MCLK, QSPI, SERCOM6},
+    prelude::*,
+    qspi,
+    sercom::v2::{
+        spi::{self, Phase, Polarity},
+        IoSet1, Sercom6,
+    },
+    time::Hertz,
+    typelevel::NoneT,
 };
-use atsamd_hal::hal::spi;
-use atsamd_hal::pac::{MCLK, QSPI, SERCOM6};
-use atsamd_hal::prelude::*;
-use atsamd_hal::qspi;
-use atsamd_hal::sercom::{PadPin, SPIMaster6, Sercom6Pad0, Sercom6Pad1, Sercom6Pad2};
-use atsamd_hal::time::Hertz;
 use embedded_sdmmc::{SdMmcSpi, TimeSource};
 
 /// QSPI Flash pins (uses `SERCOM4`)
 pub struct QSPIFlash {
     /// QSPI Flash `sck` pin
-    pub sck: Pb10<Input<Floating>>,
+    pub sck: Pin<PB10, Disabled<Floating>>,
 
     /// QSPI Flash chip select pin
-    pub cs: Pb11<Input<Floating>>,
+    pub cs: Pin<PB11, Disabled<Floating>>,
 
     /// QSPI Flash `d0` pin
-    pub d0: Pa8<Input<Floating>>,
+    pub d0: Pin<PA08, Disabled<Floating>>,
 
     /// QSPI Flash `d1` pin
-    pub d1: Pa9<Input<Floating>>,
+    pub d1: Pin<PA09, Disabled<Floating>>,
 
     /// QSPI Flash `d2` pin
-    pub d2: Pa10<Input<Floating>>,
+    pub d2: Pin<PA10, Disabled<Floating>>,
 
     /// QSPI Flash `d3` pin
-    pub d3: Pa11<Input<Floating>>,
+    pub d3: Pin<PA11, Disabled<Floating>>,
 }
 
 impl QSPIFlash {
-    pub fn init(self, mclk: &mut MCLK, _port: &mut Port, qspi: QSPI) -> qspi::Qspi<qspi::OneShot> {
+    pub fn init(self, mclk: &mut MCLK, qspi: QSPI) -> qspi::Qspi<qspi::OneShot> {
         qspi::Qspi::new(
             mclk, qspi, self.sck, self.cs, self.d0, self.d1, self.d2, self.d3,
         )
@@ -44,28 +46,24 @@ impl QSPIFlash {
 /// SD Card pins (uses `SERCOM6`)
 pub struct SDCard {
     /// SD Card chip select pin
-    pub cs: Pc19<Input<Floating>>,
+    pub cs: Pin<PC19, Disabled<Floating>>,
 
     /// SD Card `mosi` pin
-    pub mosi: Pc16<Input<Floating>>,
+    pub mosi: Pin<PC16, Disabled<Floating>>,
 
     /// SD Card `sck` pin
-    pub sck: Pc17<Input<Floating>>,
+    pub sck: Pin<PC17, Disabled<Floating>>,
 
     /// SD Card `miso` pin
-    pub miso: Pc18<Input<Floating>>,
+    pub miso: Pin<PC18, Disabled<Floating>>,
 
     /// SD Card detect pin
-    pub det: Pd21<Input<Floating>>,
+    pub det: Pin<PD21, Disabled<Floating>>,
 }
 
-type Controller<TS> = embedded_sdmmc::Controller<
-    SdMmcSpi<
-        SPIMaster6<Sercom6Pad2<Pc18<PfC>>, Sercom6Pad0<Pc16<PfC>>, Sercom6Pad1<Pc17<PfC>>>,
-        Pc19<Output<PushPull>>,
-    >,
-    TS,
->;
+pub type SdPads = spi::Pads<Sercom6, IoSet1, SdMiso, SdMosi, SdSck>;
+pub type SdSpi = spi::Spi<spi::Config<SdPads>, spi::Duplex>;
+type Controller<TS> = embedded_sdmmc::Controller<SdMmcSpi<SdSpi, SdCs>, TS>;
 
 /// An initialized SPI SDMMC controller.
 pub struct SDCardController<TS: TimeSource> {
@@ -77,7 +75,7 @@ impl<TS: TimeSource> SDCardController<TS> {
     /// Initializes the MMC card. An error is returned if there is no card
     /// or a communications error occurs.
     pub fn set_baud<B: Into<Hertz>>(&mut self, baud: B) {
-        self.cont.device().spi().set_baud(baud, &self.sercom6_clk)
+        self.cont.device().spi().reconfigure(|c| c.set_baud(baud));
     }
 }
 
@@ -102,35 +100,28 @@ impl SDCard {
         clocks: &mut GenericClockController,
         sercom6: SERCOM6,
         mclk: &mut MCLK,
-        port: &mut Port,
         ts: TS,
-    ) -> Result<(SDCardController<TS>, Pd21<Input<Floating>>), ()> {
+    ) -> Result<(SDCardController<TS>, Pin<PD21, Input<Floating>>), ()> {
         let gclk0 = clocks.gclk0();
         let sercom6_clk = clocks.sercom6_core(&gclk0).ok_or(())?;
-        let spi = SPIMaster6::new(
-            &sercom6_clk,
-            400.khz(),
-            spi::Mode {
-                phase: spi::Phase::CaptureOnFirstTransition,
-                polarity: spi::Polarity::IdleLow,
-            },
-            sercom6,
-            mclk,
-            (
-                self.miso.into_pad(port),
-                self.mosi.into_pad(port),
-                self.sck.into_pad(port),
-            ),
-        );
+        let pads = spi::Pads::default()
+            .data_out(self.mosi)
+            .data_in(self.miso)
+            .sclk(self.sck);
+        let spi = spi::Config::new(mclk, sercom6, pads, sercom6_clk.freq())
+            .cpol(Polarity::IdleLow)
+            .cpha(Phase::CaptureOnFirstTransition)
+            .baud(400.khz())
+            .enable();
 
-        let cs = self.cs.into_push_pull_output(port);
+        let cs = self.cs.into_push_pull_output();
 
         Ok((
             SDCardController {
                 cont: embedded_sdmmc::Controller::new(SdMmcSpi::new(spi, cs), ts),
                 sercom6_clk,
             },
-            self.det,
+            self.det.into(),
         ))
     }
 }

--- a/boards/wio_terminal/src/wifi.rs
+++ b/boards/wio_terminal/src/wifi.rs
@@ -1,12 +1,13 @@
-use crate::pins::{WifiRx, WifiTx};
 use atsamd_hal::{
     clock::GenericClockController,
     delay::Delay,
-    gpio::v2::*,
+    ehal::blocking::delay::DelayMs,
+    ehal::digital::v2::OutputPin,
+    ehal::serial::{Read, Write},
     pac::{interrupt, MCLK, SERCOM0},
-    prelude::*,
+    prelude::nb,
     sercom::v2::{uart, IoSet2, Sercom0},
-    time::Hertz,
+    time::{Hertz, U32Ext},
 };
 use bbqueue::{self, BBBuffer, Consumer, Producer};
 use heapless::consts::*;
@@ -17,7 +18,7 @@ use cortex_m::peripheral::NVIC;
 pub use erpc::rpcs;
 use seeed_erpc as erpc;
 
-use super::pins::*;
+use super::pins::aliases::*;
 
 use crate::WIFI_UART_BAUD;
 
@@ -70,7 +71,7 @@ impl Wifi {
             mclk,
             sercom0,
             pads,
-            clocks.sercom2_core(&gclk0).unwrap().freq(),
+            clocks.sercom0_core(&gclk0).unwrap().freq(),
         )
         .baud(
             WIFI_UART_BAUD.hz(),

--- a/hal/src/thumbv7em/usb/mod.rs
+++ b/hal/src/thumbv7em/usb/mod.rs
@@ -11,8 +11,11 @@ mod devicedesc;
 use self::devicedesc::Descriptors;
 
 /// Default SOF pad
+#[allow(deprecated)]
 pub type SofPad = gpio::v1::Pa23<gpio::v1::PfH>;
 /// Default USB D- pad
+#[allow(deprecated)]
 pub type DmPad = gpio::v1::Pa24<gpio::v1::PfH>;
 /// Default USB D+ pad
+#[allow(deprecated)]
 pub type DpPad = gpio::v1::Pa25<gpio::v1::PfH>;


### PR DESCRIPTION
# Summary

* Update `wio-terminal` to remove all uses of the `v1` APIs, thus completing its T1 status
* Remove a bunch of clippy warnings
* Update `cortex-m` and `cortex-m-rt` to `0.7`, `bbqueue` to `0.5`

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [ ] ~~All new or modified code is well documented, especially public items~~
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)

## If Adding a new Board
  - [ ] ~~Board CI added to `crates.json`~~
  - [x] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"