### PR TITLE
fix pwm divisor in get_period

### DIFF
--- a/hal/src/thumbv6m/pwm.rs
+++ b/hal/src/thumbv6m/pwm.rs
@@ -93,7 +93,7 @@ impl $TYPE {
         let count = self.tc.count16();
         let divisor = count.ctrla.read().prescaler().bits();
         let top = count.cc[0].read().cc().bits();
-        Hertz(self.clock_freq.0 / divisor as u32 / (top + 1) as u32)
+        Hertz(self.clock_freq.0 / (1u32 << divisor) / (top + 1) as u32)
     }
 }
 
@@ -229,7 +229,7 @@ impl Pwm for $TYPE {
     fn get_period(&self) -> Self::Time {
         let divisor = self.tcc.ctrla.read().prescaler().bits();
         let top = self.tcc.per().read().bits();
-        Hertz(self.clock_freq.0 / divisor as u32 / (top + 1) as u32)
+        Hertz(self.clock_freq.0 / (1u32 << divisor) / (top + 1) as u32)
     }
 
     fn get_duty(&self, channel: Self::Channel) -> Self::Duty {


### PR DESCRIPTION
# Summary

I'm currently trying to use PWM. I'm kind of stuck here but I found this bug in the code.

Regarding the ctrla::PRESCALER_A. 
- DIV1 = 0 
- DIV2 = 1 
- DIV3 = 2

Actually, this code is only working for small prescalers (up to 16). 

```
match params.divider {
    1 => w.prescaler().div1(),
    2 => w.prescaler().div2(),
    4 => w.prescaler().div4(),
    8 => w.prescaler().div8(),
    16 => w.prescaler().div16(),
    64 => w.prescaler().div64(),
    256 => w.prescaler().div256(),
    1024 => w.prescaler().div1024(),
    _ => unreachable!(),
}
```

The only way I saw with my limited experience here, is to match the other way around, (feels a bit hacky).

Any better idea?

---

# Checklist
  - [ ] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)

## If Adding a new Board
  - [x] Board CI added to `crates.json`
  - [x] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"