### PR TITLE
add second undocumented IOSET: UndocIoSet2

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased Changes
 
+- Add additional undocumented but valid IOSet for ATSAMD5x/ATSAME5x
 - Update PACs to v0.11.0 (#518)
 - Improve the `bsp_pins!` macro (#475 & #483)
 - Add undocumented but valid IOSet for ATSAMD5x/ATSAME5x (#506)

--- a/hal/src/sercom/v2/pad.rs
+++ b/hal/src/sercom/v2/pad.rs
@@ -292,11 +292,15 @@ mod ioset {
     /// After implementing `IoSet` type checking, it became clear that some
     /// existing boards were using a combinations of pins that did not match any
     /// IOSET in the datasheet. From that, we infer that there must be at least
-    /// one undocumented IOSET, and we added this new `IoSet` to account for it.
+    /// two undocumented IOSETs, and we added these new `IoSet`s to account for
+    /// it.
     ///
-    /// As of writing this documentation, only one undocumented IOSET has been
-    /// discovered: PA16, PA17, PB22 & PB23 configured for `Sercom1`. Both the
+    /// As of writing this documentation, only two undocumented IOSETs have been
+    /// discovered:
+    /// - PA16, PA17, PB22 & PB23 configured for `Sercom1`. Both the
     /// pygamer & feather_m4 uses this combination.
+    /// - PA00, PA01, PB22 & PB23 configured for `Sercom1`. The itsybitsy_m4
+    ///   uses this combination.
     ///
     /// See the [type-level enum] documentation for more details on type-level
     /// variants.
@@ -305,6 +309,10 @@ mod ioset {
     pub enum UndocIoSet1 {}
     impl Sealed for UndocIoSet1 {}
     impl IoSet for UndocIoSet1 {}
+
+    pub enum UndocIoSet2 {}
+    impl Sealed for UndocIoSet2 {}
+    impl IoSet for UndocIoSet2 {}
 
     /// Type class for SERCOM pads in a given [`IoSet`]
     ///

--- a/hal/src/sercom/v2/pad/impl_pad_thumbv7em.rs
+++ b/hal/src/sercom/v2/pad/impl_pad_thumbv7em.rs
@@ -435,3 +435,11 @@ impl InIoSet<UndocIoSet1> for Pin<PA16, Alternate<C>> {}
 impl InIoSet<UndocIoSet1> for Pin<PA17, Alternate<C>> {}
 impl InIoSet<UndocIoSet1> for Pin<PB22, Alternate<C>> {}
 impl InIoSet<UndocIoSet1> for Pin<PB23, Alternate<C>> {}
+
+// Implement an undocumented `IoSet` for PA00, PA01, PB22 & PB23 configured for
+// `Sercom1`. The itsybitsy_m4 uses this combination, but it is not
+// listed as valid in the datasheet.
+impl InIoSet<UndocIoSet2> for Pin<PA00, Alternate<D>> {}
+impl InIoSet<UndocIoSet2> for Pin<PA01, Alternate<D>> {}
+impl InIoSet<UndocIoSet2> for Pin<PB22, Alternate<C>> {}
+impl InIoSet<UndocIoSet2> for Pin<PB23, Alternate<C>> {}


### PR DESCRIPTION
# Summary
- It was necessary to add a new undocumented IOSET to the hal, as the ItsyBitsy m4 uses `PA00`, `PA01` (IOSET 4), `PB22` & `PB23`(IOSET 3) for `Sercom1`. This configuration is not listed as a valid combination in the datasheet, but works regardless. Similar to #455. Closes  #545. 

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)
