### PR TITLE
bump hal to v0.14

### DIFF
--- a/boards/circuit_playground_express/CHANGELOG.md
+++ b/boards/circuit_playground_express/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# v0.11.0
+
 - added the `neopixel_rainbow` example
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency

--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "circuit_playground_express"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Paul Sajna <paulsajna@gmail.com>"]
 description = "Board Support crate for the Adafruit Circuit Playground Express"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -15,7 +15,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/feather_m0/CHANGELOG.md
+++ b/boards/feather_m0/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# v0.11.0
+
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 * move `usbd-x` crates used only in examples to `[dev-dependencies]`
@@ -7,7 +9,7 @@
 * Bump `cortex-m`/`cortex-m-rt` dependencies to fix a build issue
 - Update to use refactored SPI module (#467)
 
-# 10.0.1
+# v0.10.1
 
 * Bump dependencies `rtic-monotonic` to `0.1.0-rc.1` and `cortex-m-rtic` to `0.6.0-rc.2`.
 

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feather_m0"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit Feather M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -16,7 +16,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/feather_m4/CHANGELOG.md
+++ b/boards/feather_m4/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# v0.9.0
+
 - replace deprecated `SpinTimer` with `TimerCounter` in the `neopixel_rainbow` example
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency

--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -16,6 +16,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feather_m4"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2018"
 authors = ["Theodore DeRego <tderego94@gmail.com>"]
 description = "Board Support crate for the Adafruit Feather M4"

--- a/boards/metro_m0/CHANGELOG.md
+++ b/boards/metro_m0/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Unreleased
 
+# v0.11.0
+
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 * move `usbd-x` crates used only in examples to `[dev-dependencies]`
 * removed unnecessary dependency on `nb` and `panic_rtt` (#510)
 - Update to use refactored SPI module (#467)
 
-# 10.0.1
+# v0.10.1
 
 * Bump dependencies `rtic-monotonic` to `0.1.0-rc.1` and `cortex-m-rtic` to `0.6.0-rc.2`.
 

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metro_m0"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["Wez Furlong <wez@wezfurlong.org>"]
 description = "Board Support crate for the Adafruit Metro M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -15,7 +15,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/metro_m4/CHANGELOG.md
+++ b/boards/metro_m4/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# v0.10.0
+
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 - move `usbd-x` crates used only in examples to `[dev-dependencies]`

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metro_m4"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Paul Sajna <sajattack@gmail.com>", "Wez Furlong <wez@wezfurlong.org>"]
 description = "Board Support crate for the Adafruit Metro M4"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -15,7 +15,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/samd11_bare/CHANGELOG.md
+++ b/boards/samd11_bare/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# v0.7.0
+
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 * move `usbd-x` crates used only in examples to `[dev-dependencies]`

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samd11_bare"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Jesse Braham <jesse@beta7.io>"]
 description = "Support crate for the ATSAMD11C"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -15,7 +15,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dev-dependencies]

--- a/boards/wio_terminal/CHANGELOG.md
+++ b/boards/wio_terminal/CHANGELOG.md
@@ -1,7 +1,8 @@
-# 0.5.0
+# Unreleased
+
+# v0.5.0
 
 - Update library and examples to use `atsamd-hal` V2 APIs and upgrade BSP to Tier 1.
-
 - Moved crates used only in examples to `[dev-dependencies]`
 
 ---

--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -41,7 +41,7 @@ seeed-erpc = { version = "0.1.1", optional = true }
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dev-dependencies]

--- a/crates.json
+++ b/crates.json
@@ -77,7 +77,7 @@
       "build": "cargo build --examples --features=unproven"
     },
     "pygamer": {
-	  "tier": 1,
+	  "tier": 2,
       "build": "cargo build --examples --features=unproven,usb,math"
     },
     "pyportal": {

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased Changes
 
+# v0.14.0
+
 - Add implementation of InputPin for Interrupt pins
 - Add additional undocumented but valid IOSet for ATSAMD5x/ATSAME5x
 - Update PACs to v0.11.0 (#518)

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atsamd-hal"
-version = "0.13.0"
+version = "0.14.0"
 authors = [
     "Wez Furlong <wez@wezfurlong.org>",
     "Paul Sajna <sajattack@gmail.com>",


### PR DESCRIPTION
# Summary
bump the hal to v0.14

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)