### PR TITLE
remove HAL path dependency from circuit_playground_express

### DIFF
--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -14,7 +14,6 @@ version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.14"
 default-features = false
 


### PR DESCRIPTION
# Summary
Only Tier One boards should have HAL path dependencies