### PR TITLE
Add sercom_interrupt example & other minor changes to xiao_m0 & itsybitsy_m4 BSPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,16 +226,56 @@ This is the preferred pure rust ecosystem method for interacting with bootloader
 
 The `cargo-hf2` crate replaces the `cargo build` command to include flashing over USB to connected UF2 devices, using hf2 flashing over HID protocol.
 
-```bash
+```Shell
 $ cargo install cargo-hf2
 ```
 
 and from a bsp directory
-```
+
+```Shell
 $ cargo hf2 --example blinky_basic --features unproven --release
 ```
 
+If you are on Linux and hf2 fails to flash your board even if it is connected and in bootloader
+mode, you might need to add some `udev` rules if you have not done that yet.
+
+You might want to have all the hf2 related rules in a single file, i.e. `/etc/udev/rules.d/99-hf2-boards.rules`,
+or have a different rules file for each vendor.
+
+The rules for Seeeduino and Adafruit boards look like this:
+
+```Shell
+#adafruit rules
+ATTRS{idVendor}=="239a", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="239a", MODE="0666"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="239a", MODE="0666"
+
+#seeeduino rules
+ATTRS{idVendor}=="2886", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="2886", MODE="0666"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="2886", MODE="0666"
+```
+
+If you want to add boards from another vendor, you can get the vendor id with the `lsusb` command,
+for example:
+
+```Shell
+$ lsusb
+Bus 001 Device 005: ID 2886:002f Seeed Technology Co., Ltd. Seeeduino XIAO
+...
+```
+
+Here `2886` is the vendor id and `002f` the product id.
+
+After adding the rules remember to reboot or run:
+
+```Shell
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
 For more information, refer to the `README` files for each crate:
+
 * [hf2 library (`hf2`)](https://github.com/jacobrosenthal/hf2-rs/tree/master/hf2)
 * [hf2 binary (`hf2-cli`)](https://github.com/jacobrosenthal/hf2-rs/tree/master/hf2-cli)
 * [hf2 cargo subcommand (`hf2-cargo`)](https://github.com/jacobrosenthal/hf2-rs/tree/master/cargo-hf2)

--- a/boards/itsybitsy_m4/CHANGELOG.md
+++ b/boards/itsybitsy_m4/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+- add `sercom_interrupt` example to show how to
+  - manually configure sercom for uart operation
+  - use sercom interrupts
+
 # 0.7.0
 
 - update bsp to use the v2 API

--- a/boards/itsybitsy_m4/README.md
+++ b/boards/itsybitsy_m4/README.md
@@ -11,18 +11,21 @@ This crate provides a type-safe Rust API for working with the
 - 2 MB SPI Flash chip
 
 ## Prerequisites
-* Install the cross compile toolchain `rustup target add thumbv7em-none-eabihf`
-* Install [cargo-hf2 the hf2 bootloader flasher tool](https://crates.io/crates/cargo-hf2) however your platform requires
+
+- Install the cross compile toolchain `rustup target add thumbv7em-none-eabihf`
+- Install [cargo-hf2 the hf2 bootloader flasher tool](https://crates.io/crates/cargo-hf2) however your platform requires
 
 ## Uploading an example
+
 Check out the repository for examples:
 
-https://github.com/atsamd-rs/atsamd/tree/master/boards/itsybitsy_m4/examples
+<https://github.com/atsamd-rs/atsamd/tree/master/boards/itsybitsy_m4/examples>
 
-* Be in this directory `cd boards/itsybitsy_m4`
-* Put your device in bootloader mode usually by hitting the reset button twice.
-* Build and upload in one step
-```
+- Be in this directory `cd boards/itsybitsy_m4`
+- Put your device in bootloader mode usually by hitting the reset button twice.
+- Build and upload in one step
+  
+```Shell
 $ cargo hf2 --release --example blinky_basic
     Finished release [optimized + debuginfo] target(s) in 0.19s
     Searching for a connected device with known vid/pid pair.
@@ -33,13 +36,16 @@ $
 ```
 
 Note some examples will tell you they need more features enabled
-```
+
+```Shell
 $ cargo hf2 --release --example usb_serial
 error: target `usb_serial` in package `itsybitsy_m4` requires the features: `usb`
 Consider enabling them by passing, e.g., `--features="usb"`
 ```
+
 Just follow the instructions to add --features like
-```
+
+```Shell
 cargo hf2 --release --example usb_serial --features="usb"
     Finished release [optimized + debuginfo] target(s) in 0.09s
     Searching for a connected device with known vid/pid pair.
@@ -48,3 +54,28 @@ cargo hf2 --release --example usb_serial --features="usb"
     Finished in 0.167s
 $
 ```
+
+If you are on Linux and hf2 fails to flash your board even if it is connected and in bootloader mode, you
+might need to add some `udev` rules if you have not done that yet.
+
+The example for adafruit boards is shown [here](https://crates.io/crates/hf2).
+
+You might want to have all the hf2 related rules in a single file, i.e. `/etc/udev/rules.d/99-hf2-boards.rules`, or have
+a different rules file for each vendor. The rules for Adafruit boards look like this:
+
+```Shell
+#adafruit rules
+ATTRS{idVendor}=="239a", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="239a", MODE="0666"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="239a", MODE="0666"
+```
+
+After adding the rules remember to reboot or run:
+
+```Shell
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+For more information on hf2 and other methods of uploading your code, take a look at
+the base project [README](https://github.com/atsamd-rs/atsamd).

--- a/boards/itsybitsy_m4/examples/sercom_interrupt.rs
+++ b/boards/itsybitsy_m4/examples/sercom_interrupt.rs
@@ -1,0 +1,156 @@
+#![no_std]
+#![no_main]
+
+//! The idea of this example is to show two different things
+//! - How to manually configure SERCOM for a desired mode (UART in this case)
+//! - How to enable an use SERCOM interrupts
+//! The second one is particularly handy because some drivers will give
+//! you a `poll()` or `update()` function, and you are expected to call it  
+//! on the receive interrupt of the peripheral i.e. SERCOM UART RXC
+//! (receive complete flag).
+//!
+//! This example is basically just a blinky script. The MCU sends itself
+//! a byte via UART that will trigger the RXC interrupt and then toggles
+//! the builtin red led
+//!
+//! Wiring
+//! - RX - A4
+//! - TX - A5
+//!
+//! > In the ATSAMX5x MCUs SERCOM UART configuration requires at least
+//! two pins from the same IOSET. You can find more info about this in
+//! the hal documentation or in the MCU datasheet at:
+//! <https://www.microchip.com/en-us/product/ATSAMD51G19A>
+
+use itsybitsy_m4 as bsp;
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
+use bsp::{entry, IoSet3Sercom0Pad0, IoSet3Sercom0Pad2};
+use core::cell::RefCell;
+use cortex_m::{interrupt::Mutex, peripheral::NVIC};
+
+use bsp::hal::{
+    clock::GenericClockController,
+    delay::Delay,
+    ehal::blocking::delay::DelayMs,
+    gpio::v2::{Pin, PushPullOutput, PA22},
+    pac::{self, interrupt, CorePeripherals, Peripherals},
+    prelude::*,
+    sercom::v2::{
+        uart::{self, BaudMode, Flags, Oversampling},
+        IoSet3, Sercom0,
+    },
+    time::Hertz,
+};
+
+type UartPads0 = uart::Pads<Sercom0, IoSet3, IoSet3Sercom0Pad2, IoSet3Sercom0Pad0>;
+type Uart0 = uart::Uart<uart::Config<UartPads0>, uart::Duplex>;
+
+/// Utility function for setting up SERCOM0 pins as an additional
+/// UART peripheral.
+pub fn uart0(
+    clocks: &mut GenericClockController,
+    baud: impl Into<Hertz>,
+    sercom0: pac::SERCOM0,
+    mclk: &mut pac::MCLK,
+    uart_rx: impl Into<IoSet3Sercom0Pad2>,
+    uart_tx: impl Into<IoSet3Sercom0Pad0>,
+) -> Uart0 {
+    let gclk0 = clocks.gclk0();
+    let clock = &clocks.sercom0_core(&gclk0).unwrap();
+    let baud = baud.into();
+    let pads = uart::Pads::default().rx(uart_rx.into()).tx(uart_tx.into());
+    uart::Config::new(mclk, sercom0, pads, clock.freq())
+        .baud(baud, BaudMode::Fractional(Oversampling::Bits16))
+        .enable()
+}
+
+/// If you want to know more on ways to share data safely,
+/// give this a read: <https://docs.rust-embedded.org/book/concurrency/>
+static LED: Mutex<RefCell<Option<Pin<PA22, PushPullOutput>>>> = Mutex::new(RefCell::new(None));
+static SERIAL: Mutex<RefCell<Option<bsp::Uart>>> = Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    //basic setup
+    let mut dp = Peripherals::take().unwrap();
+    let mut core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        dp.GCLK,
+        &mut dp.MCLK,
+        &mut dp.OSC32KCTRL,
+        &mut dp.OSCCTRL,
+        &mut dp.NVMCTRL,
+    );
+
+    let pins = bsp::Pins::new(dp.PORT);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    // custom sercom uart configuration
+    let mut serial_sercom0 = uart0(
+        &mut clocks,
+        Hertz(115200),
+        dp.SERCOM0,
+        &mut dp.MCLK,
+        pins.a5,
+        pins.a4,
+    );
+
+    // labeled "default" uart
+    let mut serial_sercom3 = bsp::uart(
+        &mut clocks,
+        Hertz(115200),
+        dp.SERCOM3,
+        &mut dp.MCLK,
+        pins.d0_rx,
+        pins.d1_tx,
+    );
+
+    // We must enable the interrupt flag by flag, in this case,
+    // we just want RXC
+    serial_sercom3.enable_interrupts(Flags::RXC);
+    let led = pins.d13.into_push_pull_output();
+    //move shared peripherals into the mutexes
+    cortex_m::interrupt::free(|cs| {
+        SERIAL.borrow(cs).replace(Some(serial_sercom3));
+        LED.borrow(cs).replace(Some(led));
+    });
+
+    unsafe {
+        // interrupt must be enabled and unmasked in the NVIC
+        // (Nested Vector Interrupt Controller) peripheral
+        core.NVIC.set_priority(interrupt::SERCOM3_2, 1);
+        NVIC::unmask(interrupt::SERCOM3_2);
+    }
+
+    loop {
+        // wait a second then send a byte
+        delay.delay_ms(1000u16);
+        let _ = nb::block!(serial_sercom0.write(b'A'));
+    }
+}
+
+#[interrupt]
+fn SERCOM3_2() {
+    // must read sercom data register or the interrupt
+    // won't trigger again
+    cortex_m::interrupt::free(|cs| {
+        if let Some(serial) = SERIAL.borrow(cs).borrow_mut().as_mut() {
+            if let Ok(c) = serial.read() {
+                let _ = nb::block!(serial.write(c));
+            }
+        }
+    });
+    toggle()
+}
+
+fn toggle() {
+    cortex_m::interrupt::free(|cs| {
+        if let Some(led) = LED.borrow(cs).borrow_mut().as_mut() {
+            led.toggle().ok();
+        }
+    });
+}

--- a/boards/itsybitsy_m4/examples/spi.rs
+++ b/boards/itsybitsy_m4/examples/spi.rs
@@ -14,15 +14,20 @@ use panic_semihosting as _;
 
 use itsybitsy_m4 as bsp;
 
-use atsamd_hal::{delay::Delay, time::MegaHertz};
 use bsp::{
     entry,
     hal::{
         clock::GenericClockController,
+        delay::Delay,
+        ehal::{
+            blocking::{delay::DelayMs, spi::Transfer},
+            serial::Write,
+        },
         pac::{CorePeripherals, Peripherals},
         prelude::*,
+        time::{Hertz, MegaHertz},
     },
-    spi_master, Hertz,
+    spi_master,
 };
 
 #[entry]

--- a/boards/itsybitsy_m4/src/lib.rs
+++ b/boards/itsybitsy_m4/src/lib.rs
@@ -66,6 +66,7 @@ hal::bsp_pins!(
         name: a4
         aliases: {
             AlternateB: Analog4
+            AlternateD: IoSet3Sercom0Pad0
         }
     }
     PA06 {
@@ -73,6 +74,7 @@ hal::bsp_pins!(
         name: a5
         aliases: {
             AlternateB: Analog5
+            AlternateD: IoSet3Sercom0Pad2
         }
     }
     PA16 {

--- a/boards/xiao_m0/CHANGELOG.md
+++ b/boards/xiao_m0/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Unreleased
 
-- create `eic` example to show the relation between `Pin`, `ExtIntX` and `INTFLAG` 
+# 0.12.0
+
+- bump hal dependency to 0.14.0
+- bump cortex-m dependency to 0.7
+- add `sercom_interrupt` example to show how to
+  - manually configure sercom for uart operation
+  - use sercom interrupts
+- create `eic` example to show the relation between `Pin`, `ExtIntX` and `INTFLAG`
 
 # 0.11.0
 

--- a/boards/xiao_m0/Cargo.toml
+++ b/boards/xiao_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xiao_m0"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Garret Kelly <gdk@google.com>", "Maciej Procyk <macieekprocyk@gmail.com>"]
 description = "Board support crate for the Seeed Studio Seeeduino XIAO"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
@@ -10,11 +10,11 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.6.15"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]
@@ -31,7 +31,7 @@ mpu6050 = "0.1.4"
 shared-bus = "0.2.2"
 
 [features]
-default = ["rt", "atsamd-hal/samd21g"]
+default = ["rt", "atsamd-hal/samd21g", "atsamd-hal/unproven"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
 unproven = ["atsamd-hal/unproven"]
 usb = ["atsamd-hal/usb", "usb-device"]
@@ -61,4 +61,4 @@ opt-level = "s"
 
 # for cargo flash
 [package.metadata]
-chip = "ATSAMD51P19A"
+chip = "ATSAMD21G18A"

--- a/boards/xiao_m0/README.md
+++ b/boards/xiao_m0/README.md
@@ -4,11 +4,13 @@ This crate provides a type-safe API for working with the [Seeed Studio
 Seeeduino XIAO](http://wiki.seeedstudio.com/Seeeduino-XIAO/).
 
 ## Prerequisites
+
 * Install the cross compile toolchain `rustup target add thumbv6m-none-eabi`
 * Install the [cargo-hf2 tool](https://crates.io/crates/cargo-hf2) however your
   platform requires
 
 ## Uploading an example
+
 Check out [the
 repository](https://github.com/atsamd-rs/atsamd/tree/master/boards/xiao_m0/examples)
 for examples.
@@ -21,3 +23,28 @@ for examples.
   * Note that if you're using an older `cargo-hf2` that you'll need to specify
     the VID/PID when flashing: `cargo hf2 --vid 0x2886 --pid 0x002f --release
     --example blink --features="unproven"`
+
+If you are on Linux and hf2 fails to flash your board even if it is connected and in bootloader mode, you
+might need to add some `udev` rules if you have not done that yet.
+
+The example for adafruit boards is shown [here](https://crates.io/crates/hf2).
+
+You might want to have all the hf2 related rules in a single file, i.e. `/etc/udev/rules.d/99-hf2-boards.rules`, or have
+a different rules file for each vendor. The rules for Seeeduino boards look like this:
+
+```Shell
+#seeeduino rules
+ATTRS{idVendor}=="2886", ENV{ID_MM_DEVICE_IGNORE}="1"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="2886", MODE="0666"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="2886", MODE="0666"
+```
+
+After adding the rules remember to reboot or run:
+
+```Shell
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+For more information on hf2 and other methods of uploading your code, take a look at
+the base project [README](https://github.com/atsamd-rs/atsamd).

--- a/boards/xiao_m0/examples/sercom_interrupt.rs
+++ b/boards/xiao_m0/examples/sercom_interrupt.rs
@@ -1,0 +1,146 @@
+#![no_std]
+#![no_main]
+
+//! The idea of this example is to show two different things
+//! - How to manually configure SERCOM for a desired mode (UART in this case)
+//! - How to enable an use SERCOM interrupts
+//! The second one is particularly handy because some drivers will give
+//! you a `poll()` or `update()` function, and you are expected to call it
+//! on the receive interrupt of the peripheral i.e. SERCOM UART RXC
+//! (receive complete flag).
+//!
+//! This example is basically just a blinky script. The MCU sends itself
+//! a byte via UART that will trigger the RXC interrupt and then toggles
+//! one of the builtin leds
+//!
+//! Wiring
+//! - RX(A7) - A4
+//! - TX(A6) - A5
+
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+use xiao_m0 as bsp;
+
+use bsp::{entry, A4Sercom0Pad0, A5Sercom0Pad1};
+use core::cell::RefCell;
+use cortex_m::{interrupt::Mutex, peripheral::NVIC};
+
+use bsp::hal::{
+    clock::GenericClockController,
+    delay::Delay,
+    ehal::blocking::delay::DelayMs,
+    gpio::v2::{Pin, PushPullOutput, PA17},
+    pac::{self, interrupt, CorePeripherals, Peripherals},
+    prelude::*,
+    sercom::v2::{
+        uart::{self, BaudMode, Oversampling},
+        Sercom0,
+    },
+    time::Hertz,
+};
+
+type UartPads0 = uart::Pads<Sercom0, A5Sercom0Pad1, A4Sercom0Pad0>;
+type Uart0 = uart::Uart<uart::Config<UartPads0>, uart::Duplex>;
+
+/// Utility function for setting up SERCOM0 pins as an additional
+/// UART peripheral.
+pub fn uart0(
+    clocks: &mut GenericClockController,
+    baud: impl Into<Hertz>,
+    sercom0: pac::SERCOM0,
+    pm: &mut pac::PM,
+    uart_rx: impl Into<A5Sercom0Pad1>,
+    uart_tx: impl Into<A4Sercom0Pad0>,
+) -> Uart0 {
+    let gclk0 = clocks.gclk0();
+    let clock = &clocks.sercom0_core(&gclk0).unwrap();
+    let baud = baud.into();
+    let pads = uart::Pads::default().rx(uart_rx.into()).tx(uart_tx.into());
+    uart::Config::new(pm, sercom0, pads, clock.freq())
+        .baud(baud, BaudMode::Fractional(Oversampling::Bits16))
+        .enable()
+}
+
+/// If you want to know more on ways to share data safely,
+/// give this a read: <https://docs.rust-embedded.org/book/concurrency/>
+static LED: Mutex<RefCell<Option<Pin<PA17, PushPullOutput>>>> = Mutex::new(RefCell::new(None));
+static SERIAL: Mutex<RefCell<Option<bsp::Uart>>> = Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    //basic setup
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.PM,
+        &mut peripherals.SYSCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+    let pins = bsp::Pins::new(peripherals.PORT);
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    // custom sercom uart configuration
+    let mut serial_sercom0 = uart0(
+        &mut clocks,
+        Hertz(115200),
+        peripherals.SERCOM0,
+        &mut peripherals.PM,
+        pins.a5,
+        pins.a4,
+    );
+
+    // labeled "default" uart
+    let mut serial_sercom4 = bsp::uart(
+        &mut clocks,
+        Hertz(115200),
+        peripherals.SERCOM4,
+        &mut peripherals.PM,
+        pins.a7,
+        pins.a6,
+    );
+    // We must enable the interrupt flag by flag, in this case,
+    // we just want RXC
+    serial_sercom4.enable_interrupts(uart::Flags::RXC);
+    let led = pins.led0.into_push_pull_output();
+    //move shared peripherals into the mutexes
+    cortex_m::interrupt::free(|cs| {
+        SERIAL.borrow(cs).replace(Some(serial_sercom4));
+        LED.borrow(cs).replace(Some(led));
+    });
+    unsafe {
+        // interrupt must be enabled and unmasked in the NVIC
+        // (Nested Vector Interrupt Controller) peripheral
+        core.NVIC.set_priority(interrupt::SERCOM4, 1);
+        NVIC::unmask(interrupt::SERCOM4);
+    }
+    loop {
+        delay.delay_ms(1000u16);
+        let _ = nb::block!(serial_sercom0.write(b'A'));
+    }
+}
+
+#[interrupt]
+fn SERCOM4() {
+    // must read sercom data register or the interrupt
+    // won't trigger again
+    cortex_m::interrupt::free(|cs| {
+        if let Some(serial) = SERIAL.borrow(cs).borrow_mut().as_mut() {
+            if let Ok(c) = serial.read() {
+                let _ = nb::block!(serial.write(c));
+            }
+        }
+    });
+    toggle()
+}
+
+fn toggle() {
+    cortex_m::interrupt::free(|cs| {
+        if let Some(led) = LED.borrow(cs).borrow_mut().as_mut() {
+            led.toggle().ok();
+        }
+    });
+}

--- a/boards/xiao_m0/src/lib.rs
+++ b/boards/xiao_m0/src/lib.rs
@@ -45,6 +45,7 @@ pub mod pins {
             name: a4
             aliases: {
                 AlternateC: Sda
+                AlternateC: A4Sercom0Pad0
             }
         }
         PA09 {
@@ -52,6 +53,7 @@ pub mod pins {
             name: a5
             aliases: {
                 AlternateC: Scl
+                AlternateC: A5Sercom0Pad1
             }
         }
         PB08 {
@@ -179,7 +181,7 @@ pub fn i2c_master(
 pub type SpiPads = Pads<Sercom0, Miso, Mosi, Sclk>;
 
 /// SPI master for the labelled SPI peripheral
-pub type Spi = spi::Spi<spi::Config<SpiPads>>;
+pub type Spi = spi::Spi<spi::Config<SpiPads>, spi::Duplex>;
 
 /// Convenience for setting up the labelled SPI peripheral.
 /// This powers up SERCOM0 and configures it for use as an


### PR DESCRIPTION
# Summary

- Add sercom_interrupt example
- bump xiao_m0 hal and cortex-m dependencies
  + implies adding `Duplex` to spi default config
- add `unproven` hal feature as default for xiao_m0
- clean itsybitsy_m4 spi example dependencies
- add documentation for setting up udev rules for both boards

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)