### PR TITLE
fixup qt_py_m0 crate which never published or got added to crates.json

### DIFF
--- a/boards/qt_py_m0/CHANGELOG.md
+++ b/boards/qt_py_m0/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 # v0.10.0
 
+- fix `cortex-m` dev-dependency (#563)
+- update to latest HAL and v2 APIs (#563)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 - move `usbd-x` crates used only in examples to `[dev-dependencies]`
 - removed unnecessary dependency on `nb` (#510)
-- fix `cortex-m` dev-dependency
 
 ---
 

--- a/boards/qt_py_m0/CHANGELOG.md
+++ b/boards/qt_py_m0/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Unreleased
 
+# v0.10.0
+
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 - move `usbd-x` crates used only in examples to `[dev-dependencies]`
 - removed unnecessary dependency on `nb` (#510)
+- fix `cortex-m` dev-dependency
 
 ---
 

--- a/boards/qt_py_m0/Cargo.toml
+++ b/boards/qt_py_m0/Cargo.toml
@@ -22,6 +22,7 @@ usbd-serial = "0.1"
 panic-halt = "0.2"
 smart-leds = "0.3"
 ws2812-timer-delay = { version = "0.3", features = ["slow"] }
+cortex-m = "0.6"
 
 [features]
 default = ["rt", "atsamd-hal/samd21e"]

--- a/boards/qt_py_m0/Cargo.toml
+++ b/boards/qt_py_m0/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.10.0"
 authors = ["Garret Kelly <gkelly@gkel.ly>"]
 description = "Board Support crate for the Adafruit QT Py"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"

--- a/boards/qt_py_m0/Cargo.toml
+++ b/boards/qt_py_m0/Cargo.toml
@@ -10,11 +10,11 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-cortex-m-rt = { version = "0.6.12", optional = true }
+cortex-m-rt = { version = "0.7", optional = true }
 usb-device = { version = "0.2", optional = true }
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dev-dependencies]
@@ -22,7 +22,7 @@ usbd-serial = "0.1"
 panic-halt = "0.2"
 smart-leds = "0.3"
 ws2812-timer-delay = { version = "0.3", features = ["slow"] }
-cortex-m = "0.6"
+cortex-m = "0.7"
 
 [features]
 default = ["rt", "atsamd-hal/samd21e"]

--- a/crates.json
+++ b/crates.json
@@ -1,167 +1,199 @@
 {
   "boards": {
     "arduino_mkr1000": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb"
     },
     "arduino_mkrvidor4000": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb"
     },
     "arduino_mkrzero": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb"
     },
     "arduino_nano33iot": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb"
     },
     "atsame54_xpro": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb"
     },
     "circuit_playground_express": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb"
     },
     "edgebadge": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb"
     },
     "feather_m0": {
-	  "tier": 1,
+      "tier": 1,
       "build": "cargo build --examples --features=unproven,dma,usb,rtic,sdmmc,adalogger"
     },
     "feather_m4": {
-	  "tier": 1,
+      "tier": 1,
       "build": "cargo build --examples --all-features"
     },
     "gemma_m0": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven"
     },
     "grand_central_m4": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb"
     },
     "itsybitsy_m0": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb"
     },
     "itsybitsy_m4": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb,use_rtt"
     },
     "metro_m0": {
-	  "tier": 1,
+      "tier": 1,
       "build": "cargo build --examples --features=unproven,usb,rtic"
     },
     "metro_m4": {
-	  "tier": 1,
+      "tier": 1,
       "build": "cargo build --examples --features=unproven,usb"
     },
     "neo_trinkey": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=leds,unproven,usb"
     },
     "neokey_trinkey": {
       "tier": 2,
-        "build": "cargo build --examples --features=leds,unproven,usb"
-      },
+      "build": "cargo build --examples --features=leds,unproven,usb"
+    },
     "p1am_100": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb"
     },
     "pfza_proto1": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven"
     },
     "pygamer": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb,math"
     },
     "pyportal": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven"
     },
     "samd11_bare": {
-	  "tier": 1,
+      "tier": 1,
       "build": "cargo build --release --examples --features=unproven,rt,use_semihosting"
     },
     "samd21_mini": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven"
     },
     "serpente": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven"
     },
     "sodaq_one": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven"
     },
     "sodaq_sara_aff": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven"
     },
     "trellis_m4": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=keypad-unproven"
     },
     "trinket_m0": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb"
     },
     "wio_lite_mg126": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb"
     },
     "wio_lite_w600": {
-	  "tier": 2,
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb"
     },
     "wio_terminal": {
-	  "tier": 1,
+      "tier": 1,
       "build": "cargo build --examples --features=usb"
     },
     "xiao_m0": {
-	  "tier": 2,
+      "tier": 2,
+      "build": "cargo build --examples --features=unproven,usb"
+    },
+    "qt_py_m0": {
+      "tier": 2,
       "build": "cargo build --examples --features=unproven,usb"
     }
   },
   "hal_doc_variants": {
     "samd11c": {
-      "features": ["samd11c", "unproven"],
+      "features": [
+        "samd11c",
+        "unproven"
+      ],
       "target": "thumbv6m-none-eabi"
     },
     "samd11d": {
-      "features": ["samd11d", "unproven"],
+      "features": [
+        "samd11d",
+        "unproven"
+      ],
       "target": "thumbv6m-none-eabi"
     },
-
     "samd21g": {
-      "features": ["samd21g", "unproven", "usb"],
+      "features": [
+        "samd21g",
+        "unproven",
+        "usb"
+      ],
       "target": "thumbv6m-none-eabi"
     },
     "samd21j": {
-      "features": ["samd21j", "unproven", "usb"],
+      "features": [
+        "samd21j",
+        "unproven",
+        "usb"
+      ],
       "target": "thumbv6m-none-eabi"
     },
-
     "samd51g": {
-      "features": ["samd51g", "unproven", "usb"],
+      "features": [
+        "samd51g",
+        "unproven",
+        "usb"
+      ],
       "target": "thumbv7em-none-eabihf"
     },
     "samd51j": {
-      "features": ["samd51j", "unproven", "usb"],
+      "features": [
+        "samd51j",
+        "unproven",
+        "usb"
+      ],
       "target": "thumbv7em-none-eabihf"
     },
     "samd51n": {
-      "features": ["samd51n", "unproven", "usb"],
+      "features": [
+        "samd51n",
+        "unproven",
+        "usb"
+      ],
       "target": "thumbv7em-none-eabihf"
     },
     "samd51p": {
-      "features": ["samd51p", "unproven", "usb"],
+      "features": [
+        "samd51p",
+        "unproven",
+        "usb"
+      ],
       "target": "thumbv7em-none-eabihf"
     }
   }


### PR DESCRIPTION
# Summary
While doing the awesome-embedded-rust PR, I noticed `qt_py_m0` was never published to crates.io. When I tried to build it, it failed, and I noticed it didn't get added to crates.json, so I did that.

Also, format crates.json because it's been bugging me. I'll publish after this gets merged.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)
