### PR TITLE
Update all tier 2 boards to atsamd-hal-0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,57 +111,6 @@ A BSP (**B**oard **S**upport **P**ackage) is a crate that contains definitions s
 
 * `wio_terminal`
 
-
-### Tier 2 BSPs
-
-* `arduino_mkr1000`
-
-* `arduino_mkrvidor4000`
-
-* `arduino_mkrzero`
-
-* `arduino_nano33iot`
-
-* `atsame54_xpro`
-
-* `circuit_playground_express`
-
-* `edgebadge`
-
-* `gemma_m0`
-
-* `grand_central_m4`
-
-* `itsybitsy_m0`
-
-* `itsybitsy_m4`
-
-* `p1am_100`
-
-* `pfza_proto1`
-
-* `pyportal`
-
-* `qt_py_m0`
-
-* `samd21_mini`
-
-* `serpente`
-
-* `sodaq_one`
-
-* `sodaq_sara_aff`
-
-* `trellis_m4`
-
-* `trinket_m0`
-
-* `wio_lite_mg126`
-
-* `wio_lite_w600`
-
-* `xiao_m0`
-
 To bootstrap your own project you should be able to copy/paste the Rust code from the examples folder within the folder of the BSP you've chosen. But you shouldn't copy the `Cargo.toml` file from there, since that's not only used for the examples, but also for the whole BSP itself. You want to make your own `Cargo.toml` file. If you're new to this and have no clue what you're doing then this is probably the line you want in there:
 
 ```rust

--- a/boards/arduino_mkr1000/CHANGELOG.md
+++ b/boards/arduino_mkr1000/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.5.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 - move `usbd-x` crates used only in examples to `[dev-dependencies]`

--- a/boards/arduino_mkr1000/Cargo.toml
+++ b/boards/arduino_mkr1000/Cargo.toml
@@ -4,17 +4,18 @@ version = "0.4.0"
 authors = ["Eric Rushing <rushinge@gmail.com>"]
 description = "Board Support crate for the Arduino MKR 1000 WiFi"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/arduino_mkr1000/Cargo.toml
+++ b/boards/arduino_mkr1000/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arduino_mkr1000"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Eric Rushing <rushinge@gmail.com>"]
 description = "Board Support crate for the Arduino MKR 1000 WiFi"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/arduino_mkrvidor4000/CHANGELOG.md
+++ b/boards/arduino_mkrvidor4000/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.6.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 - removed unnecessary dependency on `nb` (#510)

--- a/boards/arduino_mkrvidor4000/Cargo.toml
+++ b/boards/arduino_mkrvidor4000/Cargo.toml
@@ -4,17 +4,18 @@ version = "0.5.0"
 authors = ["Sameer Puri <purisame@spuri.io>"]
 description = "Board Support crate for the Arduino MKR VIDOR 4000"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dev-dependencies]

--- a/boards/arduino_mkrvidor4000/Cargo.toml
+++ b/boards/arduino_mkrvidor4000/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arduino_mkrvidor4000"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Sameer Puri <purisame@spuri.io>"]
 description = "Board Support crate for the Arduino MKR VIDOR 4000"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]

--- a/boards/arduino_mkrzero/CHANGELOG.md
+++ b/boards/arduino_mkrzero/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.12.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 - move `usbd-x` crates used only in examples to `[dev-dependencies]`

--- a/boards/arduino_mkrzero/Cargo.toml
+++ b/boards/arduino_mkrzero/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arduino_mkrzero"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Wez Furlong <wez@wezfurlong.org>", "David McGillicuddy <contact@djmcgill.co.uk>"]
 description = "Board Support crate for the Arduino MKRZERO"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]

--- a/boards/arduino_mkrzero/Cargo.toml
+++ b/boards/arduino_mkrzero/Cargo.toml
@@ -4,17 +4,18 @@ version = "0.11.0"
 authors = ["Wez Furlong <wez@wezfurlong.org>", "David McGillicuddy <contact@djmcgill.co.uk>"]
 description = "Board Support crate for the Arduino MKRZERO"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/arduino_nano33iot/CHANGELOG.md
+++ b/boards/arduino_nano33iot/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+# v0.7.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 * move `usbd-x` crates used only in examples to `[dev-dependencies]`

--- a/boards/arduino_nano33iot/Cargo.toml
+++ b/boards/arduino_nano33iot/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arduino_nano33iot"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Gus Wynn <guswynn@gmail.com>"]
 description = "Board Support crate for the Arduino Nano 33 IOT"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]

--- a/boards/arduino_nano33iot/Cargo.toml
+++ b/boards/arduino_nano33iot/Cargo.toml
@@ -4,17 +4,18 @@ version = "0.6.0"
 authors = ["Gus Wynn <guswynn@gmail.com>"]
 description = "Board Support crate for the Arduino Nano 33 IOT"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]
@@ -22,7 +23,7 @@ version = "0.2"
 optional = true
 
 [dependencies.rand]
-version = "0.8.3"
+version = "0.8"
 default-features = false
 features = ["small_rng"]
 
@@ -31,9 +32,9 @@ cortex-m = "0.7"
 usbd-serial = "0.1"
 panic-halt = "0.2"
 panic-semihosting = "0.5"
-embedded-graphics = "0.7.1"
-st7735-lcd = "0.8.1"
-ssd1306 = { version = "0.6", features = ["graphics"] }
+embedded-graphics = "0.7"
+st7735-lcd = "0.8"
+ssd1306 = { version = "0.7", features = ["graphics"] }
 
 [features]
 # ask the HAL to enable atsamd21g support

--- a/boards/arduino_nano33iot/src/lib.rs
+++ b/boards/arduino_nano33iot/src/lib.rs
@@ -257,7 +257,7 @@ pub type SpiPads = spi::Pads<Sercom1, Miso, Mosi, Sck>;
 /// SPI master for the labelled SPI peripheral
 ///
 /// This type implements [`FullDuplex<u8>`](ehal::spi::FullDuplex).
-pub type Spi = spi::Spi<spi::Config<SpiPads>>;
+pub type Spi = spi::Spi<spi::Config<SpiPads>, spi::Duplex>;
 
 /// Convenience for setting up the labelled SPI peripheral.
 /// This powers up SERCOM1 and configures it for use as an

--- a/boards/atsame54_xpro/CHANGELOG.md
+++ b/boards/atsame54_xpro/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.4.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency

--- a/boards/atsame54_xpro/Cargo.toml
+++ b/boards/atsame54_xpro/Cargo.toml
@@ -13,11 +13,11 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/atsame54_xpro/Cargo.toml
+++ b/boards/atsame54_xpro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atsame54_xpro"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Karsten Große <karsten.grosse@sympatron.de>"
 ]

--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -4,11 +4,10 @@ version = "0.11.0"
 authors = ["Paul Sajna <paulsajna@gmail.com>"]
 description = "Board Support crate for the Adafruit Circuit Playground Express"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2021"
+edition = "2018"
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.11.0"
 authors = ["Paul Sajna <paulsajna@gmail.com>"]
 description = "Board Support crate for the Adafruit Circuit Playground Express"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/edgebadge/CHANGELOG.md
+++ b/boards/edgebadge/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.9.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - move `usbd-x` crates used only in examples to `[dev-dependencies]`

--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgebadge"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Jacob Rosenthal <@jacobrosenthal>"]
 description = "Board Support crate for the Adafruit EdgeBadge"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -38,7 +38,7 @@ panic-halt = "0.2"
 embedded-graphics = "0.7.1"
 smart-leds = "0.3"
 lis3dh = "0.1.0"
-cortex-m-rtic = "0.5.1"
+cortex-m-rtic = "1.0"
 tinybmp = "0.3.1"
 
 [features]

--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -12,16 +12,16 @@ edition = "2021"
 exclude = ["assets"]
 
 [dependencies]
-cortex-m = "0.6"
+cortex-m = "0.7"
 st7735-lcd = "0.8.1"
 ws2812-timer-delay = "0.3"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.micromath]

--- a/boards/edgebadge/examples/button_rtic.rs
+++ b/boards/edgebadge/examples/button_rtic.rs
@@ -1,36 +1,43 @@
 #![no_std]
 #![no_main]
 
-use edgebadge::{self as hal, pins::ButtonReader, pins::Keys, Pins};
 use panic_halt as _;
 
-use hal::clock::GenericClockController;
-use hal::gpio::{OpenDrain, Output, Pa23};
-use hal::prelude::*;
-use rtic::app;
+use bsp::{pins::ButtonReader, pins::Keys, Pins};
+use edgebadge as bsp;
 
-#[app(device = crate::hal::pac, peripherals = true)]
-const APP: () = {
-    struct Resources {
+#[rtic::app(device = bsp::pac, peripherals = true)]
+mod app {
+    use super::*;
+
+    use bsp::clock::GenericClockController;
+    use bsp::gpio::{OpenDrain, Output, Pa23};
+    use bsp::prelude::*;
+
+    #[local]
+    struct Local {
         red_led: Pa23<Output<OpenDrain>>,
-        timer: hal::timer::TimerCounter3,
+        timer: bsp::timer::TimerCounter3,
         buttons: ButtonReader,
     }
+
+    #[shared]
+    struct Shared {}
 
     /// This function is called each time the tc3 interrupt triggers.
     /// We use it to toggle the LED.  The `wait()` call is important
     /// because it checks and resets the counter ready for the next
     /// period.
-    #[task(binds = TC3, resources = [timer, red_led, buttons])]
+    #[task(binds = TC3, local = [timer, red_led, buttons])]
     fn tc3(c: tc3::Context) {
-        if c.resources.timer.wait().is_ok() {
-            for event in c.resources.buttons.events() {
+        if c.local.timer.wait().is_ok() {
+            for event in c.local.buttons.events() {
                 match event {
                     Keys::SelectDown => {
-                        c.resources.red_led.set_high().ok();
+                        c.local.red_led.set_high().ok();
                     }
                     Keys::SelectUp => {
-                        c.resources.red_led.set_low().ok();
+                        c.local.red_led.set_low().ok();
                     }
                     _ => {}
                 }
@@ -39,7 +46,7 @@ const APP: () = {
     }
 
     #[init]
-    fn init(c: init::Context) -> init::LateResources {
+    fn init(c: init::Context) -> (Shared, Local, init::Monotonics) {
         let mut device = c.device;
         let mut clocks = GenericClockController::with_internal_32kosc(
             device.GCLK,
@@ -54,15 +61,19 @@ const APP: () = {
         let gclk0 = clocks.gclk0();
         let timer_clock = clocks.tc2_tc3(&gclk0).unwrap();
 
-        let mut tc3 = hal::timer::TimerCounter::tc3_(&timer_clock, device.TC3, &mut device.MCLK);
+        let mut tc3 = bsp::timer::TimerCounter::tc3_(&timer_clock, device.TC3, &mut device.MCLK);
 
         tc3.start(200.hz());
         tc3.enable_interrupt();
 
-        init::LateResources {
-            buttons: pins.buttons.init(&mut pins.port),
-            red_led: pins.led_pin.into_open_drain_output(&mut pins.port),
-            timer: tc3,
-        }
+        (
+            Shared {},
+            Local {
+                buttons: pins.buttons.init(&mut pins.port),
+                red_led: pins.led_pin.into_open_drain_output(&mut pins.port),
+                timer: tc3,
+            },
+            init::Monotonics(),
+        )
     }
-};
+}

--- a/boards/gemma_m0/CHANGELOG.md
+++ b/boards/gemma_m0/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.11.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 - removed unnecessary dependency on `nb` (#510)

--- a/boards/gemma_m0/Cargo.toml
+++ b/boards/gemma_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gemma_m0"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Wez Furlong <wez@wezfurlong.org>"]
 description = "Board Support crate for the Adafruit Gemma M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/gemma_m0/Cargo.toml
+++ b/boards/gemma_m0/Cargo.toml
@@ -4,17 +4,18 @@ version = "0.10.0"
 authors = ["Wez Furlong <wez@wezfurlong.org>"]
 description = "Board Support crate for the Adafruit Gemma M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dev-dependencies]

--- a/boards/grand_central_m4/CHANGELOG.md
+++ b/boards/grand_central_m4/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.5.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency

--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -16,11 +16,11 @@ readme = "README.md"
 ws2812-timer-delay = "0.3"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grand_central_m4"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
     "Dustin Little <dlittle@toyatech.net>"
 ]

--- a/boards/itsybitsy_m0/CHANGELOG.md
+++ b/boards/itsybitsy_m0/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.12.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency

--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itsybitsy_m0"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit ItsyBitsy M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -16,11 +16,11 @@ apa102-spi = "0.3"
 smart-leds = "0.3"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/neo_trinkey/CHANGELOG.md
+++ b/boards/neo_trinkey/CHANGELOG.md
@@ -7,6 +7,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+# v0.2.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - move `usbd-x` crates used only in examples to `[dev-dependencies]`
 
 ## [0.1.0] - 2021-10-07

--- a/boards/neo_trinkey/Cargo.toml
+++ b/boards/neo_trinkey/Cargo.toml
@@ -4,19 +4,20 @@ version = "0.1.0"
 authors = ["Daniel Mason <daniel@danielmason.com>"]
 description = "Board Support crate for the Adafruit Neo Trinkey"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-cortex-m-rt = { version = "0.6.12", optional = true }
+cortex-m-rt = { version = "0.7", optional = true }
 usb-device = { version = "0.2", optional = true }
 smart-leds = { version = "0.3.0", optional = true }
 ws2812-timer-delay = { version = "0.3.0", features = ["slow"], optional = true }
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dev-dependencies]

--- a/boards/neo_trinkey/Cargo.toml
+++ b/boards/neo_trinkey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neo_trinkey"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Daniel Mason <daniel@danielmason.com>"]
 description = "Board Support crate for the Adafruit Neo Trinkey"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/neokey_trinkey/Cargo.toml
+++ b/boards/neokey_trinkey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neokey_trinkey"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Broderick Carlin <broderick.carlin@gmail.com>"]
 description = "Board Support crate for the Adafruit Neokey Trinkey"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/neokey_trinkey/Cargo.toml
+++ b/boards/neokey_trinkey/Cargo.toml
@@ -4,19 +4,20 @@ version = "0.1.0"
 authors = ["Broderick Carlin <broderick.carlin@gmail.com>"]
 description = "Board Support crate for the Adafruit Neokey Trinkey"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13.0"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]
@@ -24,12 +25,12 @@ version = "0.2"
 optional = true
 
 [dependencies.ws2812-timer-delay]
-version = "0.3.0"
+version = "0.3"
 features = ["slow"]
 optional = true
 
 [dependencies.smart-leds]
-version = "0.3.0"
+version = "0.3"
 optional = true
 
 [dev-dependencies]

--- a/boards/p1am_100/CHANGELOG.md
+++ b/boards/p1am_100/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.3.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency

--- a/boards/p1am_100/Cargo.toml
+++ b/boards/p1am_100/Cargo.toml
@@ -29,7 +29,7 @@ cortex-m-semihosting = "0.3"
 drogue-nom-utils = "0.1"
 nom = { version = "5.1", default-features= false }
 heapless = "0.7"
-cortex-m-rtic = "0.5.1"
+cortex-m-rtic = "1.0"
 panic-halt = "0.2"
 panic-semihosting = "0.5"
 

--- a/boards/p1am_100/Cargo.toml
+++ b/boards/p1am_100/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/p1am_100/Cargo.toml
+++ b/boards/p1am_100/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "p1am_100"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Quentin Smith <quentin@mit.edu>"]
 description = "Board Support crate for the Facts Engineering P1AM-100"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/p1am_100/src/lib.rs
+++ b/boards/p1am_100/src/lib.rs
@@ -202,9 +202,10 @@ pub use pins::*;
 const BASE_CONTROLLER_FREQ: Hertz = Hertz(1000000);
 const BASE_CONTROLLER_SPI_MODE: hal::ehal::spi::Mode = spi::MODE_2;
 
-pub type Spi0Pads = spi::Pads<Sercom1, Spi0Miso, Spi0Mosi, Spi0Sck>;
+type Spi0Pads = spi::Pads<Sercom1, Spi0Miso, Spi0Mosi, Spi0Sck>;
 
-pub type Spi0 = spi::Spi<spi::Config<Spi0Pads>>;
+/// The [`spi::Spi`] type for the SPI labeled `SPI0`.
+pub type Spi0 = spi::Spi<spi::Config<Spi0Pads>, spi::Duplex>;
 
 /// Convenience for setting up the labeled SPI0 peripheral.
 /// SPI0 has the P1AM base controller connected.
@@ -229,7 +230,8 @@ pub fn base_controller_spi(
 
 type SdPads = spi::Pads<Sercom2, SdMiso, SdMosi, SdSck>;
 
-pub type SdSpi = spi::Spi<spi::Config<SdPads>>;
+/// The [`spi::Spi`] type for the SD card labeled `SPI2`.
+pub type SdSpi = spi::Spi<spi::Config<SdPads>, spi::Duplex>;
 
 /// Convenience for setting up the labeled SPI2 peripheral.
 /// SPI2 has the microSD card slot connected.

--- a/boards/pfza_proto1/CHANGELOG.md
+++ b/boards/pfza_proto1/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.6.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency

--- a/boards/pfza_proto1/Cargo.toml
+++ b/boards/pfza_proto1/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dev-dependencies]

--- a/boards/pfza_proto1/Cargo.toml
+++ b/boards/pfza_proto1/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pfza_proto1"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Michael van Niekerk <mvniekerk@gmail.com>"]
 description = "Board Support crate for the PathfinderZA Proto1"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/pygamer/CHANGELOG.md
+++ b/boards/pygamer/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.9.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - move `usbd-x` crates used only in examples to `[dev-dependencies]`
 - removed unnecessary dependency on `nb` (#510)

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -7,23 +7,24 @@ authors = [
 ]
 description = "Board Support crate for the Adafruit PyGamer"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 exclude = ["assets"]
 
 [dependencies]
-cortex-m = "0.6"
+cortex-m = "0.7"
 st7735-lcd = "0.8.1"
 ws2812-timer-delay = "0.3"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.micromath]

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pygamer"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "Paul Sajna <sajattack@gmail.com>",
     "Wez Furlong <wez@wezfurlong.org>"

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -46,7 +46,7 @@ embedded-graphics = "0.7.1"
 smart-leds = "0.3"
 ws2812-spi = { version = "0.4.0", features = ["mosi_idle_high"] }
 lis3dh = "0.1.0"
-cortex-m-rtic = "0.5.1"
+cortex-m-rtic = "1.0"
 tinybmp = "0.3.1"
 
 [features]

--- a/boards/pygamer/examples/button_rtic.rs
+++ b/boards/pygamer/examples/button_rtic.rs
@@ -1,37 +1,43 @@
 #![no_std]
 #![no_main]
 
+use bsp::{pins::ButtonReader, pins::Keys, Pins};
 #[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
-use pygamer::{self as hal, pins::ButtonReader, pins::Keys, Pins};
+use pygamer as bsp;
 
-use hal::clock::GenericClockController;
-use hal::gpio::{OpenDrain, Output, Pa23};
-use hal::prelude::*;
-use rtic::app;
+#[rtic::app(device = bsp::pac, peripherals = true)]
+mod app {
 
-#[app(device = crate::hal::pac, peripherals = true)]
-const APP: () = {
-    struct Resources {
+    use super::*;
+    use bsp::clock::GenericClockController;
+    use bsp::gpio::{OpenDrain, Output, Pa23};
+    use bsp::prelude::*;
+
+    #[local]
+    struct Local {
         red_led: Pa23<Output<OpenDrain>>,
-        timer: hal::timer::TimerCounter3,
+        timer: bsp::timer::TimerCounter3,
         buttons: ButtonReader,
     }
+
+    #[shared]
+    struct Shared {}
 
     /// This function is called each time the tc3 interrupt triggers.
     /// We use it to toggle the LED.  The `wait()` call is important
     /// because it checks and resets the counter ready for the next
     /// period.
-    #[task(binds = TC3, resources = [timer, red_led, buttons])]
+    #[task(binds = TC3, local = [timer, red_led, buttons])]
     fn tc3(c: tc3::Context) {
-        if c.resources.timer.wait().is_ok() {
-            for event in c.resources.buttons.events() {
+        if c.local.timer.wait().is_ok() {
+            for event in c.local.buttons.events() {
                 match event {
                     Keys::SelectDown => {
-                        c.resources.red_led.set_high().ok();
+                        c.local.red_led.set_high().ok();
                     }
                     Keys::SelectUp => {
-                        c.resources.red_led.set_low().ok();
+                        c.local.red_led.set_low().ok();
                     }
                     _ => {}
                 }
@@ -40,7 +46,7 @@ const APP: () = {
     }
 
     #[init]
-    fn init(c: init::Context) -> init::LateResources {
+    fn init(c: init::Context) -> (Shared, Local, init::Monotonics) {
         let mut device = c.device;
         let mut clocks = GenericClockController::with_internal_32kosc(
             device.GCLK,
@@ -55,15 +61,19 @@ const APP: () = {
         let gclk0 = clocks.gclk0();
         let timer_clock = clocks.tc2_tc3(&gclk0).unwrap();
 
-        let mut tc3 = hal::timer::TimerCounter::tc3_(&timer_clock, device.TC3, &mut device.MCLK);
+        let mut tc3 = bsp::timer::TimerCounter::tc3_(&timer_clock, device.TC3, &mut device.MCLK);
 
         tc3.start(200.hz());
         tc3.enable_interrupt();
 
-        init::LateResources {
-            buttons: pins.buttons.init(&mut pins.port),
-            red_led: pins.led_pin.into_open_drain_output(&mut pins.port),
-            timer: tc3,
-        }
+        (
+            Shared {},
+            Local {
+                buttons: pins.buttons.init(&mut pins.port),
+                red_led: pins.led_pin.into_open_drain_output(&mut pins.port),
+                timer: tc3,
+            },
+            init::Monotonics(),
+        )
     }
-};
+}

--- a/boards/pyportal/CHANGELOG.md
+++ b/boards/pyportal/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.9.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency

--- a/boards/pyportal/Cargo.toml
+++ b/boards/pyportal/Cargo.toml
@@ -15,11 +15,11 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dev-dependencies]

--- a/boards/pyportal/Cargo.toml
+++ b/boards/pyportal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyportal"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "Shella Stephens <shella@infracoven.io",
     "Paul Sajna <sajattack@gmail.com>",

--- a/boards/qt_py_m0/Cargo.toml
+++ b/boards/qt_py_m0/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 cortex-m-rt = { version = "0.7", optional = true }

--- a/boards/qt_py_m0/Cargo.toml
+++ b/boards/qt_py_m0/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 cortex-m-rt = { version = "0.7", optional = true }

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -4,11 +4,10 @@ version = "0.7.0"
 authors = ["Jesse Braham <jesse@beta7.io>"]
 description = "Support crate for the ATSAMD11C"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2021"
+edition = "2018"
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -4,10 +4,11 @@ version = "0.7.0"
 authors = ["Jesse Braham <jesse@beta7.io>"]
 description = "Support crate for the ATSAMD11C"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/samd21_mini/CHANGELOG.md
+++ b/boards/samd21_mini/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.10.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency

--- a/boards/samd21_mini/Cargo.toml
+++ b/boards/samd21_mini/Cargo.toml
@@ -21,7 +21,7 @@ default-features = false
 [dev-dependencies]
 panic-halt = "0.2"
 panic-semihosting = "0.5"
-cortex-m-rtic = "0.5.1"
+cortex-m-rtic = "1.0"
 
 [features]
 # ask the HAL to enable atsamd21g support

--- a/boards/samd21_mini/Cargo.toml
+++ b/boards/samd21_mini/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dev-dependencies]

--- a/boards/samd21_mini/Cargo.toml
+++ b/boards/samd21_mini/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samd21_mini"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Ze'ev Klapow <zklapow@gmail.com>"]
 description = "Board Support crate for the Sparkfun SAMD21 Mini Breakout"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/serpente/CHANGELOG.md
+++ b/boards/serpente/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.7.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 - removed unnecessary dependency on `nb` (#510)

--- a/boards/serpente/Cargo.toml
+++ b/boards/serpente/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serpente"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Jens Andersen <jens.andersen@gmail.com>"]
 description = "Board Support crate for the Serpente board"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/serpente/Cargo.toml
+++ b/boards/serpente/Cargo.toml
@@ -4,17 +4,18 @@ version = "0.6.0"
 authors = ["Jens Andersen <jens.andersen@gmail.com>"]
 description = "Board Support crate for the Serpente board"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dev-dependencies]

--- a/boards/sodaq_one/CHANGELOG.md
+++ b/boards/sodaq_one/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.10.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 - removed unnecessary dependency on `nb` (#510)

--- a/boards/sodaq_one/Cargo.toml
+++ b/boards/sodaq_one/Cargo.toml
@@ -4,17 +4,18 @@ version = "0.9.0"
 authors = ["Robert Hennig <robert.hennig@freylax.de>"]
 description = "Board Support crate for the SODAQ ONE"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dev-dependencies]

--- a/boards/sodaq_one/Cargo.toml
+++ b/boards/sodaq_one/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sodaq_one"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Robert Hennig <robert.hennig@freylax.de>"]
 description = "Board Support crate for the SODAQ ONE"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/sodaq_sara_aff/CHANGELOG.md
+++ b/boards/sodaq_sara_aff/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.9.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 - removed unnecessary dependency on `nb` (#510)

--- a/boards/sodaq_sara_aff/Cargo.toml
+++ b/boards/sodaq_sara_aff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sodaq_sara_aff"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Stefan de Lange <langestefan@msn.com>"]
 description = "Board Support crate for the Sodaq SARA AFF"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/sodaq_sara_aff/Cargo.toml
+++ b/boards/sodaq_sara_aff/Cargo.toml
@@ -4,17 +4,18 @@ version = "0.8.0"
 authors = ["Stefan de Lange <langestefan@msn.com>"]
 description = "Board Support crate for the Sodaq SARA AFF"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dev-dependencies]

--- a/boards/trellis_m4/CHANGELOG.md
+++ b/boards/trellis_m4/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.10.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency

--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 features = ["adxl343", "keypad-unproven"]
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.adxl343]
@@ -26,7 +26,7 @@ version = "0.8"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.keypad]

--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trellis_m4"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
     "Tony Arcieri <bascule@gmail.com>",
     "Paul Sajna <sajattack@gmail.com>",

--- a/boards/trinket_m0/CHANGELOG.md
+++ b/boards/trinket_m0/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.11.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 - move `usbd-x` crates used only in examples to `[dev-dependencies]`

--- a/boards/trinket_m0/Cargo.toml
+++ b/boards/trinket_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trinket_m0"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit Trinket M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/trinket_m0/Cargo.toml
+++ b/boards/trinket_m0/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.10.0"
 authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit Trinket M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-edition = "2018"
+categories = ["embedded", "hardware-support", "no-std"]
+edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
@@ -15,11 +16,11 @@ apa102-spi = "0.3"
 smart-leds = "0.3"
 
 [dependencies.cortex-m-rt]
-version = "~0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/wio_lite_mg126/CHANGELOG.md
+++ b/boards/wio_lite_mg126/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
+# v0.4.0
 
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - cleanup `cortex_m` dependency
 - move `usbd-x` crates used only in examples to `[dev-dependencies]`

--- a/boards/wio_lite_mg126/Cargo.toml
+++ b/boards/wio_lite_mg126/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wio_lite_mg126"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Max Khardin <max.khardin@gmail.com"]
 description = "Board Support crate for the Wio Lite MG126"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]

--- a/boards/wio_lite_mg126/Cargo.toml
+++ b/boards/wio_lite_mg126/Cargo.toml
@@ -4,18 +4,19 @@ version = "0.3.0"
 authors = ["Max Khardin <max.khardin@gmail.com"]
 description = "Board Support crate for the Wio Lite MG126"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g/wio_lite_mg126/"
-edition = "2018"
+edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.6.12"
+version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/wio_lite_w600/CHANGELOG.md
+++ b/boards/wio_lite_w600/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+# v0.3.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
 
 # v0.2.1
 

--- a/boards/wio_lite_w600/Cargo.toml
+++ b/boards/wio_lite_w600/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wio_lite_w600"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Daniel Mason <daniel@danielmason.com"]
 description = "Board Support crate for the Wio Lite W600"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]

--- a/boards/wio_lite_w600/Cargo.toml
+++ b/boards/wio_lite_w600/Cargo.toml
@@ -4,19 +4,20 @@ version = "0.2.1"
 authors = ["Daniel Mason <daniel@danielmason.com"]
 description = "Board Support crate for the Wio Lite W600"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
+categories = ["embedded", "hardware-support", "no-std"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g/wio_lite_w600/"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-cortex-m = "0.6"
-cortex-m-rt = { version = "0.6", optional = true }
+cortex-m = "0.7"
+cortex-m-rt = { version = "0.7", optional = true }
 usb-device = { version = "0.2", optional = true }
 
 [dependencies.atsamd-hal]
-version = "0.13"
+version = "0.14"
 default-features = false
 
 [dev-dependencies]

--- a/boards/wio_lite_w600/src/lib.rs
+++ b/boards/wio_lite_w600/src/lib.rs
@@ -263,7 +263,7 @@ type SpiPads = spi::Pads<Sercom4, Miso, Mosi, Sck>;
 /// SPI master for the labelled SPI peripheral
 ///
 /// This type implements [`FullDuplex<u8>`](ehal::spi::FullDuplex).
-pub type Spi = spi::Spi<spi::Config<SpiPads>>;
+pub type Spi = spi::Spi<spi::Config<SpiPads>, spi::Duplex>;
 
 /// Convenience function for setting up the D24/SCK, D23/MOSI, and D22/MISO pins
 /// as a SPI Master.

--- a/boards/wio_terminal/.rustfmt.toml
+++ b/boards/wio_terminal/.rustfmt.toml
@@ -1,5 +1,5 @@
 # `wrap_comments` currently requires nightly; if you are not on the nightly
 # channel it will give you a warning but otherwise be ignored.
 
-edition = "2018"
+edition = "2021"
 wrap_comments = true

--- a/build-all.py
+++ b/build-all.py
@@ -24,6 +24,8 @@ def main(clean=False, build=False):
             subprocess.check_call(shlex.split("cargo update"), cwd=crate_path)
         if build:
             subprocess.check_call(command, cwd=crate_path)
+        else:
+            subprocess.check_call(shlex.split("cargo outdated"), cwd=crate_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Summary
Updates all tier 2 boards to `atsamd-hal-0.14.0` as well as other latest dependencies (`cortex-m-rtic-1.0`, `cortex-m[-rt]-0.7` mainly). This gets us into a good position where all boards are using the latest dependencies and broader embedded rust ecosystem, leaving just porting from v1 to v2 APIs left to do, which can be done once we hit `atsamd-hal-0.15.0`.

I broke this PR pretty well into commits, so it's easier to focus on the individual parts I did along the way:
1. update all dependencies other than `cortex-m-rtic`
2. update `cortex-m-rtic` and examples to `1.0`
3. changelog & version bump

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)
