### PR TITLE
add the missing changelog

### DIFF
--- a/boards/neokey_trinkey/CHANGELOG.md
+++ b/boards/neokey_trinkey/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+# Unreleased
+
+# v0.2.0
+
+- update to `atsamd-hal-0.14` and other latest dependencies (#564)
+
+# v0.1.0
+
+- initial release


### PR DESCRIPTION
# Summary
neokey trinkey seems to not have a changelog. Add it.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)