### PR TITLE
circuit_playground_express: Add aliases for accel I2C pins

### DIFF
--- a/boards/circuit_playground_express/src/lib.rs
+++ b/boards/circuit_playground_express/src/lib.rs
@@ -139,9 +139,15 @@ pub mod pins {
         },
         PA00 {
             name: accel_sda,
+            aliases: {
+                AlternateD: AccelSda
+            }
         },
         PA01 {
             name: accel_scl,
+            aliases: {
+                AlternateD: AccelScl
+            }
         },
         PA24 {
             /// The USB D- pad


### PR DESCRIPTION
I missed these aliases when converting the board to the new pins macro...