### PR TITLE
Cleanup Clippy Lints

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased Changes
 
+- Cleanup most `clippy` lints
 - Update `seq_macro` and remove `replace_with` dependencies (#568)
 - Add a `bsp_peripherals!` macro and fix a bug in `bsp_pins!` (#515)
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)

--- a/hal/src/dmac/channel/reg.rs
+++ b/hal/src/dmac/channel/reg.rs
@@ -102,8 +102,8 @@ pub(super) trait Register<Id: ChId> {
         //
         // In practice, this means that the channel-specific registers should only be
         // accessed through the `with_chid` method.
-        let mut ch = &self.dmac().channel[Id::USIZE];
-        fun(&mut ch)
+        let ch = &self.dmac().channel[Id::USIZE];
+        fun(ch)
     }
 }
 

--- a/hal/src/dmac/dma_controller.rs
+++ b/hal/src/dmac/dma_controller.rs
@@ -20,7 +20,6 @@
 //! deinitialize the DMAC and return the underlying PAC object.
 
 use modular_bitfield::prelude::*;
-use paste::paste;
 use seq_macro::seq;
 
 #[cfg(any(feature = "samd11", feature = "samd21"))]

--- a/hal/src/dmac/mod.rs
+++ b/hal/src/dmac/mod.rs
@@ -248,8 +248,8 @@
 //! ```
 //! [RTIC]: https://rtic.rs
 
-// This is necessary until modular_bitfield fixes all their unused brace warnings
-#![allow(unused_braces)]
+// This is necessary until modular_bitfield fixes all their identity_op warnings
+#![allow(clippy::identity_op)]
 
 use modular_bitfield::prelude::*;
 

--- a/hal/src/dmac/transfer.rs
+++ b/hal/src/dmac/transfer.rs
@@ -98,6 +98,7 @@ use modular_bitfield::prelude::*;
 
 /// Useable beat sizes for DMA transfers
 #[derive(Clone, Copy, BitfieldSpecifier)]
+#[bits = 2]
 pub enum BeatSize {
     /// Byte = [`u8`](core::u8)
     Byte = 0x00,
@@ -105,11 +106,14 @@ pub enum BeatSize {
     HalfWord = 0x01,
     /// Word = [`u32`](core::u32)
     Word = 0x02,
-    #[doc(hidden)]
-    _Reserved = 0x03,
 }
+
 /// Convert 8, 16 and 32 bit types
 /// into [`BeatSize`](BeatSize)
+///
+/// # Safety
+///
+/// This trait should not be implemented outside of the crate-provided implementations
 pub unsafe trait Beat: Sealed {
     /// Convert to BeatSize enum
     const BEATSIZE: BeatSize;
@@ -140,6 +144,13 @@ impl_beat!(
 //==============================================================================
 
 /// Buffer useable by the DMAC.
+///
+/// # Safety
+///
+/// This trait should only be implemented for valid DMAC sources/sinks. That is, you need to make sure that:
+/// * `dma_ptr` points to a valid memory location useable by the DMAC
+/// * `incrementing` is correct for the source/sink. For example, an `&[u8]` of size one is not incrementing.
+/// * `buffer_len` is correct for the source/sink.
 pub unsafe trait Buffer {
     /// DMAC beat size
     type Beat: Beat;

--- a/hal/src/gpio/v2.rs
+++ b/hal/src/gpio/v2.rs
@@ -15,6 +15,8 @@
 //! between pins. However, by doing so, pins must now be tracked at run-time,
 //! and each pin has a non-zero memory footprint.
 
+#![allow(clippy::bool_comparison)]
+
 pub mod pin;
 pub use pin::*;
 

--- a/hal/src/gpio/v2/dynpin.rs
+++ b/hal/src/gpio/v2/dynpin.rs
@@ -410,14 +410,20 @@ impl DynPin {
     #[inline]
     fn _write(&mut self, bit: bool) -> Result<(), Error> {
         match self.mode {
-            DynPinMode::Output(_) => Ok(self.regs.write_pin(bit)),
+            DynPinMode::Output(_) => {
+                self.regs.write_pin(bit);
+                Ok(())
+            }
             _ => Err(Error::InvalidPinType),
         }
     }
     #[inline]
     fn _toggle(&mut self) -> Result<(), Error> {
         match self.mode {
-            DynPinMode::Output(_) => Ok(self.regs.toggle_pin()),
+            DynPinMode::Output(_) => {
+                self.regs.toggle_pin();
+                Ok(())
+            }
             _ => Err(Error::InvalidPinType),
         }
     }

--- a/hal/src/gpio/v2/reg.rs
+++ b/hal/src/gpio/v2/reg.rs
@@ -166,6 +166,7 @@ impl From<DynPinMode> for ModeFields {
 /// The SAMx5x PACs have a GROUP type to represent each [`PORT`] group, but the
 /// SAMD11 and SAMD21 PACs do not. Manually re-implement it here.
 #[repr(C)]
+#[allow(clippy::upper_case_acronyms)]
 pub(super) struct GROUP {
     dir: DIR,
     dirclr: DIRCLR,

--- a/hal/src/sercom/v2/spi.rs
+++ b/hal/src/sercom/v2/spi.rs
@@ -715,6 +715,7 @@ where
     /// Directly accessing the `SERCOM` could break the invariants of the
     /// type-level tracking in this module, so it is unsafe.
     #[inline]
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn sercom(&self) -> &P::Sercom {
         &self.regs.sercom
     }
@@ -1236,6 +1237,7 @@ where
     /// clear the RXC flag, which could break assumptions made elsewhere in
     /// this module.
     #[inline]
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn read_data(&mut self) -> DataWidth {
         self.config.as_mut().regs.read_data()
     }
@@ -1245,6 +1247,7 @@ where
     /// Writing to the data register directly is `unsafe`, because it will clear
     /// the DRE flag, which could break assumptions made elsewhere in this
     /// module.
+    #[allow(clippy::missing_safety_doc)]
     #[inline]
     pub unsafe fn write_data(&mut self, data: DataWidth) {
         self.config.as_mut().regs.write_data(data);

--- a/hal/src/sercom/v2/spi/reg.rs
+++ b/hal/src/sercom/v2/spi/reg.rs
@@ -78,7 +78,7 @@ impl<S: Sercom> Registers<S> {
     /// in each SPI transaction. Due to a hardware bug, ICSPACE must be at least
     /// one. See the silicon errata for more details.
     #[inline]
-    pub fn set_op_mode(&mut self, mode: MODE_A, mssen: bool) -> () {
+    pub fn set_op_mode(&mut self, mode: MODE_A, mssen: bool) {
         self.spi().ctrla.modify(|_, w| w.mode().variant(mode));
         self.spi().ctrlb.modify(|_, w| w.mssen().bit(mssen));
         #[cfg(feature = "min-samd51g")]

--- a/hal/src/sercom/v2/spi_future.rs
+++ b/hal/src/sercom/v2/spi_future.rs
@@ -204,6 +204,7 @@ type Data = u32;
 //=============================================================================
 
 /// Trait used to verify the [`SpiFuture`] buffer length
+#[allow(clippy::len_without_is_empty)]
 pub trait CheckBufLen: AnySpi {
     #[cfg(feature = "min-samd51g")]
     /// [`Spi`] transaction length
@@ -457,7 +458,7 @@ where
         let _ = self.spi.as_ref().read_flags_errors()?;
         let buf = self.buf.as_ref();
         if let Some(buf) = buf.get(self.sent..) {
-            let mut data = buf.into_iter();
+            let mut data = buf.iter();
             let mut bytes = [0; 4];
             let mut iter = bytes.iter_mut();
             for _ in 0..self.spi.step() {
@@ -487,7 +488,7 @@ where
         let buf = self.buf.as_mut();
         if self.rcvd < self.sent {
             let buf = unsafe { buf.get_unchecked_mut(self.rcvd..) };
-            let mut data = buf.into_iter();
+            let mut data = buf.iter_mut();
             let word = unsafe { self.spi.as_mut().read_data() as u32 };
             let bytes = word.to_le_bytes();
             let mut iter = bytes.iter();
@@ -549,6 +550,7 @@ where
     ///
     /// [`Spi`]: super::spi::Spi
     #[inline]
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn free_unchecked(self) -> (S, B, SS) {
         (self.spi, self.buf, self.ss)
     }

--- a/hal/src/sercom/v2/uart.rs
+++ b/hal/src/sercom/v2/uart.rs
@@ -736,7 +736,7 @@ where
         F: FnOnce(&mut SpecificConfig<C>),
     {
         self.config.as_mut().registers.enable_peripheral(false);
-        update(&mut self.config.as_mut());
+        update(self.config.as_mut());
         self.config.as_mut().registers.enable_peripheral(true);
     }
 }

--- a/hal/src/sercom/v2/uart/reg.rs
+++ b/hal/src/sercom/v2/uart/reg.rs
@@ -115,7 +115,7 @@ impl<S: Sercom> Registers<S> {
     /// Get the current bit order
     #[inline]
     pub(super) fn get_bit_order(&self) -> BitOrder {
-        let bits = self.usart().ctrla.read().dord().bit().into();
+        let bits = self.usart().ctrla.read().dord().bit();
 
         match bits {
             false => BitOrder::MsbFirst,
@@ -177,7 +177,7 @@ impl<S: Sercom> Registers<S> {
     /// Get the current stop bit setting
     #[inline]
     pub(super) fn get_stop_bits(&self) -> StopBits {
-        let bits = self.usart().ctrlb.read().sbmode().bit().into();
+        let bits = self.usart().ctrlb.read().sbmode().bit();
         match bits {
             false => StopBits::OneBit,
             true => StopBits::TwoBits,

--- a/hal/src/thumbv6m/adc.rs
+++ b/hal/src/thumbv6m/adc.rs
@@ -32,6 +32,7 @@ impl Adc<ADC> {
     /// * 1 sample
     /// * 1/2 gain
     /// * 1/2 VDDANA reference voltage
+    #[allow(clippy::self_named_constructors)]
     pub fn adc(adc: ADC, pm: &mut PM, clocks: &mut GenericClockController) -> Self {
         pm.apbcmask.modify(|_, w| w.adc_().set_bit());
 

--- a/hal/src/thumbv6m/clock.rs
+++ b/hal/src/thumbv6m/clock.rs
@@ -24,9 +24,9 @@ pub struct GClock {
     freq: Hertz,
 }
 
-impl Into<Hertz> for GClock {
-    fn into(self) -> Hertz {
-        self.freq
+impl From<GClock> for Hertz {
+    fn from(item: GClock) -> Hertz {
+        item.freq
     }
 }
 
@@ -64,10 +64,8 @@ impl State {
             if divider >= 2_u16.pow(5) {
                 divisor_invalid = true;
             }
-        } else {
-            if divider >= 2_u16.pow(8) {
-                divisor_invalid = true;
-            }
+        } else if divider >= 2_u16.pow(8) {
+            divisor_invalid = true;
         }
         if divisor_invalid {
             panic!("invalid divisor {} for GCLK {}", divider, gclk as u8);
@@ -357,9 +355,9 @@ impl $Type {
         self.freq
     }
 }
-impl Into<Hertz> for $Type {
-    fn into(self) -> Hertz {
-        self.freq
+impl From<$Type> for Hertz {
+    fn from(item: $Type) -> Hertz {
+        item.freq
     }
 }
 )+

--- a/hal/src/thumbv6m/eic/pin.rs
+++ b/hal/src/thumbv6m/eic/pin.rs
@@ -188,7 +188,7 @@ where
     Pin<I, M>: ExternalInterrupt,
 {
     fn id(&self) -> ExternalInterruptID {
-        Pin::<I, M>::id(self.as_ref())
+        Pin::<I, M>::id(self)
     }
 }
 

--- a/hal/src/thumbv6m/usb/bus.rs
+++ b/hal/src/thumbv6m/usb/bus.rs
@@ -607,7 +607,7 @@ impl UsbBus {
 
 impl Inner {
     fn usb(&self) -> &DEVICE {
-        unsafe { &(*USB::ptr()).device() }
+        unsafe { (*USB::ptr()).device() }
     }
 
     fn set_stall<EP: Into<EndpointAddress>>(&self, ep: EP, stall: bool) {

--- a/hal/src/thumbv7em/clock.rs
+++ b/hal/src/thumbv7em/clock.rs
@@ -80,9 +80,9 @@ pub struct GClock {
     freq: Hertz,
 }
 
-impl Into<Hertz> for GClock {
-    fn into(self) -> Hertz {
-        self.freq
+impl From<GClock> for Hertz {
+    fn from(item: GClock) -> Hertz {
+        item.freq
     }
 }
 
@@ -114,10 +114,8 @@ impl State {
             if divider as u32 >= 2_u32.pow(16) {
                 divisor_invalid = true;
             }
-        } else {
-            if divider >= 2_u16.pow(8) {
-                divisor_invalid = true;
-            }
+        } else if divider >= 2_u16.pow(8) {
+            divisor_invalid = true;
         }
         if divisor_invalid {
             panic!("invalid divisor {} for GCLK {}", divider, gclk as u8);
@@ -364,9 +362,9 @@ impl $Type {
     }
 }
 $(#[$attr])*
-impl Into<Hertz> for $Type {
-    fn into(self) -> Hertz {
-        self.freq
+impl From<$Type> for Hertz {
+    fn from(item: $Type) -> Hertz {
+        item.freq
     }
 }
 )+

--- a/hal/src/thumbv7em/eic/pin.rs
+++ b/hal/src/thumbv7em/eic/pin.rs
@@ -188,7 +188,7 @@ where
     Pin<I, M>: ExternalInterrupt,
 {
     fn id(&self) -> ExternalInterruptID {
-        Pin::<I, M>::id(self.as_ref())
+        Pin::<I, M>::id(self)
     }
 }
 

--- a/hal/src/thumbv7em/icm.rs
+++ b/hal/src/thumbv7em/icm.rs
@@ -471,6 +471,7 @@ bitfield::bitfield! {
     /// all the regions or via the `bitmask` argument
     /// narrow it down to the specific set of [`RegionNum`]
     /// of interest.
+    #[derive(Default)]
     pub struct Interrupt(u32);
     impl Debug;
     u8;
@@ -518,11 +519,6 @@ impl Interrupt {
     #[inline]
     pub fn get_rhc_int(&self) -> RegionHashCompleted {
         RegionHashCompleted::from_bits_truncate(self.get_rhc())
-    }
-}
-impl Default for Interrupt {
-    fn default() -> Self {
-        Interrupt(0)
     }
 }
 

--- a/hal/src/thumbv7em/nvm.rs
+++ b/hal/src/thumbv7em/nvm.rs
@@ -326,6 +326,7 @@ impl Nvm {
     ///
     /// If `destination_address` is not word-aligned, an error is returned.
     #[inline]
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn write_from_slice(
         &mut self,
         destination_address: u32,
@@ -341,6 +342,7 @@ impl Nvm {
     /// If either `destination_address` or `source_address` are not
     /// word-aligned, an error is returned.
     #[inline]
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn write(
         &mut self,
         destination_address: u32,
@@ -416,6 +418,7 @@ impl Nvm {
     ///
     /// Unit of `length` depends on a chosen erasing granularity.
     #[inline]
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn erase(
         &mut self,
         address: u32,

--- a/hal/src/thumbv7em/nvm/smart_eeprom.rs
+++ b/hal/src/thumbv7em/nvm/smart_eeprom.rs
@@ -167,6 +167,7 @@ impl<'a, T: SmartEepromState> SmartEeprom<'a, T> {
     /// Unsafety:
     /// `NVMCTRL.SEESTAT.BUSY` register must be 0 before memory access can be
     /// performed.
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn get_slice<TP: SmartEepromPointableSize>(&self) -> &[TP] {
         core::slice::from_raw_parts_mut(
             Self::SEEPROM_ADDR as _,
@@ -215,6 +216,7 @@ impl<'a> SmartEeprom<'a, Unlocked> {
     /// Unsafety:
     /// `NVMCTRL.SEESTAT.BUSY` register must be 0 before memory access can be
     /// performed.
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn get_mut_slice<TP: SmartEepromPointableSize>(&mut self) -> &mut [TP] {
         core::slice::from_raw_parts_mut(
             Self::SEEPROM_ADDR as _,

--- a/hal/src/thumbv7em/pukcc.rs
+++ b/hal/src/thumbv7em/pukcc.rs
@@ -202,6 +202,7 @@ impl Pukcc {
     /// multiplication can become reversible (lack of _trapdoor function_
     /// property) and an attacker might be able to reverse engineer a
     /// `private_key` from a `signature`.
+    #[allow(clippy::missing_safety_doc)]
     pub unsafe fn zp_ecdsa_sign_with_raw_k<C: Curve>(
         &self,
         signature: &mut [u8],
@@ -212,6 +213,7 @@ impl Pukcc {
         self.zp_ecdsa_sign::<C>(signature, hash, private_key, k)
     }
 
+    #[allow(clippy::just_underscores_and_digits)]
     fn zp_ecdsa_sign<C: Curve>(
         &self,
         signature: &mut [u8],
@@ -219,10 +221,7 @@ impl Pukcc {
         private_key: &[u8],
         k: &[u8],
     ) -> Result<(), EcdsaSignFailure> {
-        match C::verify_curve() {
-            Err(e) => return Err(EcdsaSignFailure::InvalidCurve(e)),
-            _ => {}
-        };
+        C::verify_curve().map_err(EcdsaSignFailure::InvalidCurve)?;
 
         if signature.len() != (2 * C::MOD_LENGTH).into() {
             return Err(EcdsaSignFailure::WrongInputParameterLength {
@@ -362,16 +361,14 @@ impl Pukcc {
     /// [`EcdsaSignatureVerificationFailure::ServiceFailure`]`(`
     /// [`Warning`][`PukclReturnCode::Warning`]`(`
     /// [`WrongSignature`][`PukclReturnCodeWarning::WrongSignature`]`))`
+    #[allow(clippy::just_underscores_and_digits)]
     pub fn zp_ecdsa_verify_signature<C: Curve>(
         &self,
         signature: &[u8],
         hash: &[u8],
         public_key: &[u8],
     ) -> Result<(), EcdsaSignatureVerificationFailure> {
-        match C::verify_curve() {
-            Err(e) => return Err(EcdsaSignatureVerificationFailure::InvalidCurve(e)),
-            _ => {}
-        };
+        C::verify_curve().map_err(EcdsaSignatureVerificationFailure::InvalidCurve)?;
 
         let (
             modulo_p,
@@ -567,6 +564,7 @@ impl Pukcc {
     ///
     /// All RSA variants up to **RSA4096** (included) will fit into CryptoRAM
     /// and therefore are supported.
+    #[allow(clippy::just_underscores_and_digits)]
     pub fn modular_exponentiation<'a>(
         &self,
         input: &[u8],
@@ -694,6 +692,7 @@ impl Pukcc {
     }
 
     /// Service producing a reduction constant value
+    #[allow(clippy::just_underscores_and_digits)]
     fn zp_calculate_cns<'a>(
         &self,
         buffer: &'a mut [u8],

--- a/hal/src/thumbv7em/pukcc/c_abi.rs
+++ b/hal/src/thumbv7em/pukcc/c_abi.rs
@@ -3,6 +3,7 @@
 #![allow(missing_docs)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![allow(clippy::missing_safety_doc)]
 
 use bitfield::bitfield;
 
@@ -753,7 +754,7 @@ pub unsafe fn wait_for_crypto_ram_clear_process() {
     const PUKCCSR: *mut u32 = 0x4200302C as _;
     const BIT_PUKCCSR_CLRRAM_BUSY: u32 = 0x1;
 
-    while *PUKCCSR & BIT_PUKCCSR_CLRRAM_BUSY != 0 {}
+    while core::ptr::read_volatile(PUKCCSR) & BIT_PUKCCSR_CLRRAM_BUSY != 0 {}
 }
 
 /// Slice wrapper that provides Rust-like access to CryptoRAM memory area

--- a/hal/src/thumbv7em/qspi.rs
+++ b/hal/src/thumbv7em/qspi.rs
@@ -30,6 +30,7 @@ pub struct Qspi<MODE> {
 impl Qspi<OneShot> {
     /// Enable the clocks for the qspi peripheral in single data rate mode
     /// assuming 120mhz system clock, for 4mhz spi mode 0 operation.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         mclk: &mut MCLK,
         qspi: QSPI,

--- a/hal/src/thumbv7em/usb/bus.rs
+++ b/hal/src/thumbv7em/usb/bus.rs
@@ -553,7 +553,7 @@ impl UsbBus {
 
 impl Inner {
     fn usb(&self) -> &DEVICE {
-        unsafe { &(*USB::ptr()).device() }
+        unsafe { (*USB::ptr()).device() }
     }
 
     fn set_stall<EP: Into<EndpointAddress>>(&self, ep: EP, stall: bool) {


### PR DESCRIPTION
# Summary
[describe your changes here]

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)

This is a quick cleanup of most `clippy` warnings.

`clippy` also threw one error:

```diff
- while *PUKCCSR & BIT_PUKCCSR_CLRRAM_BUSY != 0 {}
+ while core::ptr::read_volatile(PUKCCSR) & BIT_PUKCCSR_CLRRAM_BUSY != 0 {}
```