### PR TITLE
Fix incorrect clocking in metro_m4 uart helper function

### DIFF
--- a/boards/metro_m4/CHANGELOG.md
+++ b/boards/metro_m4/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Fix incorrect clocking in `uart` helper function
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
 
 # v0.10.0

--- a/boards/metro_m4/src/lib.rs
+++ b/boards/metro_m4/src/lib.rs
@@ -323,7 +323,7 @@ pub fn uart(
     uart_tx: impl Into<UartTx>,
 ) -> Uart {
     let gclk0 = clocks.gclk0();
-    let clock = &clocks.sercom0_core(&gclk0).unwrap();
+    let clock = &clocks.sercom3_core(&gclk0).unwrap();
     let baud = baud.into();
     let pads = uart::Pads::default().rx(uart_rx.into()).tx(uart_tx.into());
     uart::Config::new(mclk, sercom3, pads, clock.freq())


### PR DESCRIPTION
# Summary
Fix a copy-paste error in metro_m4 causing the `uart` helper function to configure the wrong SERCOM clock. Closes #528.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)