### PR TITLE
Prepare itsybitsy_m0 for 0.13.0 publish

### DIFF
--- a/boards/itsybitsy_m0/CHANGELOG.md
+++ b/boards/itsybitsy_m0/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Unreleased
+# 0.13.0
 
-- Big rework of board code by copying the code from feather_m0 and implementing the HW differences (both boards are now more similar to each other) and the corresponding examples
+- Big rework of board code by copying the code from feather_m0 and implementing the HW differences (both boards are now more similar to each other) and the corresponding examples ([#559](https://github.com/atsamd-rs/atsamd/pull/559))
 
 ---
 

--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itsybitsy_m0"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit ItsyBitsy M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
@@ -20,7 +20,6 @@ version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.14"
 default-features = false
 

--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -32,7 +32,7 @@ version = "0.3"
 optional = true
 
 [dev-dependencies]
-cortex-m-rtic = "1.0"
+cortex-m-rtic = "0.6.0-rc.4"
 cortex-m = "0.7"
 usbd-serial = "0.1"
 usbd-hid = "0.4"

--- a/boards/itsybitsy_m0/examples/blinky_basic.rs
+++ b/boards/itsybitsy_m0/examples/blinky_basic.rs
@@ -10,7 +10,7 @@ use bsp::hal;
 use bsp::pac;
 use itsybitsy_m0 as bsp;
 
-use bsp::{entry, pin_alias};
+use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -27,7 +27,7 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
+    let mut red_led: bsp::RedLed = pins.d13.into();
     let mut delay = Delay::new(core.SYST, &mut clocks);
     loop {
         delay.delay_ms(200u8);

--- a/boards/itsybitsy_m0/examples/blinky_rtic.rs
+++ b/boards/itsybitsy_m0/examples/blinky_rtic.rs
@@ -16,7 +16,7 @@ use rtic;
 #[rtic::app(device = bsp::pac, peripherals = true, dispatchers = [EVSYS])]
 mod app {
     use super::*;
-    use bsp::{hal, pin_alias};
+    use bsp::hal;
     use hal::clock::{ClockGenId, ClockSource, GenericClockController};
     use hal::pac::Peripherals;
     use hal::prelude::*;
@@ -53,7 +53,7 @@ mod app {
         clocks.configure_standby(ClockGenId::GCLK2, true);
         let rtc_clock = clocks.rtc(&rtc_clock_src).unwrap();
         let rtc = Rtc::count32_mode(peripherals.RTC, rtc_clock.freq(), &mut peripherals.PM);
-        let red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
+        let red_led: bsp::RedLed = pins.d13.into();
 
         // We can use the RTC in standby for maximum power savings
         core.SCB.set_sleepdeep();

--- a/boards/itsybitsy_m0/examples/dmac.rs
+++ b/boards/itsybitsy_m0/examples/dmac.rs
@@ -77,8 +77,8 @@ fn main() -> ! {
     let _b = buf_16[LENGTH - 1];
 
     // Manipulate the returned buffer for fun
-    for i in 0..LENGTH {
-        buf_16[i] = i as u16;
+    for (i, c) in buf_16.iter_mut().enumerate() {
+        *c = i as u16;
     }
 
     // Setup a DMA transfer (memory-to-memory -> incrementing source, fixed

--- a/boards/itsybitsy_m0/examples/pwm.rs
+++ b/boards/itsybitsy_m0/examples/pwm.rs
@@ -12,7 +12,6 @@ use bsp::hal;
 use bsp::pac;
 use itsybitsy_m0 as bsp;
 
-use bsp::pin_alias;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -33,7 +32,7 @@ fn main() -> ! {
     let mut delay = Delay::new(core.SYST, &mut clocks);
     let pins = bsp::Pins::new(peripherals.PORT);
 
-    let _d5: bsp::D5Pwm = pin_alias!(pins.d5_pwm).into();
+    let _d5: bsp::D5Pwm = pins.d5.into();
 
     let gclk0 = clocks.gclk0();
     let mut pwm3 = Pwm3::new(

--- a/boards/itsybitsy_m0/examples/sleeping_timer.rs
+++ b/boards/itsybitsy_m0/examples/sleeping_timer.rs
@@ -26,7 +26,7 @@ use bsp::hal;
 use bsp::pac;
 use itsybitsy_m0 as bsp;
 
-use bsp::{entry, pin_alias};
+use bsp::entry;
 use hal::clock::{enable_internal_32kosc, ClockGenId, ClockSource, GenericClockController};
 use hal::prelude::*;
 use hal::sleeping_delay::SleepingDelay;
@@ -96,7 +96,7 @@ fn main() -> ! {
 
     // Configure our red LED and blink forever, sleeping between!
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
+    let mut red_led: bsp::RedLed = pins.d13.into();
     loop {
         red_led.set_low().unwrap();
         sleeping_delay.delay_ms(1_000u32);

--- a/boards/itsybitsy_m0/examples/sleeping_timer_rtc.rs
+++ b/boards/itsybitsy_m0/examples/sleeping_timer_rtc.rs
@@ -26,7 +26,7 @@ use bsp::hal;
 use bsp::pac;
 use itsybitsy_m0 as bsp;
 
-use bsp::{entry, pin_alias};
+use bsp::entry;
 use hal::clock::{enable_internal_32kosc, ClockGenId, ClockSource, GenericClockController};
 use hal::prelude::*;
 use hal::rtc;
@@ -91,7 +91,7 @@ fn main() -> ! {
 
     // Configure our red LED and blink forever, sleeping between!
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
+    let mut red_led: bsp::RedLed = pins.d13.into();
     loop {
         red_led.set_low().unwrap();
         sleeping_delay.delay_ms(1_000u32);

--- a/boards/itsybitsy_m0/examples/ssd1306_graphicsmode_128x64_i2c.rs
+++ b/boards/itsybitsy_m0/examples/ssd1306_graphicsmode_128x64_i2c.rs
@@ -74,7 +74,7 @@ use bsp::hal;
 use bsp::pac;
 use itsybitsy_m0 as bsp;
 
-use bsp::{entry, periph_alias, pin_alias};
+use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -92,10 +92,10 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
+    let mut red_led: bsp::RedLed = pins.d13.into();
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
-    let i2c_sercom = periph_alias!(peripherals.i2c_sercom);
+    let i2c_sercom: bsp::I2cSercom = peripherals.SERCOM3;
     let i2c = bsp::i2c_master(
         &mut clocks,
         KiloHertz(400),

--- a/boards/itsybitsy_m0/examples/ssd1306_graphicsmode_128x64_spi.rs
+++ b/boards/itsybitsy_m0/examples/ssd1306_graphicsmode_128x64_spi.rs
@@ -63,7 +63,7 @@ use bsp::hal;
 use bsp::pac;
 use itsybitsy_m0 as bsp;
 
-use bsp::{entry, periph_alias, pin_alias};
+use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -81,10 +81,10 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
+    let mut red_led: bsp::RedLed = pins.d13.into();
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
-    let spi_sercom = periph_alias!(peripherals.spi_sercom);
+    let spi_sercom: bsp::SpiSercom = peripherals.SERCOM4;
     let spi = bsp::spi_master(
         &mut clocks,
         MegaHertz(10),

--- a/boards/itsybitsy_m0/examples/ssd1306_terminalmode_128x64_i2c.rs
+++ b/boards/itsybitsy_m0/examples/ssd1306_terminalmode_128x64_i2c.rs
@@ -73,7 +73,7 @@ use bsp::hal;
 use bsp::pac;
 use itsybitsy_m0 as bsp;
 
-use bsp::{entry, periph_alias, pin_alias};
+use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -91,10 +91,10 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
+    let mut red_led: bsp::RedLed = pins.d13.into();
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
-    let i2c_sercom = periph_alias!(peripherals.i2c_sercom);
+    let i2c_sercom: bsp::I2cSercom = peripherals.SERCOM3;
     let i2c = bsp::i2c_master(
         &mut clocks,
         KiloHertz(400),

--- a/boards/itsybitsy_m0/examples/ssd1306_terminalmode_128x64_spi.rs
+++ b/boards/itsybitsy_m0/examples/ssd1306_terminalmode_128x64_spi.rs
@@ -57,7 +57,7 @@ use bsp::hal;
 use bsp::pac;
 use itsybitsy_m0 as bsp;
 
-use bsp::{entry, periph_alias, pin_alias};
+use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
@@ -79,9 +79,9 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
+    let mut red_led: bsp::RedLed = pins.d13.into();
     let mut delay = Delay::new(core.SYST, &mut clocks);
-    let spi_sercom = periph_alias!(peripherals.spi_sercom);
+    let spi_sercom: bsp::SpiSercom = peripherals.SERCOM4;
     let spi = bsp::spi_master(
         &mut clocks,
         MegaHertz(10),

--- a/boards/itsybitsy_m0/examples/timers.rs
+++ b/boards/itsybitsy_m0/examples/timers.rs
@@ -10,7 +10,7 @@ use bsp::hal;
 use bsp::pac;
 use itsybitsy_m0 as bsp;
 
-use bsp::{entry, pin_alias};
+use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::prelude::*;
 use hal::timer::TimerCounter;
@@ -26,7 +26,7 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
+    let mut red_led: bsp::RedLed = pins.d13.into();
 
     // gclk0 represents a configured clock using the system 48MHz oscillator
     let gclk0 = clocks.gclk0();

--- a/boards/itsybitsy_m0/examples/twitching_usb_mouse.rs
+++ b/boards/itsybitsy_m0/examples/twitching_usb_mouse.rs
@@ -8,8 +8,6 @@ use itsybitsy_m0 as bsp;
 use panic_halt as _;
 #[cfg(feature = "use_semihosting")]
 use panic_semihosting as _;
-use usb_device;
-use usbd_hid;
 
 use bsp::entry;
 use hal::clock::GenericClockController;
@@ -53,9 +51,9 @@ fn main() -> ! {
     };
 
     unsafe {
-        USB_HID = Some(HIDClass::new(&bus_allocator, MouseReport::desc(), 60));
+        USB_HID = Some(HIDClass::new(bus_allocator, MouseReport::desc(), 60));
         USB_BUS = Some(
-            UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x16c0, 0x27dd))
+            UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x16c0, 0x27dd))
                 .manufacturer("Fake company")
                 .product("Twitchy Mousey")
                 .serial_number("TEST")
@@ -99,11 +97,9 @@ static mut USB_HID: Option<HIDClass<UsbBus>> = None;
 
 fn poll_usb() {
     unsafe {
-        USB_BUS.as_mut().map(|usb_dev| {
-            USB_HID.as_mut().map(|hid| {
-                usb_dev.poll(&mut [hid]);
-            });
-        });
+        if let (Some(usb_dev), Some(hid)) = (USB_BUS.as_mut(), USB_HID.as_mut()) {
+            usb_dev.poll(&mut [hid]);
+        }
     };
 }
 

--- a/boards/itsybitsy_m0/examples/uart.rs
+++ b/boards/itsybitsy_m0/examples/uart.rs
@@ -13,7 +13,7 @@ use bsp::hal;
 use bsp::pac;
 use itsybitsy_m0 as bsp;
 
-use bsp::{entry, periph_alias, pin_alias};
+use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::dmac::{DmaController, PriorityLevel};
 use hal::prelude::*;
@@ -42,9 +42,9 @@ fn main() -> ! {
     let chan1 = channels.1.init(PriorityLevel::LVL0);
 
     // Take peripheral and pins
-    let uart_sercom = periph_alias!(peripherals.uart_sercom);
-    let uart_rx = pin_alias!(pins.uart_rx);
-    let uart_tx = pin_alias!(pins.uart_tx);
+    let uart_sercom: bsp::UartSercom = peripherals.SERCOM0;
+    let uart_rx = pins.d0;
+    let uart_tx = pins.d1;
 
     // Setup UART peripheral
     let uart = bsp::uart(

--- a/boards/itsybitsy_m0/examples/usb_echo.rs
+++ b/boards/itsybitsy_m0/examples/usb_echo.rs
@@ -16,7 +16,7 @@ use bsp::hal;
 use bsp::pac;
 use itsybitsy_m0 as bsp;
 
-use bsp::{entry, pin_alias};
+use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::prelude::*;
 use hal::usb::UsbBus;
@@ -33,7 +33,7 @@ fn main() -> ! {
         &mut peripherals.NVMCTRL,
     );
     let pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
+    let mut red_led: bsp::RedLed = pins.d13.into();
 
     let bus_allocator = unsafe {
         USB_ALLOCATOR = Some(bsp::usb_allocator(
@@ -47,9 +47,9 @@ fn main() -> ! {
     };
 
     unsafe {
-        USB_SERIAL = Some(SerialPort::new(&bus_allocator));
+        USB_SERIAL = Some(SerialPort::new(bus_allocator));
         USB_BUS = Some(
-            UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x16c0, 0x27dd))
+            UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x16c0, 0x27dd))
                 .manufacturer("Fake company")
                 .product("Serial port")
                 .serial_number("TEST")
@@ -77,21 +77,19 @@ static mut USB_SERIAL: Option<SerialPort<UsbBus>> = None;
 
 fn poll_usb() {
     unsafe {
-        USB_BUS.as_mut().map(|usb_dev| {
-            USB_SERIAL.as_mut().map(|serial| {
-                usb_dev.poll(&mut [serial]);
-                let mut buf = [0u8; 64];
+        if let (Some(usb_dev), Some(serial)) = (USB_BUS.as_mut(), USB_SERIAL.as_mut()) {
+            usb_dev.poll(&mut [serial]);
+            let mut buf = [0u8; 64];
 
-                if let Ok(count) = serial.read(&mut buf) {
-                    for (i, c) in buf.iter().enumerate() {
-                        if i >= count {
-                            break;
-                        }
-                        serial.write(&[c.clone()]).ok();
+            if let Ok(count) = serial.read(&mut buf) {
+                for (i, c) in buf.iter().enumerate() {
+                    if i >= count {
+                        break;
                     }
-                };
-            });
-        });
+                    serial.write(&[*c]).ok();
+                }
+            };
+        }
     };
 }
 

--- a/boards/itsybitsy_m0/src/lib.rs
+++ b/boards/itsybitsy_m0/src/lib.rs
@@ -17,15 +17,15 @@ use hal::sercom::{
     I2CMaster3,
 };
 use hal::time::Hertz;
+use pac::{SERCOM0, SERCOM3, SERCOM4};
 
 #[cfg(feature = "usb")]
 use hal::usb::{usb_device::bus::UsbBusAllocator, UsbBus};
 
-hal::bsp_peripherals!(
-    SERCOM0 { UartSercom }
-    SERCOM3 { I2cSercom }
-    SERCOM4 { SpiSercom }
-);
+// Temporary until we can use the `bsp_pins!` macro
+pub type UartSercom = SERCOM0;
+pub type I2cSercom = SERCOM3;
+pub type SpiSercom = SERCOM4;
 
 hal::bsp_pins!(
     PA03 {


### PR DESCRIPTION
# Summary
Prepare itsybitsy_m0 for 0.13.0 release to `crates.io`

Remove path dependency to `atsamd-hal` as it is not a Tier 1 board.

Do all the necessary fixes to make it compile, plus fix all clippy lints. 

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)