### PR TITLE
Enable optional RTIC support for Xiao_m0

### DIFF
--- a/boards/xiao_m0/CHANGELOG.md
+++ b/boards/xiao_m0/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
+- added `rtic` feature flag to enable `rtic` feature in the hal
+
 # 0.12.0
 
 - bump hal dependency to 0.14.0

--- a/boards/xiao_m0/Cargo.toml
+++ b/boards/xiao_m0/Cargo.toml
@@ -36,6 +36,7 @@ default = ["rt", "atsamd-hal/samd21g", "atsamd-hal/unproven"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
 unproven = ["atsamd-hal/unproven"]
 usb = ["atsamd-hal/usb", "usb-device"]
+rtic = [ "atsamd-hal/rtic"]
 
 [[example]]
 name = "blink"


### PR DESCRIPTION
# Summary
It would be nice if the seeduino xiao_m0 supported RTIC. I'm a bit of a rust newbie, so maybe this is a naive fix¿? but it seems as simple as adding a feature flag to enable the `rtic` feature in the hal dependency.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [ ] No new warnings or clippy suggestions have been introduced (see CI or check locally)

## If Adding a new Board
  - [ ] Board CI added to `crates.json`
  - [ ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"