### PR TITLE
Remove problematic shortcut in USB poll()

### DIFF
--- a/hal/src/thumbv6m/usb/bus.rs
+++ b/hal/src/thumbv6m/usb/bus.rs
@@ -913,15 +913,6 @@ impl Inner {
                 bank1.clear_transfer_complete();
                 dbgprint!("ep {} WRITE DONE\n", ep);
                 ep_in_complete |= mask;
-                // Continuing (and hence not setting masks to indicate complete
-                // OUT transfers) is necessary for operation to proceed beyond
-                // the device-address + descriptor stage. The authors suspect a
-                // deadlock caused by waiting on a write when handling a read
-                // somewhere in an underlying class or control crate, but we
-                // can't be sure. Either way, if a write has finished, we only
-                // set the flag for a completed write on that endpoint index.
-                // Future polls will handle the reads.
-                continue;
             }
             drop(bank1);
 

--- a/hal/src/thumbv7em/usb/bus.rs
+++ b/hal/src/thumbv7em/usb/bus.rs
@@ -859,15 +859,6 @@ impl Inner {
                 bank1.clear_transfer_complete();
                 dbgprint!("ep {} WRITE DONE\n", ep);
                 ep_in_complete |= mask;
-                // Continuing (and hence not setting masks to indicate complete
-                // OUT transfers) is necessary for operation to proceed beyond
-                // the device-address + descriptor stage. The authors suspect a
-                // deadlock caused by waiting on a write when handling a read
-                // somewhere in an underlying class or control crate, but we
-                // can't be sure. Either way, if a write has finished, we only
-                // set the flag for a completed write on that endpoint index.
-                // Future polls will handle the reads.
-                continue;
             }
             drop(bank1);
 

--- a/hal/src/thumbv7em/usb/bus.rs
+++ b/hal/src/thumbv7em/usb/bus.rs
@@ -852,31 +852,28 @@ impl Inner {
 
             let idx = ep as usize;
 
-            let bank1 = self
-                .bank1(EndpointAddress::from_parts(idx, UsbDirection::In))
-                .unwrap();
-            if bank1.is_transfer_complete() {
-                bank1.clear_transfer_complete();
-                dbgprint!("ep {} WRITE DONE\n", ep);
-                ep_in_complete |= mask;
-            }
-            drop(bank1);
-
-            let bank0 = self
-                .bank0(EndpointAddress::from_parts(idx, UsbDirection::Out))
-                .unwrap();
-            if bank0.received_setup_interrupt() {
-                dbgprint!("ep {} GOT SETUP\n", ep);
-                ep_setup |= mask;
-                // usb-device crate:
-                //  "This event should continue to be reported until the packet
-                // is read." So we don't clear the flag here,
-                // instead it is cleared in the read handler.
+            if let Ok(bank1) = self.bank1(EndpointAddress::from_parts(idx, UsbDirection::In)) {
+                if bank1.is_transfer_complete() {
+                    bank1.clear_transfer_complete();
+                    dbgprint!("ep {} WRITE DONE\n", ep);
+                    ep_in_complete |= mask;
+                }
             }
 
-            if bank0.is_transfer_complete() {
-                dbgprint!("ep {} READABLE\n", ep);
-                ep_out |= mask;
+            if let Ok(bank0) = self.bank0(EndpointAddress::from_parts(idx, UsbDirection::Out)) {
+                if bank0.received_setup_interrupt() {
+                    dbgprint!("ep {} GOT SETUP\n", ep);
+                    ep_setup |= mask;
+                    // usb-device crate:
+                    //  "This event should continue to be reported until the
+                    //  packet is read." So we don't clear the flag here,
+                    //  instead it is cleared in the read handler.
+                }
+
+                if bank0.is_transfer_complete() {
+                    dbgprint!("ep {} READABLE\n", ep);
+                    ep_out |= mask;
+                }
             }
         }
 


### PR DESCRIPTION
I'm hoping to get some testing feedback; I only have a couple Linux machines to work with, and wonder if the code that this PR deletes might still address an issue on some other host/OS.

I believe this shortcut sometimes causes SETUP transactions to be dropped, which results in control transfers failing.  One way to see this on Linux is to run `# lsusb -v -d <VID>:<PID>` for a SAMD-based USB device (the usb-echo example that many boards provide, for instance) - sometimes (more than 1 in 10 on my machine) this will take a second or more to return, where it should only take a few milliseconds.  The mechanism is something like:

1. An IN transfer completes from EP0 (bank 1)
2. A SETUP transaction arrives on EP0 (bank 0)
3. The atsamd-rs `poll()` is called by [the usb-device `poll()`](https://github.com/mvirkkunen/usb-device/blob/b6037b0f98c933ff0a18a864fd34a42f89a6316a/src/device.rs#L162)
4. atsamd-rs `poll()` sees the complete IN flag on EP0 and doesn't set the set the bit in `ep_setup` for EP0 (due to the `continue;` this PR deletes).
5. usb-device `poll()` then [calls `ControlPipe::handle_out()`](https://github.com/mvirkkunen/usb-device/blob/b6037b0f98c933ff0a18a864fd34a42f89a6316a/src/device.rs#L209) which [calls the endpoint `read()`](https://github.com/mvirkkunen/usb-device/blob/b6037b0f98c933ff0a18a864fd34a42f89a6316a/src/control_pipe.rs#L151) on an empty buffer and thereby clears the RXSTP flag on the endpoint - dropping the SETUP packet.
6. Host eventually times out the transfer.