### PR TITLE
arduino_mkrzero: add blinky_rtic example

### DIFF
--- a/boards/arduino_mkrzero/Cargo.toml
+++ b/boards/arduino_mkrzero/Cargo.toml
@@ -15,6 +15,7 @@ version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
+path = "../../hal"
 version = "0.14"
 default-features = false
 
@@ -22,11 +23,16 @@ default-features = false
 version = "0.2"
 optional = true
 
+[dependencies.embedded-sdmmc]
+version = "0.3"
+optional = true
+
 [dev-dependencies]
 cortex-m = "0.7"
 usbd-serial = "0.1"
 panic-halt = "0.2"
 panic-semihosting = "0.5"
+cortex-m-rtic = "1.0"
 
 [features]
 # ask the HAL to enable atsamd21g support
@@ -35,6 +41,7 @@ rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
 usb = ["atsamd-hal/usb", "usb-device"]
 unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
+rtic = ["atsamd-hal/rtic"]
 
 # for cargo flash
 [package.metadata]
@@ -42,6 +49,10 @@ chip = "ATSAMD21G18A"
 
 [[example]]
 name = "blinky_basic"
+
+[[example]]
+name = "blinky_rtic"
+required-features = ["rtic", "unproven"]
 
 [[example]]
 name = "usb_logging"

--- a/boards/arduino_mkrzero/examples/blinky_rtic.rs
+++ b/boards/arduino_mkrzero/examples/blinky_rtic.rs
@@ -1,0 +1,73 @@
+//! Uses RTIC with the RTC as time source to blink an LED.
+//!
+//! The idle task is sleeping the CPU, so in practice this gives similar power
+//! figure as the "sleeping_timer_rtc" example.
+#![no_std]
+#![no_main]
+
+use arduino_mkrzero as bsp;
+
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+use rtic;
+
+#[rtic::app(device = bsp::pac, peripherals = true, dispatchers = [EVSYS])]
+mod app {
+    use super::*;
+    use bsp::hal;
+    use hal::clock::{ClockGenId, ClockSource, GenericClockController};
+    use hal::pac::Peripherals;
+    use hal::rtc::{Count32Mode, Duration, Rtc};
+    use hal::gpio::{Pin, Output, PushPull, v2::PB08};
+
+    #[local]
+    struct Local {}
+
+    #[shared]
+    struct Shared {
+        // The LED could be a local resource, since it is only used in one task
+        // But we want to showcase shared resources and locking
+        led: Pin<PB08, Output<PushPull>>,
+    }
+
+    #[monotonic(binds = RTC, default = true)]
+    type RtcMonotonic = Rtc<Count32Mode>;
+
+    #[init]
+    fn init(cx: init::Context) -> (Shared, Local, init::Monotonics) {
+        let mut peripherals: Peripherals = cx.device;
+        let mut pins = bsp::Pins::new(peripherals.PORT);
+        let mut core: rtic::export::Peripherals = cx.core;
+        let mut clocks = GenericClockController::with_external_32kosc(
+            peripherals.GCLK,
+            &mut peripherals.PM,
+            &mut peripherals.SYSCTRL,
+            &mut peripherals.NVMCTRL,
+        );
+        let _gclk = clocks.gclk0();
+        let rtc_clock_src = clocks
+            .configure_gclk_divider_and_source(ClockGenId::GCLK2, 1, ClockSource::XOSC32K, false)
+            .unwrap();
+        clocks.configure_standby(ClockGenId::GCLK2, true);
+        let rtc_clock = clocks.rtc(&rtc_clock_src).unwrap();
+        let rtc = Rtc::count32_mode(peripherals.RTC, rtc_clock.freq(), &mut peripherals.PM);
+        let led = pins.led_builtin.into_open_drain_output(&mut pins.port);
+
+        // We can use the RTC in standby for maximum power savings
+        core.SCB.set_sleepdeep();
+
+        // Start the blink task
+        blink::spawn().unwrap();
+
+        (Shared { led }, Local {}, init::Monotonics(rtc))
+    }
+
+    #[task(shared = [led])]
+    fn blink(mut cx: blink::Context) {
+        // If the LED were a local resource, the lock would not be necessary
+        cx.shared.led.lock(|led| led.toggle());
+        blink::spawn_after(Duration::secs(3)).ok();
+    }
+}

--- a/boards/arduino_mkrzero/examples/blinky_rtic.rs
+++ b/boards/arduino_mkrzero/examples/blinky_rtic.rs
@@ -18,9 +18,9 @@ mod app {
     use super::*;
     use bsp::hal;
     use hal::clock::{ClockGenId, ClockSource, GenericClockController};
+    use hal::gpio::{v2::PB08, Output, Pin, PushPull};
     use hal::pac::Peripherals;
     use hal::rtc::{Count32Mode, Duration, Rtc};
-    use hal::gpio::{Pin, Output, PushPull, v2::PB08};
 
     #[local]
     struct Local {}


### PR DESCRIPTION
# Summary
Add a blinky_rtic example for arduino_mkrzero.

I've adapted the example from the feather_m0 board for the arduino_mkrzero board. It's currently throwing a lot of warnings because of the use of `gpio::v1`.
