### PR TITLE
USB: Remove disused debug logging

### DIFF
--- a/hal/src/thumbv6m/usb/bus.rs
+++ b/hal/src/thumbv6m/usb/bus.rs
@@ -586,7 +586,6 @@ impl UsbBus {
         dp_pad: impl AnyPin<Id = PA25>,
         _usb: USB,
     ) -> Self {
-        dbgprint!("******** UsbBus::new\n");
         pm.apbbmask.modify(|_, w| w.usb_().set_bit());
 
         let desc = RefCell::new(Descriptors::new());
@@ -612,12 +611,6 @@ impl Inner {
 
     fn set_stall<EP: Into<EndpointAddress>>(&self, ep: EP, stall: bool) {
         let ep = ep.into();
-        dbgprint!(
-            "UsbBus::stall={} for {:?} {}\n",
-            stall,
-            ep.direction(),
-            ep.index()
-        );
         if ep.is_out() {
             if let Ok(mut bank) = self.bank0(ep) {
                 bank.set_stall(stall);
@@ -625,47 +618,6 @@ impl Inner {
         } else if let Ok(mut bank) = self.bank1(ep) {
             bank.set_stall(stall);
         }
-    }
-
-    #[allow(unused_variables)]
-    fn print_epstatus(&self, ep: usize, label: &str) {
-        let status = self.epstatus(ep).read();
-        let epint = self.epintflag(ep).read();
-        let intflag = self.usb().intflag.read();
-
-        #[allow(unused_mut)]
-        let mut desc = self.desc.borrow_mut();
-
-        dbgprint!("ep{} status {}:\n    bk1rdy={} stallrq1={} stall1={} trcpt1={} trfail1={} byte_count1={} multi_packet_size1={}\n    bk0rdy={} stallrq0={} stall0={} trcpt0={} trfail0={} byte_count0={} multi_packet_size0={}\n    curbk={} dtglin={} dtglout={} rxstp={}   lpmsusp={} lpmnyet={} ramacer={} uprsm={} eorsm={} wakeup={} eorst={} sof={} suspend={}\n",
-                ep, label,
-                status.bk1rdy().bit() as u8,
-                status.stallrq1().bit() as u8,
-                epint.stall1().bit() as u8,
-                epint.trcpt1().bit() as u8,
-                epint.trfail1().bit() as u8,
-                desc.bank(ep, 1).get_byte_count(),
-                desc.bank(ep, 1).get_multi_packet_size(),
-                status.bk0rdy().bit() as u8,
-                status.stallrq0().bit() as u8,
-                epint.stall0().bit() as u8,
-                epint.trcpt0().bit() as u8,
-                epint.trfail0().bit() as u8,
-                desc.bank(ep, 0).get_byte_count(),
-                desc.bank(ep, 0).get_multi_packet_size(),
-                status.curbk().bit() as u8,
-                status.dtglin().bit() as u8,
-                status.dtglout().bit() as u8,
-                epint.rxstp().bit() as u8,
-                intflag.lpmsusp().bit() as u8,
-                intflag.lpmnyet().bit() as u8,
-                intflag.ramacer().bit() as u8,
-                intflag.uprsm().bit() as u8,
-                intflag.eorsm().bit() as u8,
-                intflag.wakeup().bit() as u8,
-                intflag.eorst().bit() as u8,
-                intflag.sof().bit() as u8,
-                intflag.suspend().bit() as u8,
-                  );
     }
 }
 
@@ -679,7 +631,6 @@ enum FlushConfigMode {
 
 impl Inner {
     fn enable(&mut self) {
-        dbgprint!("UsbBus::enable\n");
         let usb = self.usb();
         usb.ctrla.modify(|_, w| w.swrst().set_bit());
         while usb.syncbusy.read().swrst().bit_is_set() {}
@@ -795,16 +746,11 @@ impl Inner {
     /// protocol_reset is called by the USB HAL when it detects the host has
     /// performed a USB reset.
     fn protocol_reset(&self) {
-        dbgprint!("UsbBus::reset\n");
         self.flush_eps(FlushConfigMode::ProtocolReset);
     }
 
-    fn suspend(&self) {
-        dbgprint!("UsbBus::suspend\n");
-    }
-    fn resume(&self) {
-        dbgprint!("UsbBus::resume\n");
-    }
+    fn suspend(&self) {}
+    fn resume(&self) {}
 
     fn alloc_ep(
         &mut self,
@@ -831,15 +777,6 @@ impl Inner {
 
         let buffer = self.buffers.borrow_mut().allocate_buffer(allocated_size)?;
 
-        dbgprint!(
-            "UsbBus::alloc_ep dir={:?} addr={:?} type={:?} max_packet_size={} interval={}\n",
-            dir,
-            addr,
-            ep_type,
-            max_packet_size,
-            interval
-        );
-
         let mut endpoints = self.endpoints.borrow_mut();
 
         let idx = match addr {
@@ -857,13 +794,10 @@ impl Inner {
             buffer,
         )?;
 
-        dbgprint!("alloc_ep -> {:?}\n", addr);
-
         Ok(addr)
     }
 
     fn set_device_address(&self, addr: u8) {
-        dbgprint!("UsbBus::set_device_address addr={}\n", addr);
         self.usb()
             .dadd
             .write(|w| unsafe { w.dadd().bits(addr).adden().set_bit() });
@@ -882,7 +816,6 @@ impl Inner {
         if intflags.eorst().bit() {
             // end of reset interrupt
             self.usb().intflag.write(|w| w.eorst().set_bit());
-            dbgprint!("PollResult::Reset\n");
             return PollResult::Reset;
         }
         // As the suspend & wakup interrupts/states cannot distinguish between
@@ -909,14 +842,12 @@ impl Inner {
             if let Ok(bank1) = self.bank1(EndpointAddress::from_parts(idx, UsbDirection::In)) {
                 if bank1.is_transfer_complete() {
                     bank1.clear_transfer_complete();
-                    dbgprint!("ep {} WRITE DONE\n", ep);
                     ep_in_complete |= mask;
                 }
             }
 
             if let Ok(bank0) = self.bank0(EndpointAddress::from_parts(idx, UsbDirection::Out)) {
                 if bank0.received_setup_interrupt() {
-                    dbgprint!("ep {} GOT SETUP\n", ep);
                     ep_setup |= mask;
                     // usb-device crate:
                     //  "This event should continue to be reported until the
@@ -925,7 +856,6 @@ impl Inner {
                 }
 
                 if bank0.is_transfer_complete() {
-                    dbgprint!("ep {} READABLE\n", ep);
                     ep_out |= mask;
                 }
             }
@@ -943,13 +873,6 @@ impl Inner {
 
         if bank.is_ready() {
             // Waiting for the host to pick up the existing data
-            dbgprint!(
-                "UsbBus::write {} bytes {:?} to ep {:?} -> BUSY trcpt1={}\n",
-                buf.len(),
-                buf,
-                ep,
-                bank.is_transfer_complete()
-            );
             return Err(UsbError::WouldBlock);
         }
 
@@ -957,14 +880,6 @@ impl Inner {
 
         bank.clear_transfer_complete();
         bank.set_ready(true); // ready to be sent
-
-        dbgprint!(
-            "UsbBus::write {} bytes {:?} to ep {:?} -> {:?}\n",
-            buf.len(),
-            buf,
-            ep,
-            size
-        );
 
         size
     }
@@ -980,30 +895,12 @@ impl Inner {
                 bank.clear_received_setup_interrupt();
             }
 
-            // self.print_epstatus(idx, "read");
-
             bank.clear_transfer_complete();
             bank.set_ready(false);
 
             drop(bank);
 
-            match size {
-                Ok(size) => {
-                    //dbgprint!("UsbBus::read {} bytes ok", size);
-                    dbgprint!(
-                        "UsbBus::read {} bytes from ep {:?} -> {:?}\n",
-                        size,
-                        ep,
-                        &buf[..size as usize]
-                    );
-                    Ok(size)
-                }
-                Err(err) => {
-                    dbgprint!("UsbBus::read from ep {:?} -> {:?}\n", ep, err);
-                    self.print_epstatus(ep.index(), "after read");
-                    Err(err)
-                }
-            }
+            size
         } else {
             Err(UsbError::WouldBlock)
         }


### PR DESCRIPTION
Just deleting some disused debug logging from the USB HAL.

I note that there is not much difference between the v6 and v7 USB HAL implementations, perhaps a good tidy-up task is to consolidate those.