### PR TITLE
Update USB HAL to use GPIOv2

### DIFF
--- a/hal/src/thumbv6m/usb/mod.rs
+++ b/hal/src/thumbv6m/usb/mod.rs
@@ -1,6 +1,6 @@
 //! USB Device support
 
-use crate::gpio;
+use crate::gpio::v2::{AlternateG, Pin, PA23, PA24, PA25};
 
 pub use usb_device;
 
@@ -10,11 +10,11 @@ pub use self::bus::UsbBus;
 mod devicedesc;
 use self::devicedesc::Descriptors;
 
-/// Emit SOF at 1Khz on this pin when configured as function G
-pub type SofPad = gpio::Pa23<gpio::PfG>;
+/// Emit SOF at 1Khz on this pin
+pub type SofPad = Pin<PA23, AlternateG>;
 
-/// USB D- is connected here
-pub type DmPad = gpio::Pa24<gpio::PfG>;
+/// USB D-
+pub type DmPad = Pin<PA24, AlternateG>;
 
-/// USB D+ is connected here
-pub type DpPad = gpio::Pa25<gpio::PfG>;
+/// USB D+
+pub type DpPad = Pin<PA25, AlternateG>;

--- a/hal/src/thumbv7em/usb/mod.rs
+++ b/hal/src/thumbv7em/usb/mod.rs
@@ -1,6 +1,6 @@
 //! USB Device support
 
-use crate::gpio;
+use crate::gpio::v2::{AlternateH, Pin, PA23, PA24, PA25};
 
 pub use usb_device;
 
@@ -10,12 +10,11 @@ pub use self::bus::UsbBus;
 mod devicedesc;
 use self::devicedesc::Descriptors;
 
-/// Default SOF pad
-#[allow(deprecated)]
-pub type SofPad = gpio::v1::Pa23<gpio::v1::PfH>;
-/// Default USB D- pad
-#[allow(deprecated)]
-pub type DmPad = gpio::v1::Pa24<gpio::v1::PfH>;
-/// Default USB D+ pad
-#[allow(deprecated)]
-pub type DpPad = gpio::v1::Pa25<gpio::v1::PfH>;
+/// Emit SOF at 1Khz on this pin
+pub type SofPad = Pin<PA23, AlternateH>;
+
+/// USB D-
+pub type DmPad = Pin<PA24, AlternateH>;
+
+/// USB D+
+pub type DpPad = Pin<PA25, AlternateH>;


### PR DESCRIPTION
# Summary
Trivial update types in USB HAL to use GPIOv2.

# Checklist
  - [na] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [ ] No new warnings or clippy suggestions have been introduced (see CI or check locally)

## If Adding a new Board
  - [ ] Board CI added to `crates.json`
  - [ ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"