### PR TITLE
Modify traits for  Grand Central M4 Express

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
 - updated HAL to be compatible with PAC updates due to svd2rust upgrade
 - Add an `sercom::v2::i2c` API
+- Modified traits to support the Grand Central M4 Express.
 
 # v0.14.0
 

--- a/hal/src/sercom/v2/pad/impl_pad_thumbv7em.rs
+++ b/hal/src/sercom/v2/pad/impl_pad_thumbv7em.rs
@@ -270,12 +270,16 @@ pad_table!(
     }
     #[cfg(feature = "min-samd51n")]
     PB20 {
-        C: (Sercom3, Pad0, IoSet2),
+        // According to Grand Central M4, PB20 is I2C-capable. This disagrees with datasheet
+        // table 6-8.
+        C: (Sercom3, Pad0, IoSet2) + I2C,
         D: (Sercom7, Pad1, IoSet4),
     }
     #[cfg(feature = "min-samd51n")]
     PB21 {
-        C: (Sercom3, Pad1, IoSet2),
+        // According to Grand Central M4, PB21 is I2C-capable. This disagrees with datasheet
+        // table 6-8.
+        C: (Sercom3, Pad1, IoSet2) + I2C,
         D: (Sercom7, Pad0, IoSet4),
     }
     PB22 {

--- a/hal/src/sercom/v2/spi/pads_thumbv7em.rs
+++ b/hal/src/sercom/v2/spi/pads_thumbv7em.rs
@@ -53,6 +53,11 @@ impl Dopo for NoneT {
 impl Dopo for Pad0 {
     const DOPO: Option<u8> = Some(0);
 }
+
+impl Dopo for Pad1 {
+    const DOPO: Option<u8> = Some(1);
+}
+
 impl Dopo for Pad3 {
     const DOPO: Option<u8> = Some(2);
 }


### PR DESCRIPTION
To allow future migration of the grand_central_m4 crate to gpio v2.

# Summary

Modified traits for  Grand Central M4 Express

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)

## If Adding a new Board
  - [ ] Board CI added to `crates.json`
  - [ ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"