### PR TITLE
Fix text baseline broken in recent version bump

### DIFF
--- a/boards/wio_terminal/examples/clock.rs
+++ b/boards/wio_terminal/examples/clock.rs
@@ -15,7 +15,7 @@ use eg::mono_font::{ascii::FONT_10X20, MonoTextStyle};
 use eg::pixelcolor::Rgb565;
 use eg::prelude::*;
 use eg::primitives::{PrimitiveStyleBuilder, Rectangle};
-use eg::text::Text;
+use eg::text::{Baseline, Text};
 
 use cortex_m::interrupt::free as disable_interrupts;
 use cortex_m::peripheral::NVIC;
@@ -137,7 +137,7 @@ fn main() -> ! {
             .ok()
             .unwrap();
 
-        Text::new(data.as_str(), Point::new(55, 80), style)
+        Text::with_baseline(data.as_str(), Point::new(55, 80), style, Baseline::Top)
             .draw(&mut display)
             .ok()
             .unwrap();

--- a/boards/wio_terminal/examples/microphone.rs
+++ b/boards/wio_terminal/examples/microphone.rs
@@ -19,7 +19,7 @@ use eg::mono_font::{ascii::FONT_6X12, MonoTextStyle};
 use eg::pixelcolor::Rgb565;
 use eg::prelude::*;
 use eg::primitives::{PrimitiveStyleBuilder, Rectangle};
-use eg::text::Text;
+use eg::text::{Baseline, Text};
 use heapless::consts::*;
 use heapless::String;
 
@@ -181,10 +181,15 @@ impl<'a> Terminal<'a> {
 
         if c != '\n' {
             let mut buf = [0u8; 8];
-            Text::new(c.encode_utf8(&mut buf), self.cursor, self.text_style)
-                .draw(&mut self.display)
-                .ok()
-                .unwrap();
+            Text::with_baseline(
+                c.encode_utf8(&mut buf),
+                self.cursor,
+                self.text_style,
+                Baseline::Top,
+            )
+            .draw(&mut self.display)
+            .ok()
+            .unwrap();
 
             self.cursor.x += (FONT_6X12.character_size.width + FONT_6X12.character_spacing) as i32;
         }

--- a/boards/wio_terminal/examples/qspi.rs
+++ b/boards/wio_terminal/examples/qspi.rs
@@ -21,7 +21,7 @@ use eg::mono_font::{ascii::FONT_6X12, MonoTextStyle};
 use eg::pixelcolor::Rgb565;
 use eg::prelude::*;
 use eg::primitives::{PrimitiveStyleBuilder, Rectangle};
-use eg::text::Text;
+use eg::text::{Baseline, Text};
 use heapless::consts::U256;
 use heapless::String;
 
@@ -227,10 +227,15 @@ impl<'a> Terminal<'a> {
 
         if c != '\n' {
             let mut buf = [0u8; 8];
-            Text::new(c.encode_utf8(&mut buf), self.cursor, self.text_style)
-                .draw(&mut self.display)
-                .ok()
-                .unwrap();
+            Text::with_baseline(
+                c.encode_utf8(&mut buf),
+                self.cursor,
+                self.text_style,
+                Baseline::Top,
+            )
+            .draw(&mut self.display)
+            .ok()
+            .unwrap();
 
             self.cursor.x += (FONT_6X12.character_size.width + FONT_6X12.character_spacing) as i32;
         }

--- a/boards/wio_terminal/examples/sdcard.rs
+++ b/boards/wio_terminal/examples/sdcard.rs
@@ -11,7 +11,7 @@ use eg::mono_font::{ascii::FONT_9X15, MonoTextStyle};
 use eg::pixelcolor::Rgb565;
 use eg::prelude::*;
 use eg::primitives::{PrimitiveStyleBuilder, Rectangle};
-use eg::text::Text;
+use eg::text::{Baseline, Text};
 
 use wio::entry;
 use wio::hal::clock::GenericClockController;
@@ -80,7 +80,7 @@ fn main() -> ! {
                     Ok(size) => writeln!(data, "{}Mb", size / 1024 / 1024).unwrap(),
                     Err(e) => writeln!(data, "Err: {:?}", e).unwrap(),
                 }
-                Text::new(data.as_str(), Point::new(4, 2), style)
+                Text::with_baseline(data.as_str(), Point::new(4, 2), style, Baseline::Top)
                     .draw(&mut display)
                     .ok()
                     .unwrap();
@@ -88,7 +88,7 @@ fn main() -> ! {
                 if let Err(e) = print_contents(&mut cont, &mut display) {
                     let mut data = String::<U128>::new();
                     writeln!(data, "Err: {:?}", e).unwrap();
-                    Text::new(data.as_str(), Point::new(4, 20), style)
+                    Text::with_baseline(data.as_str(), Point::new(4, 20), style, Baseline::Top)
                         .draw(&mut display)
                         .ok()
                         .unwrap();
@@ -97,7 +97,7 @@ fn main() -> ! {
             Err(e) => {
                 let mut data = String::<U128>::new();
                 writeln!(data, "Error!: {:?}", e).unwrap();
-                Text::new(data.as_str(), Point::new(4, 2), style)
+                Text::with_baseline(data.as_str(), Point::new(4, 2), style, Baseline::Top)
                     .draw(&mut display)
                     .ok()
                     .unwrap();
@@ -130,10 +130,15 @@ fn print_contents(
     let out = cont.iterate_dir(&volume, &dir, |ent| {
         let mut data = String::<U128>::new();
         writeln!(data, "{} - {:?}", ent.name, ent.attributes).unwrap();
-        Text::new(data.as_str(), Point::new(4, 20 + count * 16), style)
-            .draw(lcd)
-            .ok()
-            .unwrap();
+        Text::with_baseline(
+            data.as_str(),
+            Point::new(4, 20 + count * 16),
+            style,
+            Baseline::Top,
+        )
+        .draw(lcd)
+        .ok()
+        .unwrap();
         count += 1;
     });
     cont.close_dir(&volume, dir);

--- a/boards/wio_terminal/examples/usb_serial_display.rs
+++ b/boards/wio_terminal/examples/usb_serial_display.rs
@@ -11,7 +11,7 @@ use eg::mono_font::{ascii::FONT_6X12, MonoTextStyle};
 use eg::pixelcolor::Rgb565;
 use eg::prelude::*;
 use eg::primitives::{PrimitiveStyleBuilder, Rectangle};
-use eg::text::Text;
+use eg::text::{Baseline, Text};
 
 use cortex_m::peripheral::NVIC;
 
@@ -153,10 +153,15 @@ impl<'a> Terminal<'a> {
 
         if c != '\n' {
             let mut buf = [0u8; 8];
-            Text::new(c.encode_utf8(&mut buf), self.cursor, self.text_style)
-                .draw(&mut self.display)
-                .ok()
-                .unwrap();
+            Text::with_baseline(
+                c.encode_utf8(&mut buf),
+                self.cursor,
+                self.text_style,
+                Baseline::Top,
+            )
+            .draw(&mut self.display)
+            .ok()
+            .unwrap();
 
             self.cursor.x += (FONT_6X12.character_size.width + FONT_6X12.character_spacing) as i32;
         }

--- a/boards/wio_terminal/examples/wifi_connect.rs
+++ b/boards/wio_terminal/examples/wifi_connect.rs
@@ -20,7 +20,7 @@ use cortex_m::interrupt::free as disable_interrupts;
 use eg::mono_font::{ascii::FONT_6X12, MonoTextStyle};
 use eg::pixelcolor::Rgb565;
 use eg::prelude::*;
-use eg::text::Text;
+use eg::text::{Baseline, Text};
 
 use heapless::{consts::U256, String};
 
@@ -131,10 +131,11 @@ fn clear(display: &mut wio::LCD) {
 }
 
 fn write<'a, T: Into<&'a str>>(display: &mut wio::LCD, text: T, pos: Point) {
-    Text::new(
+    Text::with_baseline(
         text.into(),
         pos,
         MonoTextStyle::new(&FONT_6X12, Rgb565::WHITE),
+        Baseline::Top,
     )
     .draw(display)
     .ok()

--- a/boards/wio_terminal/examples/wifi_scan.rs
+++ b/boards/wio_terminal/examples/wifi_scan.rs
@@ -19,7 +19,7 @@ use eg::mono_font::{ascii::FONT_6X12, MonoTextStyle};
 use eg::pixelcolor::Rgb565;
 use eg::prelude::*;
 use eg::primitives::{PrimitiveStyleBuilder, Rectangle};
-use eg::text::Text;
+use eg::text::{Baseline, Text};
 
 use heapless::{consts::U256, String};
 
@@ -184,10 +184,11 @@ fn clear(display: &mut wio::LCD) {
 }
 
 fn write<'a, T: Into<&'a str>>(display: &mut wio::LCD, text: T, pos: Point) {
-    Text::new(
+    Text::with_baseline(
         text.into(),
         pos,
         MonoTextStyle::new(&FONT_6X12, Rgb565::WHITE),
+        Baseline::Top,
     )
     .draw(display)
     .ok()
@@ -209,10 +210,11 @@ fn write_with_clear<'a, T: Into<&'a str>>(
         .ok()
         .unwrap();
 
-    Text::new(
+    Text::with_baseline(
         text.into(),
         pos,
         MonoTextStyle::new(&FONT_6X12, Rgb565::WHITE),
+        Baseline::Top,
     )
     .draw(display)
     .ok()


### PR DESCRIPTION
As I noted in #603, PR #591 bumped a bunch of crates across what are
effectively major version boundaries, because the crates are in the
leading-zero phase of semver -- so an 0.6 to 0.7 update is breaking.
This has broken _at least_ text rendering.

This commit fixes the text baseline calculations to use the method
expected by the embedded-graphics 0.7 crate, which has (quite
reasonably) switched to using baselines instead of bounding box top to
place text, but opted to leave the old implicit-baseline `new` operation
in place and change its behavior, which allowed all of this to break
without any compile errors.

NOTE THAT WITH THIS COMMIT NEARLY ALL OF THE WIO TERMINAL DEMOS ARE
STILL BADLY BROKEN. I'm new here and I'm not sure if these worked before
the version bump, or if they were also broken by the merge of this
untested PR, but at this point, only clock and usb_serial_display work.
Everything else displays blinking garbage on the display and hangs.

# Summary
[describe your changes here]

# Checklist
  - [ ] `CHANGELOG.md` for the BSP or HAL updated
  - [ ] All new or modified code is well documented, especially public items
  - [ ] No new warnings or clippy suggestions have been introduced (see CI or check locally)

## If Adding a new Board
  - [ ] Board CI added to `crates.json`
  - [ ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"