### PR TITLE
Fix failing `bsp_pins!` invocation with no aliases

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased Changes
 
 - Add support for L-Variant of the SAMD21D
+- Fix failing `bsp_pins!` invocation with no aliases (#605 fixes #599)
 
 # v0.15.0
 

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Unreleased Changes
 
+- Fix failing `bsp_pins!` invocation with no aliases (#605 fixes #599)
+
 # v0.15.1
 
 - Fix `sercom::uart` pad definitions to reject pads conflicting with XCK.
 - Add support for L-Variant of the SAMD21D
-- Fix failing `bsp_pins!` invocation with no aliases (#605 fixes #599)
 
 # v0.15.0
 

--- a/hal/src/gpio/pin.rs
+++ b/hal/src/gpio/pin.rs
@@ -1650,9 +1650,17 @@ macro_rules! __define_pin_alias_macro {
             #[macro_export]
             macro_rules! pin_alias {
                 $(
+                    // Always provide an identity "alias"
+                    ( $pins:ident . $name ) => { $pins.$name };
+                )+
+                $(
                     $(
                         ( $pins:ident . $alias ) => {
                             {
+                                // Since attributes can't apply to expressions, only
+                                // items, apply any attributes to a dummy macro. This
+                                // lets us ensure the alias is only valid when the
+                                // corresponding attributes are valid.
                                 $( #[$attr] )*
                                 macro_rules! [<pin_alias_ $alias>] {
                                     () => { $pins.$name };


### PR DESCRIPTION
When no aliases are included in a call of `bsp_pins!`, the resulting
`pin_alias!` macro expands to a completely empty macro definition, which
is invalid.

Add identity "aliases" for each given pin name. This has two benefits.
First, it prevents the empty macro case above. And second, it precludes
any possibility of collisions between names and aliases, since all names
are now checked before resolving aliases.

Closes #599

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)