### PR TITLE
Fix UART pad definitions

### DIFF
--- a/boards/feather_m0/CHANGELOG.md
+++ b/boards/feather_m0/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.12.1
+
+- Update to `atsamd-hal` version `0.15.1`
 - Update .cargo/config
 
 # v0.12.0

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feather_m0"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit Feather M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
@@ -21,7 +21,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.15"
+version = "0.15.1"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/feather_m4/CHANGELOG.md
+++ b/boards/feather_m4/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.10.1
+
+- Update to `atsamd-hal` version `0.15.1`
 - Make use of `bsp_peripherals` macro
 
 # v0.10.0

--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feather_m4"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 authors = ["Theodore DeRego <tderego94@gmail.com>"]
 description = "Board Support crate for the Adafruit Feather M4"
@@ -21,7 +21,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.15"
+version = "0.15.1"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/metro_m0/CHANGELOG.md
+++ b/boards/metro_m0/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+# v0.12.1
+
+- Update to `atsamd-hal` version `0.15.1`
+
+# v0.12.0
+
 - Update `lib.rs` and examples to reflect removal of `v1` APIs and promotion of `v2` APIs
 - Update `i2c_master` convenience function to use the new `sercom::v2::i2c` API
 - Add an `i2c` example

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metro_m0"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Wez Furlong <wez@wezfurlong.org>"]
 description = "Board Support crate for the Adafruit Metro M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
@@ -20,7 +20,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.15"
+version = "0.15.1"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/metro_m4/CHANGELOG.md
+++ b/boards/metro_m4/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v0.11.1
+
+- Update to `atsamd-hal` version `0.15.1`
 - Make use of `bsp_peripherals` macro
 
 # v0.11.0

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metro_m4"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Paul Sajna <sajattack@gmail.com>", "Wez Furlong <wez@wezfurlong.org>"]
 description = "Board Support crate for the Adafruit Metro M4"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
@@ -20,7 +20,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.15"
+version = "0.15.1"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/samd11_bare/CHANGELOG.md
+++ b/boards/samd11_bare/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# v0.8.1
+- Update to `atsamd-hal` version `0.15.1`
+
+# v0.8.0
 - Update `lib.rs` and examples to reflect removal of `v1` APIs and promotion of `v2` APIs
 - Update `i2c_master` convenience function to use the new `sercom::v2::i2c` API
 - Add an `i2c` example

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samd11_bare"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Jesse Braham <jesse@beta7.io>"]
 description = "Support crate for the ATSAMD11C"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
@@ -19,7 +19,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.15"
+version = "0.15.1"
 default-features = false
 
 [dev-dependencies]

--- a/boards/wio_terminal/CHANGELOG.md
+++ b/boards/wio_terminal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+# v0.6.1
+
+- Update to `atsamd-hal` version `0.15.1`
+
+# v0.6.0
+
 - Fix removed deprecated modules from HAL
 - Update `lib.rs` and examples to reflect removal of `v1` APIs and promotion of `v2` APIs
 - Update `i2c_master` convenience function to use the new `sercom::v2::i2c` API

--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wio_terminal"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Tom <twitchyliquid64@ciphersink.net>"
@@ -45,7 +45,7 @@ seeed-erpc = { version = "0.1.1", optional = true }
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.15"
+version = "0.15.1"
 default-features = false
 
 [dev-dependencies]

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased Changes
 
+- Fix `sercom::uart` pad definitions to reject pads conflicting with XCK.
 - Add support for L-Variant of the SAMD21D
 
 # v0.15.0

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased Changes
 
+# v0.15.1
+
 - Fix `sercom::uart` pad definitions to reject pads conflicting with XCK.
 - Add support for L-Variant of the SAMD21D
 

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atsamd-hal"
-version = "0.15.0"
+version = "0.15.1"
 authors = [
     "Wez Furlong <wez@wezfurlong.org>",
     "Paul Sajna <sajattack@gmail.com>",

--- a/hal/src/sercom/uart/pads_thumbv7em.rs
+++ b/hal/src/sercom/uart/pads_thumbv7em.rs
@@ -55,21 +55,20 @@ where
 //=============================================================================
 
 /// Filter [`PadNum`] permutations and implement [`RxpoTxpo`]
-    #[rustfmt::skip]
-    macro_rules! impl_rxpotxpo {
+macro_rules! impl_rxpotxpo {
     // This is the entry pattern. Start by checking RTS and CTS.
     ($RX:ident, $TX:ident, $RTS:ident, $CTS:ident) => { impl_rxpotxpo!(@check_rts_cts, $RX, $TX, $RTS, $CTS); };
-    
+
     // Check whether RTS and CTS form a valid pair.
     // They both must be the correct pad or absent.
     (@check_rts_cts, $RX:ident, $TX:ident, NoneT, NoneT) => { impl_rxpotxpo!(@rxpo, $RX, $TX, NoneT, NoneT); };
     (@check_rts_cts, $RX:ident, $TX:ident, Pad2, NoneT) => { impl_rxpotxpo!(@rxpo, $RX, $TX, Pad2, NoneT); };
     (@check_rts_cts, $RX:ident, $TX:ident, NoneT, Pad3) => { impl_rxpotxpo!(@rxpo, $RX, $TX, NoneT, Pad3); };
     (@check_rts_cts, $RX:ident, $TX:ident, Pad2, Pad3) => { impl_rxpotxpo!(@rxpo, $RX, $TX, Pad2, Pad3); };
-    
+
     // If RTS and CTS are not valid, fall through to this pattern.
     (@check_rts_cts, $RX:ident, $TX:ident, $RTS:ident, $CTS:ident) => { };
-    
+
     // Assign RXPO based on RX.
     // Our options are exhaustive, so no fall through pattern is needed.
     (@rxpo, NoneT, $TX:ident, $RTS:ident, $CTS:ident) => { impl_rxpotxpo!(@txpo, NoneT, $TX, $RTS, $CTS, 0); };
@@ -77,7 +76,7 @@ where
     (@rxpo, Pad1,  $TX:ident, $RTS:ident, $CTS:ident) => { impl_rxpotxpo!(@txpo, Pad1,  $TX, $RTS, $CTS, 1); };
     (@rxpo, Pad2,  $TX:ident, $RTS:ident, $CTS:ident) => { impl_rxpotxpo!(@txpo, Pad2,  $TX, $RTS, $CTS, 2); };
     (@rxpo, Pad3,  $TX:ident, $RTS:ident, $CTS:ident) => { impl_rxpotxpo!(@txpo, Pad3,  $TX, $RTS, $CTS, 3); };
-    
+
     // Assign TXPO based on TX, RTS and CTS
     (@txpo, $RX:ident, NoneT, NoneT, NoneT, $RXPO:literal) => { impl_rxpotxpo!(@filter, $RX, NoneT, NoneT, NoneT, $RXPO, 0); };
     (@txpo, $RX:ident, NoneT, Pad2, NoneT, $RXPO:literal) => { impl_rxpotxpo!(@filter, $RX, NoneT, Pad2, NoneT, $RXPO, 3); };
@@ -85,10 +84,10 @@ where
     (@txpo, $RX:ident, Pad0, NoneT, NoneT, $RXPO:literal) => { impl_rxpotxpo!(@filter, $RX, Pad0, NoneT, NoneT, $RXPO, 0); };
     (@txpo, $RX:ident, Pad0, Pad2, NoneT, $RXPO:literal) => { impl_rxpotxpo!(@filter, $RX, Pad0, Pad2, NoneT, $RXPO, 3); };
     (@txpo, $RX:ident, Pad0, Pad2, Pad3, $RXPO:literal) => { impl_rxpotxpo!(@filter, $RX, Pad0, Pad2, Pad3, $RXPO, 2); };
-    
+
     // If TX is not valid, fall through to this pattern.
     (@txpo, $RX:ident, $TX:ident, $RTS:ident, $CTS:ident, $RXPO:literal) => { };
-    
+
     // Filter any remaining permutations that conflict.
     (@filter, NoneT, NoneT, $RTS:ident, $CTS:ident, $RXPO:literal, $TXPO:literal) => { }; // RX and TX both NoneT
     (@filter, Pad0, Pad0, $RTS:ident, $CTS:ident, $RXPO:literal, $TXPO:literal) => { }; // RX and TX both Pad0
@@ -98,16 +97,18 @@ where
     (@filter, Pad1, $TX:ident, $RTS:ident, $CTS:ident, 1, 3) => { }; // RX can't be Pad1 if TXPO is 3 because of XCK conflict
 
     // If there are no conflicts, fall through to this pattern
-    (@filter, $RX:ident, $TX:ident, $RTS:ident, $CTS:ident, $RXPO:literal, $TXPO:literal) => { impl_rxpotxpo!(@implement, $RX, $TX, $RTS, $CTS, $RXPO, $TXPO); };
-    
+    (@filter, $RX:ident, $TX:ident, $RTS:ident, $CTS:ident, $RXPO:literal, $TXPO:literal) => {
+        impl_rxpotxpo!(@implement, $RX, $TX, $RTS, $CTS, $RXPO, $TXPO);
+    };
+
     // Implement RxpoTxpo
     (@implement, $RX:ident, $TX:ident, $RTS:ident, $CTS:ident, $RXPO:literal, $TXPO:literal) => {
         impl RxpoTxpo for ($RX, $TX, $RTS, $CTS) {
-        const RXPO: u8 = $RXPO;
-        const TXPO: u8 = $TXPO;
+            const RXPO: u8 = $RXPO;
+            const TXPO: u8 = $TXPO;
         }
     };
-    }
+}
 
 /// Try to implement [`RxpoTxpo`] on all possible 4-tuple permutations of
 /// [`OptionalPadNum`]s.


### PR DESCRIPTION
# Summary

The pad definitions in sercom::uart didn't take into account that the XCK pad would be unavailable for use, even if ynchronous mode isn't in use Especially, implement the same `impl_rxpotxpo` macro system for `thumbv7em` targets as the one already in use for `thumbv6m targets`. Additionnally, reject pad combinations where XCK would conflict on `thumbv6m` targets. Closes #581.

Technically these should be breaking changes, as some pad combinations that used to be valid won't be anymore, but considering that the combinations that were invalidated by this PR were already broken to begin with, I don't think we need to wait for the next major release to squeeze it in.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)