### PR TITLE
Update hal dependency for itsybitsy_m4  to v0.15:

### DIFF
--- a/boards/itsybitsy_m4/CHANGELOG.md
+++ b/boards/itsybitsy_m4/CHANGELOG.md
@@ -1,5 +1,8 @@
-# Unreleased
+# 0.8.0
 
+- update hal dependency to v0.15
+  - Removed use of i2c v1 API
+  - Make use of the `bsp::peripherals!` macro to alias SERCOM 1,2 and 3
 - Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
 - add `sercom_interrupt` example to show how to
   - manually configure sercom for uart operation

--- a/boards/itsybitsy_m4/Cargo.toml
+++ b/boards/itsybitsy_m4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "itsybitsy_m4"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
     "Nic Hartley <nxh9052@rit.edu>",
     "Tom <twitchyliquid64@ciphersink.net>",
@@ -23,7 +23,7 @@ version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.14"
+version = "0.15"
 default-features = false
 
 [dependencies.usb-device]
@@ -34,7 +34,7 @@ optional = true
 cortex-m = "0.7"
 usbd-serial = "0.1"
 panic-halt = "0.2"
-panic-semihosting = "0.5"
+panic-semihosting = "0.6"
 
 [features]
 # ask the HAL to enable atsamd51g support

--- a/boards/itsybitsy_m4/examples/sercom_interrupt.rs
+++ b/boards/itsybitsy_m4/examples/sercom_interrupt.rs
@@ -36,10 +36,10 @@ use bsp::hal::{
     clock::GenericClockController,
     delay::Delay,
     ehal::blocking::delay::DelayMs,
-    gpio::v2::{Pin, PushPullOutput, PA22},
+    gpio::{Pin, PushPullOutput, PA22},
     pac::{self, interrupt, CorePeripherals, Peripherals},
     prelude::*,
-    sercom::v2::{
+    sercom::{
         uart::{self, BaudMode, Flags, Oversampling},
         IoSet3, Sercom0,
     },


### PR DESCRIPTION
# Summary

Update hal dependency for itsybitsy_m4  to v0.15:

- Remove use of `v2` in bsp and examples
- Removed use of i2c v1 API in bsp
- Make use of the `bsp::peripherals!` macro to alias SERCOMS 1,2 and 3
- bumped bsp version to 0.8.0
- `panic-semihosting` dependency bumped to v0.6

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)