### PR TITLE
Updated `atsamd-hal` to 0.15.1 for pyportal

### DIFF
--- a/boards/pyportal/CHANGELOG.md
+++ b/boards/pyportal/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+# v0.10.0
+
+- update to `atsamd-hal` to 0.15.1 and `cortex-m-rt` to 0.7.1
+- Added usb feature to bsp, and example
+- Added display feature to bsp and example
+
 # v0.9.0
 
 - update to `atsamd-hal-0.14` and other latest dependencies (#564)

--- a/boards/pyportal/Cargo.toml
+++ b/boards/pyportal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyportal"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
     "Shella Stephens <shella@infracoven.io",
     "Paul Sajna <sajattack@gmail.com>",
@@ -15,17 +15,32 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies.cortex-m-rt]
-version = "0.7"
+version = "0.7.1"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.14"
+version = "0.15.1"
 default-features = false
+
+[dependencies.display-interface-parallel-gpio]
+version="0.6.0"
+optional=true
+
+[dependencies.ili9341]
+version="0.5.0"
+optional=true
+
+[dependencies.usb-device]
+version = "0.2.8"
+optional = true
 
 [dev-dependencies]
 panic-halt = "0.2"
 panic-semihosting = "0.5"
 smart-leds = "~0.3"
+usbd-serial = "0.1.1"
+cortex-m = "0.7.4"
+embedded-graphics = "0.7.1"
 
 [dev-dependencies.ws2812-timer-delay]
 version = "~0.3"
@@ -35,6 +50,8 @@ version = "~0.3"
 default = ["rt", "atsamd-hal/samd51j", "atsamd-hal/samd51", "unproven"]
 unproven = ["atsamd-hal/unproven"]
 rt = ["cortex-m-rt", "atsamd-hal/samd51j-rt"]
+usb = ["atsamd-hal/usb", "usb-device"]
+display = ["display-interface-parallel-gpio", "ili9341"]
 
 [profile.dev]
 incremental = false
@@ -49,3 +66,17 @@ opt-level = "s"
 # for cargo flash
 [package.metadata]
 chip = "ATSAMD51J20A"
+
+[[example]]
+name = "blinky_basic"
+
+[[example]]
+name = "ili9341_240x320"
+required-features = ["display"]
+
+[[example]]
+name = "neopixel_rainbow"
+
+[[example]]
+name = "usb_echo"
+required-features = ["usb"]

--- a/boards/pyportal/examples/blinky_basic.rs
+++ b/boards/pyportal/examples/blinky_basic.rs
@@ -11,7 +11,7 @@ use panic_halt as _;
 #[cfg(feature = "use_semihosting")]
 use panic_semihosting as _;
 
-use bsp::entry;
+use bsp::{entry, pin_alias};
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::pac::{CorePeripherals, Peripherals};
@@ -32,8 +32,8 @@ fn main() -> ! {
     let mut delay = Delay::new(core.SYST, &mut clocks);
     delay.delay_ms(400u16);
 
-    let mut pins = bsp::Pins::new(peripherals.PORT);
-    let mut red_led = pins.d13.into_open_drain_output(&mut pins.port);
+    let pins = bsp::Pins::new(peripherals.PORT);
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
 
     let mut wdt = Watchdog::new(peripherals.WDT);
     wdt.start(WatchdogTimeout::Cycles256 as u8);

--- a/boards/pyportal/examples/ili9341_240x320.rs
+++ b/boards/pyportal/examples/ili9341_240x320.rs
@@ -1,0 +1,101 @@
+#![no_std]
+#![no_main]
+
+use bsp::hal;
+use pyportal as bsp;
+
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
+use bsp::DisplaySize240x320;
+use bsp::Orientation;
+use bsp::{entry, pin_alias};
+use embedded_graphics::pixelcolor::Rgb565;
+use embedded_graphics::prelude::*;
+use embedded_graphics::primitives::{Circle, PrimitiveStyleBuilder, Rectangle, Triangle};
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::pac::{CorePeripherals, Peripherals};
+use hal::prelude::*;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.MCLK,
+        &mut peripherals.OSC32KCTRL,
+        &mut peripherals.OSCCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+
+    let pins = bsp::Pins::new(peripherals.PORT).split();
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
+
+    let (mut disp, backlight, _tft_te) = pins.display.init(
+        DisplaySize240x320,
+        Orientation::LandscapeFlipped,
+        &mut delay,
+    );
+
+    backlight.into_push_pull_output().set_high().unwrap();
+
+    let yoffset = 24;
+    let x_max = (disp.width() as i32) - 1;
+    let y_max = (disp.height() as i32) - 1;
+
+    let red_style = PrimitiveStyleBuilder::new()
+        .stroke_color(Rgb565::RED)
+        .stroke_width(1)
+        .build();
+
+    let green_style = PrimitiveStyleBuilder::new()
+        .stroke_color(Rgb565::GREEN)
+        .stroke_width(1)
+        .build();
+
+    let blue_style = PrimitiveStyleBuilder::new()
+        .stroke_color(Rgb565::BLUE)
+        .stroke_width(1)
+        .build();
+
+    // screen outline
+    Rectangle::with_corners(Point::new(0, 0), Point::new(x_max, y_max))
+        .into_styled(red_style)
+        .draw(&mut disp)
+        .unwrap();
+
+    // triangle
+    Triangle::new(
+        Point::new(16, 16 + yoffset),
+        Point::new(16 + 16, 16 + yoffset),
+        Point::new(16 + 8, yoffset),
+    )
+    .into_styled(red_style)
+    .draw(&mut disp)
+    .unwrap();
+
+    // square
+    Rectangle::with_corners(Point::new(54, yoffset), Point::new(54 + 16, 16 + yoffset))
+        .into_styled(green_style)
+        .draw(&mut disp)
+        .unwrap();
+
+    // circle
+    Circle::new(Point::new(100, 8 + yoffset), 8)
+        .into_styled(blue_style)
+        .draw(&mut disp)
+        .unwrap();
+
+    loop {
+        delay.delay_ms(400_u16);
+        red_led.set_high().unwrap();
+        delay.delay_ms(400_u16);
+        red_led.set_low().unwrap();
+    }
+}

--- a/boards/pyportal/examples/usb_echo.rs
+++ b/boards/pyportal/examples/usb_echo.rs
@@ -1,0 +1,122 @@
+#![no_std]
+#![no_main]
+
+use bsp::hal;
+use pyportal as bsp;
+
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
+use bsp::entry;
+use bsp::pin_alias;
+use hal::clock::GenericClockController;
+use hal::pac::{interrupt, CorePeripherals, Peripherals};
+use hal::prelude::*;
+use hal::usb::UsbBus;
+
+use usb_device::bus::UsbBusAllocator;
+use usb_device::prelude::*;
+use usbd_serial::{SerialPort, USB_CLASS_CDC};
+
+use cortex_m::asm::delay as cycle_delay;
+use cortex_m::interrupt::Mutex;
+use cortex_m::peripheral::NVIC;
+
+use core::cell::RefCell;
+use core::mem::MaybeUninit;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.GCLK,
+        &mut peripherals.MCLK,
+        &mut peripherals.OSC32KCTRL,
+        &mut peripherals.OSCCTRL,
+        &mut peripherals.NVMCTRL,
+    );
+    let pins = bsp::Pins::new(peripherals.PORT);
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
+
+    let bus_allocator = unsafe {
+        USB_ALLOCATOR.write(bsp::usb_allocator(
+            pins.usb_dm,
+            pins.usb_dp,
+            peripherals.USB,
+            &mut clocks,
+            &mut peripherals.MCLK,
+        ))
+    };
+
+    cortex_m::interrupt::free(|cs| {
+        USB_SERIAL
+            .borrow(cs)
+            .replace(Some(SerialPort::new(bus_allocator)));
+        USB_BUS.borrow(cs).replace(Some(
+            UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x16c0, 0x27dd))
+                .manufacturer("Fake company")
+                .product("Serial port")
+                .serial_number("TEST")
+                .device_class(USB_CLASS_CDC)
+                .build(),
+        ));
+    });
+
+    unsafe {
+        core.NVIC.set_priority(interrupt::USB_OTHER, 1);
+        core.NVIC.set_priority(interrupt::USB_TRCPT0, 1);
+        core.NVIC.set_priority(interrupt::USB_TRCPT1, 1);
+        NVIC::unmask(interrupt::USB_OTHER);
+        NVIC::unmask(interrupt::USB_TRCPT0);
+        NVIC::unmask(interrupt::USB_TRCPT1);
+    }
+
+    loop {
+        cycle_delay(5 * 1024 * 1024);
+        red_led.toggle().unwrap();
+    }
+}
+
+static mut USB_ALLOCATOR: MaybeUninit<UsbBusAllocator<UsbBus>> = MaybeUninit::uninit();
+static USB_BUS: Mutex<RefCell<Option<UsbDevice<UsbBus>>>> = Mutex::new(RefCell::new(None));
+static USB_SERIAL: Mutex<RefCell<Option<SerialPort<UsbBus>>>> = Mutex::new(RefCell::new(None));
+
+fn poll_usb() {
+    // Disable interrupts while accessing USB_SERIAL and USB_BUS to prevent possible
+    // race conditions
+    cortex_m::interrupt::free(|cs| {
+        if let Some(usb_dev) = USB_BUS.borrow(cs).borrow_mut().as_mut() {
+            if let Some(serial) = USB_SERIAL.borrow(cs).borrow_mut().as_mut() {
+                usb_dev.poll(&mut [serial]);
+                let mut buf = [0u8; 64];
+
+                if let Ok(count) = serial.read(&mut buf) {
+                    for (i, c) in buf.iter().enumerate() {
+                        if i >= count {
+                            break;
+                        }
+                        serial.write(&[*c]).unwrap();
+                    }
+                };
+            };
+        };
+    });
+}
+
+#[interrupt]
+fn USB_OTHER() {
+    poll_usb();
+}
+
+#[interrupt]
+fn USB_TRCPT0() {
+    poll_usb();
+}
+
+#[interrupt]
+fn USB_TRCPT1() {
+    poll_usb();
+}

--- a/boards/pyportal/src/display.rs
+++ b/boards/pyportal/src/display.rs
@@ -1,0 +1,53 @@
+use super::pins::*;
+use atsamd_hal::ehal::blocking::delay::DelayMs;
+use atsamd_hal::prelude::*;
+use display_interface_parallel_gpio::{Generic8BitBus, PGPIO8BitInterface};
+use ili9341::{DisplaySize, Ili9341};
+
+pub use ili9341::{DisplaySize240x320, DisplaySize320x480, Orientation, Scroller};
+
+type LcdDataBus =
+    Generic8BitBus<LcdData0, LcdData1, LcdData2, LcdData3, LcdData4, LcdData5, LcdData6, LcdData7>;
+
+pub type Lcd = Ili9341<PGPIO8BitInterface<LcdDataBus, TftRs, TftWr>, TftReset>;
+
+impl Display {
+    /// Initialize the display. Return a tuple containing the configured display
+    /// driver struct, the backlight pin, and the tearing effect pin
+    pub fn init(
+        self,
+        display_size: impl DisplaySize,
+        orientation: Orientation,
+        delay: &mut impl DelayMs<u16>,
+    ) -> (Lcd, TftBacklightReset, TftTeReset) {
+        let bus: LcdDataBus = Generic8BitBus::new((
+            self.lcd_data0.into(),
+            self.lcd_data1.into(),
+            self.lcd_data2.into(),
+            self.lcd_data3.into(),
+            self.lcd_data4.into(),
+            self.lcd_data5.into(),
+            self.lcd_data6.into(),
+            self.lcd_data7.into(),
+        ))
+        .unwrap();
+
+        let interface = PGPIO8BitInterface::new(bus, self.tft_rs.into(), self.tft_wr.into());
+        // set to high when not in use
+        self.tft_rd.into_push_pull_output().set_high().unwrap();
+
+        // set to low to enable display
+        self.tft_cs.into_push_pull_output().set_low().unwrap();
+
+        let ili9341 = Ili9341::new(
+            interface,
+            self.tft_reset.into(),
+            delay,
+            orientation,
+            display_size,
+        )
+        .unwrap();
+
+        (ili9341, self.tft_backlight, self.tft_te)
+    }
+}

--- a/boards/pyportal/src/lib.rs
+++ b/boards/pyportal/src/lib.rs
@@ -1,21 +1,39 @@
 #![no_std]
 #![recursion_limit = "1024"]
 
-pub mod pins;
 pub use atsamd_hal as hal;
+pub use hal::pac;
 
 #[cfg(feature = "rt")]
 pub use cortex_m_rt::entry;
 
-pub use crate::pins::Pins;
-pub use hal::common::*;
-pub use hal::pac;
-pub use hal::samd51::*;
-
-use gpio::{Floating, Input, PfC, Port};
 use hal::clock::GenericClockController;
-use hal::sercom::{I2CMaster5, PadPin, SPIMaster2, UART4};
+use hal::sercom::uart;
+use hal::sercom::uart::BaudMode;
+use hal::sercom::uart::Oversampling;
+use hal::sercom::{i2c, spi, IoSet1, IoSet6};
 use hal::time::Hertz;
+
+pub mod pins;
+pub use pins::*;
+
+#[cfg(feature = "display")]
+mod display;
+#[cfg(feature = "display")]
+pub use display::*;
+
+#[cfg(feature = "usb")]
+use hal::usb::{usb_device::bus::UsbBusAllocator, UsbBus};
+
+hal::bsp_peripherals!(
+    SERCOM2 { SpiSercom }
+    SERCOM4 { EspUartSercom }
+    SERCOM5 { I2cSercom }
+);
+
+pub type SpiPads = spi::Pads<SpiSercom, IoSet1, Miso, Mosi, Sck>;
+
+pub type Spi = spi::Spi<spi::Config<SpiPads>, spi::Duplex>;
 
 /// This powers up SERCOM2 and configures it for use as an
 /// SPI Master in SPI Mode 0.
@@ -23,81 +41,96 @@ use hal::time::Hertz;
 /// one does not accept a CS pin; configuring a pin for CS
 /// is the responsibility of the caller, because it could be
 /// any OutputPin, or even a pulled up line on the slave.
-pub fn spi_master<F: Into<Hertz>>(
+pub fn spi_master(
     clocks: &mut GenericClockController,
-    bus_speed: F,
-    sercom2: pac::SERCOM2,
+    baud: impl Into<Hertz>,
+    sercom: SpiSercom,
     mclk: &mut pac::MCLK,
-    sck: gpio::Pa13<Input<Floating>>,
-    mosi: gpio::Pa12<Input<Floating>>,
-    miso: gpio::Pa14<Input<Floating>>,
-    port: &mut Port,
-) -> SPIMaster2<
-    hal::sercom::Sercom2Pad2<gpio::Pa14<gpio::PfC>>,
-    hal::sercom::Sercom2Pad0<gpio::Pa12<gpio::PfC>>,
-    hal::sercom::Sercom2Pad1<gpio::Pa13<gpio::PfC>>,
-> {
+    sclk: impl Into<Sck>,
+    mosi: impl Into<Mosi>,
+    miso: impl Into<Miso>,
+) -> Spi {
     let gclk0 = clocks.gclk0();
-    SPIMaster2::new(
-        &clocks.sercom2_core(&gclk0).unwrap(),
-        bus_speed.into(),
-        hal::hal::spi::Mode {
-            phase: hal::hal::spi::Phase::CaptureOnFirstTransition,
-            polarity: hal::hal::spi::Polarity::IdleLow,
-        },
-        sercom2,
-        mclk,
-        (miso.into_pad(port), mosi.into_pad(port), sck.into_pad(port)),
-    )
+    let clock = clocks.sercom2_core(&gclk0).unwrap();
+    let freq = clock.freq();
+    let (miso, mosi, sclk) = (miso.into(), mosi.into(), sclk.into());
+    let pads = spi::Pads::default().data_in(miso).data_out(mosi).sclk(sclk);
+    spi::Config::new(mclk, sercom, pads, freq)
+        .baud(baud)
+        .spi_mode(spi::MODE_0)
+        .enable()
 }
+
+/// I2C pads for the labelled I2C peripheral
+///
+/// You can use these pads with other, user-defined [`i2c::Config`]urations.
+pub type I2cPads = i2c::Pads<I2cSercom, IoSet6, Sda, Scl>;
+
+/// I2C master for the labelled I2C peripheral
+///
+/// This type implements [`Read`](hal::ehal::blocking::i2c::Read),
+/// [`Write`](hal::ehal::blocking::i2c::Write) and
+/// [`WriteRead`](hal::ehal::blocking::i2c::WriteRead).
+pub type I2c = i2c::I2c<i2c::Config<I2cPads>>;
 
 /// Convenience for setting up the labelled SDA, SCL pins to
 /// operate as an I2C master running at the specified frequency.
-pub fn i2c_master<F: Into<Hertz>>(
+pub fn i2c_master(
     clocks: &mut GenericClockController,
-    bus_speed: F,
-    sercom5: pac::SERCOM5,
+    baud: impl Into<Hertz>,
+    sercom: I2cSercom,
     mclk: &mut pac::MCLK,
-    sda: gpio::Pb2<Input<Floating>>,
-    scl: gpio::Pb3<Input<Floating>>,
-    port: &mut Port,
-) -> I2CMaster5<
-    hal::sercom::Sercom5Pad0<gpio::Pb2<gpio::PfD>>,
-    hal::sercom::Sercom5Pad1<gpio::Pb3<gpio::PfD>>,
-> {
+    sda: impl Into<Sda>,
+    scl: impl Into<Scl>,
+) -> I2c {
     let gclk0 = clocks.gclk0();
-    I2CMaster5::new(
-        &clocks.sercom5_core(&gclk0).unwrap(),
-        bus_speed.into(),
-        sercom5,
-        mclk,
-        sda.into_pad(port),
-        scl.into_pad(port),
-    )
+    let clock = &clocks.sercom5_core(&gclk0).unwrap();
+    let freq = clock.freq();
+    let baud = baud.into();
+    let pads = i2c::Pads::new(sda.into(), scl.into());
+    i2c::Config::new(mclk, sercom, pads, freq)
+        .baud(baud)
+        .enable()
 }
 
-/// UART is connected to the ESP32 Wi-Fi co-processor
-pub fn esp_uart<F: Into<Hertz>>(
-    clocks: &mut GenericClockController,
-    baud: F,
-    sercom4: pac::SERCOM4,
-    mclk: &mut pac::MCLK,
-    esp_rx: gpio::Pb13<Input<Floating>>,
-    esp_tx: gpio::Pb12<Input<Floating>>,
-    port: &mut Port,
-) -> UART4<
-    hal::sercom::Sercom4Pad1<gpio::Pb13<PfC>>,
-    hal::sercom::Sercom4Pad0<gpio::Pb12<PfC>>,
-    (),
-    (),
-> {
-    let gclk0 = clocks.gclk0();
+/// UART Pads for the ESP32 Wi-Fi co-processor
+pub type EspUartPads = uart::Pads<EspUartSercom, IoSet1, EspUartRx, EspUartTx>;
 
-    UART4::new(
-        &clocks.sercom4_core(&gclk0).unwrap(),
-        baud.into(),
-        sercom4,
-        mclk,
-        (esp_rx.into_pad(port), esp_tx.into_pad(port)),
-    )
+/// UART device for the ESP32 Wi-Fi co-processor
+pub type EspUart = uart::Uart<uart::Config<EspUartPads>, uart::Duplex>;
+
+/// UART is connected to the ESP32 Wi-Fi co-processor
+pub fn esp_uart(
+    clocks: &mut GenericClockController,
+    baud: impl Into<Hertz>,
+    sercom: EspUartSercom,
+    mclk: &mut pac::MCLK,
+    esp_rx: impl Into<EspUartRx>,
+    esp_tx: impl Into<EspUartTx>,
+) -> EspUart {
+    let gclk0 = clocks.gclk0();
+    let clock = &clocks.sercom4_core(&gclk0).unwrap();
+    let baud = baud.into();
+    let pads = uart::Pads::default().rx(esp_rx.into()).tx(esp_tx.into());
+    uart::Config::new(mclk, sercom, pads, clock.freq())
+        .baud(baud, BaudMode::Fractional(Oversampling::Bits16))
+        .enable()
+}
+
+#[cfg(feature = "usb")]
+/// Convenience function for setting up USB
+pub fn usb_allocator(
+    dm: impl Into<UsbDm>,
+    dp: impl Into<UsbDp>,
+    usb: pac::USB,
+    clocks: &mut GenericClockController,
+    mclk: &mut pac::MCLK,
+) -> UsbBusAllocator<UsbBus> {
+    use pac::gclk::{genctrl::SRC_A, pchctrl::GEN_A};
+
+    clocks.configure_gclk_divider_and_source(GEN_A::GCLK2, 1, SRC_A::DFLL, false);
+    let usb_gclk = clocks.get_gclk(GEN_A::GCLK2).unwrap();
+    let usb_clock = &clocks.usb(&usb_gclk).unwrap();
+    let (dm, dp) = (dm.into(), dp.into());
+    UsbBusAllocator::new(UsbBus::new(usb_clock, mclk, dm, dp, usb))
 }

--- a/boards/pyportal/src/pins.rs
+++ b/boards/pyportal/src/pins.rs
@@ -1,116 +1,350 @@
 //! PyPortal pins
 
-use super::{hal, pac};
+use super::hal;
 
-use crate::hal::gpio::{self, *};
-use hal::define_pins;
+hal::bsp_pins!(
+    PA02 {
+        /// Analog pin 0.  Can act as a true analog output
+        /// as it has a DAC (which is not currently supported
+        /// by this hal) as well as input.
+        name: speaker,
+        aliases: {
+            Reset: SpeakerReset,
+        }
+    }
+    PA27 {
+        /// enable speaker amplifier
+        name: speaker_enable,
+        aliases: {
+            Reset: SpeakerEnableReset,
+        }
+    }
+    PA07 {
+        /// Light sensor
+        name: light,
+        aliases: {
+            AlternateB: LightSensorAdc,
+            Reset: LightSensorReset,
+        }
+    }
+    PA04 {
+        // STEMMA connectors
+        /// Pin D3
+        name: d3,
+        aliases: {
+            Reset: D3Reset,
+        }
+    }
+    PA05 {
+        /// Pin D4
+        name: d4,
+        aliases: {
+            Reset: D4Reset,
+        }
+    }
+    PB23 {
+        /// D13 LED
+        name: d13,
+        aliases: {
+            PushPullOutput: RedLed,
+            Reset: RedLedReset,
+        }
+    }
+    PB22 {
+        /// Neopixel status LED
+        name: neopixel,
+        aliases: {
+            Reset: NeopixelReset,
+            PushPullOutput: Neopixel,
+        }
+    }
 
-define_pins!(
-    /// Maps the pins to their arduino names and
-    /// the numbers printed on the board.
-    struct Pins,
-    pac: pac,
+    PA00 {
+        // TFT(Thin-film-transistor liquid-crystal display) control ports
+        /// TFT Reset
+        name: tft_reset,
+        aliases: {
+            PushPullOutput: TftReset,
+            Reset: TftResetReset,
+        }
+    }
+    PB04 {
+        /// TFT RD
+        name: tft_rd,
+        aliases: {
+            PushPullOutput: TftRd,
+            Reset: TftRdReset,
+        }
+    }
+    PB05 {
+        /// TFT RS
+        name: tft_rs,
+        aliases: {
+            PushPullOutput: TftRs,
+            Reset: TftRsReset,
+        }
+    }
+    PB06 {
+        /// TFT CS
+        name: tft_cs,
+        aliases: {
+            PushPullOutput: TftCs,
+            Reset: TftCsReset,
+        }
+    }
+    PB07 {
+        /// TFT TE
+        name: tft_te,
+        aliases: {
+            Reset: TftTeReset,
+        }
+    }
+    PB09 {
+        /// TFT WR
+        name: tft_wr,
+        aliases: {
+            PushPullOutput: TftWr,
+            Reset: TftWrReset,
+        }
+    }
+    PB31 {
+        /// TFT Backlight
+        name: tft_backlight,
+        aliases: {
+            PushPullOutput: TftBacklight,
+            AlternateE: TftBacklightPwm
+            Reset: TftBacklightReset,
+        }
+    }
+    PA16 {
+        /// LCD Data 0
+        name: lcd_data0,
+        aliases: {
+            PushPullOutput: LcdData0,
+            Reset: LcdData0Reset,
+        }
+    }
+    PA17 {
+        /// LCD Data 1
+        name: lcd_data1,
+        aliases: {
+            PushPullOutput: LcdData1,
+            Reset: LcdData1Reset,
+        }
+    }
+    PA18 {
+        /// LCD Data 2
+        name: lcd_data2,
+        aliases: {
+            PushPullOutput: LcdData2,
+            Reset: LcdData2Reset,
+        }
+    }
+    PA19 {
+        /// LCD Data 3
+        name: lcd_data3,
+        aliases: {
+            PushPullOutput: LcdData3,
+            Reset: LcdData3Reset,
+        }
+    }
+    PA20 {
+        /// LCD Data 4
+        name: lcd_data4,
+        aliases: {
+            PushPullOutput: LcdData4,
+            Reset: LcdData4Reset,
+        }
+    }
+    PA21 {
+        /// LCD Data 5
+        name: lcd_data5,
+        aliases: {
+            PushPullOutput: LcdData5,
+            Reset: LcdData5Reset,
+        }
+    }
+    PA22 {
+        /// LCD Data 6
+        name: lcd_data6,
+        aliases: {
+            PushPullOutput: LcdData6,
+            Reset: LcdData6Reset,
+        }
+    }
+    PA23 {
+        /// LCD Data 7
+        name: lcd_data7,
+        aliases: {
+            PushPullOutput: LcdData7,
+            Reset: LcdData7Reset,
+        }
+    }
 
-    /// Analog pin 0.  Can act as a true analog output
-    /// as it has a DAC (which is not currently supported
-    /// by this hal) as well as input.
-    pin speaker = a2,
-    /// enable speaker amplifier
-    pin speaker_enable = a27,
+    PB00 {
+        // Touchscreen pins
+        /// Touch YD
+        name: touch_yd,
+        aliases: {
+            AlternateB: TouchYd,
+            Reset: TouchYdReset,
+        }
+    }
+    PB01 {
+        /// Touch XL
+        name: touch_xl,
+        aliases: {
+            AlternateB: TouchXl,
+            Reset: TouchXlReset,
+        }
+    }
+    PA06 {
+        /// Touch YU
+        name: touch_yu,
+        aliases: {
+            AlternateB: TouchYu,
+            Reset: TouchYuReset,
+        }
+    }
+    PB08 {
+        /// Touch XR
+        name: touch_xr,
+        aliases: {
+            AlternateB: TouchXr,
+            Reset: TouchXrReset,
+        }
+    }
 
-    /// Light sensor
-    pin light = a7,
+    PB14 {
+        // ESP control - ESP32 WiFi
+        /// Pin ESP CS
+        name: esp_cs,
+        aliases: {
+            Reset: EspCsReset,
+        }
+    }
+    PB15 {
+        /// Pin ESP GPIO0
+        name: esp_gpio0,
+        aliases: {
+            Reset: EspGpio0Reset
+        }
+    }
+    PB16 {
+        /// Pin ESP Busy
+        name: esp_busy,
+        aliases: {
+            Reset: EspBusyReset,
+        }
+    }
+    PB17 {
+        /// Pin ESP Reset
+        name: esp_reset,
+        aliases: {
+            Reset: EspResetReset,
+        }
+    }
+    PA15 {
+        /// Pin ESP RTS
+        name: esp_rts,
+        aliases: {
+            Reset: EspRtsReset,
+        }
+    }
 
-    // STEMMA connectors
-    /// Pin D3
-    pin d3 = a4,
-    /// Pin D4
-    pin d4 = a5,
+    PB12 {
+        // UART - Universal Asynchronous Receiver/Transmitter (connected to ESP32)
+        /// Pin TX
+        name: esp_tx,
+        aliases: {
+            AlternateC: EspUartTx,
+            Reset: EspUartTxReset,
+        }
+    }
+    PB13 {
+        /// Pin RX
+        name: esp_rx,
+        aliases: {
+            AlternateC: EspUartRx,
+            Reset: EspUartRxReset,
+        }
+    }
 
-    /// D13 LED
-    pin d13 = b23,
-    /// Neopixel status LED
-    pin neopixel = b22,
+    PA12 {
+        // SPI - Serial Peripheral Interface
+        /// Pin MOSI
+        name: mosi,
+        aliases: {
+            AlternateC: Mosi,
+            Reset: MosiReset,
+        }
+    }
+    PA13 {
+        /// Pin SCK
+        name: sck,
+        aliases: {
+            AlternateC: Sck,
+            Reset: SckReset,
+        }
+    }
+    PA14 {
+        /// Pin MISO
+        name: miso,
+        aliases: {
+            AlternateC: Miso,
+            Reset: MisoReset,
+        }
+    }
 
-    // TFT(Thin-film-transistor liquid-crystal display) control ports
-    /// TFT Reset
-    pin tft_reset = a0,
-    /// TFT RD
-    pin tft_rd = b4,
-    /// TFT RS
-    pin tft_rs = b5,
-    /// TFT CS
-    pin tft_cs = b6,
-    /// TFT TE
-    pin tft_te = b7,
-    /// TFT WR
-    pin tft_wr = b9,
-    /// TFT Backlight
-    pin tft_backlight = b31,
+    PB02 {
+        // I2C - ADT7410 Analog Devices temperature sensor
+        /// Pin SDA
+        name: sda,
+        aliases: {
+            AlternateD: Sda,
+            Reset: SdaReset,
+        }
+    }
+    PB03 {
+        /// Pin SCL
+        name: scl,
+        aliases: {
+            AlternateD: Scl,
+            Reset: SclReset,
+        }
+    }
 
-    /// LCD Data 0
-    pin lcd_data0 = a16,
-    /// LCD Data 1
-    pin lcd_data1 = a17,
-    /// LCD Data 2
-    pin lcd_data2 = a18,
-    /// LCD Data 3
-    pin lcd_data3 = a19,
-    /// LCD Data 4
-    pin lcd_data4 = a20,
-    /// LCD Data 5
-    pin lcd_data5 = a21,
-    /// LCD Data 6
-    pin lcd_data6 = a22,
-    /// LCD Data 7
-    pin lcd_data7 = a23,
+    PB30 {
+        /// Pin SD CS
+        name: sd_cs,
+        aliases: {
+            Reset: SdCsReset,
+        }
+    }
+    PA01 {
+        /// Pin SD card detect
+        name: sd_card_detect,
+        aliases: {
+            Reset: SdCardDetectReset,
+        }
+    }
 
-    /// Touchscreen pins
-    /// Touch YD
-    pin touch_yd = b0,
-    /// Touch XL
-    pin touch_xl = b1,
-    /// Touch YU
-    pin touch_yu = a6,
-    /// Touch XR
-    pin touch_xr = b8,
-
-    // ESP control - ESP32 WiFi
-    /// Pin ESP CS
-    pin esp_cs = b14,
-    /// Pin ESP GPIO0
-    pin esp_gpio0 = b15,
-    /// Pin ESP Busy
-    pin esp_busy = b16,
-    /// Pin ESP Reset
-    pin esp_reset = b17,
-    /// Pin ESP RTS
-    pin esp_rts = a15,
-
-    // UART - Universal Asynchronous Receiver/Transmitter (connected to ESP32)
-    /// Pin TX
-    pin esp_tx = b12,
-    /// Pin RX
-    pin esp_rx = b13,
-
-    // SPI - Serial Peripheral Interface
-    /// Pin MOSI
-    pin mosi = a12,
-    /// Pin SCK
-    pin sck = a13,
-    /// Pin MISO
-    pin miso = a14,
-
-    // I2C - ADT7410 Analog Devices temperature sensor
-    /// Pin SDA
-    pin sda = b2,
-    /// Pin SCL
-    pin scl = b3,
-
-    /// Pin SD CS
-    pin sd_cs = b30,
-    /// Pin SD card detect
-    pin sd_card_detect = a1,
+    PA24 {
+        /// The USB D- pad
+        name: usb_dm
+        aliases: {
+            AlternateG: UsbDm,
+            Reset: UsbDmReset,
+        }
+    }
+    PA25 {
+        /// The USB D+ pad
+        name: usb_dp
+        aliases: {
+            AlternateG: UsbDp,
+            Reset: UsbDpReset,
+        }
+    }
 );
 
 impl Pins {
@@ -132,13 +366,12 @@ impl Pins {
             tft_rs: self.tft_rs,
             tft_cs: self.tft_cs,
             tft_te: self.tft_te,
-
             tft_wr: self.tft_wr,
             tft_backlight: self.tft_backlight,
+
             lcd_data0: self.lcd_data0,
             lcd_data1: self.lcd_data1,
             lcd_data2: self.lcd_data2,
-
             lcd_data3: self.lcd_data3,
             lcd_data4: self.lcd_data4,
             lcd_data5: self.lcd_data5,
@@ -182,8 +415,12 @@ impl Pins {
             card_detect: self.sd_card_detect,
         };
 
+        let usb = Usb {
+            usb_dm: self.usb_dm,
+            usb_dp: self.usb_dp,
+        };
+
         Sets {
-            port: self.port,
             display,
             esp,
             light: self.light,
@@ -196,17 +433,17 @@ impl Pins {
             esp_uart,
             d13: self.d13,
             neopixel: self.neopixel,
+            usb,
         }
     }
 }
 
 pub struct Sets {
-    pub port: Port,
     pub display: Display,
-    pub d13: Pb23<Input<Floating>>,
-    pub neopixel: Pb22<Input<Floating>>,
+    pub d13: RedLedReset,
+    pub neopixel: NeopixelReset,
     pub esp: Esp,
-    pub light: Pa7<Input<Floating>>,
+    pub light: LightSensorReset,
     pub i2c: I2C,
     pub sd: SdCard,
     pub speaker: Speaker,
@@ -214,68 +451,74 @@ pub struct Sets {
     pub stemma: Stemma,
     pub touchscreen: Touchscreen,
     pub esp_uart: EspUart,
+    pub usb: Usb,
 }
 
 pub struct Display {
-    pub tft_reset: Pa0<Input<Floating>>,
-    pub tft_rd: Pb4<Input<Floating>>,
-    pub tft_rs: Pb5<Input<Floating>>,
-    pub tft_cs: Pb6<Input<Floating>>,
-    pub tft_te: Pb7<Input<Floating>>,
-    pub tft_wr: Pb9<Input<Floating>>,
-    pub tft_backlight: Pb31<Input<Floating>>,
-    pub lcd_data0: Pa16<Input<Floating>>,
-    pub lcd_data1: Pa17<Input<Floating>>,
-    pub lcd_data2: Pa18<Input<Floating>>,
-    pub lcd_data3: Pa19<Input<Floating>>,
-    pub lcd_data4: Pa20<Input<Floating>>,
-    pub lcd_data5: Pa21<Input<Floating>>,
-    pub lcd_data6: Pa22<Input<Floating>>,
-    pub lcd_data7: Pa23<Input<Floating>>,
+    pub tft_reset: TftResetReset,
+    pub tft_rd: TftRdReset,
+    pub tft_rs: TftRsReset,
+    pub tft_cs: TftCsReset,
+    pub tft_te: TftTeReset,
+    pub tft_wr: TftWrReset,
+    pub tft_backlight: TftBacklightReset,
+    pub lcd_data0: LcdData0Reset,
+    pub lcd_data1: LcdData1Reset,
+    pub lcd_data2: LcdData2Reset,
+    pub lcd_data3: LcdData3Reset,
+    pub lcd_data4: LcdData4Reset,
+    pub lcd_data5: LcdData5Reset,
+    pub lcd_data6: LcdData6Reset,
+    pub lcd_data7: LcdData7Reset,
 }
 
 pub struct Esp {
-    pub cs: Pb14<Input<Floating>>,
-    pub gpio0: Pb15<Input<Floating>>,
-    pub busy: Pb16<Input<Floating>>,
-    pub reset: Pb17<Input<Floating>>,
-    pub rts: Pa15<Input<Floating>>,
+    pub cs: EspCsReset,
+    pub gpio0: EspGpio0Reset,
+    pub busy: EspBusyReset,
+    pub reset: EspResetReset,
+    pub rts: EspRtsReset,
 }
 
 pub struct I2C {
-    pub sda: Pb2<Input<Floating>>,
-    pub scl: Pb3<Input<Floating>>,
+    pub sda: SdaReset,
+    pub scl: SclReset,
 }
 
 pub struct SdCard {
-    pub cs: Pb30<Input<Floating>>,
-    pub card_detect: Pa1<Input<Floating>>,
+    pub cs: SdCsReset,
+    pub card_detect: SdCardDetectReset,
 }
 
 pub struct Speaker {
-    pub speaker: Pa2<Input<Floating>>,
-    pub enable: Pa27<Input<Floating>>,
+    pub speaker: SpeakerReset,
+    pub enable: SpeakerEnableReset,
 }
 
 pub struct Spi {
-    pub mosi: Pa12<Input<Floating>>,
-    pub sck: Pa13<Input<Floating>>,
-    pub miso: Pa14<Input<Floating>>,
+    pub mosi: MosiReset,
+    pub sck: SckReset,
+    pub miso: MisoReset,
 }
 
 pub struct Stemma {
-    pub d3: Pa4<Input<Floating>>,
-    pub d4: Pa5<Input<Floating>>,
+    pub d3: D3Reset,
+    pub d4: D4Reset,
 }
 
 pub struct Touchscreen {
-    pub yd: Pb0<Input<Floating>>,
-    pub xl: Pb1<Input<Floating>>,
-    pub yu: Pa6<Input<Floating>>,
-    pub xr: Pb8<Input<Floating>>,
+    pub yd: TouchYdReset,
+    pub xl: TouchXlReset,
+    pub yu: TouchYuReset,
+    pub xr: TouchXrReset,
 }
 
 pub struct EspUart {
-    pub tx: Pb12<Input<Floating>>,
-    pub rx: Pb13<Input<Floating>>,
+    pub tx: EspUartTxReset,
+    pub rx: EspUartRxReset,
+}
+
+pub struct Usb {
+    pub usb_dm: UsbDmReset,
+    pub usb_dp: UsbDpReset,
 }


### PR DESCRIPTION
# Summary
Updated `atsamd-hal` from 0.14.0 to 0.15.1
Incremented crate version to 0.10.0
Added usb feature to bsp, and example
Added display feature to bsp and example

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)