### PR TITLE
Remove invalid device_class from twitching_usb_mouse example

### DIFF
--- a/boards/itsybitsy_m0/CHANGELOG.md
+++ b/boards/itsybitsy_m0/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+- Fix issue with twitching_usb_mouse example not working on MacOS
+
 # 0.13.0
 
 - Big rework of board code by copying the code from feather_m0 and implementing the HW differences (both boards are now more similar to each other) and the corresponding examples ([#559](https://github.com/atsamd-rs/atsamd/pull/559))

--- a/boards/itsybitsy_m0/examples/twitching_usb_mouse.rs
+++ b/boards/itsybitsy_m0/examples/twitching_usb_mouse.rs
@@ -57,7 +57,6 @@ fn main() -> ! {
                 .manufacturer("Fake company")
                 .product("Twitchy Mousey")
                 .serial_number("TEST")
-                .device_class(0xEF) // misc
                 .build(),
         );
     }


### PR DESCRIPTION
# Summary
Remove invalid device_class from itsybitsy_m0 twitching_usb_mouse example that stopped it from functioning on MacOS

# Checklist
  - [X] `CHANGELOG.md` for the BSP or HAL updated
  - [X] All new or modified code is well documented, especially public items
  - [X] No new warnings or clippy suggestions have been introduced (see CI or check locally)