### PR TITLE
Make items from thumbv(6|7e)m modules visible in the main docs page

### DIFF
--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -110,13 +110,17 @@ compile_error!("'usb' is enabled, but USB isn't supported on SAMD11");
 compile_error!("The 'usb' feature is enabled, but not a chip with USB support");
 
 #[cfg(any(feature = "samd11", feature = "samd21"))]
+#[doc(hidden)]
 pub mod thumbv6m;
 #[cfg(any(feature = "samd11", feature = "samd21"))]
+#[doc(inline)]
 pub use crate::thumbv6m::*;
 
 #[cfg(feature = "min-samd51g")]
+#[doc(hidden)]
 pub mod thumbv7em;
 #[cfg(feature = "min-samd51g")]
+#[doc(inline)]
 pub use crate::thumbv7em::*;
 
 #[macro_use]


### PR DESCRIPTION
# Summary

Main page in docs does not contain contents of `thumb*` modules which in turn should be an implementation detail. We can either

- Add `doc` attributes to force a desired behaviour of `rustdoc`
- Make modules private which will cause automatic documentation inlining (but will introduce a breaking change)

This PR is supposed to serve as a discussion board.