### PR TITLE
Fix bug in `dmac` where software triggers didn't work

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased Changes
 
+- Fix bug in `dmac` where software trigger would not work
 - Fix failing `bsp_pins!` invocation with no aliases (#605 fixes #599)
 - Add Advanced Encryption Standard (AES) peripheral support including RustCrypto compatible backend
 

--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -199,7 +199,7 @@ impl<Id: ChId, S: Status> Channel<Id, S> {
 
     #[inline]
     fn _trigger_private(&mut self) {
-        self.regs.swtrigctrl.write_bit(true);
+        self.regs.swtrigctrl.set_bit();
     }
 }
 

--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -252,19 +252,18 @@ impl<Id: ChId> Channel<Id, Ready> {
         // Configure the trigger source and trigger action
         // SAFETY: This is actually safe because we are writing the correct enum value
         // (imported from the PAC) into the register
-        unsafe {
-            #[cfg(any(feature = "samd11", feature = "samd21"))]
-            self.regs.chctrlb.modify(|_, w| {
-                w.trigsrc().bits(trig_src as u8);
-                w.trigact().bits(trig_act as u8)
-            });
 
-            #[cfg(feature = "min-samd51g")]
-            self.regs.chctrla.modify(|_, w| {
-                w.trigsrc().bits(trig_src as u8);
-                w.trigact().bits(trig_act as u8)
-            });
-        }
+        #[cfg(any(feature = "samd11", feature = "samd21"))]
+        self.regs.chctrlb.modify(|_, w| {
+            w.trigsrc().variant(trig_src);
+            w.trigact().variant(trig_act)
+        });
+
+        #[cfg(feature = "min-samd51g")]
+        self.regs.chctrla.modify(|_, w| {
+            w.trigsrc().variant(trig_src);
+            w.trigact().variant(trig_act)
+        });
 
         // Start channel
         self.regs.chctrla.modify(|_, w| w.enable().set_bit());

--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -250,9 +250,6 @@ impl<Id: ChId> Channel<Id, Ready> {
         trig_act: TriggerAction,
     ) -> Channel<Id, Busy> {
         // Configure the trigger source and trigger action
-        // SAFETY: This is actually safe because we are writing the correct enum value
-        // (imported from the PAC) into the register
-
         #[cfg(any(feature = "samd11", feature = "samd21"))]
         self.regs.chctrlb.modify(|_, w| {
             w.trigsrc().variant(trig_src);

--- a/hal/src/dmac/channel/reg.rs
+++ b/hal/src/dmac/channel/reg.rs
@@ -243,7 +243,7 @@ macro_rules! reg_proxy {
                     // to the bit controlled by the channel.
                     self.dmac
                         .[< $reg:lower >]
-                        .modify(|_, w| unsafe { w.bits((bit as u32) << Id::U8) });
+                        .write(|w| unsafe { w.bits((bit as u32) << Id::U8) });
                 }
             }
         }

--- a/hal/src/dmac/channel/reg.rs
+++ b/hal/src/dmac/channel/reg.rs
@@ -243,7 +243,17 @@ macro_rules! reg_proxy {
                     // to the bit controlled by the channel.
                     self.dmac
                         .[< $reg:lower >]
-                        .write(|w| unsafe { w.bits((bit as u32) << Id::U8) });
+                        .modify(|r, w| unsafe {
+                            // Set bit
+                            if bit {
+                                w.bits(r.bits() | ((bit as u32) << Id::U8))
+                            }
+
+                            // Clear bit
+                            else {
+                                w.bits(r.bits() & !((bit as u32) << Id::U8))
+                            }
+                        });
                 }
             }
         }

--- a/hal/src/dmac/channel/reg.rs
+++ b/hal/src/dmac/channel/reg.rs
@@ -243,7 +243,7 @@ macro_rules! reg_proxy {
                     // to the bit controlled by the channel.
                     self.dmac
                         .[< $reg:lower >]
-                        .modify(|r, w| unsafe { w.bits(r.bits() & ((bit as u32) << Id::U8)) });
+                        .modify(|_, w| unsafe { w.bits((bit as u32) << Id::U8) });
                 }
             }
         }

--- a/hal/src/dmac/channel/reg.rs
+++ b/hal/src/dmac/channel/reg.rs
@@ -238,22 +238,22 @@ macro_rules! reg_proxy {
             {
                 #[inline]
                 #[allow(dead_code)]
-                pub fn write_bit(&mut self, bit: bool) {
+                pub fn set_bit(&mut self) {
                     // SAFETY: This is safe because we are only writing
                     // to the bit controlled by the channel.
-                    self.dmac
-                        .[< $reg:lower >]
-                        .modify(|r, w| unsafe {
-                            // Set bit
-                            if bit {
-                                w.bits(r.bits() | ((bit as u32) << Id::U8))
-                            }
+                    unsafe {
+                        self.dmac.[< $reg:lower >].modify(|r, w| w.bits(r.bits() | (1 << Id::U8)));
+                    }
+                }
 
-                            // Clear bit
-                            else {
-                                w.bits(r.bits() & !((bit as u32) << Id::U8))
-                            }
-                        });
+                #[inline]
+                #[allow(dead_code)]
+                pub fn clear_bit(&mut self) {
+                    // SAFETY: This is safe because we are only writing
+                    // to the bit controlled by the channel.
+                    unsafe {
+                        self.dmac.[< $reg:lower >].modify(|r, w| w.bits(r.bits() & !(1 << Id::U8)));
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Summary
I realized that the `dmac` examples were no longer working. After running `git bisect`, I narrowed down the bug to #432, where the register proxy architecture introduced a bug preventing DMAC software triggers from working. This PR fixes that, along with removing an unnecessary `unsafe` block in the `dmac` module.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)