### PR TITLE
AES: Move Changelog entry to unreleased

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased Changes
 
 - Fix failing `bsp_pins!` invocation with no aliases (#605 fixes #599)
+- Add Advanced Encryption Standard (AES) peripheral support including RustCrypto compatible backend
 
 # v0.15.1
 
@@ -45,7 +46,6 @@
 - Add Device Service Unit (DSU), Non-volatile Controller (NVM), SmartEEPROM support (#526)
 - Expand Public Key Cryptography Controller (PUKCC) to support modular
   exponentiation (RSA) (#544)
-- Add Advanced Encryption Standard (AES) peripheral support including RustCrypto compatible backend
 
 ---
 


### PR DESCRIPTION
# Summary
AES Support was not moved to unreleased section after rebasing, fix this
