### PR TITLE
thumbv6m: fix USB clock recovery

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased Changes
 
+- Correct thumbv6 DFLL multiplier to fix USB clock correction
 - Fix failing `bsp_pins!` invocation with no aliases (#605 fixes #599)
 - Add Advanced Encryption Standard (AES) peripheral support including RustCrypto compatible backend
 - Add embedded-hal `InputPin` trait to EIC pins

--- a/hal/src/thumbv6m/clock.rs
+++ b/hal/src/thumbv6m/clock.rs
@@ -560,8 +560,8 @@ fn configure_and_enable_dfll48m(sysctrl: &mut SYSCTRL, use_external_crystal: boo
         sysctrl.dfllmul.write(|w| unsafe {
             w.cstep().bits(coarse / 4);
             w.fstep().bits(10);
-            // scaling factor between the clocks
-            w.mul().bits((48_000_000u32 / 32768) as u16)
+            // scaling factor for 1 kHz USB SOF signal
+            w.mul().bits((48_000_000u32 / 1000) as u16)
         });
 
         // Turn it on
@@ -575,11 +575,7 @@ fn configure_and_enable_dfll48m(sysctrl: &mut SYSCTRL, use_external_crystal: boo
             // chill cycle disable
             w.ccdis().set_bit();
 
-            // usb correction is not set due to instability issues around
-            // USB bus resets. TODO(twitchyliquid64): Maybe switch to OSC8M?
-            //
-            // TODO usb correction (still active for samd11??)
-            #[cfg(feature = "samd11")]
+            // usb correction
             w.usbcrm().set_bit();
 
             // bypass coarse lock (have calibration data)


### PR DESCRIPTION
# Summary

USB clock recovery was disabled because it caused USB resets and instability. This occurred because the DFFLMUL.MUL was set to the wrong value. The multiplier must be 48000 to obtain a 48 MHz clock from the 1 kHz USB SOF signal.

There appears to be no harm in unconditionally enabling USB clock recovery when there is no external crystal, since it will just operate in open loop mode (as before) when USB is not connected.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [ ] All new or modified code is well documented, especially public items
  - [ ] No new warnings or clippy suggestions have been introduced (see CI or check locally)

## If Adding a new Board
  - [ ] Board CI added to `crates.json`
  - [ ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"