### PR TITLE
Added InputPin trait impl to EIC pins

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix failing `bsp_pins!` invocation with no aliases (#605 fixes #599)
 - Add Advanced Encryption Standard (AES) peripheral support including RustCrypto compatible backend
+- Add embedded-hal `InputPin` trait to EIC pins
 
 # v0.15.1
 

--- a/hal/src/thumbv6m/eic/pin.rs
+++ b/hal/src/thumbv6m/eic/pin.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "unproven")]
+use crate::ehal::digital::v2::InputPin;
 use crate::gpio::{
     self, pin::*, AnyPin, FloatingInterrupt, PinId, PinMode, PullDownInterrupt, PullUpInterrupt,
 };
@@ -143,6 +145,23 @@ crate::paste::item! {
                     _ => unreachable!(),
                 }
             });
+        }
+    }
+
+    #[cfg(feature = "unproven")]
+    impl<GPIO, C> InputPin for [<$PadType $num>]<GPIO>
+    where
+        GPIO: AnyPin<Mode = Interrupt<C>>,
+        C: InterruptConfig,
+    {
+        type Error = core::convert::Infallible;
+        #[inline]
+        fn is_high(&self) -> Result<bool, Self::Error> {
+            self._pin.is_high()
+        }
+        #[inline]
+        fn is_low(&self) -> Result<bool, Self::Error> {
+            self._pin.is_low()
         }
     }
 

--- a/hal/src/thumbv7em/eic/pin.rs
+++ b/hal/src/thumbv7em/eic/pin.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "unproven")]
+use crate::ehal::digital::v2::InputPin;
 use crate::gpio::{
     self, pin::*, AnyPin, FloatingInterrupt, PinId, PinMode, PullDownInterrupt, PullUpInterrupt,
 };
@@ -143,6 +145,23 @@ crate::paste::item! {
                     _ => unreachable!(),
                 }
             });
+        }
+    }
+
+    #[cfg(feature = "unproven")]
+    impl<GPIO, C> InputPin for [<$PadType $num>]<GPIO>
+    where
+        GPIO: AnyPin<Mode = Interrupt<C>>,
+        C: InterruptConfig,
+    {
+        type Error = core::convert::Infallible;
+        #[inline]
+        fn is_high(&self) -> Result<bool, Self::Error> {
+            self._pin.is_high()
+        }
+        #[inline]
+        fn is_low(&self) -> Result<bool, Self::Error> {
+            self._pin.is_low()
         }
     }
 


### PR DESCRIPTION
# Summary
Adds embedded-hal `InputPin` trait implementation to EIC pins so that you can read the state of an EIC pin. This is useful for when you are sensing both edges and want to read the level to determine which edge was seen. Addresses #629.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)