### PR TITLE
Add Nina pin aliases to arduino_nano33iot

### DIFF
--- a/boards/arduino_nano33iot/CHANGELOG.md
+++ b/boards/arduino_nano33iot/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-# v0.7.0
+- add Nina pin aliases
+
+## v0.7.0
 
 - update to `atsamd-hal-0.14` and other latest dependencies (#564)
 - remove extraneous `embedded-hal` dependencies from BSPs


### PR DESCRIPTION
Add pin aliases for the Nina peripheral.

Sercom2 is configured on the necessary pins with pin mode C on all 4 SPI pins (https://ww1.microchip.com/downloads/en/DeviceDoc/SAM_D21_DA1_Family_DataSheet_DS40001882F.pdf)