### PR TITLE
Fix for incorrect feature gates for pins of `samd21gl` chip

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased Changes
 
+- Fix for incorrect feature gates for pins of `samd21gl` chip
 - Fix bug in `dmac` where software trigger would not work
 - Correct thumbv6 DFLL multiplier to fix USB clock correction
 - Fix failing `bsp_pins!` invocation with no aliases (#605 fixes #599)

--- a/hal/src/sercom/pad/impl_pad_thumbv6m.rs
+++ b/hal/src/sercom/pad/impl_pad_thumbv6m.rs
@@ -317,11 +317,11 @@ pad_table!(
     PB17 {
         C: (Sercom5, Pad1) + I2C,
     }
-    #[cfg(feature = "min-samd21g")]
+    #[cfg(all(feature = "min-samd21g", not(feature = "samd21gl")))]
     PB22 {
         D: (Sercom5, Pad2),
     }
-    #[cfg(feature = "min-samd21g")]
+    #[cfg(all(feature = "min-samd21g", not(feature = "samd21gl")))]
     PB23 {
         D: (Sercom5, Pad3),
     }

--- a/hal/src/thumbv6m/eic/pin.rs
+++ b/hal/src/thumbv6m/eic/pin.rs
@@ -315,7 +315,7 @@ ei!(ExtInt[6] {
     PA22,
     #[cfg(feature = "min-samd21j")]
     PB06,
-    #[cfg(feature = "min-samd21g")]
+    #[cfg(all(feature = "min-samd21g", not(feature = "samd21gl")))]
     PB22,
 });
 
@@ -325,7 +325,7 @@ ei!(ExtInt[7] {
     PA23,
     #[cfg(feature = "min-samd21j")]
     PB07,
-    #[cfg(feature = "min-samd21g")]
+    #[cfg(all(feature = "min-samd21g", not(feature = "samd21gl")))]
     PB23,
 });
 


### PR DESCRIPTION
# Summary
If trying to build the HAL for samd21gl chip, compilation fails. Some modules incorrectly assume presence of pins PB22 and PB23 which samd21gl does not seem to have

[describe your changes here]

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated