### PR TITLE
Fix `ExternalInterrupt` implementations for `eic`

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased Changes
 
+- Fix `ExternalInterrupt` implementations for `eic`
 - Fix for incorrect feature gates for pins of `samd21gl` chip
 - Fix bug in `dmac` where software trigger would not work
 - Correct thumbv6 DFLL multiplier to fix USB clock correction

--- a/hal/src/thumbv6m/eic/pin.rs
+++ b/hal/src/thumbv6m/eic/pin.rs
@@ -148,6 +148,12 @@ crate::paste::item! {
         }
     }
 
+    impl<GPIO: AnyPin> ExternalInterrupt for [<$PadType $num>]<GPIO> {
+        fn id(&self) -> ExternalInterruptID {
+            $num
+        }
+    }
+
     #[cfg(feature = "unproven")]
     impl<GPIO, C> InputPin for [<$PadType $num>]<GPIO>
     where
@@ -186,7 +192,7 @@ crate::paste::item! {
         }
 
         $(#[$attr])*
-        impl ExternalInterrupt for gpio::$PinType {
+        impl<M: PinMode> ExternalInterrupt for Pin<gpio::$PinType, M> {
             fn id(&self) -> ExternalInterruptID {
                 $num
             }
@@ -195,17 +201,6 @@ crate::paste::item! {
 }
 
     };
-}
-
-impl<I, M> ExternalInterrupt for Pin<I, M>
-where
-    I: PinId,
-    M: PinMode,
-    Pin<I, M>: ExternalInterrupt,
-{
-    fn id(&self) -> ExternalInterruptID {
-        Pin::<I, M>::id(self)
-    }
 }
 
 // The SAMD11 and SAMD21 devices have different ExtInt designations. Just for

--- a/hal/src/thumbv7em/eic/pin.rs
+++ b/hal/src/thumbv7em/eic/pin.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "unproven")]
 use crate::ehal::digital::v2::InputPin;
 use crate::gpio::{
-    self, pin::*, AnyPin, FloatingInterrupt, PinId, PinMode, PullDownInterrupt, PullUpInterrupt,
+    self, pin::*, AnyPin, FloatingInterrupt, PinMode, PullDownInterrupt, PullUpInterrupt,
 };
 use crate::pac;
 
@@ -148,6 +148,12 @@ crate::paste::item! {
         }
     }
 
+    impl<GPIO: AnyPin> ExternalInterrupt for [<$PadType $num>]<GPIO> {
+        fn id(&self) -> ExternalInterruptID {
+            $num
+        }
+    }
+
     #[cfg(feature = "unproven")]
     impl<GPIO, C> InputPin for [<$PadType $num>]<GPIO>
     where
@@ -186,7 +192,8 @@ crate::paste::item! {
         }
 
         $(#[$attr])*
-        impl ExternalInterrupt for gpio::$PinType {
+        impl<M: PinMode> ExternalInterrupt for Pin<gpio::$PinType, M>
+        {
             fn id(&self) -> ExternalInterruptID {
                 $num
             }
@@ -195,17 +202,6 @@ crate::paste::item! {
 }
 
     };
-}
-
-impl<I, M> ExternalInterrupt for Pin<I, M>
-where
-    I: PinId,
-    M: PinMode,
-    Pin<I, M>: ExternalInterrupt,
-{
-    fn id(&self) -> ExternalInterruptID {
-        Pin::<I, M>::id(self)
-    }
 }
 
 ei!(ExtInt[0] {


### PR DESCRIPTION
# Summary
Fix broken `ExternalInterrupt` implementations for `thumbv6m::eic` and `thumbv7em::eic` modules.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)

## If Adding a new Board
  - [ ] Board CI added to `crates.json`
  - [ ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"