### PR TITLE
Fix wio-terminal Wi-Fi

### DIFF
--- a/boards/wio_terminal/src/wifi.rs
+++ b/boards/wio_terminal/src/wifi.rs
@@ -76,8 +76,7 @@ impl Wifi {
         .baud(
             WIFI_UART_BAUD.hz(),
             uart::BaudMode::Fractional(uart::Oversampling::Bits16),
-        )
-        .enable();
+        );
 
         delay.delay_ms(10u8);
 
@@ -93,6 +92,7 @@ impl Wifi {
 
         let sequence = 0;
 
+        let uart = uart.enable();
         Wifi {
             _pwr: pwr,
             uart,


### PR DESCRIPTION
# Summary
Delay enable of the UART until the device has been reset.

Fixes #628
