### PR TITLE
Fix wio_terminal buttons display

### DIFF
--- a/boards/wio_terminal/examples/buttons.rs
+++ b/boards/wio_terminal/examples/buttons.rs
@@ -109,7 +109,7 @@ where
                 .ok();
         }
         Button::Left => {
-            Rectangle::with_corners(Point::new(90, 120), Point::new(120, 120))
+            Rectangle::with_corners(Point::new(100, 120), Point::new(130, 120))
                 .into_styled(style)
                 .draw(display)
                 .ok();
@@ -165,7 +165,7 @@ where
             .ok();
         }
         Button::Click => {
-            Circle::new(Point::new(160, 120), 15)
+            Circle::with_center(Point::new(160, 120), 15)
                 .into_styled(style)
                 .draw(display)
                 .ok();


### PR DESCRIPTION
# Summary

Joystick click should be centered within joystick arrows.  The left arrow base was offset by 10 pixels.

See also #627.