### PR TITLE
Fix wio_terminal usb_serial_display

### DIFF
--- a/boards/wio_terminal/CHANGELOG.md
+++ b/boards/wio_terminal/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Fix end-of-line glyph loss in usb_serial_display example
 - Fix display frequency in examples that did not work
 - Fix display offsets in buttons example
 - Fix buttons by re-enabling debounce code

--- a/boards/wio_terminal/examples/usb_serial_display.rs
+++ b/boards/wio_terminal/examples/usb_serial_display.rs
@@ -143,7 +143,7 @@ impl<'a> Terminal<'a> {
     }
 
     pub fn write_character(&mut self, c: char) {
-        if self.cursor.x >= 320 || c == '\n' {
+        if self.cursor.x >= 320 - FONT_6X12.character_size.width as i32 || c == '\n' {
             self.cursor = Point::new(0, self.cursor.y + FONT_6X12.character_size.height as i32);
         }
         if self.cursor.y >= 240 {


### PR DESCRIPTION
Don't write at a position where the character would go past the edge of the screen.