### PR TITLE
various diagnostic cleanups

### DIFF
--- a/hal/src/gpio/pin.rs
+++ b/hal/src/gpio/pin.rs
@@ -777,7 +777,7 @@ impl_core_convert_from!(
 ///
 /// ## `v1` Compatibility
 ///
-/// Normally, this trait would use Is<Type = SpecificPin<Self>> as a super
+/// Normally, this trait would use `Is<Type = SpecificPin<Self>>` as a super
 /// trait. But doing so would restrict implementations to only the `v2` `Pin`
 /// type in this module. To aid in backwards compatibility, we want to implement
 /// `AnyPin` for the `v1` `Pin` type as well. This is possible for a few

--- a/hal/src/sercom/uart/pads_thumbv7em.rs
+++ b/hal/src/sercom/uart/pads_thumbv7em.rs
@@ -381,8 +381,8 @@ where
 
 /// Marker trait for valid sets of [`Pads`]
 ///
-/// This trait labels sets of [`Pads`] that satisfy the [`Rxpo`] and [`Txpo`]
-/// traits. It guarantees to the [`Config`] struct that this set of `Pads` can
+/// This trait labels sets of [`Pads`] that satisfy the [`RxpoTxpo`]
+/// trait. It guarantees to the [`Config`] struct that this set of `Pads` can
 /// be configured through those traits.
 ///
 /// [`Config`]: crate::sercom::uart::Config

--- a/hal/src/thumbv6m/eic/pin.rs
+++ b/hal/src/thumbv6m/eic/pin.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "unproven")]
 use crate::ehal::digital::v2::InputPin;
 use crate::gpio::{
-    self, pin::*, AnyPin, FloatingInterrupt, PinId, PinMode, PullDownInterrupt, PullUpInterrupt,
+    self, pin::*, AnyPin, FloatingInterrupt, PinMode, PullDownInterrupt, PullUpInterrupt,
 };
 use crate::pac;
 


### PR DESCRIPTION
Fix diagnostics emitted by `cargo build` or `cargo doc`.  This is not intended to be comprehensive.