### PR TITLE
Fix User Row Mapping bitfield

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased Changes
 
+- Fix NVM User Row Mapping for `BOD12` Calibration Parameters
 - Fix `ExternalInterrupt` implementations for `eic`
 - Fix for incorrect feature gates for pins of `samd21gl` chip
 - Fix bug in `dmac` where software trigger would not work

--- a/hal/src/thumbv7em/nvm.rs
+++ b/hal/src/thumbv7em/nvm.rs
@@ -541,7 +541,7 @@ bitfield! {
     bod33_level, _: 8, 1;
     bod33_action, _: 10, 9;
     bod33_hysteresis, _: 14, 11;
-    bod12_calibration_parameters, _: 25, 12;
+    bod12_calibration_parameters, _: 25, 15;
     nvm_bootloader_size, _: 29, 26;
     see_sblk, _: 35, 32;
     see_psz, _: 38, 36;


### PR DESCRIPTION
According to the data sheet [1] the bit positions for "BOD 12 Calibration Parameters" are `25:15` and not `25:12`.

This patch just changes the bits for the above mentioned parameter to match the data sheet.

[1]: SAM-D5x-E5x-Family-Data-Sheet-DS60001507.pdf

# Summary
Updated bitfield macro to so that bits match data sheet.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)

## If Adding a new Board
  - [ ] Board CI added to `crates.json`
  - [ ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"