### PR TITLE
Fix build-all.py

### DIFF
--- a/boards/gemma_m0/CHANGELOG.md
+++ b/boards/gemma_m0/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Fixed the `use_semihosting` feature of the BSP
 
 # v0.11.0
 

--- a/boards/gemma_m0/Cargo.toml
+++ b/boards/gemma_m0/Cargo.toml
@@ -18,6 +18,10 @@ optional = true
 version = "0.14"
 default-features = false
 
+[dependencies.panic-semihosting]
+version = "0.6.0"
+optional = true
+
 [dev-dependencies]
 panic-halt = "0.2"
 
@@ -26,7 +30,7 @@ panic-halt = "0.2"
 default = ["rt", "atsamd-hal/samd21e"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21e-rt"]
 unproven = ["atsamd-hal/unproven"]
-use_semihosting = []
+use_semihosting = ["panic-semihosting"]
 
 # for cargo flash
 [package.metadata]

--- a/boards/neokey_trinkey/CHANGELOG.md
+++ b/boards/neokey_trinkey/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # Unreleased
+- Fixed the `use_semihosting` feature of the BSP
 
 # v0.2.0
 

--- a/boards/neokey_trinkey/Cargo.toml
+++ b/boards/neokey_trinkey/Cargo.toml
@@ -10,11 +10,14 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 edition = "2021"
 
-[dependencies]
+[dependencies.panic-semihosting]
+version = "0.6"
+optional = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"
 optional = true
+
 
 [dependencies.atsamd-hal]
 version = "0.14"
@@ -44,7 +47,7 @@ default = ["rt", "atsamd-hal/samd21e"]
 leds = ["ws2812-timer-delay", "smart-leds"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21e-rt"]
 unproven = ["atsamd-hal/unproven"]
-use_semihosting = []
+use_semihosting = ["panic-semihosting"]
 usb = ["atsamd-hal/usb", "usb-device"]
 
 [[example]]

--- a/boards/serpente/CHANGELOG.md
+++ b/boards/serpente/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Fixed the `use_semihosting` feature of the BSP
 
 # v0.7.0
 

--- a/boards/serpente/Cargo.toml
+++ b/boards/serpente/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 edition = "2021"
 
+[dependencies.panic-semihosting]
+version = "0.6"
+optional = true
+
 [dependencies.cortex-m-rt]
 version = "0.7"
 optional = true
@@ -26,7 +30,7 @@ panic-halt = "0.2"
 default = ["rt", "atsamd-hal/samd21e"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21e-rt"]
 unproven = ["atsamd-hal/unproven"]
-use_semihosting = []
+use_semihosting = ["panic-semihosting"]
 
 # for cargo flash
 [package.metadata]

--- a/boards/sodaq_sara_aff/CHANGELOG.md
+++ b/boards/sodaq_sara_aff/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Fixed the `use_semihosting` feature of the BSP 
 
 # v0.9.0
 

--- a/boards/sodaq_sara_aff/Cargo.toml
+++ b/boards/sodaq_sara_aff/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 edition = "2021"
 
+[dependencies.panic-semihosting]
+version = "0.6"
+optional = true
+
 [dependencies.cortex-m-rt]
 version = "0.7"
 optional = true
@@ -26,7 +30,7 @@ panic-halt = "0.2"
 default = ["rt", "atsamd-hal/samd21j"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21j-rt"]
 unproven = ["atsamd-hal/unproven"]
-use_semihosting = []
+use_semihosting = ["panic-semihosting"]
 
 # for cargo flash
 [package.metadata]

--- a/crates.json
+++ b/crates.json
@@ -2,35 +2,35 @@
   "boards": {
     "arduino_mkr1000": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "arduino_mkrvidor4000": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "arduino_mkrzero": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "arduino_nano33iot": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "atsame54_xpro": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "circuit_playground_express": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "edgebadge": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "feather_m0": {
       "tier": 1,
-      "build": "cargo build --examples --features=unproven,dma,usb,rtic,sdmmc,adalogger"
+      "build": "cargo build --examples"
     },
     "feather_m4": {
       "tier": 1,
@@ -38,71 +38,71 @@
     },
     "gemma_m0": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven"
+      "build": "cargo build --examples --all-features"
     },
     "grand_central_m4": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "itsybitsy_m0": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb,dma,sdmmc,rtic"
+      "build": "cargo build --examples --all-features"
     },
     "itsybitsy_m4": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb,use_rtt"
+      "build": "cargo build --examples --all-features"
     },
     "metro_m0": {
       "tier": 1,
-      "build": "cargo build --examples --features=unproven,usb,rtic"
+      "build": "cargo build --examples --all-features"
     },
     "metro_m4": {
       "tier": 1,
-      "build": "cargo build --examples --features=unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "neo_trinkey": {
       "tier": 2,
-      "build": "cargo build --examples --features=leds,unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "neokey_trinkey": {
       "tier": 2,
-      "build": "cargo build --examples --features=leds,unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "p1am_100": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "pfza_proto1": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven"
+      "build": "cargo build --examples --all-features"
     },
     "pygamer": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb,math"
+      "build": "cargo build --examples --all-features"
     },
     "pyportal": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven"
+      "build": "cargo build --examples --all-features"
     },
     "samd11_bare": {
       "tier": 1,
-      "build": "cargo build --release --examples --features=unproven,rt,use_semihosting"
+      "build": "cargo build --release --examples --all-features"
     },
     "samd21_mini": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven"
+      "build": "cargo build --examples --all-features"
     },
     "serpente": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven"
+      "build": "cargo build --examples --all-features"
     },
     "sodaq_one": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven"
+      "build": "cargo build --examples --all-features"
     },
     "sodaq_sara_aff": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven"
+      "build": "cargo build --examples --all-features"
     },
     "trellis_m4": {
       "tier": 2,
@@ -110,27 +110,27 @@
     },
     "trinket_m0": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "wio_lite_mg126": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "wio_lite_w600": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "wio_terminal": {
       "tier": 1,
-      "build": "cargo build --examples --features=usb"
+      "build": "cargo build --examples --all-features"
     },
     "xiao_m0": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb"
+      "build": "cargo build --examples --all-features"
     },
     "qt_py_m0": {
       "tier": 2,
-      "build": "cargo build --examples --features=unproven,usb"
+      "build": "cargo build --examples --all-features"
     }
   },
   "hal_doc_variants": {


### PR DESCRIPTION
# Summary
- crates.json updated to compile examples with `all-features` (in most cases)
- gemma_m0 and descendent BSPs had the use_semihosting feature without the panic-semihosting crate.
- feather_m0 has conflicting features (rt and rtic) that prevent compiling with `--all-features`
- a bunch of the trellis_m4 examples are broken, leaving those out of scope of this PR

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)