### PR TITLE
Integration with the `mcan`

### DIFF
--- a/boards/atsame54_xpro/Cargo.toml
+++ b/boards/atsame54_xpro/Cargo.toml
@@ -26,6 +26,7 @@ version = "0.2"
 optional = true
 
 [dev-dependencies]
+mcan = "0.2"
 cortex-m-rtic = "1.1"
 dwt-systick-monotonic = "1.1"
 panic-rtt-target = { version = "0.1", features = ["cortex-m"] }
@@ -36,6 +37,7 @@ default = ["rt", "atsamd-hal/same54p", "atsamd-hal/unproven"]
 rt = ["cortex-m-rt", "atsamd-hal/same54p-rt"]
 unproven = ["atsamd-hal/unproven"]
 usb = ["atsamd-hal/usb", "usb-device"]
+can = ["atsamd-hal/can"]
 
 [profile.dev]
 incremental = false
@@ -46,3 +48,7 @@ lto = true
 [profile.release]
 lto = true
 opt-level = "s"
+
+[[example]]
+name = "mcan"
+required-features = ["can"]

--- a/boards/atsame54_xpro/examples/mcan.rs
+++ b/boards/atsame54_xpro/examples/mcan.rs
@@ -1,0 +1,317 @@
+//! MCAN example
+//! Assumed bus:
+//! - 375 kb/s nominal bitrate
+//! - 750 kb/s data bitrate if sending/receiving CAN FD frames with bitrate
+//!   switching
+//!
+//! 1. Sends a message over CAN on SW0 button press and prints out transmit
+//! event queue content, protocol status register and error counter register in
+//! RTT terminal.
+//!
+//! 2. Sets up an interrupt line and message filters
+//! - messages with standard IDs will end up in RxFifo0
+//! - messages with extended IDs will end up in RxFifo1
+//! - messages content will be printed out in RTT terminal upon arrival
+//!
+//! 3. LED0 will blink to indicate activity (sending & receiving)
+
+#![no_std]
+#![no_main]
+
+use atsame54_xpro as bsp;
+use bsp::hal;
+use hal::clock::v2 as clock;
+use hal::eic::pin::*;
+use hal::gpio::{Interrupt as GpioInterrupt, *};
+use hal::prelude::*;
+
+use dwt_systick_monotonic::fugit::RateExtU32 as _;
+use dwt_systick_monotonic::{DwtSystick, ExtU32};
+
+use mcan::embedded_can as ecan;
+use mcan::generic_array::typenum::consts::*;
+use mcan::interrupt::{Interrupt, InterruptLine, OwnedInterruptSet};
+use mcan::message::rx;
+use mcan::message::tx;
+use mcan::messageram::SharedMemory;
+use mcan::prelude::*;
+use mcan::rx_fifo::Fifo0;
+use mcan::rx_fifo::Fifo1;
+use mcan::rx_fifo::RxFifo;
+use mcan::{
+    config::{BitTiming, Mode},
+    filter::{Action, ExtFilter, Filter},
+};
+use panic_rtt_target as _;
+use rtt_target::{rprintln, rtt_init_print};
+
+pub struct Capacities;
+
+impl mcan::messageram::Capacities for Capacities {
+    type StandardFilters = U1;
+    type ExtendedFilters = U1;
+    type RxBufferMessage = rx::Message<64>;
+    type DedicatedRxBuffers = U0;
+    type RxFifo0Message = rx::Message<64>;
+    type RxFifo0 = U64;
+    type RxFifo1Message = rx::Message<64>;
+    type RxFifo1 = U64;
+    type TxMessage = tx::Message<64>;
+    type TxBuffers = U32;
+    type DedicatedTxBuffers = U0;
+    type TxEventFifo = U32;
+}
+
+type RxFifo0 = RxFifo<
+    'static,
+    Fifo0,
+    clock::types::Can1,
+    <Capacities as mcan::messageram::Capacities>::RxFifo0Message,
+>;
+type RxFifo1 = RxFifo<
+    'static,
+    Fifo1,
+    clock::types::Can1,
+    <Capacities as mcan::messageram::Capacities>::RxFifo1Message,
+>;
+type Tx = mcan::tx_buffers::Tx<'static, clock::types::Can1, Capacities>;
+type TxEventFifo = mcan::tx_event_fifo::TxEventFifo<'static, clock::types::Can1>;
+type Aux = mcan::bus::Aux<
+    'static,
+    clock::types::Can1,
+    hal::can::Dependencies<
+        clock::types::Can1,
+        clock::gclk::Gclk0Id,
+        bsp::Ata6561Rx,
+        bsp::Ata6561Tx,
+        bsp::pac::CAN1,
+    >,
+>;
+type Button = ExtInt15<Pin<PB31, GpioInterrupt<PullUp>>>;
+
+#[rtic::app(device = hal::pac, peripherals = true, dispatchers = [FREQM])]
+mod app {
+    use super::*;
+
+    #[monotonic(binds = SysTick, default = true)]
+    type Mono = DwtSystick<48_000_000>;
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {
+        button: Button,
+        led: bsp::Led,
+        line_interrupts: OwnedInterruptSet<clock::types::Can1>,
+        rx_fifo_0: RxFifo0,
+        rx_fifo_1: RxFifo1,
+        tx: Tx,
+        tx_event_fifo: TxEventFifo,
+        aux: Aux,
+    }
+
+    #[init(local = [
+        #[link_section = ".can"]
+        can_memory: SharedMemory<Capacities> = SharedMemory::new()
+    ])]
+    fn init(mut ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+        rtt_init_print!();
+        rprintln!("Application up!");
+
+        let (_buses, clocks, tokens) = clock::clock_system_at_reset(
+            ctx.device.OSCCTRL,
+            ctx.device.OSC32KCTRL,
+            ctx.device.GCLK,
+            ctx.device.MCLK,
+            &mut ctx.device.NVMCTRL,
+        );
+
+        let (_, _, _, mut mclk) = unsafe { clocks.pac.steal() };
+
+        let mono = DwtSystick::new(
+            &mut ctx.core.DCB,
+            ctx.core.DWT,
+            ctx.core.SYST,
+            clocks.gclk0.freq().0,
+        );
+
+        let pins = bsp::Pins::new(ctx.device.PORT);
+
+        let (pclk_eic, gclk0) = clock::pclk::Pclk::enable(tokens.pclks.eic, clocks.gclk0);
+
+        let mut eic = hal::eic::init_with_ulp32k(&mut mclk, pclk_eic.into(), ctx.device.EIC);
+        let mut button = bsp::pin_alias!(pins.button).into_pull_up_ei();
+        eic.button_debounce_pins(&[button.id()]);
+        button.sense(&mut eic, Sense::FALL);
+        button.enable_interrupt(&mut eic);
+        eic.finalize();
+
+        let can1_rx = bsp::pin_alias!(pins.ata6561_rx).into_mode();
+        let can1_tx = bsp::pin_alias!(pins.ata6561_tx).into_mode();
+        let mut can1_standby = bsp::pin_alias!(pins.ata6561_standby).into_push_pull_output();
+
+        let _ = can1_standby.set_low();
+
+        let (pclk_can1, gclk0) = clock::pclk::Pclk::enable(tokens.pclks.can1, gclk0);
+
+        let (dependencies, _gclk0) = hal::can::Dependencies::new(
+            gclk0,
+            pclk_can1,
+            clocks.ahbs.can1,
+            can1_rx,
+            can1_tx,
+            ctx.device.CAN1,
+        );
+
+        let mut can =
+            mcan::bus::CanConfigurable::new(375.kHz(), dependencies, ctx.local.can_memory).unwrap();
+
+        can.config().mode = Mode::Fd {
+            allow_bit_rate_switching: true,
+            data_phase_timing: BitTiming::new(750.kHz()),
+        };
+
+        let line_interrupts = can
+            .interrupts()
+            .enable(
+                [
+                    Interrupt::RxFifo0NewMessage,
+                    Interrupt::RxFifo0Full,
+                    Interrupt::RxFifo0MessageLost,
+                    Interrupt::RxFifo1NewMessage,
+                    Interrupt::RxFifo1Full,
+                    Interrupt::RxFifo1MessageLost,
+                ]
+                .into_iter()
+                .collect(),
+                InterruptLine::Line0,
+                // ATSAMD chips do not expose separate NVIC lines to MCAN
+                // InterruptLine::Line0 and InterruptLine::Line1 are wired
+                // together in the hardware.
+            )
+            .unwrap();
+
+        can.filters_standard()
+            .push(Filter::Classic {
+                action: Action::StoreFifo0,
+                filter: ecan::StandardId::MAX,
+                mask: ecan::StandardId::ZERO,
+            })
+            .unwrap_or_else(|_| panic!("Standard filter application failed"));
+
+        can.filters_extended()
+            .push(ExtFilter::Classic {
+                action: Action::StoreFifo1,
+                filter: ecan::ExtendedId::MAX,
+                mask: ecan::ExtendedId::ZERO,
+            })
+            .unwrap_or_else(|_| panic!("Extended filter application failed"));
+
+        let can = can.finalize().unwrap();
+
+        let rx_fifo_0 = can.rx_fifo_0;
+        let rx_fifo_1 = can.rx_fifo_1;
+        let tx = can.tx;
+        let tx_event_fifo = can.tx_event_fifo;
+        let aux = can.aux;
+
+        let led = bsp::pin_alias!(pins.led).into();
+
+        bump_activity_led();
+
+        (
+            Shared {},
+            Local {
+                button,
+                led,
+                line_interrupts,
+                rx_fifo_0,
+                rx_fifo_1,
+                tx,
+                tx_event_fifo,
+                aux,
+            },
+            init::Monotonics(mono),
+        )
+    }
+
+    #[task(binds = EIC_EXTINT_15, local = [counter: u16 = 0, button, tx_event_fifo, aux, tx])]
+    fn button(ctx: button::Context) {
+        ctx.local.button.clear_interrupt();
+        bump_activity_led();
+        rprintln!("Button pressed! Status:");
+        while let Some(e) = ctx.local.tx_event_fifo.pop() {
+            rprintln!("TxEvent: {:0X?}", e);
+        }
+        rprintln!("{:?}", ctx.local.aux.protocol_status());
+        rprintln!("{:?}", ctx.local.aux.error_counters());
+
+        let counter = *ctx.local.counter;
+        let wrapped_counter = (counter % u8::MAX as u16) as u8;
+        let mut payload = [0_u8; 64];
+        payload.fill(wrapped_counter);
+
+        ctx.local
+            .tx
+            .transmit_queued(
+                tx::MessageBuilder {
+                    id: ecan::Id::Extended(ecan::ExtendedId::new(counter as _).unwrap()),
+                    frame_type: tx::FrameType::FlexibleDatarate {
+                        payload: &payload,
+                        bit_rate_switching: true,
+                        force_error_state_indicator: false,
+                    },
+                    store_tx_event: Some(wrapped_counter),
+                }
+                .build()
+                .unwrap(),
+            )
+            .unwrap();
+        rprintln!("Message {:0X} sent!", counter);
+        *ctx.local.counter += 1;
+    }
+
+    #[task(priority = 2, binds = CAN1, local = [line_interrupts, rx_fifo_0, rx_fifo_1])]
+    fn can1(mut ctx: can1::Context) {
+        bump_activity_led();
+        let line_interrupts = ctx.local.line_interrupts;
+        for interrupt in line_interrupts.iter_flagged() {
+            match interrupt {
+                Interrupt::RxFifo0NewMessage => {
+                    for message in &mut ctx.local.rx_fifo_0 {
+                        log("RxFifo0", &message);
+                    }
+                }
+                Interrupt::RxFifo1NewMessage => {
+                    for message in &mut ctx.local.rx_fifo_1 {
+                        log("RxFifo1", &message);
+                    }
+                }
+                i => rprintln!("{:?} interrupt triggered", i),
+            }
+        }
+    }
+
+    #[task(local = [led])]
+    fn activity_led(ctx: activity_led::Context, led_on: bool) {
+        let _ = ctx.local.led.set_state((!led_on).into());
+        if led_on {
+            let _ = activity_led::spawn_after(100.millis(), false);
+        }
+    }
+
+    fn bump_activity_led() {
+        let _ = activity_led::spawn(true);
+    }
+
+    fn log(fifo: &str, message: &impl mcan::message::Raw) {
+        rprintln!("New message received ({})", fifo);
+        rprintln!("id:                 {:0X?}", message.id());
+        rprintln!("decoded_dlc:        {:?}", message.decoded_dlc());
+        rprintln!("fd_format:          {:?}", message.fd_format());
+        rprintln!("bit_rate_switching: {:?}", message.bit_rate_switching());
+        rprintln!("is_remote_frame:    {:?}", message.is_remote_frame());
+        rprintln!("data:               {:0X?}", message.data());
+    }
+}

--- a/crates.json
+++ b/crates.json
@@ -288,15 +288,15 @@
       "target": "thumbv7em-none-eabihf"
     },
     "same51g": {
-      "features": [ "same51g", "unproven", "usb", "dma", "sdmmc", "rtic" ],
+      "features": [ "same51g", "unproven", "usb", "dma", "sdmmc", "rtic", "can" ],
       "target": "thumbv7em-none-eabihf"
     },
     "same51j": {
-      "features": [ "same51j", "unproven", "usb", "dma", "sdmmc", "rtic" ],
+      "features": [ "same51j", "unproven", "usb", "dma", "sdmmc", "rtic", "can" ],
       "target": "thumbv7em-none-eabihf"
     },
     "same51n": {
-      "features": [ "same51n", "unproven", "usb", "dma", "sdmmc", "rtic" ],
+      "features": [ "same51n", "unproven", "usb", "dma", "sdmmc", "rtic", "can" ],
       "target": "thumbv7em-none-eabihf"
     },
     "same53j": {
@@ -308,11 +308,11 @@
       "target": "thumbv7em-none-eabihf"
     },
     "same54n": {
-      "features": [ "same54n", "unproven", "usb", "dma", "sdmmc", "rtic" ],
+      "features": [ "same54n", "unproven", "usb", "dma", "sdmmc", "rtic", "can" ],
       "target": "thumbv7em-none-eabihf"
     },
     "same54p": {
-      "features": [ "same54p", "unproven", "usb", "dma", "sdmmc", "rtic" ],
+      "features": [ "same54p", "unproven", "usb", "dma", "sdmmc", "rtic", "can" ],
       "target": "thumbv7em-none-eabihf"
     }
   }

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased Changes
 
+- Add `mcan` integration (#654)
 - Fix incorrect PAC provided for `same51g` target
 - Fix NVM User Row Mapping for `BOD12` Calibration Parameters
 - Fix `ExternalInterrupt` implementations for `eic`

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -54,6 +54,7 @@ void = {version = "1.0", default-features = false}
 embedded-sdmmc = {version = "0.3", optional = true}
 fugit = {version = "0.3", optional = true}
 jlink_rtt = {version = "0.2", optional = true}
+mcan-core = {version = "0.2", optional = true}
 rtic-monotonic = {version = "1.0", optional = true}
 usb-device = {version = "0.2", optional = true}
 
@@ -174,6 +175,7 @@ same54p-rt = ["same54p", "atsame54p/rt"]
 # Until then, we make `unproven` a default feature.
 default = ["unproven"]
 
+can = ["mcan-core"]
 dma = ["unproven"]
 enable_unsafe_aes_newblock_cipher = []
 max-channels = ["dma"]
@@ -284,7 +286,8 @@ pins-e54p = ["pins-128"]
 #-------------------------------------------------------------------------------
 
 # Define a feature for each optional peripheral
-has-can = []
+has-can0 = []
+has-can1 = []
 has-ethernet = []
 has-gmac = []
 has-i2s = []
@@ -357,12 +360,12 @@ periph-d51j = ["periph-d51g", "has-i2s", "has-tcc2", "has-tcc3", "has-tc4", "has
 periph-d51n = ["periph-d51j", "has-tc6", "has-tc7", "has-sdhc1", "has-sercom6", "has-sercom7"]
 periph-d51p = ["periph-d51n"]
 
-periph-e51g = ["periph-d51g", "has-can"]
-periph-e51j = ["periph-d51j", "has-can"]
-periph-e51n = ["periph-d51j", "has-can", "has-tc6", "has-tc7", "has-sercom6", "has-sercom7"]
+periph-e51g = ["periph-d51g", "has-can0"]
+periph-e51j = ["periph-d51j", "has-can0", "has-can1"]
+periph-e51n = ["periph-d51j", "has-can0", "has-can1", "has-tc6", "has-tc7", "has-sercom6", "has-sercom7"]
 
 periph-e53j = ["periph-d51j", "has-ethernet"]
 periph-e53n = ["periph-d51n", "has-ethernet"]
 
-periph-e54n = ["periph-d51n", "has-ethernet", "has-can"]
-periph-e54p = ["periph-d51p", "has-ethernet", "has-can"]
+periph-e54n = ["periph-d51n", "has-ethernet", "has-can0", "has-can1"]
+periph-e54p = ["periph-d51p", "has-ethernet", "has-can0", "has-can1"]

--- a/hal/src/thumbv7em/can.rs
+++ b/hal/src/thumbv7em/can.rs
@@ -1,0 +1,177 @@
+//! This module provides target specific integration with the [`mcan`] crate.
+//!
+//! MCAN is an off-the-shelf peripheral that is synthesized and integrated
+//! into, among the others, E51/E54 MCUs.
+//!
+//! Instance of the [`Dependencies`] struct is necessary in order to make `mcan`
+//! abstractions operational.
+//!
+//! More information regarding the `mcan` API can be found in its
+//! documentation.
+//!
+//! [`mcan`]: https://crates.io/crates/mcan
+use crate::{
+    clock::v2::{
+        ahb::{AhbClk, AhbId},
+        gclk::Gclk0Id,
+        pclk::{Pclk, PclkId, PclkSourceId},
+        types::Can0,
+        Source,
+    },
+    gpio::*,
+    typelevel::{Decrement, Increment},
+};
+
+#[cfg(feature = "has-can1")]
+use crate::clock::v2::types::Can1;
+
+use mcan_core::fugit::HertzU32;
+use mcan_core::CanId;
+
+/// Struct enclosing all the dependencies required to bootstrap `ID` instance of
+/// MCAN.
+///
+/// Its construction means that all platform-specific prerequisites are in place
+/// and `mcan` abstractions are operational.
+pub struct Dependencies<ID: PclkId + AhbId, PS: PclkSourceId, RX, TX, CAN> {
+    pclk: Pclk<ID, PS>,
+    host_freq: HertzU32,
+    ahbclk: AhbClk<ID>,
+    rx: RX,
+    tx: TX,
+    can: CAN,
+}
+
+impl<ID: PclkId + AhbId, PS: PclkSourceId, RX, TX, CAN> Dependencies<ID, PS, RX, TX, CAN> {
+    /// Create an instance of `Dependencies` struct.
+    ///
+    /// This struct implements [`mcan_core::Dependencies`] trait, making it
+    /// possible to construct an instance of `mcan::bus::CanConfigurable`.
+    pub fn new<S>(
+        gclk0: S,
+        pclk: Pclk<ID, PS>,
+        ahbclk: AhbClk<ID>,
+        rx: RX,
+        tx: TX,
+        can: CAN,
+    ) -> (Self, S::Inc)
+    where
+        S: Source<Id = Gclk0Id> + Increment,
+    {
+        (
+            Self {
+                pclk,
+                host_freq: HertzU32::from_raw(gclk0.freq().0),
+                ahbclk,
+                rx,
+                tx,
+                can,
+            },
+            gclk0.inc(),
+        )
+    }
+    /// Destroy an instance of `Dependencies` struct.
+    ///
+    /// Releases all enclosed objects back to the user.
+    pub fn free<S>(self, gclk0: S) -> (Pclk<ID, PS>, HertzU32, AhbClk<ID>, RX, TX, CAN, S::Dec)
+    where
+        S: Source<Id = Gclk0Id> + Decrement,
+    {
+        let Self {
+            pclk,
+            host_freq,
+            ahbclk,
+            rx,
+            tx,
+            can,
+        } = self;
+        (pclk, host_freq, ahbclk, rx, tx, can, gclk0.dec())
+    }
+}
+
+unsafe impl<ID, PS, RX, TX, CAN> mcan_core::Dependencies<ID> for Dependencies<ID, PS, RX, TX, CAN>
+where
+    ID: CanId + PclkId + AhbId,
+    PS: PclkSourceId,
+    RX: RxPin<ValidFor = ID>,
+    TX: TxPin<ValidFor = ID>,
+    CAN: OwnedPeripheral<Represents = ID>,
+{
+    fn host_clock(&self) -> HertzU32 {
+        self.host_freq
+    }
+
+    fn can_clock(&self) -> HertzU32 {
+        HertzU32::from_raw(self.pclk.freq().0)
+    }
+
+    fn eligible_message_ram_start(&self) -> *const () {
+        0x2000_0000 as _
+    }
+}
+
+unsafe impl CanId for Can0 {
+    const ADDRESS: *const () = crate::pac::CAN0::PTR as *const _;
+}
+
+#[cfg(feature = "has-can1")]
+unsafe impl CanId for Can1 {
+    const ADDRESS: *const () = crate::pac::CAN1::PTR as *const _;
+}
+
+trait OwnedPeripheral {
+    type Represents: CanId;
+}
+
+impl OwnedPeripheral for crate::pac::CAN0 {
+    type Represents = Can0;
+}
+
+#[cfg(feature = "has-can1")]
+impl OwnedPeripheral for crate::pac::CAN1 {
+    type Represents = Can1;
+}
+
+trait RxPin {
+    type ValidFor: CanId;
+}
+
+trait TxPin {
+    type ValidFor: CanId;
+}
+
+impl RxPin for Pin<PA23, AlternateI> {
+    type ValidFor = Can0;
+}
+
+impl RxPin for Pin<PA25, AlternateI> {
+    type ValidFor = Can0;
+}
+
+impl TxPin for Pin<PA22, AlternateI> {
+    type ValidFor = Can0;
+}
+
+impl TxPin for Pin<PA24, AlternateI> {
+    type ValidFor = Can0;
+}
+
+#[cfg(feature = "has-can1")]
+impl RxPin for Pin<PB13, AlternateH> {
+    type ValidFor = Can1;
+}
+
+#[cfg(feature = "has-can1")]
+impl RxPin for Pin<PB15, AlternateH> {
+    type ValidFor = Can1;
+}
+
+#[cfg(feature = "has-can1")]
+impl TxPin for Pin<PB12, AlternateH> {
+    type ValidFor = Can1;
+}
+
+#[cfg(feature = "has-can1")]
+impl TxPin for Pin<PB14, AlternateH> {
+    type ValidFor = Can1;
+}

--- a/hal/src/thumbv7em/clock/v1.rs
+++ b/hal/src/thumbv7em/clock/v1.rs
@@ -459,9 +459,9 @@ clock_generator!(
     (evsys9, Evsys9Clock, EVSYS9, EvSys9),
     (evsys10, Evsys10Clock, EVSYS10, EvSys10),
     (evsys11, Evsys11Clock, EVSYS11, EvSys11),
-    #[cfg(any(feature = "has-can"))]
+    #[cfg(feature = "has-can0")]
     (can0, Can0Clock, CAN0, Can0),
-    #[cfg(any(feature = "has-can"))]
+    #[cfg(feature = "has-can1")]
     (can1, Can1Clock, CAN1, Can1),
     (pdec, PdecClock, PDEC, PDec),
     (ac, AcClock, AC, Ac),

--- a/hal/src/thumbv7em/clock/v2/ahb.rs
+++ b/hal/src/thumbv7em/clock/v2/ahb.rs
@@ -385,9 +385,9 @@ define_ahb_types!(
     Sdhc0 = 15,
     #[cfg(feature = "has-sdhc1")]
     Sdhc1 = 16,
-    #[cfg(feature = "has-can")]
+    #[cfg(feature = "has-can0")]
     Can0 = 17,
-    #[cfg(feature = "has-can")]
+    #[cfg(feature = "has-can1")]
     Can1 = 18,
     Icm = 19,
     Pukcc = 20,

--- a/hal/src/thumbv7em/clock/v2/pclk.rs
+++ b/hal/src/thumbv7em/clock/v2/pclk.rs
@@ -169,6 +169,10 @@ pub mod ids {
         SlowClk, Tc0Tc1, Tc2Tc3, Tcc0Tcc1, Tcc2Tcc3, Usb,
     };
 
+    #[cfg(feature = "has-can0")]
+    pub use super::super::types::Can0;
+    #[cfg(feature = "has-can1")]
+    pub use super::super::types::Can1;
     #[cfg(feature = "has-sdhc1")]
     pub use super::super::types::Sdhc1;
     #[cfg(all(feature = "has-tc4", feature = "has-tc5"))]
@@ -177,8 +181,6 @@ pub mod ids {
     pub use super::super::types::Tc6Tc7;
     #[cfg(feature = "has-tcc4")]
     pub use super::super::types::Tcc4;
-    #[cfg(feature = "has-can")]
-    pub use super::super::types::{Can0, Can1};
     #[cfg(feature = "has-i2s")]
     pub use super::super::types::{I2S0, I2S1};
 }
@@ -250,9 +252,9 @@ macro_rules! with_pclk_types_ids {
             (Sercom3 = 24, sercom3)
             (Tcc0Tcc1 = 25, tcc0_tcc1)
             (Tc2Tc3 = 26, tc2_tc3)
-            #[cfg(feature = "has-can")]
+            #[cfg(feature = "has-can0")]
             (Can0 = 27, can0)
-            #[cfg(feature = "has-can")]
+            #[cfg(feature = "has-can1")]
             (Can1 = 28, can1)
             (Tcc2Tcc3 = 29, tcc2_tcc3)
             #[cfg(all(feature = "has-tc4", feature = "has-tc5"))]

--- a/hal/src/thumbv7em/clock/v2/types.rs
+++ b/hal/src/thumbv7em/clock/v2/types.rs
@@ -50,8 +50,10 @@ macro_rules! create_types {
 create_types!(Ac);
 create_types!(Adc0, Adc1);
 create_types!(Aes);
-#[cfg(feature = "has-can")]
-create_types!(Can0, Can1);
+#[cfg(feature = "has-can0")]
+create_types!(Can0);
+#[cfg(feature = "has-can1")]
+create_types!(Can1);
 create_types!(Ccl);
 create_types!(Cmcc);
 create_types!(CM4Trace);

--- a/hal/src/thumbv7em/mod.rs
+++ b/hal/src/thumbv7em/mod.rs
@@ -1,5 +1,7 @@
 pub mod aes;
 pub mod calibration;
+#[cfg(all(any(feature = "has-can0", feature = "has-can1"), feature = "can"))]
+pub mod can;
 pub mod clock;
 pub mod eic;
 pub mod pukcc;


### PR DESCRIPTION
This PR provides trait implementations from [`mcan-core`](https://crates.io/crates/mcan-core) crate. It enables the safe usage of the [`mcan`](https://crates.io/crates/mcan) crate.

`mcan` crate provides a HAL for the CAN peripheral embedded into ATSAME5{1, 4}.
