### PR TITLE
Fix Alternate for USB pins in BSP for boards that use SAMD51

### DIFF
--- a/boards/feather_m4/CHANGELOG.md
+++ b/boards/feather_m4/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Use correct alternate for USB (#661)
+
 # v0.10.1
 
 - Update to `atsamd-hal` version `0.15.1`

--- a/boards/feather_m4/src/lib.rs
+++ b/boards/feather_m4/src/lib.rs
@@ -155,14 +155,14 @@ hal::bsp_pins!(
         /// The USB D- pad
         name: usb_dm,
         aliases: {
-            AlternateG: UsbDm
+            AlternateH: UsbDm
         }
     }
     PA25 {
         /// The USB D+ pad
         name: usb_dp,
         aliases: {
-            AlternateG: UsbDp
+            AlternateH: UsbDp
         }
     }
 );

--- a/boards/grand_central_m4/CHANGELOG.md
+++ b/boards/grand_central_m4/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Use correct alternate for USB (#661)
 - update to `atsamd-hal-0.15` (v2 drivers of peripherals and removal of deprecated things)
 - correction to the USB clock in the bsp convenience function
 

--- a/boards/grand_central_m4/src/lib.rs
+++ b/boards/grand_central_m4/src/lib.rs
@@ -466,14 +466,14 @@ hal::bsp_pins!(
             /// The USB D- pad
             name: usb_dm
             aliases: {
-                AlternateG: UsbDm,
+                AlternateH: UsbDm,
             }
         }
         PA25 {
             /// The USB D+ pad
             name: usb_dp
             aliases: {
-                AlternateG: UsbDp,
+                AlternateH: UsbDp,
             }
         }
 );

--- a/boards/metro_m4/CHANGELOG.md
+++ b/boards/metro_m4/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Use correct alternate for USB (#661)
 - Correction to the clock in the usb convenience function
 - Add aliases for A6 and A7.
 

--- a/boards/metro_m4/src/lib.rs
+++ b/boards/metro_m4/src/lib.rs
@@ -221,7 +221,7 @@ hal::bsp_pins!(
         /// The USB D- pad
         name: usb_dm
         aliases: {
-            AlternateG: UsbDm
+            AlternateH: UsbDm
         }
 
     }
@@ -229,7 +229,7 @@ hal::bsp_pins!(
         /// The USB D+ pad
         name: usb_dp
         aliases: {
-            AlternateG: UsbDp
+            AlternateH: UsbDp
         }
 
     }

--- a/boards/pyportal/CHANGELOG.md
+++ b/boards/pyportal/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Use correct alternate for USB (#661)
+
 # v0.10.0
 
 - update to `atsamd-hal` to 0.15.1 and `cortex-m-rt` to 0.7.1

--- a/boards/pyportal/src/pins.rs
+++ b/boards/pyportal/src/pins.rs
@@ -333,7 +333,7 @@ hal::bsp_pins!(
         /// The USB D- pad
         name: usb_dm
         aliases: {
-            AlternateG: UsbDm,
+            AlternateH: UsbDm,
             Reset: UsbDmReset,
         }
     }
@@ -341,7 +341,7 @@ hal::bsp_pins!(
         /// The USB D+ pad
         name: usb_dp
         aliases: {
-            AlternateG: UsbDp,
+            AlternateH: UsbDp,
             Reset: UsbDpReset,
         }
     }


### PR DESCRIPTION
The SAMD51 uses alternate `H` for USB functionality. This PR updates the pin definitions in the BSP for some boards using the SAMD51 that incorrectly model this as `AlternateG`.

This does not affect the [default](https://github.com/atsamd-rs/atsamd/blob/master/hal/src/thumbv7em/usb/mod.rs#L16-L23) in the HAL, or the [implementation](https://github.com/atsamd-rs/atsamd/blob/master/hal/src/thumbv7em/usb/bus.rs#L531) in `UsbBus` that always uses `AlternateH`