### PR TITLE
Add aliases for A6 and A7 to Metro M4

### DIFF
--- a/boards/metro_m4/CHANGELOG.md
+++ b/boards/metro_m4/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Correction to the clock in the usb convenience function
+- Add aliases for A6 and A7.
 
 # v0.11.1
 

--- a/boards/metro_m4/src/lib.rs
+++ b/boards/metro_m4/src/lib.rs
@@ -134,6 +134,7 @@ hal::bsp_pins!(
         name: sda
         aliases: {
             AlternateD: Sda
+            AlternateB: A6
         }
     }
     PB03 {
@@ -141,6 +142,7 @@ hal::bsp_pins!(
         name: scl
         aliases: {
             AlternateD: Scl
+            AlternateB: A7
         }
     }
 


### PR DESCRIPTION
# Summary

Add aliases for A6 and A7 to Metro M4

# Checklist
  - [ x ] `CHANGELOG.md` for the BSP or HAL updated
  - [ x ] All new or modified code is well documented, especially public items
  - [ x ] No new warnings or clippy suggestions have been introduced (see CI or check locally)
