### PR TITLE
Upgrade atsame54_xpro BSP to Tier I

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ A BSP (**B**oard **S**upport **P**ackage) is a crate that contains definitions s
 
 * `wio_terminal`
 
+* `atsame54_xpro`
+
 To bootstrap your own project you should be able to copy/paste the Rust code from the examples folder within the folder of the BSP you've chosen. But you shouldn't copy the `Cargo.toml` file from there, since that's not only used for the examples, but also for the whole BSP itself. You want to make your own `Cargo.toml` file. If you're new to this and have no clue what you're doing then this is probably the line you want in there:
 
 ```rust

--- a/boards/atsame54_xpro/CHANGELOG.md
+++ b/boards/atsame54_xpro/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+- Limit RAM memory to avoid HardFaults when `UROW:ECCRAM` is enabled
+- Remove re-export of `cortex-m-rt::entry`
 
 # v0.5.0
 - update to `atsamd-hal-0.15`

--- a/boards/atsame54_xpro/Cargo.toml
+++ b/boards/atsame54_xpro/Cargo.toml
@@ -18,7 +18,7 @@ version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.15"
+path = "../../hal"
 default-features = false
 
 [dependencies.usb-device]
@@ -26,8 +26,10 @@ version = "0.2"
 optional = true
 
 [dev-dependencies]
-panic-halt = "0.2"
-panic-semihosting = "0.6"
+cortex-m-rtic = "1.1"
+dwt-systick-monotonic = "1.1"
+panic-rtt-target = { version = "0.1", features = ["cortex-m"] }
+rtt-target = { version = "0.3", features = ["cortex-m"] }
 
 [features]
 default = ["rt", "atsamd-hal/same54p", "atsamd-hal/unproven"]
@@ -44,6 +46,3 @@ lto = true
 [profile.release]
 lto = true
 opt-level = "s"
-
-[[example]]
-name = "blinky_basic"

--- a/boards/atsame54_xpro/Embed.toml
+++ b/boards/atsame54_xpro/Embed.toml
@@ -1,0 +1,32 @@
+[default.probe]
+# EDBG on SAME54XPro
+usb_vid = "03eb"
+usb_pid = "2111"
+protocol = "Swd"
+
+[default.flashing]
+enabled = true
+restore_unwritten_bytes = false
+do_chip_erase = false
+
+[default.reset]
+enabled = true
+halt_afterwards = false
+
+[default.general]
+chip = "ATSAME54P20A"
+chip_descriptions = []
+log_level = "ERROR"
+connect_under_reset = false
+
+[default.rtt]
+enabled = true
+channels = [
+   { up = 0, down = 0, name = "idle", format = "String" },
+]
+timeout = 500
+show_timestamps = true
+log_enabled = false
+
+[default.gdb]
+enabled = false

--- a/boards/atsame54_xpro/README.md
+++ b/boards/atsame54_xpro/README.md
@@ -5,29 +5,21 @@ This crate provides a type-safe Rust API for working with the
 
 ## Board Features
 
-- Microchip [ATSAME54P] Cortex-M4 microcontroller @ 120 MHz (32-bit, 3.3V logic and power)
+- Microchip [ATSAME54P] Cortex-M4F microcontroller
   - 1MB Flash
-  - 256kB SRAM
+  - 256kB SRAM (128kB if ECCRAM is enabled)
   - 8MB SPI Flash chip
 
 ## Prerequisites
-* Install the cross compile toolchain `rustup target add thumbv7em-none-eabihf`
-* Install [cargo-hf2 the hf2 bootloader flasher tool](https://crates.io/crates/cargo-hf2) however your platform requires
 
-## Uploading an example
-Check out the repository for examples:
+* Install the cross-compilation target
+    * `$ rustup target add thumbv7em-none-eabihf`
+* Install the [`cargo-embed`](https://github.com/probe-rs/probe-rs/tree/master/cargo-embed)
+    * `$ cargo install cargo-embed`
 
-https://github.com/atsamd-rs/atsamd/tree/master/boards/atsame54_xpro/examples
+## Running an example
 
-* Be in this directory `cd boards/atsame54_xpro`
-* Put your device in bootloader mode usually by hitting the reset button twice.
-* Build and upload in one step
-```
-$ cargo hf2 --release --example blinky_basic
-    Finished release [optimized + debuginfo] target(s) in 2m 02s
-    Searching for a connected device with known vid/pid pair.
-    Trying  Ok(Some("Microchip")) Ok(Some("SAM E54 Xplained Pro Evaluation Kit"))
-    Flashing "/path/to/atsamd/boards/atsame54_xpro/target/thumbv7em-none-eabihf/release/examples/blinky_basic"
-    Finished in 0.085s
-$
-```
+* Checkout the atsamd repository
+* Go to directory `boards/atsame54_xpro`
+* Build and flash the device
+    * eg. `cargo embed --release --example blinky_rtic`

--- a/boards/atsame54_xpro/examples/blinky_basic.rs
+++ b/boards/atsame54_xpro/examples/blinky_basic.rs
@@ -4,22 +4,20 @@
 use atsame54_xpro as bsp;
 use bsp::hal;
 
-#[cfg(not(feature = "use_semihosting"))]
-use panic_halt as _;
-#[cfg(feature = "use_semihosting")]
-use panic_semihosting as _;
+use panic_rtt_target as _;
+use rtt_target::{rprintln, rtt_init_print};
 
-use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::pac::{CorePeripherals, Peripherals};
 use hal::prelude::*;
-use hal::watchdog::{Watchdog, WatchdogTimeout};
 
-#[entry]
+#[cortex_m_rt::entry]
 fn main() -> ! {
+    rtt_init_print!();
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
+
     let mut clocks = GenericClockController::with_external_32kosc(
         peripherals.GCLK,
         &mut peripherals.MCLK,
@@ -27,21 +25,18 @@ fn main() -> ! {
         &mut peripherals.OSCCTRL,
         &mut peripherals.NVMCTRL,
     );
+
     let mut delay = Delay::new(core.SYST, &mut clocks);
-    delay.delay_ms(400u16);
 
     let pins = bsp::Pins::new(peripherals.PORT);
     let mut led = bsp::pin_alias!(pins.led).into_push_pull_output();
 
-    let mut wdt = Watchdog::new(peripherals.WDT);
-    wdt.start(WatchdogTimeout::Cycles256 as u8);
-
     loop {
         delay.delay_ms(200u8);
-        wdt.feed();
         led.set_high().unwrap();
+        rprintln!("LED OFF");
         delay.delay_ms(200u8);
-        wdt.feed();
         led.set_low().unwrap();
+        rprintln!("LED ON");
     }
 }

--- a/boards/atsame54_xpro/examples/blinky_rtic.rs
+++ b/boards/atsame54_xpro/examples/blinky_rtic.rs
@@ -1,0 +1,81 @@
+#![no_std]
+#![no_main]
+
+use atsame54_xpro as bsp;
+use bsp::hal;
+use bsp::hal::clock::v2 as clock;
+use dwt_systick_monotonic::DwtSystick;
+use dwt_systick_monotonic::ExtU32 as _;
+// TODO: Any reason this cannot be in a HAL's prelude?
+use hal::ehal::digital::v2::StatefulOutputPin as _;
+use hal::prelude::*;
+use panic_rtt_target as _;
+use rtt_target::{rprintln, rtt_init_print};
+
+#[rtic::app(device = hal::pac, peripherals = true, dispatchers = [FREQM])]
+mod app {
+    use super::*;
+
+    #[monotonic(binds = SysTick, default = true)]
+    type Mono = DwtSystick<12_000_000>;
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {
+        led: bsp::Led,
+    }
+
+    #[init]
+    fn init(mut ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+        rtt_init_print!();
+
+        let (_buses, clocks, tokens) = clock::clock_system_at_reset(
+            ctx.device.OSCCTRL,
+            ctx.device.OSC32KCTRL,
+            ctx.device.GCLK,
+            ctx.device.MCLK,
+            &mut ctx.device.NVMCTRL,
+        );
+
+        let pins = bsp::Pins::new(ctx.device.PORT);
+        let xosc = clock::xosc::Xosc::from_crystal(
+            tokens.xosc1,
+            bsp::pin_alias!(pins.xosc1_x_in),
+            bsp::pin_alias!(pins.xosc1_x_out),
+            // Xosc1 on Same54Xpro is 12 MHz
+            12.mhz(),
+        )
+        .enable();
+
+        let (gclk0, _, _) = clocks.gclk0.swap_sources(clocks.dfll, xosc);
+
+        let mono = DwtSystick::new(
+            &mut ctx.core.DCB,
+            ctx.core.DWT,
+            ctx.core.SYST,
+            gclk0.freq().0,
+        );
+
+        let led = bsp::pin_alias!(pins.led).into();
+
+        led::spawn().unwrap();
+
+        (Shared {}, Local { led }, init::Monotonics(mono))
+    }
+
+    #[task(local = [led])]
+    fn led(ctx: led::Context) {
+        ctx.local.led.toggle().unwrap();
+        rprintln!(
+            "LED {}!",
+            if ctx.local.led.is_set_high().unwrap() {
+                "OFF"
+            } else {
+                "ON"
+            }
+        );
+        led::spawn_at(monotonics::now() + 200.millis()).unwrap();
+    }
+}

--- a/boards/atsame54_xpro/memory.x
+++ b/boards/atsame54_xpro/memory.x
@@ -1,7 +1,17 @@
 MEMORY
 {
   FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 0x100000
-  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x40000
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x20000
+  /*
+    Defensive RAM configuration:
+    - If RAMECC is enabled in the UROW (userpage), RAM is cut in half.
+    - Accessing the higher addresses when ECC is enabled yields very
+      nasty and hard to debug HardFaults.
+    - In order to avoid user's frustration, BSP limits the RAM to lower half.
+
+    Original setting:
+  /*
+  /* RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 0x40000 */
 }
 
 /* This is where the call stack will be allocated. */

--- a/boards/atsame54_xpro/src/pins.rs
+++ b/boards/atsame54_xpro/src/pins.rs
@@ -332,6 +332,19 @@ hal::bsp_pins!(
             AlternateI: SdData3
         }
     }
+    PB22 {
+        /// PB22: Xosc1 XIn/clock pin
+        aliases: {
+            FloatingDisabled: Xosc1XIn
+            FloatingDisabled: Xosc1Clock
+        }
+    }
+    PB23 {
+        /// PB23: Xosc1 XOut pin
+        aliases: {
+            FloatingDisabled: Xosc1XOut
+        }
+    }
     PB24 {
         /// PB24: EDBG connection UART receive pin
         aliases: {

--- a/crates.json
+++ b/crates.json
@@ -21,7 +21,7 @@
       "target": "thumbv6m-none-eabi"
     },
     "atsame54_xpro": {
-      "tier": 2,
+      "tier": 1,
       "build": "cargo build --examples --all-features",
       "target": "thumbv7em-none-eabihf"
     },


### PR DESCRIPTION
- Add `cargo-embed` support (minimal version `0.14` required)
- Limit RAM memory to avoid HardFaults when `UROW:ECCRAM` enabled

Examples:
- Panicking: switch from semihosting/halt to RTT
- Removed watchdog feeding from `blinky_basic` - By default watchdog should be disabled in UROW and if not, it should be hopefully much easier to debug than the ECC case.
- Added `blinky_rtic` example that uses RTIC to blink the LED and uses 12 MHz Xosc as the main clock source.

