### PR TITLE
Add into_parts for `QSpi`

### DIFF
--- a/hal/src/thumbv7em/qspi.rs
+++ b/hal/src/thumbv7em/qspi.rs
@@ -240,6 +240,25 @@ impl Qspi<OneShot> {
             _mode: PhantomData,
         }
     }
+
+    /// Return the consumed pins and the QSPI peripheral
+    ///
+    /// Order: `(qspi, sck, cs, io0, io1, io2, io3)`
+    pub fn free(
+        self,
+    ) -> (
+        QSPI,
+        Pin<PB10, AlternateH>,
+        Pin<PB11, AlternateH>,
+        Pin<PA08, AlternateH>,
+        Pin<PA09, AlternateH>,
+        Pin<PA10, AlternateH>,
+        Pin<PA11, AlternateH>,
+    ) {
+        (
+            self.qspi, self._sck, self._cs, self._io0, self._io1, self._io2, self._io3,
+        )
+    }
 }
 
 /// Operations available in XIP mode


### PR DESCRIPTION
# Summary
Add `into_parts` for `Qspi` to retreive pins

# Checklist
  - [ ] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)

## If Adding a new Board
  - [ ] Board CI added to `crates.json`
  - [ ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"

## If Adding a new cargo `feature` to the HAL
  - [ ] Feature is added to the test matrix for applicable boards / PACs in `crates.json`

I was short on time and just needed a quick fix for my use case, but I figured I might as well open this PR to open discussion.

Is there any specific reason these methods to return the consumed pins/peripherals aren't available? Or is this a discussion that needs to happen at `embedded-hal`?. I've seen both `into_inner` and `into_parts` for naming, not sure which is more standard.

The quick fix I did here was for Qspi only, but the same goes for Spi, I2C, Uart, etc.