### PR TITLE
Usb low speed

### DIFF
--- a/boards/metro_m0/CHANGELOG.md
+++ b/boards/metro_m0/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `usb_low_speed` usb cfg feature to set USB speed to low speed (1.5Mbps).
+
 # v0.12.1
 
 - Update to `atsamd-hal` version `0.15.1`

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -42,6 +42,7 @@ rtic = ["atsamd-hal/rtic"]
 unproven = ["atsamd-hal/unproven"]
 use_rtt = ["atsamd-hal/use_rtt"]
 usb = ["atsamd-hal/usb", "usb-device"]
+usb_low_speed = ["atsamd-hal/usb_low_speed"]
 use_semihosting = []
 
 [profile.dev]

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix failing `bsp_pins!` invocation with no aliases (#605 fixes #599)
 - Add Advanced Encryption Standard (AES) peripheral support including RustCrypto compatible backend
 - Add embedded-hal `InputPin` trait to EIC pins
+- Add `usb_low_speed` usb cfg feature to set USB speed to low speed (1.5Mbps).
 
 # v0.15.1
 

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -181,6 +181,7 @@ rtic = ["rtic-monotonic", "fugit"]
 sdmmc = ["embedded-sdmmc"]
 unproven = ["embedded-hal/unproven"]
 usb = ["usb-device"]
+usb_low_speed = []
 use_rtt = ["jlink_rtt"]
 
 #===============================================================================

--- a/hal/src/thumbv6m/usb/bus.rs
+++ b/hal/src/thumbv6m/usb/bus.rs
@@ -645,6 +645,9 @@ impl Inner {
         });
         // full speed
         usb.ctrlb.modify(|_, w| w.spdconf().fs());
+        #[cfg(feature = "usb_low_speed")] {
+            usb.ctrlb.modify(|_, w| w.spdconf().ls());
+        }
 
         usb.ctrla.modify(|_, w| w.enable().set_bit());
         while usb.syncbusy.read().enable().bit_is_set() {}

--- a/hal/src/thumbv6m/usb/bus.rs
+++ b/hal/src/thumbv6m/usb/bus.rs
@@ -645,7 +645,8 @@ impl Inner {
         });
         // full speed
         usb.ctrlb.modify(|_, w| w.spdconf().fs());
-        #[cfg(feature = "usb_low_speed")] {
+        #[cfg(feature = "usb_low_speed")]
+        {
             usb.ctrlb.modify(|_, w| w.spdconf().ls());
         }
 

--- a/hal/src/thumbv7em/usb/bus.rs
+++ b/hal/src/thumbv7em/usb/bus.rs
@@ -589,6 +589,9 @@ impl Inner {
         });
         // full speed
         usb.ctrlb.modify(|_, w| w.spdconf().fs());
+        #[cfg(feature = "usb_low_speed")] {
+            usb.ctrlb.modify(|_, w| w.spdconf().ls());
+        }
 
         usb.ctrla.modify(|_, w| w.enable().set_bit());
         while usb.syncbusy.read().enable().bit_is_set() {}

--- a/hal/src/thumbv7em/usb/bus.rs
+++ b/hal/src/thumbv7em/usb/bus.rs
@@ -589,7 +589,8 @@ impl Inner {
         });
         // full speed
         usb.ctrlb.modify(|_, w| w.spdconf().fs());
-        #[cfg(feature = "usb_low_speed")] {
+        #[cfg(feature = "usb_low_speed")]
+        {
             usb.ctrlb.modify(|_, w| w.spdconf().ls());
         }
 


### PR DESCRIPTION
# Summary
Add cargo cfg feature to allow user to use USB in low speed mode instead of the default full speed mode.   

## Reasoning
My specific use case is using the microcontroller to emulate a keyboard / mouse for use in BIOS configuration.  Some motherboards do not support full speed USB interfaces in BIOS so I need the ability to set the USB subsystem to low speed mode.

## Notes
I'm not sure if the way I implemented the cfg feature is idiomatic so I'm open to feedback on that but it does work on the metro_m0 board I tested on.  I did not add the feature to all the other board types as I have no way to actually test them (although I see no reason it would not work especially for any boards based on SAMD21).

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)

## If Adding a new cargo `feature` to the HAL
  - [ ] Feature is added to the test matrix for applicable boards / PACs in `crates.json`
