### PR TITLE
Add missing ADC pins for ATSAMD11D

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -24,6 +24,7 @@
       - `Nvm::write_from_slice` -> `Nvm::write_flash_from_slice`
       - `Nvm::erase` -> `Nvm::erase_flash`
   - Refactor `Nvm::command_sync` to be less error-prone
+- Add the missing ADC traits for the SAMD11D
 
 # v0.15.1
 

--- a/hal/src/thumbv6m/adc.rs
+++ b/hal/src/thumbv6m/adc.rs
@@ -186,6 +186,15 @@ adc_pins! {
     PA15: 7
 }
 
+#[cfg(feature = "pins-d11d")]
+adc_pins! {
+    PA03: 1,
+    PA06: 4,
+    PA07: 5,
+    PA10: 8,
+    PA11: 9
+}
+
 #[cfg(feature = "samd21")]
 adc_pins! {
     PA02: 0,


### PR DESCRIPTION
# Summary
The ATSAMD11D has 20 or 24 pins. Some of them are also ADC pins, however the traits were not implemented for them.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced (see CI or check locally)