### PR TITLE
Fix example in wio_terminal

### DIFF
--- a/boards/wio_terminal/examples/snake.rs
+++ b/boards/wio_terminal/examples/snake.rs
@@ -88,7 +88,7 @@ fn main() -> ! {
             &mut clocks,
             peripherals.SERCOM7,
             &mut peripherals.MCLK,
-            100.mhz(),
+            100.MHz(),
             &mut delay,
         )
         .unwrap();


### PR DESCRIPTION
Overlooked example that failed to compile in #672.

