### PR TITLE
Fix release HAL crate workflow

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -72,8 +72,8 @@ jobs:
         run: |
           set -ex
 
-          # Install random crate to force update of the registry
-          cargo install lazy_static || true
+          # Force update of the registry
+          cargo update || true
 
           cd "hal" && cargo publish --no-verify
 
@@ -85,7 +85,7 @@ jobs:
           set -ex
 
           # Install random crate to force update of the registry
-          cargo install lazy_static || true
+          cargo update || true
 
           sudo apt-get install -y jq
 

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           set -ex
 
-          # Install random crate to force update of the registry
+          # Force update of the registry
           cargo update || true
 
           sudo apt-get install -y jq

--- a/boards/pygamer/src/lib.rs
+++ b/boards/pygamer/src/lib.rs
@@ -40,7 +40,5 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
     let mut pins = Pins::new(peripherals.PORT);
     let _ = pins.d13.into_open_drain_output(&mut pins.port).set_high();
 
-    loop {
-        cortex_m::asm::udf()
-    }
+    cortex_m::asm::udf()
 }


### PR DESCRIPTION
# Summary
Installing `lazy_static` no longer works as a workaround to force a refresh of the Cargo registry. Replace with `cargo update` instead.
