### PR TITLE
Point atsamd11d README.md to the correct docs/crates.io

### DIFF
--- a/pac/atsamd11d/README.md
+++ b/pac/atsamd11d/README.md
@@ -3,9 +3,9 @@
 A peripheral access crate for the ATSAMD11D chip from Microchip (née Atmel) for Rust Embedded projects.
 
 [![Build Status](https://travis-ci.org/atsamd-rs/atsamd.svg?branch=master)](https://travis-ci.org/atsamd-rs/atsamd)
-[![Crates.io](https://img.shields.io/crates/v/atsamd11c.svg)](https://crates.io/crates/atsamd11c)
+[![Crates.io](https://img.shields.io/crates/v/atsamd11d.svg)](https://crates.io/crates/atsamd11d)
 
-## [Documentation](https://docs.rs/atsamd11c)
+## [Documentation](https://docs.rs/atsamd11d)
 
 This source was automatically generated using `svd2rust`, split into smaller pieces using `form` and formatted via `rustfmt`.
 


### PR DESCRIPTION
# Summary

Correct the atsamd11d `README.md` to  the corresponding docs and crates.io listing

It was previously pointing to links for atsamd11`c` instead of `d`

# Checklist
  - [ N/A ] `CHANGELOG.md` for the BSP or HAL updated
  - [ N/A ] All new or modified code is well documented, especially public items
  - [ N/A`*` ] No new warnings or clippy suggestions have been introduced (see CI or check locally)

`*` = CI check still pending at the time this issue was submitted

## If Adding a new Board
  - [ N/A ] Board CI added to `crates.json`
  - [ N/A ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"

## If Adding a new cargo `feature` to the HAL
  - [ N/A ] Feature is added to the test matrix for applicable boards / PACs in `crates.json`

