### PR TITLE
Fix DMAC documentation

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased Changes
 
+- Add compile error for combined `library` and `dma` features
+- Add `dma` feature to docs metadata
 - Update the PACs to svd2rust 0.30.2.
 
 # v0.16.0

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -23,7 +23,7 @@ rust-version = "1.65"
 version = "0.16.0"
 
 [package.metadata.docs.rs]
-features = ["samd21g", "samd21g-rt", "unproven", "usb"]
+features = ["samd21g", "samd21g-rt", "unproven", "usb", "dma"]
 
 #===============================================================================
 # Required depdendencies

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -15,6 +15,9 @@ compile_error!(
 #[cfg(all(feature = "library", feature = "device"))]
 compile_error!("Cannot combine `library` and `device` features");
 
+#[cfg(all(feature = "library", feature = "dma"))]
+compile_error!("Cannot combine `library` and `dma` features");
+
 macro_rules! define_pac {
     ( $( ($pac:ident, $feat:literal)),+ ) => {
         $(


### PR DESCRIPTION
# Summary
The current documentation for the HAL on crates.io does not include documentation for the DMAC peripheral. This PR modifies the metadata to include the `dma` trait such that this is included in the online documentation. Simultaneously, the `dma` and `library` features should not be combined, due to `dma` enabling code that relies on a PAC across many source files. A compile error is added to prohibit compilation with `dma` and `library` features combined.
