### PR TITLE
Fix xiao_m0 spi clock used in spi_master

### DIFF
--- a/boards/xiao_m0/src/lib.rs
+++ b/boards/xiao_m0/src/lib.rs
@@ -200,7 +200,7 @@ pub fn spi_master(
     miso: impl Into<Miso>,
 ) -> Spi {
     let gclk0 = clocks.gclk0();
-    let clock = clocks.sercom4_core(&gclk0).unwrap();
+    let clock = clocks.sercom0_core(&gclk0).unwrap();
     let freq = clock.freq();
     let baud = baud.into();
     let (miso, mosi, sclk) = (miso.into(), mosi.into(), sclk.into());


### PR DESCRIPTION
# Summary
Use proper clock in spi_master

https://github.com/atsamd-rs/atsamd/commit/35e3a1ad96d7681c31f2a8fab2eb19667414a28f#diff-50cf0af7e1c3cc57008455475eef99c880de47307bbf5b685c24ca1f0f985a0cL136 changed sercom0 -> sercom4 accidentally.

# Checklist
  - [ ] `CHANGELOG.md` for the BSP or HAL updated
  - [ ] All new or modified code is well documented, especially public items
  - [ ] No new warnings or clippy suggestions have been introduced (see CI or check locally)

## If Adding a new Board
  - [ ] Board CI added to `crates.json`
  - [ ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"

## If Adding a new cargo `feature` to the HAL
  - [ ] Feature is added to the test matrix for applicable boards / PACs in `crates.json`
