### PR TITLE
Remove pin pa28 from d21el

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update the PACs to svd2rust 0.30.2.
 - Fix warnings for thumbv7 targets
 - Update README.md - moves some content to wiki
+- Remove pin `pa28` from the `d21el` target (#717)
 
 # v0.16.0
 

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -265,7 +265,7 @@ pins-d21e = ["pins-32a", "has-pa28"]
 pins-d21g = ["pins-48a", "has-pa28"]
 pins-d21j = ["pins-64", "has-pa28"]
 
-pins-d21el = ["pins-32l", "has-pa28"]
+pins-d21el = ["pins-32l"]
 pins-d21gl = ["pins-48l", "has-pa28"]
 
 pins-d51g = ["pins-48a"]


### PR DESCRIPTION
# Summary

The `pa28` pin is not present on the `d21el` device, but the pin was added in `Cargo.toml` by mistake.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 
