### PR TITLE
Update usb-device

### DIFF
--- a/boards/atsame54_xpro/Cargo.toml
+++ b/boards/atsame54_xpro/Cargo.toml
@@ -23,11 +23,11 @@ features = ["critical-section-single-core"]
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.16.0"
+version = "0.17.0"
 default-features = false
 
 [dependencies.usb-device]
-version = "0.2"
+version = "0.3.1"
 optional = true
 
 [dev-dependencies]

--- a/boards/atsame54_xpro/Cargo.toml
+++ b/boards/atsame54_xpro/Cargo.toml
@@ -23,7 +23,7 @@ features = ["critical-section-single-core"]
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.17.0"
+version = "0.16.0"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -21,7 +21,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.16.0"
+version = "0.17.0"
 default-features = false
 
 [dependencies.cortex-m]
@@ -29,7 +29,7 @@ version = "0.7"
 features = ["critical-section-single-core"]
 
 [dependencies.usb-device]
-version = "0.2"
+version = "0.3.1"
 optional = true
 
 [dependencies.embedded-sdmmc]
@@ -39,7 +39,7 @@ optional = true
 [dev-dependencies]
 cortex-m-rtic = "1.0"
 cortex-m = "0.7"
-usbd-serial = "0.1"
+usbd-serial = "0.2"
 cortex-m-semihosting = "0.3"
 ssd1306 = "0.7"
 embedded-graphics = "0.7.1"

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -21,7 +21,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.17.0"
+version = "0.16.0"
 default-features = false
 
 [dependencies.cortex-m]

--- a/boards/feather_m0/examples/usb_echo.rs
+++ b/boards/feather_m0/examples/usb_echo.rs
@@ -50,9 +50,11 @@ fn main() -> ! {
         USB_SERIAL = Some(SerialPort::new(bus_allocator));
         USB_BUS = Some(
             UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x16c0, 0x27dd))
-                .manufacturer("Fake company")
-                .product("Serial port")
-                .serial_number("TEST")
+                .strings(&[StringDescriptors::new(LangID::EN)
+                    .manufacturer("Fake company")
+                    .product("Serial port")
+                    .serial_number("TEST")])
+                .expect("Failed to set strings")
                 .device_class(USB_CLASS_CDC)
                 .build(),
         );

--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -25,15 +25,15 @@ features = ["critical-section-single-core"]
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.16.0"
+version = "0.17.0"
 default-features = false
 
 [dependencies.usb-device]
-version = "0.2"
+version = "0.3.1"
 optional = true
 
 [dev-dependencies]
-usbd-serial = "0.1"
+usbd-serial = "0.2"
 cortex-m-rtic = "0.6.0-rc.2"
 panic-halt = "0.2"
 panic-semihosting = "0.5"

--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -25,7 +25,7 @@ features = ["critical-section-single-core"]
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.17.0"
+version = "0.16.0"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/feather_m4/examples/nvm_dsu.rs
+++ b/boards/feather_m4/examples/nvm_dsu.rs
@@ -59,9 +59,11 @@ fn main() -> ! {
         USB_SERIAL = Some(SerialPort::new(bus_allocator));
         USB_BUS = Some(
             UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x16c0, 0x27dd))
-                .manufacturer("Fake company")
-                .product("Serial port")
-                .serial_number("TEST")
+                .strings(&[StringDescriptors::new(LangID::EN)
+                    .manufacturer("Fake company")
+                    .product("Serial port")
+                    .serial_number("TEST")])
+                .expect("Failed to set strings")
                 .device_class(USB_CLASS_CDC)
                 .build(),
         );

--- a/boards/feather_m4/examples/pukcc_test.rs
+++ b/boards/feather_m4/examples/pukcc_test.rs
@@ -53,9 +53,11 @@ fn main() -> ! {
         USB_SERIAL = Some(SerialPort::new(bus_allocator));
         USB_BUS = Some(
             UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x16c0, 0x27dd))
-                .manufacturer("Fake company")
-                .product("Serial port")
-                .serial_number("TEST")
+                .strings(&[StringDescriptors::new(LangID::EN)
+                    .manufacturer("Fake company")
+                    .product("Serial port")
+                    .serial_number("TEST")])
+                .expect("Failed to set strings")
                 .device_class(USB_CLASS_CDC)
                 .build(),
         );

--- a/boards/feather_m4/examples/smart_eeprom.rs
+++ b/boards/feather_m4/examples/smart_eeprom.rs
@@ -57,9 +57,11 @@ fn main() -> ! {
         USB_SERIAL = Some(SerialPort::new(bus_allocator));
         USB_BUS = Some(
             UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x16c0, 0x27dd))
-                .manufacturer("Fake company")
-                .product("Serial port")
-                .serial_number("TEST")
+                .strings(&[StringDescriptors::new(LangID::EN)
+                    .manufacturer("Fake company")
+                    .product("Serial port")
+                    .serial_number("TEST")])
+                .expect("Failed to set strings")
                 .device_class(USB_CLASS_CDC)
                 .build(),
         );

--- a/boards/feather_m4/examples/usb_echo.rs
+++ b/boards/feather_m4/examples/usb_echo.rs
@@ -51,9 +51,11 @@ fn main() -> ! {
         USB_SERIAL = Some(SerialPort::new(bus_allocator));
         USB_BUS = Some(
             UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x16c0, 0x27dd))
-                .manufacturer("Fake company")
-                .product("Serial port")
-                .serial_number("TEST")
+                .strings(&[StringDescriptors::new(LangID::EN)
+                    .manufacturer("Fake company")
+                    .product("Serial port")
+                    .serial_number("TEST")])
+                .expect("Failed to set strings")
                 .device_class(USB_CLASS_CDC)
                 .build(),
         );
@@ -70,7 +72,9 @@ fn main() -> ! {
 
     loop {
         cycle_delay(5 * 1024 * 1024);
-        red_led.toggle().unwrap();
+        red_led.set_high().unwrap();
+        cycle_delay(5 * 1024 * 1024);
+        red_led.set_low().unwrap();
     }
 }
 

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -24,16 +24,16 @@ features = ["critical-section-single-core"]
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.16.0"
+version = "0.17.0"
 default-features = false
 
 [dependencies.usb-device]
-version = "0.2"
+version = "0.3.1"
 optional = true
 
 [dev-dependencies]
 cortex-m = "0.7"
-usbd-serial = "0.1"
+usbd-serial = "0.2"
 panic-halt = "0.2"
 panic-semihosting = "0.5"
 cortex-m-rtic = "1.0"

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -24,7 +24,7 @@ features = ["critical-section-single-core"]
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.17.0"
+version = "0.16.0"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/metro_m0/examples/usb_echo.rs
+++ b/boards/metro_m0/examples/usb_echo.rs
@@ -47,9 +47,11 @@ fn main() -> ! {
         USB_SERIAL = Some(SerialPort::new(bus_allocator));
         USB_BUS = Some(
             UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x16c0, 0x27dd))
-                .manufacturer("Fake company")
-                .product("Serial port")
-                .serial_number("TEST")
+                .strings(&[StringDescriptors::new(LangID::EN)
+                    .manufacturer("Fake company")
+                    .product("Serial port")
+                    .serial_number("TEST")])
+                .expect("Failed to set strings")
                 .device_class(USB_CLASS_CDC)
                 .build(),
         );

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -20,7 +20,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.17.0"
+version = "0.16.0"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -20,11 +20,11 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.16.0"
+version = "0.17.0"
 default-features = false
 
 [dependencies.usb-device]
-version = "0.2"
+version = "0.3.1"
 optional = true
 
 [dependencies.cortex-m]
@@ -33,7 +33,7 @@ features = ["critical-section-single-core"]
 
 [dev-dependencies]
 cortex-m = "0.7"
-usbd-serial = "0.1"
+usbd-serial = "0.2"
 panic-probe = "0.3"
 panic-halt = "0.2"
 panic-semihosting = "0.5"

--- a/boards/metro_m4/examples/usb_logging.rs
+++ b/boards/metro_m4/examples/usb_logging.rs
@@ -54,9 +54,11 @@ fn main() -> ! {
         USB_SERIAL = Some(SerialPort::new(bus_allocator));
         USB_BUS = Some(
             UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x2222, 0x3333))
-                .manufacturer("Fake company")
-                .product("Serial port")
-                .serial_number("TEST")
+                .strings(&[StringDescriptors::new(LangID::EN)
+                    .manufacturer("Fake company")
+                    .product("Serial port")
+                    .serial_number("TEST")])
+                .expect("Failed to set strings")
                 .device_class(USB_CLASS_CDC)
                 .build(),
         );

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -23,7 +23,7 @@ features = ["critical-section-single-core"]
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.17.0"
+version = "0.16.0"
 default-features = false
 
 [dev-dependencies]

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -23,7 +23,7 @@ features = ["critical-section-single-core"]
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.16.0"
+version = "0.17.0"
 default-features = false
 
 [dev-dependencies]

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Update README.md - moves some content to wiki
 - Remove pin `pa28` from the `d21el` target (#717)
 - Fix a pwm configuration for the `tc4` on `D5x` targets (#720)
+- Update to usb-device 0.3.1
 
 # v0.16.0
 

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -20,7 +20,7 @@ name = "atsamd-hal"
 readme = "README.md"
 repository = "https://github.com/atsamd-rs/atsamd"
 rust-version = "1.65"
-version = "0.17.0"
+version = "0.16.0"
 
 [package.metadata.docs.rs]
 features = ["samd21g", "samd21g-rt", "unproven", "usb", "dma"]

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -20,7 +20,7 @@ name = "atsamd-hal"
 readme = "README.md"
 repository = "https://github.com/atsamd-rs/atsamd"
 rust-version = "1.65"
-version = "0.16.0"
+version = "0.17.0"
 
 [package.metadata.docs.rs]
 features = ["samd21g", "samd21g-rt", "unproven", "usb", "dma"]
@@ -56,7 +56,7 @@ embedded-sdmmc = {version = "0.3", optional = true}
 jlink_rtt = {version = "0.2", optional = true}
 mcan-core = {version = "0.2", optional = true}
 rtic-monotonic = {version = "1.0", optional = true}
-usb-device = {version = "0.2", optional = true}
+usb-device = {version = "0.3.1", optional = true}
 defmt = {version = "0.3.4", optional = true}
 
 #===============================================================================

--- a/hal/src/thumbv6m/usb/bus.rs
+++ b/hal/src/thumbv6m/usb/bus.rs
@@ -40,7 +40,7 @@ impl From<EndpointType> for EndpointTypeBits {
     fn from(ep_type: EndpointType) -> EndpointTypeBits {
         match ep_type {
             EndpointType::Control => EndpointTypeBits::Control,
-            EndpointType::Isochronous => EndpointTypeBits::Isochronous,
+            EndpointType::Isochronous { .. } => EndpointTypeBits::Isochronous,
             EndpointType::Bulk => EndpointTypeBits::Bulk,
             EndpointType::Interrupt => EndpointTypeBits::Interrupt,
         }

--- a/hal/src/thumbv7em/usb/bus.rs
+++ b/hal/src/thumbv7em/usb/bus.rs
@@ -40,7 +40,7 @@ impl From<EndpointType> for EndpointTypeBits {
     fn from(ep_type: EndpointType) -> EndpointTypeBits {
         match ep_type {
             EndpointType::Control => EndpointTypeBits::Control,
-            EndpointType::Isochronous => EndpointTypeBits::Isochronous,
+            EndpointType::Isochronous { .. } => EndpointTypeBits::Isochronous,
             EndpointType::Bulk => EndpointTypeBits::Bulk,
             EndpointType::Interrupt => EndpointTypeBits::Interrupt,
         }


### PR DESCRIPTION
# Summary
The usb-device crate is used by both the HAL and USB Class crates, to create a USB Device.  The same version of usb-device needs to be used for all the dependencies of a firmware, which can lead to difficulty for instance if a required USB Class crate hasn't been updated.

This PR updates usb-device to the latest released version.  This is a breaking change for both usb-device and our HAL.

This commit updates our tier 1 BSPs only.

(when we cut the usb-device 0.3.0 release, we forgot to include a new type in the prelude, which made it somewhat annoying to use - hence the 0.2 -> 0.3.1)

# Checklist
  - [X] `CHANGELOG.md` for the BSP or HAL updated
  - [X] All new or modified code is well documented, especially public items
  - [X] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 