### PR TITLE
Fix a pwm pin configuration for D5x

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix warnings for thumbv7 targets
 - Update README.md - moves some content to wiki
 - Remove pin `pa28` from the `d21el` target (#717)
+- Fix a pwm configuration for the `tc4` on `D5x` targets (#720)
 
 # v0.16.0
 

--- a/hal/src/thumbv7em/pwm.rs
+++ b/hal/src/thumbv7em/pwm.rs
@@ -100,8 +100,8 @@ impl_tc_pinout!(TC3Pinout: [
 #[cfg(feature = "has-tc4")]
 impl_tc_pinout!(TC4Pinout: [
     (Pa23, PA23),
-    #[cfg(feature = "has-pb00")]
-    (Pb0, PB09),
+    #[cfg(feature = "pins-48")]
+    (Pb9, PB09),
     #[cfg(feature = "pins-64")]
     (Pb13, PB13)
 ]);


### PR DESCRIPTION
# Summary
The `tc4` uses pins `pa23`, `pb09` and `pb13` on the D5x. The pin `pb09` is present on all `pins-48` devices and above.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 