### PR TITLE
edgebadge: Update embedded-graphics to 0.8.1

### DIFF
--- a/boards/edgebadge/CHANGELOG.md
+++ b/boards/edgebadge/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Unreleased
 
+- update embedded-graphics to 0.8.1
+
 # v0.9.0
 
 - update to `atsamd-hal-0.14` and other latest dependencies (#564)
-- Updated to 2021 edition, updated dependencies, removed unused dependencies (#562)
+- update to 2021 edition, updated dependencies, removed unused dependencies (#562)
 - remove extraneous `embedded-hal` dependencies from BSPs
 - move `usbd-x` crates used only in examples to `[dev-dependencies]`
-- removed unnecessary dependency on `nb` (#510)
+- remove unnecessary dependency on `nb` (#510)
 
 ---
 

--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -53,7 +53,7 @@ math = ["micromath"]
 # opt-level = 2 # uncomment for neopixel functionality during debug
 incremental = false
 debug = true
-lto = "thin"        # thin for debug speed
+lto = "thin" # thin for debug speed
 
 [profile.release]
 debug = true

--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -35,7 +35,7 @@ optional = true
 [dev-dependencies]
 usbd-serial = "0.1"
 panic-halt = "0.2"
-embedded-graphics = "0.7.1"
+embedded-graphics = "0.8.1"
 smart-leds = "0.3"
 lis3dh = "0.1.0"
 cortex-m-rtic = "1.0"
@@ -53,7 +53,7 @@ math = ["micromath"]
 # opt-level = 2 # uncomment for neopixel functionality during debug
 incremental = false
 debug = true
-lto = "thin" # thin for debug speed
+lto = "thin"        # thin for debug speed
 
 [profile.release]
 debug = true


### PR DESCRIPTION
# Summary

Update `embedded-graphics` to the latest version.

Close #724

Close https://github.com/LuckyTurtleDev/pybadge-high/issues/11

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 
