### PR TITLE
edgebadge: update embedded-graphics to 0.8

### DIFF
--- a/boards/edgebadge/CHANGELOG.md
+++ b/boards/edgebadge/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+
+# v0.10.0
+- update `embedded-graphics` to 0.8.1 (#726)
+- update `st7735-lcd` to 0.9.0 (#726)
+- update `tinybmp` to 0.5.0 (#726)
+
 # v0.9.0
 
 - update to `atsamd-hal-0.14` and other latest dependencies (#564)

--- a/boards/edgebadge/CHANGELOG.md
+++ b/boards/edgebadge/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Unreleased
 
-
-# v0.10.0
 - update `embedded-graphics` to 0.8.1 (#726)
 - update `st7735-lcd` to 0.9.0 (#726)
 - update `tinybmp` to 0.5.0 (#726)

--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgebadge"
-version = "0.10.0"
+version = "0.9.0"
 authors = ["Jacob Rosenthal <@jacobrosenthal>"]
 description = "Board Support crate for the Adafruit EdgeBadge"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "edgebadge"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Jacob Rosenthal <@jacobrosenthal>"]
 description = "Board Support crate for the Adafruit EdgeBadge"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
@@ -13,7 +13,7 @@ exclude = ["assets"]
 
 [dependencies]
 cortex-m = "0.7"
-st7735-lcd = "0.8.1"
+st7735-lcd = "0.9.0"
 ws2812-timer-delay = "0.3"
 
 [dependencies.cortex-m-rt]
@@ -35,11 +35,11 @@ optional = true
 [dev-dependencies]
 usbd-serial = "0.1"
 panic-halt = "0.2"
-embedded-graphics = "0.7.1"
+embedded-graphics = "0.8.1"
 smart-leds = "0.3"
 lis3dh = "0.1.0"
 cortex-m-rtic = "1.0"
-tinybmp = "0.3.1"
+tinybmp = "0.5.0"
 
 [features]
 # ask the HAL to enable atsamd51j support


### PR DESCRIPTION
# Summary
fix #724 

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 
