### PR TITLE
Update atsamd-hal-macros Cargo.toml for publishing

### DIFF
--- a/atsamd-hal-macros/Cargo.toml
+++ b/atsamd-hal-macros/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "atsamd-hal-macros"
-version = "0.16.0"
+version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
+categories = ["embedded", "hardware-support", "no-std"]
+description = "Procedural macros for the atsamd-hal library"
+documentation = "https://docs.rs/crate/atsamd-hal-macros/"
+repository = "https://github.com/atsamd-rs/atsamd"
 
 [lib]
 proc-macro = true

--- a/atsamd-hal-macros/Cargo.toml
+++ b/atsamd-hal-macros/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+authors = ["Tethys Svensson"]
 name = "atsamd-hal-macros"
 version = "0.1.0"
 edition = "2021"

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -31,7 +31,7 @@ features = ["samd21g", "samd21g-rt", "usb", "dma"]
 
 [dependencies]
 aes = "0.7.5"
-atsamd-hal-macros = { version = "0.16.0", path = "../atsamd-hal-macros" }
+atsamd-hal-macros = { version = "0.1.0", path = "../atsamd-hal-macros" }
 bitfield = "0.13"
 bitflags = "1.2.1"
 cipher = "0.3"


### PR DESCRIPTION
 The atsamd-hal-macros Cargo.toml needed updating in order to be able to publish it, which is required to publish atsamd-hal.