### PR TITLE
atsamd11: Add USB clock

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased Changes
 
+- Allow configuring USB clock with `GenericClockController` on atsamd11
+
 # v0.17.0
 
 - Remove `unproven` Cargo feature

--- a/hal/src/peripherals/clock/d11.rs
+++ b/hal/src/peripherals/clock/d11.rs
@@ -412,6 +412,7 @@ clock_generator!(
     (adc, AdcClock, ADC),
     (wdt, WdtClock, WDT),
     (eic, EicClock, EIC),
+    (usb, UsbClock, USB),
     (evsys0, Evsys0Clock, EVSYS_0),
     (evsys1, Evsys1Clock, EVSYS_1),
     (evsys2, Evsys2Clock, EVSYS_2),


### PR DESCRIPTION
# Summary
Allow configuring USB clock with `GenericClockController` on atsamd11.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 
