### PR TITLE
Remove statement excluding samd51j from i2s peripheral

### DIFF
--- a/atsamd-hal-macros/devices.yaml
+++ b/atsamd-hal-macros/devices.yaml
@@ -134,6 +134,6 @@ families:
       - tcc: { count: 3, only: ["samd51g", "same51g"] }
       - tcc: { count: 5, only: ["samd51j", "samd51n", "samd51p", "same51j", "same51n", "same53j", "same53n", "same54n", "same54p"] }
       - ptc
-      - i2s: { except: ["samd51j"] }
+      - i2s
       - pcc
       - pdec

--- a/atsamd-hal-macros/devices.yaml
+++ b/atsamd-hal-macros/devices.yaml
@@ -134,6 +134,6 @@ families:
       - tcc: { count: 3, only: ["samd51g", "same51g"] }
       - tcc: { count: 5, only: ["samd51j", "samd51n", "samd51p", "same51j", "same51n", "same53j", "same53n", "same54n", "same54p"] }
       - ptc
-      - i2s
+      - i2s: { except: ["samd51g"] }
       - pcc
       - pdec

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased Changes
 
+- fix samd51j not having i2s support
+
 # v0.17.0
 
 - Remove `unproven` Cargo feature

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased Changes
 
 - fix samd51j not having i2s support
+- remove i2s functionality for samd51g since it does not have it
 
 # v0.17.0
 


### PR DESCRIPTION
# Summary
Removes a statement excluding the samd51j from i2s peripheral. The samd51j series of chips supports i2s. [Source](https://www.microchip.com/en-us/product/atsamd51j19a)

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 