### PR TITLE
Add Winc1500 pins

### DIFF
--- a/boards/feather_m0/CHANGELOG.md
+++ b/boards/feather_m0/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- Added 'winc' feature for Feather with a WINC1500 Wifi chip
 
 # v0.14.0
 

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -63,6 +63,8 @@ dma = ["atsamd-hal/dma"]
 max-channels = ["dma", "atsamd-hal/max-channels"]
 # Enable pins for the adalogger SD card reader
 adalogger = []
+# Enable pins for Feather with WINC1500 wifi
+winc = []
 sdmmc = ["embedded-sdmmc", "atsamd-hal/sdmmc"]
 rtic = ["atsamd-hal/rtic"]
 use_semihosting = []

--- a/boards/feather_m0/src/lib.rs
+++ b/boards/feather_m0/src/lib.rs
@@ -169,12 +169,12 @@ pub mod pins {
             }
         }
 
-        #[cfg(all(feature = "rfm", not(feature = "express")))]
+        #[cfg(all(feature = "rfm", not(feature = "express"), not(feature = "winc")))]
         PA06 {
             /// SPI chip select for the RFM module
             name: rfm_cs
         }
-        #[cfg(all(feature = "rfm", not(feature = "express"), not(feature = "adalogger")))]
+        #[cfg(all(feature = "rfm", not(feature = "express"), not(feature = "adalogger"), not(feature = "winc")))]
         PA08 {
             /// Reset for the RFM module
             name: rfm_reset
@@ -185,7 +185,7 @@ pub mod pins {
             name: rfm_irq
         }
 
-        #[cfg(all(feature = "express", not(feature = "rfm")))]
+        #[cfg(all(feature = "express", not(feature = "rfm"), not(feature = "winc")))]
         PA06 {
             /// Neopixel data
             name: neopixel
@@ -196,12 +196,12 @@ pub mod pins {
             /// SPI clock for the external flash
             name: flash_sclk
         }
-        #[cfg(all(feature = "express", not(feature = "rfm"), not(feature = "adalogger")))]
+        #[cfg(all(feature = "express", not(feature = "rfm"), not(feature = "adalogger"), not(feature = "winc")))]
         PA08 {
             /// SPI MOSI for the external flash
             name: flash_mosi
         }
-        #[cfg(feature = "express")]
+        #[cfg(all(feature = "express", not(feature= "winc")))]
         PA14 {
             /// SPI MISO for the external flash
             name: flash_miso
@@ -212,7 +212,7 @@ pub mod pins {
             name: flash_cs
         }
 
-        #[cfg(all(feature = "adalogger", not(feature = "rfm"), not(feature = "express")))]
+        #[cfg(all(feature = "adalogger", not(feature = "rfm"), not(feature = "express"), not(feature = "winc")))]
         PA08 {
             /// SD card SPI chip select
             name: sd_cs
@@ -220,7 +220,7 @@ pub mod pins {
                 PushPullOutput: SdCs
             }
         },
-        #[cfg(all(feature = "adalogger", not(feature = "rfm"), not(feature = "express")))]
+        #[cfg(all(feature = "adalogger", not(feature = "rfm"), not(feature = "express") , not(feature = "winc")))]
         PA21 {
             /// SD card detect
             name: sd_cd
@@ -228,6 +228,43 @@ pub mod pins {
                 PullUpInput: SdCd
             }
         },
+
+        #[cfg(all(feature = "winc", not(feature = "rfm"), not(feature = "express"), not(feature = "adalogger")))]
+        PA08 {
+            /// Reset for the WINC1500 module
+            name: winc_rst
+            aliases: {
+                PushPullOutput: WincRst
+            }
+        },
+
+        #[cfg(all(feature = "winc", not(feature= "express")))]
+        PA14 {
+            /// Enable for the WINC1500 module
+            name: winc_ena
+            aliases: {
+                PushPullOutput: WincEna
+            }
+        }
+
+        #[cfg(all(feature = "winc", not(feature = "adalogger")))]
+        PA21 {
+            /// Interrupt for the WINC1500 module
+            name: winc_irq
+            aliases: {
+                PullUpInterrupt: WincIrq
+            }
+        },
+
+        #[cfg(all(feature = "winc", not(feature = "rfm"), not(feature = "express")))]
+        PA06 {
+            /// SPI chip select for the WINC1500 module
+            name: winc_cs
+            aliases: {
+                PushPullOutput: WincCs
+            }
+        },
+
     );
 }
 pub use pins::*;

--- a/crates.json
+++ b/crates.json
@@ -248,10 +248,6 @@
     }
   },
   "hal_build_variants": {
-    "feather_m0": {
-      "features" : [ "feather_m0", "usb", "dma", "sdmmc", "rtic", "defmt", "express","adalogger","rfm", "winc"],
-      "target": "thumbv6m-none-eabi"
-    },
     "samd11c":  {
       "features": [ "samd11c", "dma", "rtic", "defmt" ],
       "target": "thumbv6m-none-eabi"

--- a/crates.json
+++ b/crates.json
@@ -248,6 +248,10 @@
     }
   },
   "hal_build_variants": {
+    "feather_m0": {
+      "features" : [ "feather_m0", "usb", "dma", "sdmmc", "rtic", "defmt", "express","adalogger","rfm", "winc"],
+      "target": "thumbv6m-none-eabi"
+    },
     "samd11c":  {
       "features": [ "samd11c", "dma", "rtic", "defmt" ],
       "target": "thumbv6m-none-eabi"


### PR DESCRIPTION
# Summary
Added a cargo feature for the board variant with Winc1500 chip and corresponding pins.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 

## If Adding a new Board
  - [x] Board CI added to `crates.json` - **not applicable** here as this is a board variant, not a new board 
  - [x] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1" - **i think it is?**

## If Adding a new cargo `feature` to the HAL
  - [x] Feature is added to the test matrix for applicable boards / PACs in `crates.json` ( unsure how to actually add a BSP/board feature into the matrix )
