### PR TITLE
Fix Nightly doc build errors

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Allow configuring USB clock with `GenericClockController` on atsamd11
 - fix samd51j not having i2s support
 - remove i2s functionality for samd51g since it does not have it
+- Fix docbuild indentation errors with nightly toolchain
 
 # v0.17.0
 

--- a/hal/src/dmac/transfer.rs
+++ b/hal/src/dmac/transfer.rs
@@ -4,17 +4,17 @@
 //!
 //! Four basic transfer types are supported:
 //!
-//! * Incrementing-source to incrementing-destination
-//! (normally used for memory-to-memory transfers)
+//! * Incrementing-source to incrementing-destination (normally used for
+//!   memory-to-memory transfers)
 //!
-//! * Incrementing-source to fixed-destination (normally used
-//! for memory-to-peripheral transfers)
+//! * Incrementing-source to fixed-destination (normally used for
+//!   memory-to-peripheral transfers)
 //!
 //! * Fixed-source to incrementing-destination (normally used for
-//! peripheral-to-memory transfers)
+//!   peripheral-to-memory transfers)
 //!
 //! * Fixed-source to fixed-destination (normally used for
-//! peripheral-to-peripheral transfers)
+//!   peripheral-to-peripheral transfers)
 //!
 //! # Beat sizes
 //!
@@ -71,17 +71,16 @@
 //! Three trigger actions are available:
 //!
 //! * BLOCK: One trigger required for each block transfer. In the context of
-//!   this driver,
-//! one Transfer is equivalent to one Block transfer.
+//!   this driver, one Transfer is equivalent to one Block transfer.
 //!
 //! * BEAT: One trigger required for each beat transfer. In the context of this
-//!   driver, the beat
-//! size will depend on the type of buffer used (8, 16 or 32 bits).
+//!   driver, the beat size will depend on the type of buffer used (8, 16 or 32
+//!   bits).
 //!
 //! * TRANSACTION: One trigger required for a full DMA transaction. this is
-//!   useful for circular
-//! transfers in the context of this driver. One trigger will set off the
-//! transaction, that will now run uninterrupted until it is stopped.
+//!   useful for circular transfers in the context of this driver. One trigger
+//!   will set off the transaction, that will now run uninterrupted until it is
+//!   stopped.
 
 use super::{
     channel::{AnyChannel, Busy, CallbackStatus, Channel, ChannelId, InterruptFlags, Ready},

--- a/hal/src/sercom/mod.rs
+++ b/hal/src/sercom/mod.rs
@@ -10,20 +10,19 @@
 //! those features work as intended.
 //!
 //! * [`UndocIoSet1`](pad::UndocIoSet1): Implement an undocumented `IoSet` for
-//!   PA16, PA17,
-//! PB22 & PB23 configured for [`Sercom1`]. The pygamer & feather_m4 use this
-//! combination, but it is not listed as valid in the datasheet.
+//!   PA16, PA17, PB22 & PB23 configured for [`Sercom1`]. The pygamer &
+//!   feather_m4 use this combination, but it is not listed as valid in the
+//!   datasheet.
 //!
 //! * [`UndocIoSet2`](pad::UndocIoSet2): Implement an undocumented `IoSet` for
-//!   PA00, PA01,
-//! PB22 & PB23 configured for [`Sercom1`]. The itsybitsy_m4 uses this
-//! combination, but it is not listed as valid in the datasheet.
+//!   PA00, PA01, PB22 & PB23 configured for [`Sercom1`]. The itsybitsy_m4 uses
+//!   this combination, but it is not listed as valid in the datasheet.
 //!
 //! * [`PB02`] is I2C-capable according to metro_m4. As such, [`PB02`]
-//! implements [`IsI2cPad`].
+//!   implements [`IsI2cPad`].
 //!
 //! * [`PB03`] is I2C-capable according to metro_m4. As such, [`PB03`]
-//! implements [`IsI2cPad`](pad::IsI2cPad).
+//!   implements [`IsI2cPad`](pad::IsI2cPad).
 //!
 //! [`PB02`]: crate::gpio::pin::PB02
 //! [`PB03`]: crate::gpio::pin::PB03

--- a/hal/src/sercom/pad.rs
+++ b/hal/src/sercom/pad.rs
@@ -302,8 +302,7 @@ mod ioset {
     /// As of writing this documentation, only two undocumented IOSETs have been
     /// discovered:
     /// - [`UndocIoSet1`]: PA16, PA17, PB22 & PB23 configured for `Sercom1`.
-    ///   Both the
-    /// pygamer & feather_m4 uses this combination.
+    ///   Both the pygamer & feather_m4 uses this combination.
     /// - [`UndocIoSet2`]: PA00, PA01, PB22 & PB23 configured for `Sercom1`. The
     ///   itsybitsy_m4 uses this combination.
     ///
@@ -327,8 +326,7 @@ mod ioset {
     /// As of writing this documentation, only two undocumented IOSETs have been
     /// discovered:
     /// - [`UndocIoSet1`]: PA16, PA17, PB22 & PB23 configured for `Sercom1`.
-    ///   Both the
-    /// pygamer & feather_m4 uses this combination.
+    ///   Both the pygamer & feather_m4 uses this combination.
     /// - [`UndocIoSet2`]: PA00, PA01, PB22 & PB23 configured for `Sercom1`. The
     ///   itsybitsy_m4 uses this combination.
     ///


### PR DESCRIPTION
# Summary
Fix docbuild issues with nightly toolchain - these currently prevent green checks on PRs like #736

This PR has no functional changes, only doc comment edits to pass clippy+rustfmt checks.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 

