### PR TITLE
usb: fix enumeration issues by propagating buffer overflow error.

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased Changes
 
+- Fix USB enumeration issues with fast host controllers
 - Allow configuring USB clock with `GenericClockController` on atsamd11
 - fix samd51j not having i2s support
 - remove i2s functionality for samd51g since it does not have it

--- a/hal/src/peripherals/usb/d11/bus.rs
+++ b/hal/src/peripherals/usb/d11/bus.rs
@@ -898,7 +898,7 @@ impl Inner {
         let rxstp = bank.received_setup_interrupt();
 
         if bank.is_ready() || rxstp {
-            let size = bank.read(buf);
+            let size = bank.read(buf)?;
 
             if rxstp {
                 bank.clear_received_setup_interrupt();
@@ -907,7 +907,7 @@ impl Inner {
             bank.clear_transfer_complete();
             bank.set_ready(false);
 
-            size
+            Ok(size)
         } else {
             Err(UsbError::WouldBlock)
         }

--- a/hal/src/peripherals/usb/d5x/bus.rs
+++ b/hal/src/peripherals/usb/d5x/bus.rs
@@ -841,7 +841,7 @@ impl Inner {
         let rxstp = bank.received_setup_interrupt();
 
         if bank.is_ready() || rxstp {
-            let size = bank.read(buf);
+            let size = bank.read(buf)?;
 
             if rxstp {
                 bank.clear_received_setup_interrupt();
@@ -850,7 +850,7 @@ impl Inner {
             bank.clear_transfer_complete();
             bank.set_ready(false);
 
-            size
+            Ok(size)
         } else {
             Err(UsbError::WouldBlock)
         }


### PR DESCRIPTION
# Summary
Fixes USB enumeration issues with fast host controllers.

The USB spec permits SETUP for control transfers to be sent at any time. The device is not permitted to STALL or NAK, so the USBD controller ignores BK0RDY status when it receives a SETUP.

Some faster host controllers may send a SETUP very soon after the previous OUT, for example the Raspberry Pi5 has been confirmed on USB analyzer to SETUP in as little as 20us after the previous OUT. This is a very narrow window to handle the OUT and maintain proper state.

In my project (atsamd21 at 32mhz cpu clock with USB at mid priority), by the time the OUT in the endpoint buffer is read it has already been overwritten by the SETUP packet. The USB stack is expecting a zero length packet to end the previous descriptor read, so it has passed in a zero length slice. The bank read finds that the endpoint has more than zero data and throws a BufferOverflow.

This change allows the error to propagate without dropping the SETUP in the endpoint buffer. The USB stack will then exit the previous descriptor read and proceed with the SETUP of the next control transfer.

In my project this fixes (at least) enumeration issues with Pi5, Pi CM4, and so far a couple of x86 class PCs running Windows or Linux. So far all hosts known to have enumeration issues that were tested with this change have been resolved.

# Checklist
  - [ X] `CHANGELOG.md` for the BSP or HAL updated
  - [ ] All new or modified code is well documented, especially public items
