### PR TITLE
eic: replace modify with write. prevent losing interrupts in intflag

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Allow configuring USB clock with `GenericClockController` on atsamd11
 - fix samd51j not having i2s support
 - remove i2s functionality for samd51g since it does not have it
+- Fix EIC issue leading to lost interrupts
 
 # v0.17.0
 

--- a/hal/src/peripherals/eic/d11/pin.rs
+++ b/hal/src/peripherals/eic/d11/pin.rs
@@ -80,7 +80,7 @@ crate::paste::item! {
         }
 
         pub fn enable_interrupt(&mut self, eic: &mut EIC) {
-            eic.eic.intenset.modify(|_, w| {
+            eic.eic.intenset.write(|w| {
                 w.[<extint $num>]().set_bit()
             });
         }
@@ -92,7 +92,7 @@ crate::paste::item! {
         }
 
         pub fn disable_interrupt(&mut self, eic: &mut EIC) {
-            eic.eic.intenclr.modify(|_, w| {
+            eic.eic.intenclr.write(|w| {
                 w.[<extint $num>]().set_bit()
             });
         }
@@ -102,7 +102,7 @@ crate::paste::item! {
         }
 
         pub fn clear_interrupt(&mut self) {
-            unsafe { &(*pac::EIC::ptr()) }.intflag.modify(|_, w| {
+            unsafe { &(*pac::EIC::ptr()) }.intflag.write(|w| {
                 w.[<extint $num>]().set_bit()
             });
         }


### PR DESCRIPTION
# Summary
Fixes d11 EIC lost interrupt issue, by replacing a couple modify operations with write on registers that were meant mostly for writing. This is in line with the d5x implementation.

Modify on INTENCLR and INTENSET is probably benign, but unnecessary.

Modify on INTFLAG will clear all active bits, not just the channel requesting to be cleared, which leads to lost interrupts.

# Checklist
  - [ x] `CHANGELOG.md` for the BSP or HAL updated
  - [ ] All new or modified code is well documented, especially public items