### PR TITLE
Make I2C transactions continuous according to specification (#740)

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased Changes
 
+- Fix I2C transaction to be as continuous as possible according to `embedded-hal` specification
 - Allow configuring USB clock with `GenericClockController` on atsamd11
 - fix samd51j not having i2s support
 - remove i2s functionality for samd51g since it does not have it

--- a/hal/src/sercom/i2c.rs
+++ b/hal/src/sercom/i2c.rs
@@ -370,9 +370,25 @@ impl<C: AnyConfig> I2c<C> {
         self.config.as_mut().registers.do_write(addr, bytes)
     }
 
+    /// Continue a write operation that was issued before with
+    /// [`do_write`](Self::do_write) or [`continue_write`](Self::continue_write)
+    /// without a repeated start condition in between
+    #[inline]
+    fn continue_write(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        self.config.as_mut().registers.continue_write(bytes)
+    }
+
     #[inline]
     fn do_read(&mut self, addr: u8, bytes: &mut [u8]) -> Result<(), Error> {
         self.config.as_mut().registers.do_read(addr, bytes)
+    }
+
+    /// Continue a read operation that was issued before with
+    /// [`do_read`](Self::do_read) or [`continue_read`](Self::continue_read)
+    /// without a repeated start condition in between
+    #[inline]
+    fn continue_read(&mut self, bytes: &mut [u8]) -> Result<(), Error> {
+        self.config.as_mut().registers.continue_read(bytes)
     }
 
     #[inline]

--- a/hal/src/sercom/i2c/reg.rs
+++ b/hal/src/sercom/i2c/reg.rs
@@ -401,9 +401,25 @@ impl<S: Sercom> Registers<S> {
         self.send_bytes(bytes)
     }
 
+    /// Continue a write operation that was issued before with
+    /// [`do_write`](Self::do_write) or [`continue_write`](Self::continue_write)
+    /// without a repeated start condition in between
+    #[inline]
+    pub(super) fn continue_write(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        self.send_bytes(bytes)
+    }
+
     #[inline]
     pub(super) fn do_read(&mut self, addr: u8, buffer: &mut [u8]) -> Result<(), Error> {
         self.start_read_blocking(addr)?;
+        self.fill_buffer(buffer)
+    }
+
+    /// Continue a read operation that was issued before with
+    /// [`do_read`](Self::do_read) or [`continue_read`](Self::continue_read)
+    /// without a repeated start condition in between
+    #[inline]
+    pub(super) fn continue_read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
         self.fill_buffer(buffer)
     }
 


### PR DESCRIPTION
# Summary
Changes the implementation of the [`ehal::i2c::I2c::transaction`](https://docs.rs/embedded-hal/latest/embedded_hal/i2c/trait.I2c.html#tymethod.transaction) method to match the specification. The corresponding issue is #740.

I would be thankful if someone could have a look at it, to make sure that it now actually matches the specified behaviour. My code seems works now, but I might have misunderstood something.

# Checklist
  - [X] `CHANGELOG.md` for the BSP or HAL updated
  - [X] All new or modified code is well documented, especially public items
  - [X] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 