### PR TITLE
Wait at end of ehal 0.2 blocking SPI writes

### DIFF
--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased Changes
 
+- Fix blocking behaviour for `embedded-hal` 0.2 SPI writes
 - Fix I2C transaction to be as continuous as possible according to `embedded-hal` specification
 - Allow configuring USB clock with `GenericClockController` on atsamd11
 - fix samd51j not having i2s support

--- a/hal/src/sercom/spi/impl_ehal_thumbv6m.rs
+++ b/hal/src/sercom/spi/impl_ehal_thumbv6m.rs
@@ -571,6 +571,8 @@ macro_rules! impl_blocking_spi_write {
                             }
                         }
                     }
+                    // Wait until all data is shifted out
+                    while !self.read_flags().contains(Flags::TXC) {}
                     Ok(())
                 }
             }
@@ -666,6 +668,8 @@ macro_rules! impl_blocking_spi_write_iter {
                             }
                         }
                     }
+                    // Wait until all data is shifted out
+                    while !self.read_flags().contains(Flags::TXC) {}
                     Ok(())
                 }
             }

--- a/hal/src/sercom/spi/impl_ehal_thumbv7em.rs
+++ b/hal/src/sercom/spi/impl_ehal_thumbv7em.rs
@@ -570,6 +570,8 @@ macro_rules! impl_blocking_spi_write {
                             }
                         }
                     }
+                    // Wait until all data is shifted out
+                    while !self.read_flags().contains(Flags::TXC) {}
                     Ok(())
                 }
             }
@@ -632,7 +634,10 @@ where
             panic!("Slice length does not equal SPI transfer length");
         }
         let sercom = unsafe { self.config.as_ref().sercom() };
-        write_slice(sercom, buf, false)
+        write_slice(sercom, buf, false)?;
+        // Wait until all data is shifted out
+        while !self.read_flags().contains(Flags::TXC) {}
+        Ok(())
     }
 }
 
@@ -687,7 +692,10 @@ where
             panic!("Slice length does not equal SPI transfer length");
         }
         let sercom = unsafe { self.config.as_ref().sercom() };
-        write_slice(sercom, buf, false)
+        write_slice(sercom, buf, false)?;
+        // Wait until all data is shifted out
+        while !self.read_flags().contains(Flags::TXC) {}
+        Ok(())
     }
 }
 
@@ -779,6 +787,8 @@ macro_rules! impl_blocking_spi_write_iter {
                             }
                         }
                     }
+                    // Wait until all data is shifted out
+                    while !self.read_flags().contains(Flags::TXC) {}
                     Ok(())
                 }
             }


### PR DESCRIPTION
# Summary
Discovered while tracking down an issue with the PyGamer display identified [here](https://github.com/atsamd-rs/atsamd/pull/455) - basically for non-duplex SPIs, the embedded-hal 0.2 blocking writes were returning as soon as the last word was written to the SERCOM, not waiting until it had been shifted out.  This resulted in the command/data line for the LCD controller being toggled out of sync with the SPI data stream.

I've tested this only with the PyGamer example.

# Checklist
  - [X] `CHANGELOG.md` for the BSP or HAL updated
  - [X] All new or modified code is well documented, especially public items
  - [X] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 
