### PR TITLE
CI: continue BSP building workflow if build any BSP fails

### DIFF
--- a/.github/actions/list-BSPs/action.yml
+++ b/.github/actions/list-BSPs/action.yml
@@ -12,5 +12,5 @@ runs:
     - id: compute-matrix
       shell: bash
       run: |
-        matrix_json=$(cat crates.json | jq -Mr -c '{ "bsp": (.boards | keys ), "toolchain": ["stable", "nightly"] }')
+        matrix_json=$(cat crates.json | jq -Mr -c '{ "bsp": [ (.boards | to_entries | .[] | {"name": (.key), "tier": .value.tier}) ] , "toolchain": ["stable", "nightly"] }')
         echo "matrix=${matrix_json}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-bsp.yml
+++ b/.github/workflows/build-bsp.yml
@@ -13,6 +13,8 @@ jobs:
       uses: ./.github/actions/list-BSPs
 
   build:
+    # This name is matched against the project's branch protection settings
+    name: "build (${{matrix.bsp.name}}, ${{matrix.toolchain}})"
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.toolchain == 'nightly' }}
     needs: setup
@@ -26,25 +28,25 @@ jobs:
       run: |
         rustup set profile minimal
         rustup override set ${{ matrix.toolchain }}
-        target=$(cat ./crates.json | jq -Mr --arg board '${{ matrix.bsp }}' -c '.boards | .[$board] | .target')
+        target=$(cat ./crates.json | jq -Mr --arg board '${{ matrix.bsp.name }}' -c '.boards | .[$board] | .target')
         rustup target add ${target}
         rustup component add clippy
 
     - name: Setup cache
       uses: Swatinem/rust-cache@v2
 
-    - name: Build ${{ matrix.bsp }}
+    - name: Build ${{ matrix.bsp.name }}
       run: |
-        build_invocation=$(cat ./crates.json | jq -Mr --arg board '${{ matrix.bsp }}' -c '.boards | .[$board] | .build')
+        build_invocation=$(cat ./crates.json | jq -Mr --arg board '${{ matrix.bsp.name }}' -c '.boards | .[$board] | .build')
         set -ex
-        cd boards/${{ matrix.bsp }}
+        cd boards/${{ matrix.bsp.name }}
         $(${build_invocation})
 
-    - name: Clippy ${{ matrix.bsp }}
+    - name: Clippy ${{ matrix.bsp.name }}
       if: ${{ matrix.toolchain == 'nightly' }}
       run: |
         set -ex
-        build_invocation=$(cat ./crates.json | jq -Mr --arg board '${{ matrix.bsp }}' -c '.boards | .[$board] | .build')
+        build_invocation=$(cat ./crates.json | jq -Mr --arg board '${{ matrix.bsp.name }}' -c '.boards | .[$board] | .build')
         clippy_invocation=$(echo ${build_invocation} | sed 's/cargo build/cargo clippy/g')
-        cd boards/${{ matrix.bsp }}
+        cd boards/${{ matrix.bsp.name }}
         $(${clippy_invocation})

--- a/.github/workflows/build-bsp.yml
+++ b/.github/workflows/build-bsp.yml
@@ -16,7 +16,7 @@ jobs:
     # This name is matched against the project's branch protection settings
     name: "build (${{matrix.bsp.name}}, ${{matrix.toolchain}})"
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.toolchain == 'nightly' }}
+    continue-on-error: ${{ matrix.toolchain == 'nightly' || matrix.bsp.tier != 1 }}
     needs: setup
     strategy:
       matrix: ${{fromJson(needs.setup.outputs.matrix)}}

--- a/.github/workflows/build-bsp.yml
+++ b/.github/workflows/build-bsp.yml
@@ -8,7 +8,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - id: set-matrix
       uses: ./.github/actions/list-BSPs
 
@@ -22,7 +22,7 @@ jobs:
       matrix: ${{fromJson(needs.setup.outputs.matrix)}}
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Rust
       run: |

--- a/.github/workflows/build-bsp.yml
+++ b/.github/workflows/build-bsp.yml
@@ -13,10 +13,14 @@ jobs:
       uses: ./.github/actions/list-BSPs
 
   build:
-    # This name is matched against the project's branch protection settings
-    name: "build (${{matrix.bsp.name}}, ${{matrix.toolchain}})"
+    name: "${{matrix.bsp.name}} (Tier ${{matrix.bsp.tier}}, ${{matrix.toolchain}})"
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.toolchain == 'nightly' || matrix.bsp.tier != 1 }}
+    # There is a subtle difference between continue-on-error and setting
+    # strategy.fail-fast=false.  Both will allow all jobs to run to completion,
+    # however continue-on-error lets the next workflow stage run regardless of
+    # failed jobs, strategy.fail-fast=false will skip subsequent stages if any
+    # job fails.
+    continue-on-error: true
     needs: setup
     strategy:
       matrix: ${{fromJson(needs.setup.outputs.matrix)}}
@@ -39,8 +43,11 @@ jobs:
       run: |
         build_invocation=$(cat ./crates.json | jq -Mr --arg board '${{ matrix.bsp.name }}' -c '.boards | .[$board] | .build')
         set -ex
-        cd boards/${{ matrix.bsp.name }}
+        pushd boards/${{ matrix.bsp.name }}
         $(${build_invocation})
+        popd
+        mkdir -p output
+        touch "output/build"
 
     - name: Clippy ${{ matrix.bsp.name }}
       if: ${{ matrix.toolchain == 'nightly' }}
@@ -50,3 +57,40 @@ jobs:
         clippy_invocation=$(echo ${build_invocation} | sed 's/cargo build/cargo clippy/g')
         cd boards/${{ matrix.bsp.name }}
         $(${clippy_invocation})
+
+    - name: Done
+      uses: actions/upload-artifact@v4
+      with:
+        # name needs to be unique in the workspace
+        name: "${{ matrix.bsp.name }}-${{ matrix.toolchain }}"
+        path: output
+
+  check:
+    runs-on: ubuntu-latest
+    needs: [setup, build]
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: successful-jobs
+      - name: Tier 1 BSPs built on stable
+        env:
+          MATRIX: ${{ needs.setup.outputs.matrix }}
+        run: |
+          tier_1_bsps=$(jq -Mr -c '.bsp[] | select(.tier == 1) | .name' <<< ${MATRIX})
+
+          success="true"
+          for bsp in ${tier_1_bsps}; do
+            if [ -f successful-jobs/"${bsp}"-stable/build ]; then
+              echo "${bsp}" built on stable toolchain
+            else
+              echo "${bsp}" failed to build on stable toolchain
+              success="false"
+            fi
+          done
+
+          if [ ${success} = "true" ]; then
+            echo "Tier 1 BSPs all built on stable"
+          else
+            false
+          fi

--- a/.github/workflows/build-hal.yml
+++ b/.github/workflows/build-hal.yml
@@ -8,7 +8,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - id: set-matrix
       uses: ./.github/actions/list-HAL-variants
 
@@ -20,7 +20,7 @@ jobs:
       matrix: ${{fromJson(needs.setup.outputs.matrix)}}
     steps:
     - name: Checkout sources
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Rust
       run: |

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Rust
         run: |

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Rust
         run: |
           rustup set profile minimal


### PR DESCRIPTION
# Summary
Potential fix for https://github.com/atsamd-rs/atsamd/issues/744 - this change to CI has the "Build BSPs" workflow continue regardless of tier >1 BSP builds failing.

One downside to this approach is that the overall workflow run may show success despite there actually being BSP build failures.  This PR is a test case to see how obvious this situation is in practice - a tier 2 BSP is expected to fail.