### PR TITLE
Update bitflags and remove `TryFrom<()>` impls

### DIFF
--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -33,7 +33,7 @@ features = ["samd21g", "samd21g-rt", "usb", "dma"]
 aes = "0.7.5"
 atsamd-hal-macros = { version = "0.1.0", path = "../atsamd-hal-macros" }
 bitfield = "0.13"
-bitflags = "1.2.1"
+bitflags = "2.6.0"
 cipher = "0.3"
 cortex-m = "0.7"
 embedded-hal-02 = {package = "embedded-hal", version = "0.2", features = ["unproven"]}

--- a/hal/src/sercom/i2c/flags.rs
+++ b/hal/src/sercom/i2c/flags.rs
@@ -11,6 +11,7 @@ bitflags! {
     ///
     /// The available interrupt flags are `MB`, `SB`, and `ERROR`. The binary format of the underlying bits exactly matches the
     /// INTFLAG bits.
+    #[derive(Clone, Copy)]
     pub struct Flags: u8 {
         /// Master on bus interrupt
         const MB = 0x01;
@@ -63,6 +64,16 @@ pub struct Status {
 }
 
 impl Status {
+    /// Check whether [`Self`] originates from an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `STATUS` contains:
+    ///
+    /// * `BUSERR`
+    /// * `ARBLOST`
+    /// * `LENERR`
+    /// * `RXNACK`
     pub fn check_bus_error(self) -> Result<(), Error> {
         if self.buserr() {
             Err(Error::BusError)

--- a/hal/src/sercom/i2c/flags.rs
+++ b/hal/src/sercom/i2c/flags.rs
@@ -70,10 +70,10 @@ impl Status {
     ///
     /// Returns an error if `STATUS` contains:
     ///
-    /// * `BUSERR`
-    /// * `ARBLOST`
-    /// * `LENERR`
-    /// * `RXNACK`
+    /// * `BUSERR` - Bus Error
+    /// * `ARBLOST` - Arbitration lost
+    /// * `LENERR` - Length error
+    /// * `RXNACK` - Receive not acknowledged
     pub fn check_bus_error(self) -> Result<(), Error> {
         if self.buserr() {
             Err(Error::BusError)

--- a/hal/src/sercom/spi/reg.rs
+++ b/hal/src/sercom/spi/reg.rs
@@ -340,7 +340,7 @@ impl<S: Sercom> Registers<S> {
     /// Try to read the interrupt flags, but first check the error status flags.
     #[inline]
     pub fn read_flags_errors(&self) -> Result<Flags, Error> {
-        self.read_status().try_into()?;
+        self.read_status().check_bus_error()?;
         Ok(self.read_flags())
     }
 }

--- a/hal/src/sercom/uart.rs
+++ b/hal/src/sercom/uart.rs
@@ -619,14 +619,14 @@ where
     /// `Capability`
     #[inline]
     fn capability_flags(flags: Flags) -> Flags {
-        flags & unsafe { Flags::from_bits_unchecked(D::FLAG_MASK) }
+        flags & Flags::from_bits_retain(D::FLAG_MASK)
     }
 
     /// Helper method to remove the status flags not pertinent to `Self`'s
     /// `Capability`
     #[inline]
     fn capability_status(status: Status) -> Status {
-        status & unsafe { Status::from_bits_unchecked(D::STATUS_MASK) }
+        status & Status::from_bits_retain(D::STATUS_MASK)
     }
 
     /// Read the interrupt flags
@@ -751,7 +751,7 @@ where
         self.config
             .as_mut()
             .registers
-            .clear_flags(unsafe { Flags::from_bits_unchecked(bit) });
+            .clear_flags(Flags::from_bits_retain(bit));
     }
 
     /// Enable the `CTSIC` interrupt
@@ -761,7 +761,7 @@ where
         self.config
             .as_mut()
             .registers
-            .enable_interrupts(unsafe { Flags::from_bits_unchecked(bit) });
+            .enable_interrupts(Flags::from_bits_retain(bit));
     }
 
     /// Disable the `CTSIC` interrupt
@@ -771,7 +771,7 @@ where
         self.config
             .as_mut()
             .registers
-            .disable_interrupts(unsafe { Flags::from_bits_unchecked(bit) });
+            .disable_interrupts(Flags::from_bits_retain(bit));
     }
 }
 
@@ -910,7 +910,7 @@ where
     /// containing the corresponding [`Flags`] or [`Error`]
     #[inline]
     fn read_flags_errors(&self) -> Result<Flags, Error> {
-        self.read_status().try_into()?;
+        self.read_status().check_bus_error()?;
         Ok(self.read_flags())
     }
 

--- a/hal/src/sercom/uart/flags.rs
+++ b/hal/src/sercom/uart/flags.rs
@@ -78,11 +78,11 @@ impl Status {
     ///
     /// Returns an error if `STATUS` contains:
     ///
-    /// * `PERR`
-    /// * `FERR`
-    /// * `BUFOVF`
-    /// * `ISF`
-    /// * `COLL`
+    /// * `PERR` - Parity error
+    /// * `FERR` - Frame error
+    /// * `BUFOVF` - Buffer overflow
+    /// * `ISF` - Inconsistent SYNC field
+    /// * `COLL` - Collision
     #[inline]
     pub fn check_bus_error(self) -> Result<(), Error> {
         use Error::*;

--- a/hal/src/sercom/uart/flags.rs
+++ b/hal/src/sercom/uart/flags.rs
@@ -26,6 +26,7 @@ bitflags! {
     /// The available interrupt flags are `DRE`, `TXC`, `RXC`, `RXS`, `CTSIC`, `RXBRK` and
     /// `ERROR`. The binary format of the underlying bits exactly matches the
     /// INTFLAG bits.
+    #[derive(Clone, Copy)]
     pub struct Flags: u8 {
         const DRE = DRE;
         const TXC = TXC;
@@ -70,6 +71,37 @@ bitflags! {
     }
 }
 
+impl Status {
+    /// Check whether [`Self`] originates from an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `STATUS` contains:
+    ///
+    /// * `PERR`
+    /// * `FERR`
+    /// * `BUFOVF`
+    /// * `ISF`
+    /// * `COLL`
+    #[inline]
+    pub fn check_bus_error(self) -> Result<(), Error> {
+        use Error::*;
+        if self.contains(Status::PERR) {
+            Err(ParityError)
+        } else if self.contains(Status::FERR) {
+            Err(FrameError)
+        } else if self.contains(Status::BUFOVF) {
+            Err(Overflow)
+        } else if self.contains(Status::ISF) {
+            Err(InconsistentSyncField)
+        } else if self.contains(Status::COLL) {
+            Err(CollisionDetected)
+        } else {
+            Ok(())
+        }
+    }
+}
+
 //=============================================================================
 // Error
 //=============================================================================
@@ -88,28 +120,6 @@ pub enum Error {
     InconsistentSyncField,
     /// Detected a collision
     CollisionDetected,
-}
-
-impl TryFrom<Status> for () {
-    type Error = Error;
-
-    #[inline]
-    fn try_from(errors: Status) -> Result<(), Error> {
-        use Error::*;
-        if errors.contains(Status::PERR) {
-            Err(ParityError)
-        } else if errors.contains(Status::FERR) {
-            Err(FrameError)
-        } else if errors.contains(Status::BUFOVF) {
-            Err(Overflow)
-        } else if errors.contains(Status::ISF) {
-            Err(InconsistentSyncField)
-        } else if errors.contains(Status::COLL) {
-            Err(CollisionDetected)
-        } else {
-            Ok(())
-        }
-    }
 }
 
 impl From<Error> for Status {


### PR DESCRIPTION
# Summary
The `TryFrom<()>` impls are a bit of a weird construct, and they now trigger build failures on nightly. By the same occasion also update bitflags and fix some bugs preventing the USB peripheral from building for SAMD11 targets.

# Checklist
  - [ ] ~~`CHANGELOG.md` for the BSP or HAL updated~~ Not necessary - all changes are internal APIs only
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced