### PR TITLE
CI: Rename BSP check for clearer project settings

### DIFF
--- a/.github/workflows/build-bsp.yml
+++ b/.github/workflows/build-bsp.yml
@@ -65,7 +65,7 @@ jobs:
         name: "${{ matrix.bsp.name }}-${{ matrix.toolchain }}"
         path: output
 
-  check:
+  check-tier-1-bsps-build-stable:
     runs-on: ubuntu-latest
     needs: [setup, build]
     steps:
@@ -73,7 +73,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: successful-jobs
-      - name: Tier 1 BSPs built on stable
+      - name: Do checks
         env:
           MATRIX: ${{ needs.setup.outputs.matrix }}
         run: |


### PR DESCRIPTION
In the previous implementation, the job just appeared as "check" in the branch protection settings, this renames it to
"check-tier-1-bsps-build-stable" so it's a little clearer.

Doing this should allow us to replace this chunk of settings:
![image](https://github.com/user-attachments/assets/ddf5d832-777a-4293-a529-99c362cb72d5)

With a single entry `check-tier-1-bsps-build-stable`.  So, when we add/remove Tier 1 BSPs, the branch protection settings don't need to be updated.  The source of truth is the `crates.json` file in the repo.
