### PR TITLE
grand_central_m4: Bump usb-device version

### DIFF
--- a/boards/grand_central_m4/CHANGELOG.md
+++ b/boards/grand_central_m4/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - update path of Cargo config
+- bumped usb-device version to 0.3
 
 # v0.6.0
 

--- a/boards/grand_central_m4/CHANGELOG.md
+++ b/boards/grand_central_m4/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 - update path of Cargo config
-- bumped usb-device version to 0.3
+- update to `atsamd-hal-0.17` and other dependencies (#753)
 
 # v0.6.0
 

--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -20,7 +20,7 @@ version = "0.17.0"
 default-features = false
 
 [dependencies.usb-device]
-version = "0.3.1"
+version = "0.3"
 optional = true
 
 [dependencies.cortex-m]

--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -23,6 +23,10 @@ default-features = false
 version = "0.3.1"
 optional = true
 
+[dependencies.cortex-m]
+version = "0.7"
+features = ["critical-section-single-core"]
+
 [dev-dependencies]
 cortex-m = "0.7"
 usbd-serial = "0.2"

--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "grand_central_m4"
 version = "0.6.0"
-authors = [
-    "Dustin Little <dlittle@toyatech.net>"
-]
+authors = ["Dustin Little <dlittle@toyatech.net>"]
 description = "Board Support crate for the Adafruit Grand Central M4 Express"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
@@ -12,32 +10,30 @@ edition = "2021"
 repository = "https://github.com/atsamd-rs/atsamd"
 readme = "README.md"
 
-[dependencies]
-ws2812-timer-delay = "0.3"
-
 [dependencies.cortex-m-rt]
 version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.15"
+path = "../../hal"
+version = "0.17.0"
 default-features = false
 
 [dependencies.usb-device]
-version = "0.3"
+version = "0.3.1"
 optional = true
 
 [dev-dependencies]
 cortex-m = "0.7"
-usbd-serial = "0.1"
+usbd-serial = "0.2"
 panic-halt = "0.2"
 panic-semihosting = "0.5"
 smart-leds = "0.3"
+ws2812-timer-delay = "0.3"
 
 [features]
-default = ["rt", "atsamd-hal/samd51p", "atsamd-hal/unproven"]
+default = ["rt", "atsamd-hal/samd51p"]
 rt = ["cortex-m-rt", "atsamd-hal/samd51p-rt"]
-unproven = ["atsamd-hal/unproven"]
 usb = ["atsamd-hal/usb", "usb-device"]
 
 [profile.dev]
@@ -63,4 +59,3 @@ name = "neopixel_rainbow"
 [[example]]
 name = "usb_serial"
 required-features = ["usb"]
-

--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -15,7 +15,6 @@ version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-path = "../../hal"
 version = "0.17.0"
 default-features = false
 

--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.15"
 default-features = false
 
 [dependencies.usb-device]
-version = "0.2"
+version = "0.3"
 optional = true
 
 [dev-dependencies]

--- a/boards/grand_central_m4/examples/blinky_basic.rs
+++ b/boards/grand_central_m4/examples/blinky_basic.rs
@@ -3,7 +3,6 @@
 
 use grand_central_m4 as bsp;
 
-use bsp::ehal;
 use bsp::hal;
 use bsp::pac;
 
@@ -17,7 +16,6 @@ use hal::clock::GenericClockController;
 use hal::prelude::*;
 use pac::{CorePeripherals, Peripherals};
 
-use ehal::blocking::delay::DelayMs;
 use hal::delay::Delay;
 
 #[entry]
@@ -35,9 +33,9 @@ fn main() -> ! {
     let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
     let mut delay = Delay::new(core.SYST, &mut clocks);
     loop {
-        delay.delay_ms(200u16);
+        delay.delay_ms(200u8);
         red_led.set_high().unwrap();
-        delay.delay_ms(200u16);
+        delay.delay_ms(200u8);
         red_led.set_low().unwrap();
     }
 }

--- a/boards/grand_central_m4/examples/neopixel_rainbow.rs
+++ b/boards/grand_central_m4/examples/neopixel_rainbow.rs
@@ -14,8 +14,10 @@ use panic_semihosting as _;
 use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
-use hal::prelude::*;
+use hal::ehal::delay::DelayNs;
+use hal::time::Hertz;
 use hal::timer::TimerCounter;
+use hal::timer_traits::InterruptDrivenTimer;
 use pac::{CorePeripherals, Peripherals};
 
 use smart_leds::{
@@ -38,7 +40,7 @@ fn main() -> ! {
     let gclk0 = clocks.gclk0();
     let tc2_3 = clocks.tc2_tc3(&gclk0).unwrap();
     let mut timer = TimerCounter::tc3_(&tc2_3, peripherals.TC3, &mut peripherals.MCLK);
-    timer.start(3.mhz());
+    timer.start(Hertz::MHz(3).into_duration());
 
     let pins = bsp::Pins::new(peripherals.PORT);
     let neopixel_pin = pins.neopixel.into_push_pull_output();
@@ -53,7 +55,7 @@ fn main() -> ! {
                 val: 32,
             })];
             neopixel.write(colors.iter().cloned()).unwrap();
-            delay.delay_ms(5u8);
+            delay.delay_ms(5);
         }
     }
 }

--- a/boards/grand_central_m4/src/lib.rs
+++ b/boards/grand_central_m4/src/lib.rs
@@ -493,7 +493,7 @@ pub type Spi = spi::Spi<spi::Config<SpiPads>, spi::Duplex>;
 /// SPI Master in SPI Mode 0.
 pub fn spi_master(
     clocks: &mut GenericClockController,
-    baud: impl Into<Hertz>,
+    baud: Hertz,
     sercom7: SpiSercom,
     mclk: &mut pac::MCLK,
     sclk: impl Into<Sclk>,
@@ -603,10 +603,10 @@ pub fn usb_allocator(
     dm: impl Into<UsbDm>,
     dp: impl Into<UsbDp>,
 ) -> UsbBusAllocator<UsbBus> {
-    use pac::gclk::{genctrl::SRC_A, pchctrl::GEN_A};
+    use pac::gclk::{genctrl::SRCSELECT_A, pchctrl::GENSELECT_A};
 
-    clocks.configure_gclk_divider_and_source(GEN_A::GCLK2, 1, SRC_A::DFLL, false);
-    let usb_gclk = clocks.get_gclk(GEN_A::GCLK2).unwrap();
+    clocks.configure_gclk_divider_and_source(GENSELECT_A::GCLK2, 1, SRCSELECT_A::DFLL, false);
+    let usb_gclk = clocks.get_gclk(GENSELECT_A::GCLK2).unwrap();
     let usb_clock = &clocks.usb(&usb_gclk).unwrap();
     let (dm, dp) = (dm.into(), dp.into());
     UsbBusAllocator::new(UsbBus::new(usb_clock, mclk, dm, dp, usb))

--- a/pac/atsamd51p/Cargo.toml
+++ b/pac/atsamd51p/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-cortex-m = "0.7"
+cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 vcell = "0.1"
 critical-section = "1.1"
 

--- a/pac/atsamd51p/Cargo.toml
+++ b/pac/atsamd51p/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
+cortex-m = "0.7"
 vcell = "0.1"
 critical-section = "1.1"
 


### PR DESCRIPTION
# Summary
I am bumping the version of usb-device for the grand central.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 