### PR TITLE
Update itsybitsy_m0 and itsybitsy_m4 to HAL 0.17

### DIFF
--- a/boards/itsybitsy_m0/CHANGELOG.md
+++ b/boards/itsybitsy_m0/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- update hal dependency to v0.17
 - update path of Cargo config
 
 # v0.13.1

--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 [dependencies]
 bitbang-hal = "0.3"
 apa102-spi = "0.3"
+embedded-hal-02 = {package = "embedded-hal", version = "0.2", features = ["unproven"]}
 smart-leds = "0.3"
 
 [dependencies.cortex-m-rt]
@@ -20,11 +21,11 @@ version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.14"
+version = "0.17"
 default-features = false
 
 [dependencies.usb-device]
-version = "0.2"
+version = "0.3.1"
 optional = true
 
 [dependencies.embedded-sdmmc]
@@ -32,10 +33,10 @@ version = "0.3"
 optional = true
 
 [dev-dependencies]
-cortex-m-rtic = "0.6.0-rc.4"
-cortex-m = "0.7"
-usbd-serial = "0.1"
-usbd-hid = "0.4"
+cortex-m-rtic = "1.0"
+cortex-m = {version = "0.7", features = ["critical-section-single-core"]}
+usbd-serial = "0.2.2"
+usbd-hid = "0.8.2"
 cortex-m-semihosting = "0.3"
 ssd1306 = "0.7"
 embedded-graphics = "0.7.1"
@@ -47,9 +48,8 @@ panic-semihosting = "0.5"
 
 [features]
 # ask the HAL to enable atsamd21g support
-default = ["rt", "atsamd-hal/samd21g", "atsamd-hal/unproven"]
+default = ["rt", "atsamd-hal/samd21g"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
-unproven = ["atsamd-hal/unproven"]
 use_rtt = ["atsamd-hal/use_rtt"]
 usb = ["atsamd-hal/usb", "usb-device"]
 dma = ["atsamd-hal/dma"]

--- a/boards/itsybitsy_m0/examples/blinky_rtic.rs
+++ b/boards/itsybitsy_m0/examples/blinky_rtic.rs
@@ -11,7 +11,6 @@ use itsybitsy_m0 as bsp;
 use panic_halt as _;
 #[cfg(feature = "use_semihosting")]
 use panic_semihosting as _;
-use rtic;
 
 #[rtic::app(device = bsp::pac, peripherals = true, dispatchers = [EVSYS])]
 mod app {

--- a/boards/itsybitsy_m0/examples/clock.rs
+++ b/boards/itsybitsy_m0/examples/clock.rs
@@ -70,9 +70,11 @@ fn main() -> ! {
         USB_SERIAL = Some(SerialPort::new(bus_allocator));
         USB_BUS = Some(
             UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x16c0, 0x27dd))
-                .manufacturer("Fake company")
-                .product("Serial port")
-                .serial_number("TEST")
+                .strings(&[StringDescriptors::new(LangID::EN)
+                    .manufacturer("Fake company")
+                    .product("Serial port")
+                    .serial_number("TEST")])
+                .expect("Failed to set strings")
                 .device_class(USB_CLASS_CDC)
                 .build(),
         );

--- a/boards/itsybitsy_m0/examples/dotstar_flashing.rs
+++ b/boards/itsybitsy_m0/examples/dotstar_flashing.rs
@@ -16,7 +16,7 @@ use hal::{
     delay::Delay,
     pac::{CorePeripherals, Peripherals},
     prelude::*,
-    time::MegaHertz,
+    time::Hertz,
     timer::TimerCounter,
 };
 
@@ -43,7 +43,7 @@ fn main() -> ! {
     // instantiate a timer objec for the TC4 peripheral
     let mut timer = TimerCounter::tc4_(tc45, peripherals.TC4, &mut peripherals.PM);
     // start a 4 MHz timer
-    timer.start(MegaHertz(4));
+    InterruptDrivenTimer::start(&mut timer, Hertz::MHz(4).into_duration());
     let mut rgb = bsp::dotstar_bitbang(
         pins.dotstar_miso.into(),
         pins.dotstar_mosi.into(),

--- a/boards/itsybitsy_m0/examples/dotstar_rainbow.rs
+++ b/boards/itsybitsy_m0/examples/dotstar_rainbow.rs
@@ -14,7 +14,7 @@ use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::pac::{CorePeripherals, Peripherals};
 use hal::prelude::*;
-use hal::time::MegaHertz;
+use hal::time::Hertz;
 use hal::timer::TimerCounter;
 
 use smart_leds::{hsv::RGB8, SmartLedsWrite};
@@ -66,7 +66,7 @@ fn main() -> ! {
     // instantiate a timer objec for the TC4 peripheral
     let mut timer = TimerCounter::tc4_(tc45, peripherals.TC4, &mut peripherals.PM);
     // start a 4 MHz timer
-    timer.start(MegaHertz(4));
+    InterruptDrivenTimer::start(&mut timer, Hertz::MHz(4).into_duration());
     let mut rgb = bsp::dotstar_bitbang(
         pins.dotstar_miso.into(),
         pins.dotstar_mosi.into(),

--- a/boards/itsybitsy_m0/examples/eic.rs
+++ b/boards/itsybitsy_m0/examples/eic.rs
@@ -19,7 +19,7 @@ use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::eic::pin::{ExtInt2, Sense};
 use hal::eic::EIC;
-use hal::gpio::v2::{Pin, PullUpInterrupt};
+use hal::gpio::{Pin, PullUpInterrupt};
 use hal::prelude::*;
 use pac::{interrupt, CorePeripherals, Peripherals};
 

--- a/boards/itsybitsy_m0/examples/pwm.rs
+++ b/boards/itsybitsy_m0/examples/pwm.rs
@@ -37,7 +37,7 @@ fn main() -> ! {
     let gclk0 = clocks.gclk0();
     let mut pwm3 = Pwm3::new(
         &clocks.tcc2_tc3(&gclk0).unwrap(),
-        1.khz(),
+        1.kHz(),
         peripherals.TC3,
         &mut peripherals.PM,
     );

--- a/boards/itsybitsy_m0/examples/ssd1306_graphicsmode_128x64_i2c.rs
+++ b/boards/itsybitsy_m0/examples/ssd1306_graphicsmode_128x64_i2c.rs
@@ -78,7 +78,6 @@ use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
-use hal::time::KiloHertz;
 use pac::{CorePeripherals, Peripherals};
 
 #[entry]
@@ -98,7 +97,7 @@ fn main() -> ! {
     let i2c_sercom: bsp::I2cSercom = peripherals.SERCOM3;
     let i2c = bsp::i2c_master(
         &mut clocks,
-        KiloHertz(400),
+        400.kHz(),
         i2c_sercom,
         &mut peripherals.PM,
         pins.sda,

--- a/boards/itsybitsy_m0/examples/ssd1306_graphicsmode_128x64_spi.rs
+++ b/boards/itsybitsy_m0/examples/ssd1306_graphicsmode_128x64_spi.rs
@@ -67,7 +67,6 @@ use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
-use hal::time::MegaHertz;
 use pac::{CorePeripherals, Peripherals};
 
 #[entry]
@@ -87,7 +86,7 @@ fn main() -> ! {
     let spi_sercom: bsp::SpiSercom = peripherals.SERCOM4;
     let spi = bsp::spi_master(
         &mut clocks,
-        MegaHertz(10),
+        10.MHz(),
         spi_sercom,
         &mut peripherals.PM,
         pins.sclk,

--- a/boards/itsybitsy_m0/examples/ssd1306_terminalmode_128x64_i2c.rs
+++ b/boards/itsybitsy_m0/examples/ssd1306_terminalmode_128x64_i2c.rs
@@ -77,7 +77,6 @@ use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
-use hal::time::KiloHertz;
 use pac::{CorePeripherals, Peripherals};
 
 #[entry]
@@ -97,7 +96,7 @@ fn main() -> ! {
     let i2c_sercom: bsp::I2cSercom = peripherals.SERCOM3;
     let i2c = bsp::i2c_master(
         &mut clocks,
-        KiloHertz(400),
+        400.kHz(),
         i2c_sercom,
         &mut peripherals.PM,
         pins.sda,

--- a/boards/itsybitsy_m0/examples/ssd1306_terminalmode_128x64_spi.rs
+++ b/boards/itsybitsy_m0/examples/ssd1306_terminalmode_128x64_spi.rs
@@ -61,7 +61,6 @@ use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::prelude::*;
-use hal::time::MegaHertz;
 use pac::{CorePeripherals, Peripherals};
 
 use ssd1306::{prelude::*, Ssd1306};
@@ -84,7 +83,7 @@ fn main() -> ! {
     let spi_sercom: bsp::SpiSercom = peripherals.SERCOM4;
     let spi = bsp::spi_master(
         &mut clocks,
-        MegaHertz(10),
+        10.MHz(),
         spi_sercom,
         &mut peripherals.PM,
         pins.sclk,

--- a/boards/itsybitsy_m0/examples/timers.rs
+++ b/boards/itsybitsy_m0/examples/timers.rs
@@ -12,8 +12,11 @@ use itsybitsy_m0 as bsp;
 
 use bsp::entry;
 use hal::clock::GenericClockController;
-use hal::prelude::*;
+use hal::ehal::digital::OutputPin;
+use hal::nb;
+use hal::time::Hertz;
 use hal::timer::TimerCounter;
+use hal::timer_traits::InterruptDrivenTimer;
 use pac::Peripherals;
 
 #[entry]
@@ -35,7 +38,7 @@ fn main() -> ! {
     // instantiate a timer objec for the TC4 peripheral
     let mut timer = TimerCounter::tc4_(tc45, peripherals.TC4, &mut peripherals.PM);
     // start a 5Hz timer
-    timer.start(5.hz());
+    timer.start(Hertz::Hz(5).into_duration());
 
     // toggle the red LED at the frequency set by the timer
     loop {

--- a/boards/itsybitsy_m0/examples/twitching_usb_mouse.rs
+++ b/boards/itsybitsy_m0/examples/twitching_usb_mouse.rs
@@ -54,9 +54,11 @@ fn main() -> ! {
         USB_HID = Some(HIDClass::new(bus_allocator, MouseReport::desc(), 60));
         USB_BUS = Some(
             UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x16c0, 0x27dd))
-                .manufacturer("Fake company")
-                .product("Twitchy Mousey")
-                .serial_number("TEST")
+                .strings(&[StringDescriptors::new(LangID::EN)
+                    .manufacturer("Fake company")
+                    .product("Twitchy Mousey")
+                    .serial_number("TEST")])
+                .expect("Failed to set strings")
                 .build(),
         );
     }
@@ -72,6 +74,8 @@ fn main() -> ! {
             x: 0,
             y: 4,
             buttons: 0,
+            pan: 0,
+            wheel: 0,
         })
         .ok()
         .unwrap_or(0);
@@ -80,6 +84,8 @@ fn main() -> ! {
             x: 0,
             y: -4,
             buttons: 0,
+            pan: 0,
+            wheel: 0,
         })
         .ok()
         .unwrap_or(0);

--- a/boards/itsybitsy_m0/examples/uart.rs
+++ b/boards/itsybitsy_m0/examples/uart.rs
@@ -16,6 +16,7 @@ use itsybitsy_m0 as bsp;
 use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::dmac::{DmaController, PriorityLevel};
+use hal::nb;
 use hal::prelude::*;
 
 use pac::Peripherals;
@@ -49,7 +50,7 @@ fn main() -> ! {
     // Setup UART peripheral
     let uart = bsp::uart(
         &mut clocks,
-        9600.hz(),
+        9600.Hz(),
         uart_sercom,
         &mut pm,
         uart_rx,

--- a/boards/itsybitsy_m0/examples/usb_echo.rs
+++ b/boards/itsybitsy_m0/examples/usb_echo.rs
@@ -50,9 +50,11 @@ fn main() -> ! {
         USB_SERIAL = Some(SerialPort::new(bus_allocator));
         USB_BUS = Some(
             UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x16c0, 0x27dd))
-                .manufacturer("Fake company")
-                .product("Serial port")
-                .serial_number("TEST")
+                .strings(&[StringDescriptors::new(LangID::EN)
+                    .manufacturer("Fake company")
+                    .product("Serial port")
+                    .serial_number("TEST")])
+                .expect("Failed to set strings")
                 .device_class(USB_CLASS_CDC)
                 .build(),
         );

--- a/boards/itsybitsy_m0/src/lib.rs
+++ b/boards/itsybitsy_m0/src/lib.rs
@@ -7,14 +7,12 @@ pub use atsamd_hal as hal;
 pub use hal::ehal;
 pub use hal::pac;
 
+use embedded_hal_02::timer::{CountDown, Periodic};
 use hal::clock::GenericClockController;
-use hal::ehal::timer::{CountDown, Periodic};
 use hal::sercom::{
-    v2::{
-        spi,
-        uart::{self, BaudMode, Oversampling},
-    },
-    I2CMaster3,
+    i2c, spi,
+    uart::{self, BaudMode, Oversampling},
+    Sercom3,
 };
 use hal::time::Hertz;
 use pac::{SERCOM0, SERCOM3, SERCOM4};
@@ -254,30 +252,39 @@ pub fn spi_master(
     let (miso, mosi, sclk) = (miso.into(), mosi.into(), sclk.into());
     let pads = spi::Pads::default().data_in(miso).data_out(mosi).sclk(sclk);
     spi::Config::new(pm, sercom, pads, freq)
-        .baud(baud)
+        .baud(baud.into())
         .spi_mode(spi::MODE_0)
         .enable()
 }
 
-/// I2C master for the labelled SDA & SCL pins
-pub type I2C = I2CMaster3<Sda, Scl>;
+/// I2C pads for the labelled I2C peripheral
+///
+/// You can use these pads with other, user-defined [`i2c::Config`]urations.
+pub type I2cPads = i2c::Pads<Sercom3, Sda, Scl>;
+
+/// I2C master for the labelled I2C peripheral
+///
+/// This type implements [`Read`](ehal::blocking::i2c::Read),
+/// [`Write`](ehal::blocking::i2c::Write) and
+/// [`WriteRead`](ehal::blocking::i2c::WriteRead).
+pub type I2c = i2c::I2c<i2c::Config<I2cPads>>;
 
 /// Convenience for setting up the labelled SDA, SCL pins to
 /// operate as an I2C master running at the specified frequency.
 pub fn i2c_master(
     clocks: &mut GenericClockController,
     baud: impl Into<Hertz>,
-    sercom: I2cSercom,
+    sercom: Sercom3,
     pm: &mut pac::PM,
     sda: impl Into<Sda>,
     scl: impl Into<Scl>,
-) -> I2C {
+) -> I2c {
     let gclk0 = clocks.gclk0();
     let clock = &clocks.sercom3_core(&gclk0).unwrap();
+    let freq = clock.freq();
     let baud = baud.into();
-    let sda = sda.into();
-    let scl = scl.into();
-    I2CMaster3::new(clock, baud, sercom, pm, sda, scl)
+    let pads = i2c::Pads::new(sda.into(), scl.into());
+    i2c::Config::new(pm, sercom, pads, freq).baud(baud).enable()
 }
 
 /// UART pads for the labelled RX & TX pins

--- a/boards/itsybitsy_m4/CHANGELOG.md
+++ b/boards/itsybitsy_m4/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- update hal dependency to v0.17
 - update path of Cargo config
 
 # 0.8.0

--- a/boards/itsybitsy_m4/Cargo.toml
+++ b/boards/itsybitsy_m4/Cargo.toml
@@ -16,6 +16,7 @@ readme = "README.md"
 [dependencies]
 bitbang-hal = "0.3"
 apa102-spi = "0.3"
+embedded-hal-02 = {package = "embedded-hal", version = "0.2", features = ["unproven"]}
 smart-leds = "0.3"
 
 [dependencies.cortex-m-rt]
@@ -23,26 +24,26 @@ version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.15"
+version = "0.17"
 default-features = false
 
 [dependencies.usb-device]
-version = "0.2"
+version = "0.3.1"
 optional = true
 
 [dev-dependencies]
-cortex-m = "0.7"
-usbd-serial = "0.1"
+cortex-m = {version = "0.7", features = ["critical-section-single-core"]}
+usbd-serial = "0.2.2"
 panic-halt = "0.2"
 panic-semihosting = "0.6"
 
 [features]
 # ask the HAL to enable atsamd51g support
-default = ["rt", "atsamd-hal/samd51g", "atsamd-hal/unproven"]
+default = ["rt", "atsamd-hal/samd51g"]
 rt = ["cortex-m-rt", "atsamd-hal/samd51g-rt"]
-unproven = ["atsamd-hal/unproven"]
 usb = ["atsamd-hal/usb", "usb-device"]
 use_rtt = ["atsamd-hal/use_rtt"]
+use_semihosting = []
 
 [profile.dev]
 incremental = false

--- a/boards/itsybitsy_m4/examples/dotstar.rs
+++ b/boards/itsybitsy_m4/examples/dotstar.rs
@@ -16,7 +16,7 @@ use hal::{
     delay::Delay,
     pac::{CorePeripherals, Peripherals},
     prelude::*,
-    time::MegaHertz,
+    time::Hertz,
     timer::TimerCounter,
 };
 
@@ -39,7 +39,7 @@ fn main() -> ! {
     let gclk0 = clocks.gclk0();
     let tc2_3 = clocks.tc2_tc3(&gclk0).unwrap();
     let mut timer = TimerCounter::tc3_(&tc2_3, peripherals.TC3, &mut peripherals.MCLK);
-    timer.start(MegaHertz(4));
+    InterruptDrivenTimer::start(&mut timer, Hertz::MHz(4).into_duration());
     let mut rgb = bsp::dotstar_bitbang(
         pins.dotstar_miso.into(),
         pins.dotstar_mosi.into(),

--- a/boards/itsybitsy_m4/examples/sercom_interrupt.rs
+++ b/boards/itsybitsy_m4/examples/sercom_interrupt.rs
@@ -4,6 +4,7 @@
 //! The idea of this example is to show two different things
 //! - How to manually configure SERCOM for a desired mode (UART in this case)
 //! - How to enable an use SERCOM interrupts
+//!
 //! The second one is particularly handy because some drivers will give
 //! you a `poll()` or `update()` function, and you are expected to call it  
 //! on the receive interrupt of the peripheral i.e. SERCOM UART RXC
@@ -17,9 +18,9 @@
 //! - RX - A4
 //! - TX - A5
 //!
-//! > In the ATSAMX5x MCUs SERCOM UART configuration requires at least
+//! In the ATSAMX5x MCUs SERCOM UART configuration requires at least
 //! two pins from the same IOSET. You can find more info about this in
-//! the hal documentation or in the MCU datasheet at:
+//! the HAL documentation or in the MCU datasheet at:
 //! <https://www.microchip.com/en-us/product/ATSAMD51G19A>
 
 use itsybitsy_m4 as bsp;
@@ -35,8 +36,8 @@ use cortex_m::{interrupt::Mutex, peripheral::NVIC};
 use bsp::hal::{
     clock::GenericClockController,
     delay::Delay,
-    ehal::blocking::delay::DelayMs,
     gpio::{Pin, PushPullOutput, PA22},
+    nb,
     pac::{self, interrupt, CorePeripherals, Peripherals},
     prelude::*,
     sercom::{
@@ -92,7 +93,7 @@ fn main() -> ! {
     // custom sercom uart configuration
     let mut serial_sercom0 = uart0(
         &mut clocks,
-        Hertz(115200),
+        115200.Hz(),
         dp.SERCOM0,
         &mut dp.MCLK,
         pins.a5,
@@ -102,7 +103,7 @@ fn main() -> ! {
     // labeled "default" uart
     let mut serial_sercom3 = bsp::uart(
         &mut clocks,
-        Hertz(115200),
+        115200.Hz(),
         dp.SERCOM3,
         &mut dp.MCLK,
         pins.d0_rx,

--- a/boards/itsybitsy_m4/examples/spi.rs
+++ b/boards/itsybitsy_m4/examples/spi.rs
@@ -19,13 +19,9 @@ use bsp::{
     hal::{
         clock::GenericClockController,
         delay::Delay,
-        ehal::{
-            blocking::{delay::DelayMs, spi::Transfer},
-            serial::Write,
-        },
+        nb,
         pac::{CorePeripherals, Peripherals},
         prelude::*,
-        time::{Hertz, MegaHertz},
     },
     spi_master,
 };
@@ -45,7 +41,7 @@ fn main() -> ! {
     let mut delay = Delay::new(core.SYST, &mut clocks);
     let mut serial = bsp::uart(
         &mut clocks,
-        Hertz(115200),
+        115200.Hz(),
         peripherals.SERCOM3,
         &mut peripherals.MCLK,
         pins.d0_rx,
@@ -53,7 +49,7 @@ fn main() -> ! {
     );
     let mut spi1 = spi_master(
         &mut clocks,
-        MegaHertz(4),
+        4.MHz(),
         peripherals.SERCOM1,
         &mut peripherals.MCLK,
         pins.sck,

--- a/boards/itsybitsy_m4/src/lib.rs
+++ b/boards/itsybitsy_m4/src/lib.rs
@@ -4,15 +4,13 @@
 #[cfg(feature = "rt")]
 pub use cortex_m_rt::entry;
 
-use crate::ehal::timer::CountDown;
 pub use atsamd_hal as hal;
+use embedded_hal_02::timer::{CountDown, Periodic};
 pub use hal::ehal;
 
 pub use hal::{
     clock::GenericClockController,
-    dbgprint,
-    ehal::timer::Periodic,
-    pac,
+    dbgprint, pac,
     qspi::{OneShot, Qspi},
     sercom::{
         i2c, spi,
@@ -354,10 +352,10 @@ pub fn usb_allocator(
     dm: impl Into<UsbDm>,
     dp: impl Into<UsbDp>,
 ) -> UsbBusAllocator<UsbBus> {
-    use pac::gclk::{genctrl::SRC_A, pchctrl::GEN_A};
+    use pac::gclk::{genctrl::SRCSELECT_A, pchctrl::GENSELECT_A};
 
-    clocks.configure_gclk_divider_and_source(GEN_A::GCLK2, 1, SRC_A::DFLL, false);
-    let usb_gclk = clocks.get_gclk(GEN_A::GCLK2).unwrap();
+    clocks.configure_gclk_divider_and_source(GENSELECT_A::GCLK2, 1, SRCSELECT_A::DFLL, false);
+    let usb_gclk = clocks.get_gclk(GENSELECT_A::GCLK2).unwrap();
     let usb_clock = &clocks.usb(&usb_gclk).unwrap();
     let (dm, dp) = (dm.into(), dp.into());
     UsbBusAllocator::new(UsbBus::new(usb_clock, mclk, dm, dp, usb))
@@ -404,7 +402,7 @@ pub fn spi_master(
     let (miso, mosi, sck) = (miso.into(), mosi.into(), sck.into());
     let pads = spi::Pads::default().data_in(miso).data_out(mosi).sclk(sck);
     spi::Config::new(mclk, sercom1, pads, freq)
-        .baud(baud)
+        .baud(baud.into())
         .spi_mode(spi::MODE_0)
         .enable()
 }


### PR DESCRIPTION
# Summary
Quite a few small updates

I'm a bit unsettled about the HAL prelude.  Using it winds up bringing in multiple traits which apparently require ugly disambiguation, it seems like this should be cleaner:

```Rust
InterruptDrivenTimer::start(&mut timer, Hertz::MHz(4).into_duration());
```

# Checklist
  - [X] `CHANGELOG.md` for the BSP or HAL updated
  - [X] All new or modified code is well documented, especially public items
  - [X] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 