### PR TITLE
Fix nightly clippy lints

### DIFF
--- a/hal/src/peripherals/clock/d11.rs
+++ b/hal/src/peripherals/clock/d11.rs
@@ -1,4 +1,5 @@
 //! Configuring the system clock sources.
+//!
 //! You will typically need to create an instance of `GenericClockController`
 //! before you can set up most of the peripherals on the atsamd21 device.
 //! The other types in this module are used to enforce at compile time
@@ -20,6 +21,7 @@ pub type ClockGenId = pac::gclk::clkctrl::GENSELECT_A;
 pub type ClockSource = pac::gclk::genctrl::SRCSELECT_A;
 
 /// Represents a configured clock generator.
+///
 /// Can be converted into the effective clock frequency.
 /// Its primary purpose is to be passed in to methods
 /// such as `GenericClockController::tcc2_tc3` to configure
@@ -121,6 +123,7 @@ impl State {
 }
 
 /// `GenericClockController` encapsulates the GCLK hardware.
+///
 /// It provides a type safe way to configure the system clocks.
 /// Initializing the `GenericClockController` instance configures
 /// the system to run at 48Mhz by setting gclk1 as a 32khz source
@@ -347,6 +350,7 @@ macro_rules! clock_generator {
 $(
 /// A typed token that indicates that the clock for the peripheral(s)
 /// with the matching name has been configured.
+///
 /// The effective clock frequency is available via the `freq` method,
 /// or by converting the object into a `Hertz` instance.
 /// The peripheral initialization code will typically require passing
@@ -374,6 +378,7 @@ impl GenericClockController {
     $(
     /// Configure the clock for peripheral(s) that match the name
     /// of this function to use the specific clock generator.
+    ///
     /// The `GClock` parameter may be one of default clocks
     /// return from `gclk0()`, `gclk1()` or a clock configured
     /// by the host application using the `configure_gclk_divider_and_source`

--- a/hal/src/peripherals/clock/d5x/v1.rs
+++ b/hal/src/peripherals/clock/d5x/v1.rs
@@ -80,6 +80,7 @@ impl From<ClockId> for u8 {
 }
 
 /// Represents a configured clock generator.
+///
 /// Can be converted into the effective clock frequency.
 /// Its primary purpose is to be passed in to methods
 /// such as `GenericClockController::tcc2_tc3` to configure
@@ -159,6 +160,7 @@ impl State {
 }
 
 /// `GenericClockController` encapsulates the GCLK hardware.
+///
 /// It provides a type safe way to configure the system clocks.
 /// Initializing the `GenericClockController` instance configures
 /// the system to run at 120MHz by taking the DFLL48
@@ -353,6 +355,7 @@ $(
 
 /// A typed token that indicates that the clock for the peripheral(s)
 /// with the matching name has been configured.
+///
 /// The effective clock frequency is available via the `freq` method,
 /// or by converting the object into a `Hertz` instance.
 /// The peripheral initialization code will typically require passing

--- a/hal/src/peripherals/timer/d11.rs
+++ b/hal/src/peripherals/timer/d11.rs
@@ -21,6 +21,7 @@ use crate::timer_traits::InterruptDrivenTimer;
 // TC5 + TC6 can be paired to make a 32-bit counter
 
 /// A generic hardware timer counter.
+///
 /// The counters are exposed in 16-bit mode only.
 /// The hardware allows configuring the 8-bit mode
 /// and pairing up some instances to run in 32-bit
@@ -59,9 +60,10 @@ where
     }
 
     fn wait(&mut self) -> nb::Result<(), void::Void> {
-        nb::block!{
+        nb::block! {
             <Self as InterruptDrivenTimer>::wait(self)
-        }.unwrap(); // wait() is Infallible
+        }
+        .unwrap(); // wait() is Infallible
         Ok(())
     }
 }

--- a/hal/src/peripherals/timer/d5x.rs
+++ b/hal/src/peripherals/timer/d5x.rs
@@ -20,6 +20,7 @@ use crate::time::{Hertz, Nanoseconds};
 // TC5 + TC6 can be paired to make a 32-bit counter
 
 /// A generic hardware timer counter.
+///
 /// The counters are exposed in 16-bit mode only.
 /// The hardware allows configuring the 8-bit mode
 /// and pairing up some instances to run in 32-bit
@@ -56,9 +57,10 @@ where
     }
 
     fn wait(&mut self) -> nb::Result<(), void::Void> {
-        nb::block!{
+        nb::block! {
             <Self as InterruptDrivenTimer>::wait(self)
-        }.unwrap(); // wait() is Infallible
+        }
+        .unwrap(); // wait() is Infallible
         Ok(())
     }
 }

--- a/hal/src/rtc.rs
+++ b/hal/src/rtc.rs
@@ -70,7 +70,9 @@ pub enum ClockMode {}
 impl RtcMode for ClockMode {}
 impl Sealed for ClockMode {}
 
-/// Count32Mode represents the 32-bit counter mode. This is a free running
+/// Count32Mode represents the 32-bit counter mode.
+///
+/// This is a free running
 /// count-up timer. When used in Periodic/CountDown mode with the embedded-hal
 /// trait(s), it resets to zero on compare and starts counting up again.
 pub enum Count32Mode {}

--- a/hal/src/sercom/dma.rs
+++ b/hal/src/sercom/dma.rs
@@ -25,8 +25,9 @@ use crate::{
 //=============================================================================
 
 /// Token type representing an [`I2c`](super::i2c::I2c) for which the bus is
-/// ready to start a transaction. For use with
-/// [`send_with_dma`](super::i2c::I2c::send_with_dma) and
+/// ready to start a transaction.
+///
+/// For use with [`send_with_dma`](super::i2c::I2c::send_with_dma) and
 /// [`receive_with_dma`](super::i2c::I2c::send_with_dma).
 pub struct I2cBusReady;
 


### PR DESCRIPTION
# Summary
Just small doc fixes to make nightly clippy happy again.

# Checklist
  - [x] `CHANGELOG.md` for the BSP or HAL updated
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 
