### PR TITLE
CI improvements (continued)

### DIFF
--- a/.github/workflows/bump-t2-bsp.yml
+++ b/.github/workflows/bump-t2-bsp.yml
@@ -75,11 +75,11 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           commit-message: |
-            Bump ${{ github.event.input.bsp_name }} (${{ github.event.inputs.bsp_bump }})
+            Bump ${{ github.event.inputs.bsp_name }} (${{ github.event.inputs.bsp_bump }})
           committer: GitHub <noreply@github.com>
           author: atsamd-bot <atsamd-bot@users.noreply.github.com>
           signoff: false
-          branch: bump-${{ github.event.input.bsp_name }}
+          branch: bump-${{ github.event.inputs.bsp_name }}
           delete-branch: true
           title: '[atsamd-bot] Bump crate versions'
           body: |

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -48,12 +48,25 @@ jobs:
           #
           # All errors start with the form 'error: ', so we detect that and
           # bail the subshell to crash out on other publish errors.
+          #
+          # Before publishing, we also tag each PAC with its current version.
+          # If creating+pushing the tag fails, we check if there already is an
+          # identical tag at the same commit, and continue processing if that's
+          # the case. If tagging fails for any other reason, bail the subshell.
 
           for d in pac/*/
           do
             (
               cd "${d}"
               set +e
+
+              PAC_NAME="${d#pac/}"
+              PAC_NAME="${PAC_NAME%/}"
+
+              VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+              TAG_NAME="${PAC_NAME}-${VERSION}"
+              (git tag -a $TAG_NAME -m "${PAC_NAME} release ${VERSION}" && git push origin tag "$TAG_NAME")|| (git tag --points-at $(git rev-parse HEAD) | grep "$TAG_NAME" > /dev/null && echo '(and points at this commit). Continuing.')
+
               PUBLISH_ERR=$(cargo publish 2>&1 >/dev/null)
               set -e
               if [[ "$PUBLISH_ERR" == *" is already uploaded"* ]]; then
@@ -79,11 +92,16 @@ jobs:
           # Force update of the registry
           cargo update || true
 
-          cd "hal" && cargo publish --no-verify
+          cd hal
 
-          version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
-          git tag -a "v${version}" -m "atsamd-hal release v${version}"
-          git push origin tag "v${version}"
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          TAG_NAME="atsamd-hal-${VERSION}"
+          
+          # Create+push a git tag. If that fails, check if an identical tag already exists at the
+          # same commit. Bail otherwise.
+          (git tag -a $TAG_NAME -m "atsamd-hal release ${VERSION}" && git push origin tag "$TAG_NAME") || (git tag --points-at $(git rev-parse HEAD) | grep "$TAG_NAME" > /dev/null && echo '(and points at this commit). Continuing.')
+
+          cargo publish
 
 
       - name: Release BSP crates
@@ -108,12 +126,22 @@ jobs:
           #
           # All errors start with the form 'error: ', so we detect that and
           # bail the subshell to crash out on other publish errors.
+          #
+          # Before publishing, we also tag each BSP with its current version.
+          # If creating+pushing the tag fails, we check if there already is an
+          # identical tag at the same commit, and continue processing if that's
+          # the case. If tagging fails for any other reason, bail the subshell.
 
           for bsp in $(cat crates.json | jq -Mr -c '.boards | keys[]');
           do
             (
               cd "boards/${bsp}"
               set +e
+
+              VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+              TAG_NAME="${bsp}-${VERSION}"
+              (git tag -a $TAG_NAME -m "${bsp} release ${VERSION}" && git push origin tag "$TAG_NAME") || (git tag --points-at $(git rev-parse HEAD) | grep "$TAG_NAME" > /dev/null && echo '(and points at this commit). Continuing.')
+
               PUBLISH_ERR=$(cargo publish 2>&1 >/dev/null)
               set -e
               if [[ "$PUBLISH_ERR" == *" is already uploaded"* ]]; then

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -65,7 +65,14 @@ jobs:
 
               VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
               TAG_NAME="${PAC_NAME}-${VERSION}"
-              (git tag -a $TAG_NAME -m "${PAC_NAME} release ${VERSION}" && git push origin tag "$TAG_NAME")|| (git tag --points-at $(git rev-parse HEAD) | grep "$TAG_NAME" > /dev/null && echo '(and points at this commit). Continuing.')
+              
+              if ! git tag -a $TAG_NAME -m "${PAC_NAME} release ${VERSION}" && git push origin tag "$TAG_NAME"; then
+                if git tag --points-at "$(git rev-parse HEAD)" | grep "$TAG_NAME" > /dev/null; then
+                  echo '(and points at this commit). Continuing.'
+                else
+                  false
+                fi
+              fi
 
               PUBLISH_ERR=$(cargo publish 2>&1 >/dev/null)
               set -e
@@ -99,7 +106,14 @@ jobs:
           
           # Create+push a git tag. If that fails, check if an identical tag already exists at the
           # same commit. Bail otherwise.
-          (git tag -a $TAG_NAME -m "atsamd-hal release ${VERSION}" && git push origin tag "$TAG_NAME") || (git tag --points-at $(git rev-parse HEAD) | grep "$TAG_NAME" > /dev/null && echo '(and points at this commit). Continuing.')
+          if ! git tag -a $TAG_NAME -m "atsamd-hal release ${VERSION}" && git push origin tag "$TAG_NAME"; then
+            if git tag --points-at "$(git rev-parse HEAD)" | grep "$TAG_NAME" > /dev/null; then
+              echo '(and points at this commit). Continuing.'
+            else
+              false
+            fi
+          fi
+
 
           cargo publish
 
@@ -140,7 +154,14 @@ jobs:
 
               VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
               TAG_NAME="${bsp}-${VERSION}"
-              (git tag -a $TAG_NAME -m "${bsp} release ${VERSION}" && git push origin tag "$TAG_NAME") || (git tag --points-at $(git rev-parse HEAD) | grep "$TAG_NAME" > /dev/null && echo '(and points at this commit). Continuing.')
+
+              if ! git tag -a $TAG_NAME -m "${bsp} release ${VERSION}" && git push origin tag "$TAG_NAME"; then
+                if git tag --points-at "$(git rev-parse HEAD)" | grep "$TAG_NAME" > /dev/null; then
+                  echo '(and points at this commit). Continuing.'
+                else
+                  false
+                fi
+              fi
 
               PUBLISH_ERR=$(cargo publish 2>&1 >/dev/null)
               set -e

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -58,7 +58,6 @@ jobs:
           do
             (
               cd "${d}"
-              set +e
 
               PAC_NAME="${d#pac/}"
               PAC_NAME="${PAC_NAME%/}"
@@ -74,6 +73,7 @@ jobs:
                 fi
               fi
 
+              set +e
               PUBLISH_ERR=$(cargo publish 2>&1 >/dev/null)
               set -e
               if [[ "$PUBLISH_ERR" == *" is already uploaded"* ]]; then
@@ -150,7 +150,6 @@ jobs:
           do
             (
               cd "boards/${bsp}"
-              set +e
 
               VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
               TAG_NAME="${bsp}-${VERSION}"
@@ -163,6 +162,7 @@ jobs:
                 fi
               fi
 
+              set +e
               PUBLISH_ERR=$(cargo publish 2>&1 >/dev/null)
               set -e
               if [[ "$PUBLISH_ERR" == *" is already uploaded"* ]]; then


### PR DESCRIPTION
# Summary

* Fix a typo in the commit message introduced by #757.
* Tag all crates upon release, not just `atsamd-hal`.

Current CI/CD runs are affected by #760, which is currently out of our control. However this can most likely be safely ignored in the context of this PR.