### PR TITLE
fix: Changes to the `dmac` public API

### DIFF
--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -31,6 +31,8 @@
 //! `Uninitialized` state. You will be required to call [`Channel::init`]
 //! again before being able to use it with a `Transfer`.
 
+#![allow(unused_braces)]
+
 use atsamd_hal_macros::{hal_cfg, hal_macro_helper};
 
 use super::dma_controller::{ChId, PriorityLevel, TriggerAction, TriggerSource};

--- a/hal/src/dmac/dma_controller.rs
+++ b/hal/src/dmac/dma_controller.rs
@@ -18,6 +18,7 @@
 //!
 //! Using the [`DmaController::free`] method will
 //! deinitialize the DMAC and return the underlying PAC object.
+#![allow(unused_braces)]
 
 use atsamd_hal_macros::{hal_cfg, hal_macro_helper};
 
@@ -40,7 +41,7 @@ pub use crate::pac::dmac::channel::{
 
 use super::{
     channel::{new_chan, Channel, Uninitialized},
-    DESCRIPTOR_SECTION, WRITEBACK,
+    sram,
 };
 use crate::pac::{Dmac, Pm};
 
@@ -93,17 +94,13 @@ pub struct PriorityLevelMask {
     #[skip]
     _reserved: B8,
     /// Level 0
-    #[allow(dead_code)]
-    level0: bool,
+    pub level0: bool,
     /// Level 1
-    #[allow(dead_code)]
-    level1: bool,
+    pub level1: bool,
     /// Level 2
-    #[allow(dead_code)]
-    level2: bool,
+    pub level2: bool,
     /// Level 3
-    #[allow(dead_code)]
-    level3: bool,
+    pub level3: bool,
     #[skip]
     _reserved: B4,
 }
@@ -121,23 +118,19 @@ pub struct RoundRobinMask {
     #[skip]
     _reserved: B7,
     /// Level 0
-    #[allow(dead_code)]
-    level0: bool,
+    pub level0: bool,
     #[skip]
     _reserved: B7,
     /// Level 1
-    #[allow(dead_code)]
-    level1: bool,
+    pub level1: bool,
     #[skip]
     _reserved: B7,
     /// Level 2
-    #[allow(dead_code)]
-    level2: bool,
+    pub level2: bool,
     #[skip]
     _reserved: B7,
     /// Level 3
-    #[allow(dead_code)]
-    level3: bool,
+    pub level3: bool,
 }
 
 impl DmaController {
@@ -166,10 +159,12 @@ impl DmaController {
         // are valid.
         #[allow(static_mut_refs)]
         unsafe {
-            dmac.baseaddr()
-                .write(|w| w.baseaddr().bits(DESCRIPTOR_SECTION.as_mut_ptr() as u32));
+            dmac.baseaddr().write(|w| {
+                w.baseaddr()
+                    .bits(sram::DESCRIPTOR_SECTION.as_mut_ptr() as u32)
+            });
             dmac.wrbaddr()
-                .write(|w| w.wrbaddr().bits(WRITEBACK.as_mut_ptr() as u32));
+                .write(|w| w.wrbaddr().bits(sram::WRITEBACK.as_mut_ptr() as u32));
         }
 
         // ----- Select priority levels ----- //

--- a/hal/src/dmac/transfer.rs
+++ b/hal/src/dmac/transfer.rs
@@ -85,7 +85,7 @@
 use super::{
     channel::{AnyChannel, Busy, CallbackStatus, Channel, ChannelId, InterruptFlags, Ready},
     dma_controller::{ChId, TriggerAction, TriggerSource},
-    BlockTransferControl, DmacDescriptor, Error, Result, DESCRIPTOR_SECTION,
+    sram, Error, Result,
 };
 use crate::typelevel::{Is, Sealed};
 use core::{ptr::null_mut, sync::atomic};
@@ -378,7 +378,7 @@ where
             // SAFETY This is safe as we are only reading the descriptor's address,
             // and not actually writing any data to it. We also assume the descriptor
             // will never be moved.
-            &mut DESCRIPTOR_SECTION[id] as *mut _
+            &mut sram::DESCRIPTOR_SECTION[id] as *mut _
         } else {
             null_mut()
         };
@@ -397,13 +397,13 @@ where
         // that a transfer has completed iff the blockact field in btctrl is not
         // set to SUSPEND.  We implicitly leave blockact set to NOACT here; if
         // that changes Channel::xfer_complete() may need to be modified.
-        let btctrl = BlockTransferControl::new()
+        let btctrl = sram::BlockTransferControl::new()
             .with_srcinc(src_inc)
             .with_dstinc(dst_inc)
             .with_beatsize(S::Beat::BEATSIZE)
             .with_valid(true);
 
-        let xfer_descriptor = DmacDescriptor {
+        let xfer_descriptor = sram::DmacDescriptor {
             // Next descriptor address:  0x0 terminates the transaction (no linked list),
             // any other address points to the next block descriptor
             descaddr,
@@ -421,7 +421,7 @@ where
         // belonging to OUR channel. We assume this is the only place
         // in the entire library that this section or the array
         // will be written to.
-        DESCRIPTOR_SECTION[id] = xfer_descriptor;
+        sram::DESCRIPTOR_SECTION[id] = xfer_descriptor;
     }
 }
 


### PR DESCRIPTION
# Summary

I noticed that there were a few mistakes in the public API of the `dmac` module. Some things were missing, and some others were publicly exposed when they shouldn't.

* Remove `BlockTransferControl` and `DmacDescriptor` structs from the public API
* Add getters/setters for level0, level1, level2 and level3 for `PriorityLevelMask` and `RoundRobinMask` structs

