### PR TITLE
fix(ci): Login to crates.io before running release-plz

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -24,6 +24,9 @@ jobs:
         with:
             targets: thumbv6m-none-eabi, thumbv7em-none-eabihf
 
+      - name: Login to crates.io
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:


### PR DESCRIPTION
Try to fix CI by logging into crates.io before running releases.

Closed #768 and reopened a new PR, because I think release-plz will only attempt to release crates if:
* A branch is merged to `master`
* It belongs to the `atsamd` repo (and not a fork)
* Its name starts with `release-plz`