### PR TITLE
chore: Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,6 @@
 [describe your changes here]
 
 # Checklist
-  - [ ] `CHANGELOG.md` for the BSP or HAL updated
   - [ ] All new or modified code is well documented, especially public items
   - [ ] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 
 
@@ -12,3 +11,13 @@
 
 ## If Adding a new cargo `feature` to the HAL
   - [ ] Feature is added to the test matrix for applicable boards / PACs in `crates.json`
+
+#### Note
+The crate changelogs **should no longer** be manually updated! Changelogs are now automatically generated. Instead:
+
+- If your PR is contained to a single crate, or a single feature:
+  - Nothing else to do; your PR will likely be squashed down to a single commit.
+  - Please consider using [conventional commmit phrasing](https://www.conventionalcommits.org) in the PR title.
+- If your PR brings in large, sweeping changes across multiple crates:
+  - Organize your commits such that each commit only touches a single crate, or a single feature across multiple crates. Please don't create commits that span multiple features over multiple crates.
+  - Use [conventional commmits](https://www.conventionalcommits.org) for your commit messages.

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -24,9 +24,6 @@ jobs:
         with:
             targets: thumbv6m-none-eabi, thumbv7em-none-eabihf
 
-      - name: Login to crates.io
-        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:


### PR DESCRIPTION
Update PR template to reflect the fact that manually updating changelogs in PRs should now be discouraged. Instead, a clean commit history should be encouraged for large PRs.

Also, remove `cargo login` from the release workflow as it probably wasn't the cause of the release issues.
