### PR TITLE
DMA-enabled `embedded-hal` blocking implementations

### DIFF
--- a/boards/atsame54_xpro/Cargo.toml
+++ b/boards/atsame54_xpro/Cargo.toml
@@ -39,9 +39,16 @@ rtt-target = { version = "0.3", features = ["cortex-m"] }
 
 [features]
 default = ["rt", "atsamd-hal/same54p"]
+dma = ["atsamd-hal/dma"]
 rt = ["cortex-m-rt", "atsamd-hal/same54p-rt"]
 usb = ["atsamd-hal/usb", "usb-device"]
 can = ["atsamd-hal/can"]
+
+[[example]]
+name = "blinky_basic"
+
+[[example]]
+name = "blinky_rtic"
 
 [[example]]
 name = "mcan"

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -127,8 +127,19 @@ required-features = ["rtic"]
 
 [[example]]
 name = "uart"
+
+[[example]]
+name = "uart_dma_nonblocking"
+required-features = ["dma"]
+
+[[example]]
+name = "uart_dma_blocking"
 required-features = ["dma"]
 
 [[example]]
 name = "i2c"
+required-features = ["dma"]
+
+[[example]]
+name = "spi"
 required-features = ["dma"]

--- a/boards/feather_m0/examples/i2c.rs
+++ b/boards/feather_m0/examples/i2c.rs
@@ -1,4 +1,5 @@
-//! This example showcases the i2c module.
+//! This example showcases the i2c module, and uses DMA to perform I2C
+//! transactions.
 
 #![no_std]
 #![no_main]
@@ -23,8 +24,9 @@ use hal::ehal::i2c::I2c;
 use hal::fugit::RateExtU32;
 use hal::sercom::i2c;
 
-const LENGTH: usize = 1;
-const ADDRESS: u8 = 0x77;
+// This example is based on the BMP388 pressure sensor. Adjust the device and
+// register addresses to your liking
+const ADDRESS: u8 = 0x76;
 
 #[entry]
 fn main() -> ! {
@@ -48,31 +50,18 @@ fn main() -> ! {
     let channels = dmac.split();
     let chan0 = channels.0.init(PriorityLevel::Lvl0);
 
-    let buf_src: &'static mut [u8; LENGTH] =
-        cortex_m::singleton!(: [u8; LENGTH] = [0x00; LENGTH]).unwrap();
-    let buf_dest: &'static mut [u8; LENGTH] =
-        cortex_m::singleton!(: [u8; LENGTH] = [0x00; LENGTH]).unwrap();
-
     let gclk0 = clocks.gclk0();
     let sercom3_clock = &clocks.sercom3_core(&gclk0).unwrap();
     let pads = i2c::Pads::new(sda, scl);
     let mut i2c = i2c::Config::new(&pm, peripherals.sercom3, pads, sercom3_clock.freq())
         .baud(100.kHz())
-        .enable();
+        .enable()
+        .with_dma_channel(chan0);
 
-    let mut buffer = [0x00; 1];
+    let mut received = [0x00; 1];
 
     // Test writing then reading from an I2C chip
-    i2c.write_read(ADDRESS, &[0x00], &mut buffer).unwrap();
-
-    // Test writing then reading using DMA
-    let init_token = i2c.init_dma_transfer().unwrap();
-    let xfer = i2c.send_with_dma(ADDRESS, init_token, buf_src, chan0, |_| {});
-    let (chan0, _buf_src, mut i2c) = xfer.wait();
-
-    let init_token = i2c.init_dma_transfer().unwrap();
-    let xfer = i2c.receive_with_dma(ADDRESS, init_token, buf_dest, chan0, |_| {});
-    let (_chan0, _i2c, _buf_dest) = xfer.wait();
+    i2c.write_read(ADDRESS, &[0x00; 8], &mut received).unwrap();
 
     loop {
         // Go to sleep

--- a/boards/feather_m0/examples/uart_dma_nonblocking.rs
+++ b/boards/feather_m0/examples/uart_dma_nonblocking.rs
@@ -1,0 +1,100 @@
+//! This example shows how to use the UART to perform non-blocking transfers
+//! using DMA.
+
+#![no_std]
+#![no_main]
+
+use cortex_m::asm;
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
+use bsp::hal;
+use bsp::pac;
+use feather_m0 as bsp;
+
+use bsp::{entry, periph_alias, pin_alias};
+use hal::clock::GenericClockController;
+use hal::dmac::{DmaController, PriorityLevel};
+use hal::fugit::RateExtU32;
+
+use pac::Peripherals;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.gclk,
+        &mut peripherals.pm,
+        &mut peripherals.sysctrl,
+        &mut peripherals.nvmctrl,
+    );
+
+    let mut pm = peripherals.pm;
+    let dmac = peripherals.dmac;
+    let pins = bsp::Pins::new(peripherals.port);
+
+    // Setup DMA channels for later use
+    let mut dmac = DmaController::init(dmac, &mut pm);
+    let channels = dmac.split();
+
+    let chan0 = channels.0.init(PriorityLevel::Lvl0);
+    let chan1 = channels.1.init(PriorityLevel::Lvl0);
+
+    // Take peripheral and pins
+    let uart_sercom = periph_alias!(peripherals.uart_sercom);
+    let uart_rx = pin_alias!(pins.uart_rx);
+    let uart_tx = pin_alias!(pins.uart_tx);
+
+    // Setup UART peripheral. We shouldn't attach DMA channels to the UART; they
+    // instead must be passed to `send_with_dma` and `receive_with_dma`.
+    let uart = bsp::uart(
+        &mut clocks,
+        9600.Hz(),
+        uart_sercom,
+        &mut pm,
+        uart_rx,
+        uart_tx,
+    );
+
+    // Split uart in rx + tx halves
+    let (mut rx, tx) = uart.split();
+
+    // Get a 50 byte buffer to store data to send/receive
+    const LENGTH: usize = 50;
+    let rx_buffer: &'static mut [u8; LENGTH] =
+        cortex_m::singleton!(: [u8; LENGTH] = [0x00; LENGTH]).unwrap();
+    let tx_buffer: &'static mut [u8; LENGTH] =
+        cortex_m::singleton!(: [u8; LENGTH] = [0x00; LENGTH]).unwrap();
+
+    // For fun, store numbers from 0 to 49 in buffer
+    for (i, c) in tx_buffer.iter_mut().enumerate() {
+        *c = i as u8;
+    }
+
+    //...and receive (blocking) using DMA
+    rx.flush_rx_buffer();
+
+    // Let's receive AND send data at the same time with DMA. Note that these
+    // transfers require static buffers
+
+    // Setup a DMA transfer to send our data asynchronously.
+    // We'll set the waker to be a no-op
+    let tx_dma = tx.send_with_dma(tx_buffer, chan0, |_| {});
+
+    // Setup a DMA transfer to receive our data asynchronously.
+    // Again, we'll set the waker to be a no-op
+    let rx_dma = rx.receive_with_dma(rx_buffer, chan1, |_| {});
+
+    // Wait for transmit DMA transfer to complete
+    let (_chan0, _tx_buffer, _tx) = tx_dma.wait();
+
+    // Wait for receive DMA transfer to complete
+    let (_chan1, _rx_buffer, _rx) = rx_dma.wait();
+
+    loop {
+        // Go to sleep
+        asm::wfi();
+    }
+}

--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -48,6 +48,7 @@ rt = ["cortex-m-rt", "atsamd-hal/samd51j-rt"]
 usb = ["atsamd-hal/usb", "usb-device"]
 dma = ["atsamd-hal/dma"]
 max-channels = ["dma", "atsamd-hal/dma"]
+use_semihosting =  []
 
 [[example]]
 name = "pwm"
@@ -62,6 +63,16 @@ required-features = ["dma"]
 
 [[example]]
 name = "uart"
+
+[[example]]
+name = "uart_poll_echo"
+
+[[example]]
+name = "uart_dma_nonblocking"
+required-features = ["dma"]
+
+[[example]]
+name = "uart_dma_blocking"
 required-features = ["dma"]
 
 [[example]]
@@ -78,4 +89,8 @@ required-features = [ "usb"]
 
 [[example]]
 name = "i2c"
-required-features = ["atsamd-hal/dma"]
+required-features = ["dma"]
+
+[[example]]
+name = "spi"
+required-features = ["dma"]

--- a/boards/feather_m4/examples/spi.rs
+++ b/boards/feather_m4/examples/spi.rs
@@ -9,7 +9,7 @@ use panic_halt as _;
 #[cfg(feature = "use_semihosting")]
 use panic_semihosting as _;
 
-use metro_m4 as bsp;
+use feather_m4 as bsp;
 
 use bsp::entry;
 use bsp::hal;
@@ -37,7 +37,7 @@ fn main() -> ! {
     let pins = bsp::Pins::new(peripherals.port);
 
     // Take SPI pins
-    let (miso, mosi, sclk) = (pins.miso, pins.mosi, pins.sclk);
+    let (miso, mosi, sclk) = (pins.miso, pins.mosi, pins.sck);
 
     // Setup DMA channels for later use
     let mut dmac = DmaController::init(dmac, &mut peripherals.pm);
@@ -48,7 +48,7 @@ fn main() -> ! {
     let mut spi = bsp::spi_master(
         &mut clocks,
         100.kHz(),
-        peripherals.sercom2,
+        peripherals.sercom1,
         &mut peripherals.mclk,
         sclk,
         mosi,

--- a/boards/feather_m4/examples/uart_dma_blocking.rs
+++ b/boards/feather_m4/examples/uart_dma_blocking.rs
@@ -1,0 +1,83 @@
+//! This example shows how to use the UART to perform blocking transfers using
+//! DMA and the embedded-io traits.
+
+#![no_std]
+#![no_main]
+
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
+use bsp::hal;
+use bsp::pac;
+use feather_m4 as bsp;
+
+use bsp::{entry, periph_alias, pin_alias};
+use hal::clock::GenericClockController;
+use hal::dmac::{DmaController, PriorityLevel};
+use hal::embedded_io::{Read, Write};
+use hal::fugit::RateExtU32;
+
+use pac::Peripherals;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.gclk,
+        &mut peripherals.mclk,
+        &mut peripherals.osc32kctrl,
+        &mut peripherals.oscctrl,
+        &mut peripherals.nvmctrl,
+    );
+
+    let mut pm = peripherals.pm;
+    let dmac = peripherals.dmac;
+    let pins = bsp::Pins::new(peripherals.port);
+
+    // Setup DMA channels for later use
+    let mut dmac = DmaController::init(dmac, &mut pm);
+    let channels = dmac.split();
+
+    let chan0 = channels.0.init(PriorityLevel::Lvl0);
+    let chan1 = channels.1.init(PriorityLevel::Lvl0);
+
+    // Take peripheral and pins
+    let uart_sercom = periph_alias!(peripherals.uart_sercom);
+    let uart_rx = pin_alias!(pins.uart_rx);
+    let uart_tx = pin_alias!(pins.uart_tx);
+
+    // Setup UART peripheral and attach DMA channels
+    let uart = bsp::uart(
+        &mut clocks,
+        9600.Hz(),
+        uart_sercom,
+        &mut peripherals.mclk,
+        uart_rx,
+        uart_tx,
+    )
+    .with_rx_channel(chan0)
+    .with_tx_channel(chan1);
+
+    // Split uart in rx + tx halves
+    let (mut rx, mut tx) = uart.split();
+
+    loop {
+        // Make buffers to store data to send/receive
+        let mut rx_buffer = [0x00; 50];
+        let mut tx_buffer = [0x00; 50];
+
+        // For fun, store numbers from 0 to 49 in buffer
+        for (i, c) in tx_buffer.iter_mut().enumerate() {
+            *c = i as u8;
+        }
+
+        // Send data using DMA...
+        tx.write(&tx_buffer).unwrap();
+
+        //...and receive using DMA
+        rx.flush_rx_buffer();
+        rx.read(&mut rx_buffer).unwrap();
+    }
+}

--- a/boards/feather_m4/examples/uart_dma_nonblocking.rs
+++ b/boards/feather_m4/examples/uart_dma_nonblocking.rs
@@ -1,0 +1,101 @@
+//! This example shows how to use the UART to perform non-blocking transfers
+//! using DMA.
+
+#![no_std]
+#![no_main]
+
+use cortex_m::asm;
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
+use bsp::hal;
+use bsp::pac;
+use feather_m4 as bsp;
+
+use bsp::{entry, periph_alias, pin_alias};
+use hal::clock::GenericClockController;
+use hal::dmac::{DmaController, PriorityLevel};
+use hal::fugit::RateExtU32;
+
+use pac::Peripherals;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.gclk,
+        &mut peripherals.mclk,
+        &mut peripherals.osc32kctrl,
+        &mut peripherals.oscctrl,
+        &mut peripherals.nvmctrl,
+    );
+
+    let mut pm = peripherals.pm;
+    let dmac = peripherals.dmac;
+    let pins = bsp::Pins::new(peripherals.port);
+
+    // Setup DMA channels for later use
+    let mut dmac = DmaController::init(dmac, &mut pm);
+    let channels = dmac.split();
+
+    let chan0 = channels.0.init(PriorityLevel::Lvl0);
+    let chan1 = channels.1.init(PriorityLevel::Lvl0);
+
+    // Take peripheral and pins
+    let uart_sercom = periph_alias!(peripherals.uart_sercom);
+    let uart_rx = pin_alias!(pins.uart_rx);
+    let uart_tx = pin_alias!(pins.uart_tx);
+
+    // Setup UART peripheral. We shouldn't attach DMA channels to the UART; they
+    // instead must be passed to `send_with_dma` and `receive_with_dma`.
+    let uart = bsp::uart(
+        &mut clocks,
+        9600.Hz(),
+        uart_sercom,
+        &mut peripherals.mclk,
+        uart_rx,
+        uart_tx,
+    );
+
+    // Split uart in rx + tx halves
+    let (mut rx, tx) = uart.split();
+
+    // Get a 50 byte buffer to store data to send/receive
+    const LENGTH: usize = 50;
+    let rx_buffer: &'static mut [u8; LENGTH] =
+        cortex_m::singleton!(: [u8; LENGTH] = [0x00; LENGTH]).unwrap();
+    let tx_buffer: &'static mut [u8; LENGTH] =
+        cortex_m::singleton!(: [u8; LENGTH] = [0x00; LENGTH]).unwrap();
+
+    // For fun, store numbers from 0 to 49 in buffer
+    for (i, c) in tx_buffer.iter_mut().enumerate() {
+        *c = i as u8;
+    }
+
+    //...and receive (blocking) using DMA
+    rx.flush_rx_buffer();
+
+    // Let's receive AND send data at the same time with DMA. Note that these
+    // transfers require static buffers
+
+    // Setup a DMA transfer to send our data asynchronously.
+    // We'll set the waker to be a no-op
+    let tx_dma = tx.send_with_dma(tx_buffer, chan0, |_| {});
+
+    // Setup a DMA transfer to receive our data asynchronously.
+    // Again, we'll set the waker to be a no-op
+    let rx_dma = rx.receive_with_dma(rx_buffer, chan1, |_| {});
+
+    // Wait for transmit DMA transfer to complete
+    let (_chan0, _tx_buffer, _tx) = tx_dma.wait();
+
+    // Wait for receive DMA transfer to complete
+    let (_chan1, _rx_buffer, _rx) = rx_dma.wait();
+
+    loop {
+        // Go to sleep
+        asm::wfi();
+    }
+}

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -63,3 +63,7 @@ name = "blinky_basic"
 [[example]]
 name = "i2c"
 required-features = ["dma"]
+
+[[example]]
+name = "spi"
+required-features = ["dma"]

--- a/boards/metro_m0/examples/i2c.rs
+++ b/boards/metro_m0/examples/i2c.rs
@@ -1,4 +1,5 @@
-//! This example showcases the i2c module.
+//! This example showcases the i2c module, and uses DMA to perform I2C
+//! transactions.
 
 #![no_std]
 #![no_main]
@@ -23,8 +24,9 @@ use hal::ehal::i2c::I2c;
 use hal::fugit::RateExtU32;
 use hal::sercom::i2c;
 
-const LENGTH: usize = 1;
-const ADDRESS: u8 = 0x77;
+// This example is based on the BMP388 pressure sensor. Adjust the device and
+// register addresses to your liking
+const ADDRESS: u8 = 0x76;
 
 #[entry]
 fn main() -> ! {
@@ -48,31 +50,18 @@ fn main() -> ! {
     let channels = dmac.split();
     let chan0 = channels.0.init(PriorityLevel::Lvl0);
 
-    let buf_src: &'static mut [u8; LENGTH] =
-        cortex_m::singleton!(: [u8; LENGTH] = [0x00; LENGTH]).unwrap();
-    let buf_dest: &'static mut [u8; LENGTH] =
-        cortex_m::singleton!(: [u8; LENGTH] = [0x00; LENGTH]).unwrap();
-
     let gclk0 = clocks.gclk0();
     let sercom3_clock = &clocks.sercom3_core(&gclk0).unwrap();
     let pads = i2c::Pads::new(sda, scl);
     let mut i2c = i2c::Config::new(&pm, peripherals.sercom3, pads, sercom3_clock.freq())
         .baud(100.kHz())
-        .enable();
+        .enable()
+        .with_dma_channel(chan0);
 
-    let mut buffer = [0x00; 1];
+    let mut received = [0x00; 1];
 
     // Test writing then reading from an I2C chip
-    i2c.write_read(ADDRESS, &[0x00], &mut buffer).unwrap();
-
-    // Test writing then reading using DMA
-    let init_token = i2c.init_dma_transfer().unwrap();
-    let xfer = i2c.send_with_dma(ADDRESS, init_token, buf_src, chan0, |_| {});
-    let (chan0, _buf_src, mut i2c) = xfer.wait();
-
-    let init_token = i2c.init_dma_transfer().unwrap();
-    let xfer = i2c.receive_with_dma(ADDRESS, init_token, buf_dest, chan0, |_| {});
-    let (_chan0, _i2c, _buf_dest) = xfer.wait();
+    i2c.write_read(ADDRESS, &[0x00; 8], &mut received).unwrap();
 
     loop {
         // Go to sleep

--- a/boards/metro_m0/examples/spi.rs
+++ b/boards/metro_m0/examples/spi.rs
@@ -1,4 +1,4 @@
-//! This example showcases the spi module, and uses DMA to perform SPI
+//! This example showcases the spi module, and uses DMA to perform I2C
 //! transactions.
 
 #![no_std]
@@ -9,7 +9,7 @@ use panic_halt as _;
 #[cfg(feature = "use_semihosting")]
 use panic_semihosting as _;
 
-use metro_m4 as bsp;
+use metro_m0 as bsp;
 
 use bsp::entry;
 use bsp::hal;
@@ -25,31 +25,32 @@ use hal::fugit::RateExtU32;
 #[entry]
 fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
-    let mut clocks = GenericClockController::with_external_32kosc(
+    let mut clocks = GenericClockController::with_internal_32kosc(
         peripherals.gclk,
-        &mut peripherals.mclk,
-        &mut peripherals.osc32kctrl,
-        &mut peripherals.oscctrl,
+        &mut peripherals.pm,
+        &mut peripherals.sysctrl,
         &mut peripherals.nvmctrl,
     );
 
+    let mut pm = peripherals.pm;
     let dmac = peripherals.dmac;
     let pins = bsp::Pins::new(peripherals.port);
 
     // Take SPI pins
-    let (miso, mosi, sclk) = (pins.miso, pins.mosi, pins.sclk);
+    let (miso, mosi, sclk) = (pins.miso, pins.mosi, pins.sck);
 
     // Setup DMA channels for later use
-    let mut dmac = DmaController::init(dmac, &mut peripherals.pm);
+    let mut dmac = DmaController::init(dmac, &mut pm);
     let channels = dmac.split();
     let chan0 = channels.0.init(PriorityLevel::Lvl0);
     let chan1 = channels.1.init(PriorityLevel::Lvl0);
 
+    // Create a Spi with DMA enabled
     let mut spi = bsp::spi_master(
         &mut clocks,
         100.kHz(),
-        peripherals.sercom2,
-        &mut peripherals.mclk,
+        peripherals.sercom4,
+        &mut pm,
         sclk,
         mosi,
         miso,

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -75,9 +75,6 @@ name = "pwm"
 name = "serial"
 
 [[example]]
-name = "spi"
-
-[[example]]
 name = "timer"
 
 [[example]]
@@ -92,4 +89,8 @@ required-features = ["usb"]
 
 [[example]]
 name = "i2c"
+required-features = ["dma"]
+
+[[example]]
+name = "spi"
 required-features = ["dma"]

--- a/boards/metro_m4/examples/i2c.rs
+++ b/boards/metro_m4/examples/i2c.rs
@@ -1,4 +1,5 @@
-//! This example showcases the i2c module.
+//! This example showcases the i2c module, and uses DMA to perform I2C
+//! transactions.
 
 #![no_std]
 #![no_main]
@@ -23,8 +24,9 @@ use hal::ehal::i2c::I2c;
 use hal::fugit::RateExtU32;
 use hal::sercom::i2c;
 
-const LENGTH: usize = 1;
-const ADDRESS: u8 = 0x77;
+// This example is based on the BMP388 pressure sensor. Adjust the device and
+// register addresses to your liking
+const ADDRESS: u8 = 0x76;
 
 #[entry]
 fn main() -> ! {
@@ -49,32 +51,19 @@ fn main() -> ! {
     let channels = dmac.split();
     let chan0 = channels.0.init(PriorityLevel::Lvl0);
 
-    let buf_src: &'static mut [u8; LENGTH] =
-        cortex_m::singleton!(: [u8; LENGTH] = [0x00; LENGTH]).unwrap();
-    let buf_dest: &'static mut [u8; LENGTH] =
-        cortex_m::singleton!(: [u8; LENGTH] = [0x00; LENGTH]).unwrap();
-
     let gclk0 = clocks.gclk0();
     let sercom5_clock = &clocks.sercom5_core(&gclk0).unwrap();
     let pads = i2c::Pads::new(sda, scl);
     let i2c_sercom = periph_alias!(peripherals.i2c_sercom);
     let mut i2c = i2c::Config::new(&mclk, i2c_sercom, pads, sercom5_clock.freq())
         .baud(100.kHz())
-        .enable();
+        .enable()
+        .with_dma_channel(chan0);
 
-    let mut buffer = [0x00; 1];
+    let mut received = [0x00; 1];
 
     // Test writing then reading from an I2C chip
-    i2c.write_read(ADDRESS, &[0x00], &mut buffer).unwrap();
-
-    // Test writing then reading using DMA
-    let init_token = i2c.init_dma_transfer().unwrap();
-    let xfer = i2c.send_with_dma(ADDRESS, init_token, buf_src, chan0, |_| {});
-    let (chan0, _buf_src, mut i2c) = xfer.wait();
-
-    let init_token = i2c.init_dma_transfer().unwrap();
-    let xfer = i2c.receive_with_dma(ADDRESS, init_token, buf_dest, chan0, |_| {});
-    let (_chan0, _i2c, _buf_dest) = xfer.wait();
+    i2c.write_read(ADDRESS, &[0x00; 8], &mut received).unwrap();
 
     loop {
         // Go to sleep

--- a/boards/samd11_bare/examples/i2c.rs
+++ b/boards/samd11_bare/examples/i2c.rs
@@ -1,4 +1,5 @@
-//! This example showcases the i2c::v2 module.
+//! This example showcases the i2c module, and uses DMA to perform I2C
+//! transactions.
 
 #![no_std]
 #![no_main]
@@ -23,8 +24,9 @@ use hal::ehal::i2c::I2c;
 use hal::fugit::RateExtU32;
 use hal::sercom::i2c;
 
-const LENGTH: usize = 1;
-const ADDRESS: u8 = 0x77;
+// This example is based on the BMP388 pressure sensor. Adjust the device and
+// register addresses to your liking
+const ADDRESS: u8 = 0x76;
 
 #[entry]
 fn main() -> ! {
@@ -48,31 +50,18 @@ fn main() -> ! {
     let channels = dmac.split();
     let chan0 = channels.0.init(PriorityLevel::Lvl0);
 
-    let buf_src: &'static mut [u8; LENGTH] =
-        cortex_m::singleton!(: [u8; LENGTH] = [0x00; LENGTH]).unwrap();
-    let buf_dest: &'static mut [u8; LENGTH] =
-        cortex_m::singleton!(: [u8; LENGTH] = [0x00; LENGTH]).unwrap();
-
     let gclk0 = clocks.gclk0();
     let sercom0_clock = &clocks.sercom0_core(&gclk0).unwrap();
     let pads = i2c::Pads::new(sda, scl);
     let mut i2c = i2c::Config::new(&pm, peripherals.sercom0, pads, sercom0_clock.freq())
         .baud(100.kHz())
-        .enable();
+        .enable()
+        .with_dma_channel(chan0);
 
-    let mut buffer = [0x00; 1];
+    let mut received = [0x00; 1];
 
     // Test writing then reading from an I2C chip
-    i2c.write_read(ADDRESS, &[0x00], &mut buffer).unwrap();
-
-    // Test writing then reading using DMA
-    let init_token = i2c.init_dma_transfer().unwrap();
-    let xfer = i2c.send_with_dma(ADDRESS, init_token, buf_src, chan0, |_| {});
-    let (chan0, _buf_src, mut i2c) = xfer.wait();
-
-    let init_token = i2c.init_dma_transfer().unwrap();
-    let xfer = i2c.receive_with_dma(ADDRESS, init_token, buf_dest, chan0, |_| {});
-    let (_chan0, _i2c, _buf_dest) = xfer.wait();
+    i2c.write_read(ADDRESS, &[0x00; 8], &mut received).unwrap();
 
     loop {
         // Go to sleep

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT OR Apache-2.0"
 name = "atsamd-hal"
 readme = "README.md"
 repository = "https://github.com/atsamd-rs/atsamd"
-rust-version = "1.65"
+rust-version = "1.77.2"
 version = "0.18.2"
 
 [package.metadata.docs.rs]

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -41,6 +41,7 @@ embedded-hal-1 = {package = "embedded-hal", version = "1.0.0"}
 embedded-hal-nb = "1.0.0"
 embedded-io = "0.6"
 fugit = "0.3"
+heapless = "0.8"
 modular-bitfield = "0.11"
 nb = "1.0"
 num-traits = {version = "0.2.14", default-features = false}

--- a/hal/src/dmac/dma_controller.rs
+++ b/hal/src/dmac/dma_controller.rs
@@ -157,14 +157,11 @@ impl DmaController {
         // and the descriptor array addesses will never change since they are static.
         // We just need to ensure the writeback and descriptor_section addresses
         // are valid.
-        #[allow(static_mut_refs)]
         unsafe {
-            dmac.baseaddr().write(|w| {
-                w.baseaddr()
-                    .bits(sram::DESCRIPTOR_SECTION.as_mut_ptr() as u32)
-            });
+            dmac.baseaddr()
+                .write(|w| w.baseaddr().bits(sram::descriptor_section_addr() as u32));
             dmac.wrbaddr()
-                .write(|w| w.wrbaddr().bits(sram::WRITEBACK.as_mut_ptr() as u32));
+                .write(|w| w.wrbaddr().bits(sram::writeback_addr() as u32));
         }
 
         // ----- Select priority levels ----- //

--- a/hal/src/dmac/mod.rs
+++ b/hal/src/dmac/mod.rs
@@ -270,6 +270,26 @@ pub enum Error {
 
     /// Operation is not valid in the current state of the object.
     InvalidState,
+    /// Chip reported an error during transfer
+    TransferError,
+}
+
+impl From<Error> for crate::sercom::spi::Error {
+    fn from(value: Error) -> Self {
+        crate::sercom::spi::Error::Dma(value)
+    }
+}
+
+impl From<Error> for crate::sercom::i2c::Error {
+    fn from(value: Error) -> Self {
+        crate::sercom::i2c::Error::Dma(value)
+    }
+}
+
+impl From<Error> for crate::sercom::uart::Error {
+    fn from(value: Error) -> Self {
+        crate::sercom::uart::Error::Dma(value)
+    }
 }
 
 /// Result for DMAC operations
@@ -339,8 +359,10 @@ macro_rules! get {
 pub const NUM_CHANNELS: usize = with_num_channels!(get);
 
 /// DMAC SRAM registers
-mod sram {
+pub(crate) mod sram {
     #![allow(dead_code, unused_braces)]
+
+    use core::cell::UnsafeCell;
 
     use super::{BeatSize, NUM_CHANNELS};
 
@@ -348,6 +370,35 @@ mod sram {
         bitfield,
         specifiers::{B2, B3},
     };
+
+    /// Wrapper type around a [`DmacDescriptor`] to allow interior mutability
+    /// while keeping them in static storage
+    #[repr(transparent)]
+    pub struct DescriptorCell(UnsafeCell<DmacDescriptor>);
+
+    impl DescriptorCell {
+        const fn default() -> Self {
+            Self(UnsafeCell::new(DmacDescriptor::default()))
+        }
+    }
+
+    // DescriptorCell is not not *really* sync; we must manually uphold the sync
+    // guarantees on every access.
+    unsafe impl Sync for DescriptorCell {}
+
+    impl core::ops::Deref for DescriptorCell {
+        type Target = UnsafeCell<DmacDescriptor>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl core::ops::DerefMut for DescriptorCell {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
+    }
 
     /// Bitfield representing the BTCTRL SRAM DMAC register
     #[allow(unused_braces)]
@@ -377,7 +428,7 @@ mod sram {
     /// Descriptor representing a SRAM register. Datasheet section 19.8.2
     #[derive(Clone, Copy)]
     #[repr(C, align(16))]
-    pub(super) struct DmacDescriptor {
+    pub struct DmacDescriptor {
         pub(super) btctrl: BlockTransferControl,
         pub(super) btcnt: u16,
         pub(super) srcaddr: *const (),
@@ -385,23 +436,78 @@ mod sram {
         pub(super) descaddr: *const DmacDescriptor,
     }
 
-    pub(super) const DEFAULT_DESCRIPTOR: DmacDescriptor = DmacDescriptor {
-        btctrl: BlockTransferControl::new(),
-        btcnt: 0,
-        srcaddr: 0 as *mut _,
-        dstaddr: 0 as *mut _,
-        descaddr: 0 as *mut _,
-    };
+    impl DmacDescriptor {
+        pub const fn default() -> Self {
+            Self {
+                btctrl: BlockTransferControl::new(),
+                btcnt: 0,
+                srcaddr: 0 as *mut _,
+                dstaddr: 0 as *mut _,
+                descaddr: 0 as *mut _,
+            }
+        }
 
-    /// Writeback section. This static variable should never be written to in an
-    /// interrupt or thread context.
-    pub(super) static mut WRITEBACK: [DmacDescriptor; NUM_CHANNELS] =
-        [DEFAULT_DESCRIPTOR; NUM_CHANNELS];
+        pub fn next_descriptor(&self) -> *const DmacDescriptor {
+            self.descaddr
+        }
 
-    /// Descriptor section. This static variable should never be written to in
-    /// an interrupt or thread context.
-    pub(super) static mut DESCRIPTOR_SECTION: [DmacDescriptor; NUM_CHANNELS] =
-        [DEFAULT_DESCRIPTOR; NUM_CHANNELS];
+        pub fn set_next_descriptor(&mut self, next: *mut DmacDescriptor) {
+            self.descaddr = next;
+        }
+
+        pub fn beat_count(&self) -> u16 {
+            self.btcnt
+        }
+    }
+
+    /// Writeback section.
+    ///
+    /// # Safety
+    ///
+    /// This variable should never be accessed. The only thing we need
+    /// to know about it is its starting address, given by
+    /// [`writeback_addr`].
+    static WRITEBACK: [DescriptorCell; NUM_CHANNELS] =
+        [const { DescriptorCell::default() }; NUM_CHANNELS];
+
+    // We only ever need to know its starting address.
+    pub(super) fn writeback_addr() -> *mut DmacDescriptor {
+        WRITEBACK[0].get()
+    }
+
+    /// Descriptor section.
+    ///
+    /// # Safety
+    ///
+    /// All accesses to this variable should be synchronized. Elements of the
+    /// array should only ever be accessed using [`UnsafeCell::get`]. Any other
+    /// access method, such as taking a reference to the [`UnsafeCell`] itself,
+    /// is UB and *will* break DMA transfers - speaking from personal
+    /// experience.
+    static DESCRIPTOR_SECTION: [DescriptorCell; NUM_CHANNELS] =
+        [const { DescriptorCell::default() }; NUM_CHANNELS];
+
+    #[inline]
+    pub(super) fn descriptor_section_addr() -> *mut DmacDescriptor {
+        DESCRIPTOR_SECTION[0].get()
+    }
+
+    /// Get a mutable pointer to the specified channel's DMAC descriptor
+    ///
+    /// # Safety
+    ///
+    /// The caller must manually synchronize any access to the pointee
+    /// [`DmacDescriptor`].
+    ///
+    /// Additionnally, if the pointer is used to create references to
+    /// [`DmacDescriptor`], the caller must guarantee that there will **never**
+    /// be overlapping `&mut` references (or overlapping `&mut` and `&`
+    /// references) to the pointee *at any given time*, as it would be
+    /// instantaneous undefined behaviour.
+    #[inline]
+    pub(super) unsafe fn get_descriptor(channel_id: usize) -> *mut DmacDescriptor {
+        DESCRIPTOR_SECTION[channel_id].get()
+    }
 }
 
 pub mod channel;

--- a/hal/src/sercom/dma.rs
+++ b/hal/src/sercom/dma.rs
@@ -314,8 +314,14 @@ where
     C: uart::ValidConfig,
     D: uart::Receive,
 {
-    /// Transform an [`Uart`] into a DMA [`Transfer`]) and
-    /// start receiving into the provided buffer.
+    /// Transform an [`Uart`] into a DMA [`Transfer`]) and start reveiving into
+    /// the provided buffer.
+    ///
+    /// In order to be (safely) non-blocking, his method has to take a `'static`
+    /// buffer. If you'd rather use DMA with the blocking
+    /// [`embedded_io::Read`](crate::embedded_io::Read) trait, and avoid having
+    /// to use static buffers,
+    /// use[`Uart::with_rx_channel`](Self::with_tx_channel) instead.
     #[inline]
     #[hal_macro_helper]
     pub fn receive_with_dma<Ch, B, W>(
@@ -353,8 +359,14 @@ where
     C: uart::ValidConfig,
     D: uart::Transmit,
 {
-    /// Transform an [`Uart`] into a DMA [`Transfer`]) and
-    /// start sending the provided buffer.
+    /// Transform an [`Uart`] into a DMA [`Transfer`]) and start sending the
+    /// provided buffer.
+    ///
+    /// In order to be (safely) non-blocking, his method takes a `'static`
+    /// buffer. If you'd rather use DMA with the blocking
+    /// [`embedded_io::Write`](crate::embedded_io::Write) trait, and avoid
+    /// having to use static buffers,
+    /// use[`Uart::with_tx_channel`](Self::with_tx_channel) instead.
     #[inline]
     #[hal_macro_helper]
     pub fn send_with_dma<Ch, B, W>(

--- a/hal/src/sercom/dma.rs
+++ b/hal/src/sercom/dma.rs
@@ -116,6 +116,10 @@ unsafe impl<T: Beat> Buffer for SercomPtr<T> {
 ///
 /// For use with [`send_with_dma`](super::i2c::I2c::send_with_dma) and
 /// [`receive_with_dma`](super::i2c::I2c::send_with_dma).
+#[deprecated(
+    since = "0.19.0",
+    note = "Use `I2c::with_dma_channel` instead. You will have access to DMA-enabled `embedded-hal` implementations."
+)]
 pub struct I2cBusReady;
 
 unsafe impl<C: i2c::AnyConfig> Buffer for I2c<C> {
@@ -156,6 +160,11 @@ impl<C: i2c::AnyConfig> I2c<C> {
     /// [`init_dma_transfer`]: super::i2c::I2c::init_dma_transfer
     /// [`send_with_dma`]: super::i2c::I2c::send_with_dma
     /// [`receive_with_dma`]: super::i2c::I2c::receive_with_dma
+    #[deprecated(
+        since = "0.19.0",
+        note = "Use `I2c::with_dma_channel` instead. You will have access to DMA-enabled `embedded-hal` implementations."
+    )]
+    #[allow(deprecated)]
     pub fn init_dma_transfer(&mut self) -> Result<I2cBusReady, super::i2c::Error> {
         self.check_bus_status()?;
         Ok(I2cBusReady)
@@ -167,6 +176,11 @@ impl<C: i2c::AnyConfig> I2c<C> {
     ///
     /// It is recommended that you check for errors after the transfer is
     /// complete by calling [`read_status`](I2c::read_status).
+    #[deprecated(
+        since = "0.19.0",
+        note = "Use `I2c::with_dma_channel` instead. You will have access to DMA-enabled `embedded-hal` implementations."
+    )]
+    #[allow(deprecated)]
     #[hal_macro_helper]
     pub fn receive_with_dma<Ch, B, W>(
         self,
@@ -217,6 +231,11 @@ impl<C: i2c::AnyConfig> I2c<C> {
     /// complete by calling [`read_status`](I2c::read_status).
     #[inline]
     #[hal_macro_helper]
+    #[deprecated(
+        since = "0.19.0",
+        note = "Use `I2c::with_dma_chahnnel` instead. You will have access to DMA-enabled `embedded-hal` implementations."
+    )]
+    #[allow(deprecated)]
     pub fn send_with_dma<Ch, B, W>(
         self,
         address: u8,

--- a/hal/src/sercom/i2c.rs
+++ b/hal/src/sercom/i2c.rs
@@ -136,13 +136,12 @@
 //! parameter, representing the underlying [`Config`].
 //!
 //! Only the [`I2c`] struct can actually perform
-//! transactions. To do so, use the embedded HAL traits, like
-//! [`i2c::WriteRead`], [`i2c::Read`] and [`i2c::Write`].
+//! transactions. To do so, use the [`embedded_hal::i2c::I2c`] trait.
 //!
 //! ```
-//! use embedded_hal::blocking::i2c::Write;
+//! use embedded_hal::i2c::I2c;
 //!
-//! i2c.write(0x54, 0x0fe)
+//! i2c.write(0x54, 0x0fe).unwrap();
 //! ```
 //!
 //! # Reading the current configuration
@@ -163,7 +162,6 @@
 //!
 //! ```no_run
 //! use atsamd_hal::sercom::i2c::I2c;
-//! use atsamd_hal::time::*;
 //!
 //! // Assume config is a valid Duplex I2C Config struct
 //! let i2c = config.enable();
@@ -183,8 +181,48 @@
 //! * High-speed mode is not supported.
 //! * 4-wire mode is not supported.
 //! * 32-bit extension mode is not supported (SAMx5x). If you need to transfer
-//!   slices, consider using the DMA methods instead. The `dma` Cargo feature
-//!   must be enabled.
+//!   slices, consider using the DMA methods instead . The <span class="stab
+//!   portability" title="Available on crate feature `dma`
+//!   only"><code>dma</code></span> Cargo feature must be enabled.
+//!
+//! # Using I2C with DMA <span class="stab portability" title="Available on crate feature `dma` only"><code>dma</code></span>
+//!
+//! This HAL includes support for DMA-enabled I2C transfers. Use
+//! [`I2c::with_dma_channel`] to attach a DMA channel to the [`I2c`] struct. A
+//! DMA-enabled [`I2c`] implements the blocking
+//! [`embedded_hal::i2c::I2c`](crate::ehal::i2c::I2c) trait, which can be used
+//! to perform I2C transfers which are fast, continuous and low jitter, even
+//! if they are preemped by a higher priority interrupt.
+//!
+//!
+//! ```no_run
+//! use atsamd_hal::dmac::channel::{AnyChannel, Ready};
+//! use atsand_hal::sercom::i2c::{I2c, AnyConfig, Error};
+//! use atsamd_hal::embedded_hal::i2c::I2c;
+//! fn i2c_send_with_dma<A: AnyConfig, C: AnyChannel<Status = Ready>>(i2c: I2c<A>, channel: C, bytes: &[u8]) -> Result<(), Error>{
+//!     // Attach a DMA channel
+//!     let i2c = i2c.with_dma_channel(channel);
+//!     i2c.send(0x54, bytes)?;
+//! }
+//! ```
+//!
+//! ## Limitations of using DMA with I2C
+//!
+//! * The I2C peripheral only supports continuous DMA read/writes of up to 255
+//!   bytes. Trying to read/write with a transfer of 256 bytes or more will
+//!   result in a panic. This also applies to using [`I2c::transaction`] with
+//!   adjacent write/read operations of the same type; the total number of bytes
+//!   across all adjacent operations must not exceed 256. If you need continuous
+//!   transfers of 256 bytes or more, use the non-DMA [`I2c`] implementations.
+//!
+//! * Using [`I2c::transaction`] consumes significantly more memory than the
+//!   other methods provided by [`embedded_hal::i2c::I2c`] (at least 256 bytes
+//!   extra).
+//!
+//! * When using [`I2c::transaction`], up to 17 adjacent operations of the same
+//!   type can be continuously handled by DMA without CPU intervention. If you
+//!   need more than 17 adjacent operations of the same type, the transfer will
+//!   reverted to using the byte-by-byte (non-DMA) implementation.
 //!
 //! [`enable`]: Config::enable
 //! [`disable`]: I2c::disable
@@ -199,61 +237,8 @@
 //! [`Pin`]: crate::gpio::pin::Pin
 //! [`PinId`]: crate::gpio::pin::PinId
 //! [`PinMode`]: crate::gpio::pin::PinMode
-//! [`i2c::Write`]: embedded_hal::blocking::i2c::Write
-//! [`i2c::Read`]: embedded_hal::blocking::i2c::Read
-//! [`i2c::WriteRead`]: embedded_hal::blocking::i2c::WriteRead
-#![cfg_attr(
-    feature = "dma",
-    doc = "
-# Using I2C with DMA
-
-This HAL includes support for DMA-enabled I2C transfers. [`I2c`]
-implements the DMAC [`Buffer`]
-trait. The provided [`send_with_dma`] and
-[`receive_with_dma`] build and begin a
-[`dmac::Transfer`], thus starting the I2C
-in a non-blocking way.
-
-Note that the [`init_dma_transfer`] method should be called immediately before
-starting a DMA transfer with I2C. This will check that the bus is in a correct
-state before starting the transfer, and providing a token type to pass to the
-[`send_with_dma`] and [`receive_with_dma`] methods.
-
-Optionally, interrupts can be enabled on the provided
-[`Channel`]. Note that the `dma` feature must
-be enabled. Please refer to the [`dmac`](crate::dmac) module-level
-documentation for more information.
-
-```no_run
-use atsamd_hal::dmac::channel::{AnyChannel, Ready};
-use atsand_hal::sercom::i2c::{I2c, AnyConfig, Error};
-fn i2c_send_with_dma<A: AnyConfig, C: AnyChannel<Status = Ready>>(i2c: I2c<A>, channel: C) -> Result<(), Error>{
-    // Create data to send. Note that it must be `'static`.
-    let buffer: [u8; 50] = [0xff; 50];
-
-    // Initialize the bus and check for errors
-    let token = i2c.init_dma_transfer()?;
-    let transfer = i2c.send_with_dma(0x54, token, buffer, channel0, |_| {})
-
-
-    // Wait for transfers to complete and reclaim resources
-    let (chan0, buffer, i2c) = transfer.wait();
-
-    // Check for errors that may have occured during the transfer.
-    i2c.read_status().check_bus_error()?;
-}
-```
-
-[`Buffer`]: crate::dmac::transfer::Buffer
-[`init_dma_transfer`]: I2c::init_dma_transfer
-[`send_with_dma`]: I2c::send_with_dma
-[`receive_with_dma`]: I2c::receive_with_dma
-[`dmac::Transfer`]: crate::dmac::Transfer
-[`Channel`]: crate::dmac::channel::Channel
-[`dmac`]: crate::dmac
-
-"
-)]
+//! [`embedded_hal::i2c::I2c`]: crate::ehal::i2c::I2c
+//! [`I2c::transaction`]: crate::ehal::i2c::I2c::transaction
 
 use atsamd_hal_macros::hal_module;
 
@@ -294,11 +279,12 @@ pub enum InactiveTimeout {
 }
 
 /// Abstraction over a I2C peripheral, allowing to perform I2C transactions.
-pub struct I2c<C: AnyConfig> {
+pub struct I2c<C: AnyConfig, D = crate::typelevel::NoneT> {
     config: C,
+    dma_channel: D,
 }
 
-impl<C: AnyConfig> I2c<C> {
+impl<C: AnyConfig, D> I2c<C, D> {
     /// Obtain a pointer to the `DATA` register. Necessary for DMA transfers.
     #[inline]
     pub fn data_ptr(&self) -> *mut Word {
@@ -429,6 +415,37 @@ impl<C: AnyConfig> I2c<C> {
         let mut config = self.config;
         config.as_mut().registers.disable();
         config
+    }
+}
+
+impl<C: AnyConfig> I2c<C> {
+    /// Attach a DMA channel to this [`I2c`]. Its
+    /// [`embedded_hal::i2c::I2c`](crate::ehal::i2c::I2c) implementation will
+    /// use DMA to carry out its transactions.
+    #[cfg(feature = "dma")]
+    #[inline]
+    pub fn with_dma_channel<Chan: crate::dmac::AnyChannel<Status = crate::dmac::Ready>>(
+        self,
+        channel: Chan,
+    ) -> I2c<C, Chan> {
+        I2c {
+            config: self.config,
+            dma_channel: channel,
+        }
+    }
+}
+
+#[cfg(feature = "dma")]
+impl<C: AnyConfig, D: crate::dmac::AnyChannel<Status = crate::dmac::Ready>> I2c<C, D> {
+    /// Reclaim the DMA channels
+    pub fn take_dma_channel(self) -> (I2c<C, crate::typelevel::NoneT>, D) {
+        (
+            I2c {
+                config: self.config,
+                dma_channel: crate::typelevel::NoneT,
+            },
+            self.dma_channel,
+        )
     }
 }
 

--- a/hal/src/sercom/i2c/config.rs
+++ b/hal/src/sercom/i2c/config.rs
@@ -5,7 +5,7 @@ use crate::{
     pac::sercom0::i2cm::ctrla::Modeselect,
     sercom::{ApbClkCtrl, Sercom},
     time::Hertz,
-    typelevel::{Is, Sealed},
+    typelevel::{Is, NoneT, Sealed},
 };
 
 //=============================================================================
@@ -230,7 +230,10 @@ impl<P: PadSet> Config<P> {
     {
         self.registers.enable();
 
-        I2c { config: self }
+        I2c {
+            config: self,
+            dma_channel: NoneT,
+        }
     }
 }
 

--- a/hal/src/sercom/i2c/flags.rs
+++ b/hal/src/sercom/i2c/flags.rs
@@ -87,6 +87,10 @@ impl Status {
             Ok(())
         }
     }
+
+    pub fn is_idle(self) -> bool {
+        self.busstate() == BusState::Idle
+    }
 }
 
 /// Errors available for I2C transactions
@@ -98,4 +102,6 @@ pub enum Error {
     LengthError,
     Nack,
     Timeout,
+    #[cfg(feature = "dma")]
+    Dma(crate::dmac::Error),
 }

--- a/hal/src/sercom/i2c/impl_ehal.rs
+++ b/hal/src/sercom/i2c/impl_ehal.rs
@@ -4,6 +4,7 @@ use super::{config::AnyConfig, flags::Error, I2c};
 use crate::ehal::i2c::{self, ErrorKind, ErrorType, NoAcknowledgeSource};
 
 impl i2c::Error for Error {
+    #[allow(unreachable_patterns)]
     fn kind(&self) -> ErrorKind {
         match self {
             Error::BusError => ErrorKind::Bus,
@@ -11,20 +12,22 @@ impl i2c::Error for Error {
             Error::LengthError => ErrorKind::Other,
             Error::Nack => ErrorKind::NoAcknowledge(NoAcknowledgeSource::Unknown),
             Error::Timeout => ErrorKind::Other,
+            // Pattern reachable when "dma" feature is enabled
+            _ => ErrorKind::Other,
         }
     }
 }
 
-impl<C: AnyConfig> ErrorType for I2c<C> {
+impl<C: AnyConfig, D> ErrorType for I2c<C, D> {
     type Error = Error;
 }
 
-impl<C: AnyConfig> i2c::I2c for I2c<C> {
-    fn transaction(
+impl<C: AnyConfig, D> I2c<C, D> {
+    fn transaction_byte_by_byte(
         &mut self,
         address: u8,
         operations: &mut [i2c::Operation<'_>],
-    ) -> Result<(), Self::Error> {
+    ) -> Result<(), Error> {
         /// Helper type for keeping track of the type of operation that was
         /// executed last
         #[derive(Clone, Copy)]
@@ -61,6 +64,17 @@ impl<C: AnyConfig> i2c::I2c for I2c<C> {
         self.cmd_stop();
         Ok(())
     }
+}
+
+impl<C: AnyConfig> i2c::I2c for I2c<C> {
+    fn transaction(
+        &mut self,
+        address: u8,
+        operations: &mut [i2c::Operation<'_>],
+    ) -> Result<(), Self::Error> {
+        self.transaction_byte_by_byte(address, operations)?;
+        Ok(())
+    }
 
     fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
         self.do_write(address, bytes)?;
@@ -83,6 +97,312 @@ impl<C: AnyConfig> i2c::I2c for I2c<C> {
         self.do_write_read(address, bytes, buffer)?;
         self.cmd_stop();
         Ok(())
+    }
+}
+
+#[cfg(feature = "dma")]
+mod dma {
+    use super::*;
+    use crate::dmac::{channel, sram::DmacDescriptor, AnyChannel, Ready};
+    use crate::sercom::dma::{read_dma_linked, write_dma_linked, SercomPtr, SharedSliceBuffer};
+    use crate::sercom::{self, Sercom};
+
+    impl<C, D, S> I2c<C, D>
+    where
+        C: AnyConfig<Sercom = S>,
+        S: Sercom,
+        D: AnyChannel<Status = Ready>,
+    {
+        fn sercom_ptr(&self) -> SercomPtr<sercom::i2c::Word> {
+            SercomPtr(self.data_ptr())
+        }
+
+        /// Walk up the transfer linked list, and calculate the number of beats
+        /// the entire block list contains.
+        ///
+        /// # Safety
+        ///
+        /// If `next` is [`Some`], the pointer in its `descaddr` field, along
+        /// with the descriptor it points to, etc, must point to a valid
+        /// [`DmacDescriptor`] memory location, or be null. They must not be
+        /// circular (ie, points to itself).
+        #[inline]
+        unsafe fn linked_transfer_length(next: &Option<&mut DmacDescriptor>) -> usize {
+            let mut cnt = 0;
+
+            if let Some(next) = next {
+                cnt += next.beat_count() as usize;
+                let mut next_ptr = next.next_descriptor();
+
+                while !next_ptr.is_null() {
+                    let next = *next_ptr;
+                    cnt += next.beat_count() as usize;
+                    next_ptr = next.next_descriptor();
+                }
+            }
+
+            cnt
+        }
+
+        /// Make an I2C read transaction, with the option to add in linked
+        /// transfers after this first transaction.
+        ///
+        /// # Safety
+        ///
+        /// If `next` is [`Some`], the pointer in its `descaddr` field, along
+        /// with the descriptor it points to, etc, must point to a valid
+        /// [`DmacDescriptor`] memory location, or be null. They must not be
+        /// circular (ie, points to itself). Any linked transfer must
+        /// strictly be a read transaction (destination pointer is a byte
+        /// buffer, source pointer is the SERCOM DATA register).
+        #[inline]
+        unsafe fn read_linked(
+            &mut self,
+            address: u8,
+            mut dest: &mut [u8],
+            next: Option<&mut DmacDescriptor>,
+        ) -> Result<(), Error> {
+            self.check_bus_status()?;
+            let sercom_ptr = self.sercom_ptr();
+
+            if dest.is_empty() {
+                return Ok(());
+            }
+
+            // Calculate the total number of bytes for this transaction across all linked
+            // transfers, including the first transfer.
+            let transfer_len = dest.len() + Self::linked_transfer_length(&next);
+
+            assert!(
+                transfer_len <= 255,
+                "I2C read transfers of more than 255 bytes are unsupported."
+            );
+
+            self.start_dma_read(address, transfer_len as u8);
+            let channel = self.dma_channel.as_mut();
+
+            // SAFETY: We must make sure that any DMA transfer is complete or stopped before
+            // returning.
+            read_dma_linked::<_, _, S>(channel, sercom_ptr, &mut dest, next);
+
+            while !channel.xfer_complete() {
+                core::hint::spin_loop();
+            }
+
+            // Defensively disable channel
+            channel.stop();
+
+            self.read_status().check_bus_error()?;
+            self.dma_channel.as_mut().xfer_success()?;
+            Ok(())
+        }
+
+        /// Make an I2C write transaction, with the option to add in linked
+        /// transfers after this first transaction.
+        ///
+        /// # Safety
+        ///
+        /// If `next` is [`Some`], the pointer in its `descaddr` field, along
+        /// with the descriptor it points to, etc, must point to a valid
+        /// [`DmacDescriptor`] memory location, or be null. They must not be
+        /// circular (ie, points to itself). Any linked transfer must
+        /// strictly be a write transaction (source pointer is a byte buffer,
+        /// destination pointer is the SERCOM DATA register).
+        #[inline]
+        unsafe fn write_linked(
+            &mut self,
+            address: u8,
+            source: &[u8],
+            next: Option<&mut DmacDescriptor>,
+        ) -> Result<(), Error> {
+            self.check_bus_status()?;
+            let sercom_ptr = self.sercom_ptr();
+
+            if source.is_empty() {
+                return Ok(());
+            }
+
+            // Calculate the total number of bytes for this transaction across all linked
+            // transfers, including the first transfer.
+            let transfer_len = source.len() + Self::linked_transfer_length(&next);
+
+            assert!(
+                transfer_len <= 255,
+                "I2C write transfers of more than 255 bytes are unsupported."
+            );
+
+            self.start_dma_write(address, transfer_len as u8);
+            let mut bytes = SharedSliceBuffer::from_slice(source);
+            let channel = self.dma_channel.as_mut();
+
+            // SAFETY: We must make sure that any DMA transfer is complete or stopped before
+            // returning.
+            write_dma_linked::<_, _, S>(channel, sercom_ptr, &mut bytes, next);
+
+            while !channel.xfer_complete() {
+                core::hint::spin_loop();
+            }
+
+            // Defensively disable channel
+            channel.stop();
+
+            while !self.read_status().is_idle() {
+                core::hint::spin_loop();
+            }
+
+            self.read_status().check_bus_error()?;
+            self.dma_channel.as_mut().xfer_success()?;
+            Ok(())
+        }
+    }
+
+    impl<C, D, S> i2c::I2c for I2c<C, D>
+    where
+        C: AnyConfig<Sercom = S>,
+        S: Sercom,
+        D: AnyChannel<Status = Ready>,
+    {
+        #[inline]
+        fn transaction(
+            &mut self,
+            address: u8,
+            operations: &mut [i2c::Operation<'_>],
+        ) -> Result<(), Self::Error> {
+            use i2c::Operation::{Read, Write};
+
+            const NUM_LINKED_TRANSFERS: usize = 16;
+
+            if operations.is_empty() {
+                return Ok(());
+            }
+
+            let mut sercom_ptr = self.sercom_ptr();
+
+            // Reserve some space for linked DMA transfer descriptors.
+            // Uses 256 bytes of memory.
+            //
+            // In practice this means that we can only support 17 continuously
+            // linked operations of the same type (R/W) before having to issue
+            // an I2C STOP. DMA-enabled I2C transfers automatically issue stop
+            // commands, and there is no way to turn off that behaviour.
+            //
+            //  In the event that we have more than 17 contiguous operations of
+            //  the same type, we must revert to the byte-by-byte I2C implementations.
+            let mut descriptors = heapless::Vec::<DmacDescriptor, NUM_LINKED_TRANSFERS>::new();
+
+            // Arrange operations in groups of contiguous types (R/W)
+            let op_groups = operations.chunk_by_mut(|this, next| {
+                matches!((this, next), (Write(_), Write(_)) | (Read(_), Read(_)))
+            });
+
+            for group in op_groups {
+                descriptors.clear();
+
+                // Default to byte-by-byte impl if we have more than 17 continuous operations,
+                // as we would overflow our DMA linked transfer reeserved space otherwise.
+                if group.len() > NUM_LINKED_TRANSFERS {
+                    self.transaction_byte_by_byte(address, group)?;
+                } else {
+                    // --- Setup all linked descriptors ---
+
+                    // Skip the first operation; we will deal with it when creating the I2C transfer
+                    // (read_dma_linked/write_dma_linked). Every other operation is a linked
+                    // transfer, and we must treat them accordingly.
+                    for op in group.iter_mut().skip(1) {
+                        match op {
+                            Read(ref mut buffer) => {
+                                if buffer.is_empty() {
+                                    continue;
+                                }
+                                // Add a new linked descriptor to the stack
+                                descriptors
+                                    .push(DmacDescriptor::default())
+                                    .unwrap_or_else(|_| panic!("BUG: DMAC descriptors overflow"));
+                                let last_descriptor = descriptors.last_mut().unwrap();
+                                let next_ptr =
+                                    (last_descriptor as *mut DmacDescriptor).wrapping_add(1);
+
+                                unsafe {
+                                    channel::write_descriptor(
+                                        last_descriptor,
+                                        &mut sercom_ptr,
+                                        buffer,
+                                        // Always link the next descriptor. We then set the last
+                                        // transfer's link pointer to null lower down in the code.
+                                        next_ptr,
+                                    );
+                                }
+                            }
+
+                            Write(bytes) => {
+                                if bytes.is_empty() {
+                                    continue;
+                                }
+                                // Add a new linked descriptor to the stack
+                                descriptors
+                                    .push(DmacDescriptor::default())
+                                    .unwrap_or_else(|_| panic!("BUG: DMAC descriptors overflow"));
+                                let last_descriptor = descriptors.last_mut().unwrap();
+                                let next_ptr =
+                                    (last_descriptor as *mut DmacDescriptor).wrapping_add(1);
+
+                                let mut bytes = SharedSliceBuffer::from_slice(bytes);
+                                unsafe {
+                                    channel::write_descriptor(
+                                        last_descriptor,
+                                        &mut bytes,
+                                        &mut sercom_ptr,
+                                        // Always link the next descriptor. We then set the last
+                                        // transfer's link pointer to null lower down in the code.
+                                        next_ptr,
+                                    );
+                                }
+                            }
+                        }
+                    }
+
+                    // Set the last descriptor to a null pointer to stop the transfer, and avoid
+                    // buffer overflow UB.
+                    if let Some(d) = descriptors.last_mut() {
+                        d.set_next_descriptor(core::ptr::null_mut());
+                    }
+
+                    // Now setup and perform the actual transfer
+                    match group.first_mut().unwrap() {
+                        Read(ref mut buffer) => unsafe {
+                            self.read_linked(address, buffer, descriptors.first_mut())?;
+                        },
+                        Write(bytes) => unsafe {
+                            self.write_linked(address, bytes, descriptors.first_mut())?;
+                        },
+                    }
+                }
+            }
+
+            Ok(())
+        }
+
+        #[inline]
+        fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Self::Error> {
+            unsafe { self.write_linked(address, bytes, None) }
+        }
+
+        #[inline]
+        fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Self::Error> {
+            unsafe { self.read_linked(address, buffer, None) }
+        }
+
+        #[inline]
+        fn write_read(
+            &mut self,
+            address: u8,
+            bytes: &[u8],
+            buffer: &mut [u8],
+        ) -> Result<(), Self::Error> {
+            self.write(address, bytes)?;
+            self.read(address, buffer)?;
+            Ok(())
+        }
     }
 }
 

--- a/hal/src/sercom/spi.rs
+++ b/hal/src/sercom/spi.rs
@@ -554,7 +554,9 @@ seq_macro::seq!(N in 1..=4 {
 /// the [type-level enum] documentation for more details.
 ///
 /// [type-level enum]: crate::typelevel#type-level-enums
-pub trait Capability: Sealed + Default {}
+pub trait Capability: Sealed + Default {
+    const RX_ENABLE: bool;
+}
 
 /// Sub-set of [`Capability`] variants that can receive data, i.e. [`Rx`] and
 /// [`Duplex`]
@@ -581,7 +583,9 @@ pub struct Rx {
 }
 
 impl Sealed for Rx {}
-impl Capability for Rx {}
+impl Capability for Rx {
+    const RX_ENABLE: bool = true;
+}
 impl Receive for Rx {}
 
 /// Type-level variant of the [`Capability`] enum for simplex, [`Transmit`]-only
@@ -593,7 +597,9 @@ impl Receive for Rx {}
 pub struct Tx;
 
 impl Sealed for Tx {}
-impl Capability for Tx {}
+impl Capability for Tx {
+    const RX_ENABLE: bool = false;
+}
 impl Transmit for Tx {}
 
 /// Type-level variant of the [`Capability`] enum for duplex transactions
@@ -605,7 +611,9 @@ impl Transmit for Tx {}
 pub struct Duplex;
 
 impl Sealed for Duplex {}
-impl Capability for Duplex {}
+impl Capability for Duplex {
+    const RX_ENABLE: bool = true;
+}
 impl Receive for Duplex {}
 impl Transmit for Duplex {}
 
@@ -985,11 +993,15 @@ where
     where
         Self: ValidConfig,
     {
-        self.regs.rx_enable();
+        if P::Capability::RX_ENABLE {
+            self.regs.rx_enable();
+        }
         self.regs.enable();
         Spi {
             config: self,
             capability: P::Capability::default(),
+            rx_channel: NoneT,
+            tx_channel: NoneT,
         }
     }
 }

--- a/hal/src/sercom/spi.rs
+++ b/hal/src/sercom/spi.rs
@@ -1524,6 +1524,76 @@ where
     }
 }
 
+/// Wrapper type around a [`Spi`] that allows using
+/// [`embedded_hal::spi::SpiBus`] even though it only has RX capability. Will
+/// panic if any write-adjacent method is used (ie, `write`, `transfer`,
+/// `transfer_in_place`, and `flush`).
+///
+/// Also implements `Into<Spi>, `AsRef<Spi>` and `AsMut<Spi>` if you need to use
+/// `Spi` methods.
+///
+/// [`embedded_hal::spi::SpiBus`]: crate::ehal::spi::SpiBus
+pub struct PanicOnWrite<T: crate::ehal::spi::ErrorType>(T);
+
+impl<C: ValidConfig, R, T> From<PanicOnWrite<Spi<C, Rx, R, T>>> for Spi<C, Rx, R, T> {
+    fn from(value: PanicOnWrite<Spi<C, Rx, R, T>>) -> Self {
+        value.0
+    }
+}
+
+impl<C: ValidConfig, R, T> AsRef<Spi<C, Rx, R, T>> for PanicOnWrite<Spi<C, Rx, R, T>> {
+    fn as_ref(&self) -> &Spi<C, Rx, R, T> {
+        &self.0
+    }
+}
+impl<C: ValidConfig, R, T> AsMut<Spi<C, Rx, R, T>> for PanicOnWrite<Spi<C, Rx, R, T>> {
+    fn as_mut(&mut self) -> &mut Spi<C, Rx, R, T> {
+        &mut self.0
+    }
+}
+
+impl<C: ValidConfig, R, T> Spi<C, Tx, R, T> {
+    /// Turn a [`Tx`] [`Spi`] into a [`PanicOnWrite`]
+    pub fn into_panic_on_write(self) -> PanicOnWrite<Self> {
+        PanicOnWrite(self)
+    }
+}
+
+/// Wrapper type around a [`Spi`] that allows using
+/// [`embedded_hal::spi::SpiBus`] even though it only has TX capability. Will
+/// panic if any write-adjacent method is used (ie, `read`, `transfer`, and
+/// `transfer_in_place`).
+///
+/// Also implements `Into<Spi>, `AsRef<Spi>` and `AsMut<Spi>` if you need to use
+/// `Spi` methods.
+///
+/// [`embedded_hal::spi::SpiBus`]: crate::ehal::spi::SpiBus
+pub struct PanicOnRead<T: crate::ehal::spi::ErrorType>(T);
+
+impl<C: ValidConfig, R, T> From<PanicOnRead<Spi<C, Tx, R, T>>> for Spi<C, Tx, R, T> {
+    fn from(value: PanicOnRead<Spi<C, Tx, R, T>>) -> Self {
+        value.0
+    }
+}
+
+impl<C: ValidConfig, R, T> AsRef<Spi<C, Tx, R, T>> for PanicOnRead<Spi<C, Tx, R, T>> {
+    fn as_ref(&self) -> &Spi<C, Tx, R, T> {
+        &self.0
+    }
+}
+
+impl<C: ValidConfig, R, T> AsMut<Spi<C, Tx, R, T>> for PanicOnRead<Spi<C, Tx, R, T>> {
+    fn as_mut(&mut self) -> &mut Spi<C, Tx, R, T> {
+        &mut self.0
+    }
+}
+
+impl<C: ValidConfig, R, T> Spi<C, Tx, R, T> {
+    /// Turn a [`Rx`] [`Spi`] into a [`PanicOnRead`]
+    pub fn into_panic_on_read(self) -> PanicOnRead<Self> {
+        PanicOnRead(self)
+    }
+}
 
 #[hal_cfg("sercom0-d5x")]
 impl<P, M, A> Spi<Config<P, M, DynLength>, A>

--- a/hal/src/sercom/spi/impl_ehal.rs
+++ b/hal/src/sercom/spi/impl_ehal.rs
@@ -7,6 +7,7 @@ use num_traits::PrimInt;
 
 #[cfg(feature = "dma")]
 mod dma;
+mod panic_on;
 
 #[hal_module(
     any("sercom0-d11", "sercom0-d21") => "impl_ehal_thumbv6m.rs",

--- a/hal/src/sercom/spi/impl_ehal.rs
+++ b/hal/src/sercom/spi/impl_ehal.rs
@@ -1,8 +1,12 @@
 use super::*;
-use crate::ehal::spi::{self, ErrorType, SpiBus};
+use crate::ehal::spi::{self, SpiBus};
 #[allow(unused_imports)]
 use crate::ehal_02::{blocking, serial};
+use crate::ehal_nb;
 use num_traits::PrimInt;
+
+#[cfg(feature = "dma")]
+mod dma;
 
 #[hal_module(
     any("sercom0-d11", "sercom0-d21") => "impl_ehal_thumbv6m.rs",
@@ -11,15 +15,19 @@ use num_traits::PrimInt;
 pub mod impl_ehal_02 {}
 
 impl spi::Error for Error {
+    #[allow(unreachable_patterns)]
+    #[inline]
     fn kind(&self) -> crate::ehal::spi::ErrorKind {
         match self {
             Error::Overflow => crate::ehal::spi::ErrorKind::Overrun,
             Error::LengthError => crate::ehal::spi::ErrorKind::Other,
+            // Pattern reachable when "dma" feature is enabled
+            _ => crate::ehal::spi::ErrorKind::Other,
         }
     }
 }
 
-impl<C, D> ErrorType for Spi<C, D>
+impl<C, D, R, T> ehal::spi::ErrorType for Spi<C, D, R, T>
 where
     C: ValidConfig,
     D: Capability,
@@ -27,16 +35,53 @@ where
     type Error = Error;
 }
 
-impl<P, M, C> Spi<Config<P, M, C>, Duplex>
+impl embedded_io::Error for Error {
+    fn kind(&self) -> embedded_io::ErrorKind {
+        embedded_io::ErrorKind::Other
+    }
+}
+
+impl<C, D, R, T> embedded_io::ErrorType for Spi<C, D, R, T>
+where
+    C: ValidConfig,
+    D: Capability,
+{
+    type Error = Error;
+}
+
+impl ehal_nb::serial::Error for Error {
+    #[allow(unreachable_patterns)]
+    fn kind(&self) -> ehal_nb::serial::ErrorKind {
+        match self {
+            Error::Overflow => ehal_nb::serial::ErrorKind::Overrun,
+            Error::LengthError => ehal_nb::serial::ErrorKind::Other,
+            // Pattern reachable when "dma" feature is enabled
+            _ => ehal_nb::serial::ErrorKind::Other,
+        }
+    }
+}
+
+impl<C, D, R, T> ehal_nb::serial::ErrorType for Spi<C, D, R, T>
+where
+    C: ValidConfig,
+    D: Capability,
+{
+    type Error = Error;
+}
+
+// Implementations for SPIs in either Master or Slave mode.
+impl<P, M, C, D, R, T> Spi<Config<P, M, C>, D, R, T>
 where
     Config<P, M, C>: ValidConfig,
     P: ValidPads,
-    M: MasterMode,
+    M: OpMode,
     C: Size + 'static,
     C::Word: PrimInt + AsPrimitive<DataWidth>,
     DataWidth: AsPrimitive<C::Word>,
+    D: Capability,
 {
     /// Read and write a single word to the bus simultaneously.
+    #[inline]
     fn transfer_word_in_place(&mut self, word: C::Word) -> Result<C::Word, Error> {
         self.block_on_flags(Flags::DRE)?;
 
@@ -44,7 +89,7 @@ where
             self.write_data(word.as_());
         }
 
-        self.block_on_flags(Flags::TXC | Flags::RXC)?;
+        self.flush_rx()?;
         let word = unsafe { self.read_data().as_() };
         Ok(word)
     }
@@ -53,12 +98,14 @@ where
     ///
     /// No-op words will be written if `read` is longer than `write`. Extra
     /// words are ignored if `write` is longer than `read`.
+    #[inline]
     fn transfer_word_by_word(
         &mut self,
         read: &mut [C::Word],
         write: &[C::Word],
     ) -> Result<(), Error> {
         let nop_word = self.config.nop_word;
+
         for (r, w) in read
             .iter_mut()
             .zip(write.iter().chain(core::iter::repeat(&nop_word.as_())))
@@ -66,10 +113,74 @@ where
             *r = self.transfer_word_in_place(*w)?;
         }
 
+        self.flush_tx();
+        Ok(())
+    }
+
+    /// Wait on a TXC while ignoring buffer overflow errors.
+    #[inline]
+    fn flush_tx(&mut self) {
+        // Ignore buffer overflow errors
+        let _ = self.block_on_flags(Flags::TXC);
+    }
+
+    /// Wait on RXC flag
+    #[inline]
+    fn flush_rx(&mut self) -> Result<(), Error> {
+        self.block_on_flags(Flags::RXC)
+    }
+
+    /// Wait on TXC and RXC flags
+    #[inline]
+    fn flush_tx_rx(&mut self) -> Result<(), Error> {
+        self.block_on_flags(Flags::TXC | Flags::RXC)
+    }
+}
+
+// Implementations specific to Master mode SPIs.
+impl<P, M, C, D> Spi<Config<P, M, C>, D>
+where
+    Config<P, M, C>: ValidConfig,
+    P: ValidPads,
+    M: MasterMode,
+    C: Size + 'static,
+    C::Word: PrimInt + AsPrimitive<DataWidth> + Copy,
+    D: Capability,
+    DataWidth: AsPrimitive<C::Word>,
+{
+    #[inline]
+    fn read_word_by_word(&mut self, words: &mut [Word<C>]) -> Result<(), Error> {
+        // Due to the nature of how SPI works, we must send a word in order to clock a
+        // receive
+        for word in words.iter_mut() {
+            *word = self.transfer_word_in_place(self.config.nop_word.as_())?;
+        }
+        self.flush_tx();
+        Ok(())
+    }
+
+    #[inline]
+    fn write_word_by_word(&mut self, words: &[Word<C>]) -> Result<(), Error> {
+        // Ignore RX buffer overflows by disabling the receiver
+        self.config.as_mut().regs.rx_disable();
+
+        for word in words {
+            self.block_on_flags(Flags::DRE)?;
+            unsafe {
+                self.write_data(word.as_());
+            }
+        }
+        self.flush_tx();
+
+        // Reenable receiver only if necessary
+        if D::RX_ENABLE {
+            self.config.as_mut().regs.rx_enable();
+        }
         Ok(())
     }
 }
 
+/// [`SpiBus`] implementation for [`Spi`], using word-by-word transfers.
 impl<P, M, C> SpiBus<Word<C>> for Spi<Config<P, M, C>, Duplex>
 where
     Config<P, M, C>: ValidConfig,
@@ -79,22 +190,14 @@ where
     C::Word: PrimInt + AsPrimitive<DataWidth> + Copy,
     DataWidth: AsPrimitive<C::Word>,
 {
+    #[inline]
     fn read(&mut self, words: &mut [Word<C>]) -> Result<(), Self::Error> {
-        for word in words.iter_mut() {
-            *word = self.transfer_word_in_place(self.config.nop_word.as_())?;
-        }
-
-        Ok(())
+        self.read_word_by_word(words)
     }
 
     #[inline]
     fn write(&mut self, words: &[Word<C>]) -> Result<(), Self::Error> {
-        // We are `Duplex`, so we must receive as many words as we send,
-        // otherwise we could trigger an overflow
-        for word in words {
-            let _ = self.transfer_word_in_place(*word)?;
-        }
-        Ok(())
+        self.write_word_by_word(words)
     }
 
     #[inline]
@@ -103,19 +206,19 @@ where
     }
 
     #[inline]
-    fn transfer_in_place<'w>(&mut self, words: &mut [Word<C>]) -> Result<(), Self::Error> {
+    fn transfer_in_place(&mut self, words: &mut [Word<C>]) -> Result<(), Self::Error> {
         for word in words {
             let read = self.transfer_word_in_place(*word)?;
             *word = read;
         }
 
+        self.flush_tx();
         Ok(())
     }
 
     #[inline]
     fn flush(&mut self) -> Result<(), Error> {
-        // Ignore buffer overflow errors
-        let _ = self.block_on_flags(Flags::TXC);
+        self.flush_tx();
         Ok(())
     }
 }

--- a/hal/src/sercom/spi/impl_ehal/dma.rs
+++ b/hal/src/sercom/spi/impl_ehal/dma.rs
@@ -1,0 +1,408 @@
+//! `embedded-hal` and `embedded-io` implementations for DMA-enabled [`Spi`]s
+
+use num_traits::{AsPrimitive, PrimInt};
+
+use crate::dmac::{channel, sram::DmacDescriptor, AnyChannel, Beat, Buffer, Ready};
+use crate::ehal::spi::SpiBus;
+use crate::sercom::dma::{
+    read_dma, read_dma_linked, write_dma, write_dma_linked, SercomPtr, SharedSliceBuffer,
+};
+use atsamd_hal_macros::hal_macro_helper;
+
+use super::{
+    Capability, Config, DataWidth, Duplex, Error, MasterMode, OpMode, Receive, Sercom, Size, Slave,
+    Spi, Transmit, ValidConfig, ValidPads, Word,
+};
+
+struct SinkSourceBuffer<'a, T: Beat> {
+    word: &'a mut T,
+    length: usize,
+}
+
+/// Sink/source buffer to use for unidirectional SPI-DMA transfers.
+///
+/// When reading/writing from a [`Duplex`] [`Spi`] with DMA enabled,
+/// we must always read and write the same number of words, regardless of
+/// whether we care about the result (ie, for write, we discard the read
+/// words, whereas for read, we must send a no-op word).
+///
+/// This [`Buffer`] implementation provides a source/sink for a single word,
+/// but with a variable length.
+impl<'a, T: Beat> SinkSourceBuffer<'a, T> {
+    fn new(word: &'a mut T, length: usize) -> Self {
+        Self { word, length }
+    }
+}
+unsafe impl<T: Beat> Buffer for SinkSourceBuffer<'_, T> {
+    type Beat = T;
+    #[inline]
+    fn incrementing(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    fn buffer_len(&self) -> usize {
+        self.length
+    }
+
+    #[inline]
+    fn dma_ptr(&mut self) -> *mut Self::Beat {
+        self.word as *mut _
+    }
+}
+
+impl<P, M, Z, D, R, T> Spi<Config<P, M, Z>, D, R, T>
+where
+    P: ValidPads,
+    M: OpMode,
+    Z: Size,
+    Config<P, M, Z>: ValidConfig,
+    D: Capability,
+    Z::Word: Beat,
+{
+    #[inline]
+    pub(super) fn sercom_ptr(&self) -> SercomPtr<Z::Word> {
+        SercomPtr(self.config.regs.spi().data().as_ptr() as *mut _)
+    }
+}
+
+// Write implementation is the same for Master and Slave SPIs.
+impl<P, M, Z, D, R, T, S> Spi<Config<P, M, Z>, D, R, T>
+where
+    P: ValidPads,
+    M: OpMode,
+    Z: Size + 'static,
+    Config<P, M, Z>: ValidConfig<Sercom = S>,
+    D: Transmit,
+    S: Sercom,
+    Z::Word: PrimInt + AsPrimitive<DataWidth> + Beat,
+    DataWidth: AsPrimitive<Z::Word>,
+    T: AnyChannel<Status = Ready>,
+{
+    pub(super) fn write_dma(&mut self, buf: &[Z::Word]) -> Result<usize, Error> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        // Ignore RX buffer overflows by disabling the receiver
+        self.config.as_mut().regs.rx_disable();
+
+        let sercom_ptr = self.sercom_ptr();
+        let tx = self.tx_channel.as_mut();
+        let mut words = crate::sercom::dma::SharedSliceBuffer::from_slice(buf);
+
+        // SAFETY: We make sure that any DMA transfer is complete or stopped before
+        // returning. The order of operations is important; the RX transfer
+        // must be ready to receive before the TX transfer is initiated.
+        unsafe {
+            crate::sercom::dma::write_dma::<_, _, S>(tx, sercom_ptr, &mut words);
+        }
+
+        while !tx.xfer_complete() {
+            core::hint::spin_loop();
+        }
+
+        // Defensively disable channels
+        tx.stop();
+
+        // Reenable receiver only if necessary
+        if D::RX_ENABLE {
+            self.config.as_mut().regs.rx_enable();
+        }
+
+        self.tx_channel.as_mut().xfer_success()?;
+        self.flush_tx();
+        Ok(buf.len())
+    }
+}
+
+impl<P, M, S, C, D, R, T> Spi<Config<P, M, C>, D, R, T>
+where
+    Config<P, M, C>: ValidConfig<Sercom = S>,
+    S: Sercom,
+    P: ValidPads,
+    M: MasterMode,
+    C: Size + 'static,
+    C::Word: PrimInt + AsPrimitive<DataWidth> + Beat,
+    DataWidth: AsPrimitive<C::Word>,
+    D: Capability,
+    R: AnyChannel<Status = Ready>,
+    T: AnyChannel<Status = Ready>,
+{
+    #[inline]
+    fn transfer_blocking<Source: Buffer<Beat = C::Word>, Dest: Buffer<Beat = C::Word>>(
+        &mut self,
+        dest: &mut Dest,
+        source: &mut Source,
+    ) -> Result<(), Error> {
+        let sercom_ptr = self.sercom_ptr();
+        let rx = self.rx_channel.as_mut();
+        let tx = self.tx_channel.as_mut();
+
+        // SAFETY: We make sure that any DMA transfer is complete or stopped before
+        // returning. The order of operations is important; the RX transfer
+        // must be ready to receive before the TX transfer is initiated.
+        unsafe {
+            read_dma::<_, _, S>(rx, sercom_ptr.clone(), dest);
+            write_dma::<_, _, S>(tx, sercom_ptr, source);
+        }
+
+        while !(rx.xfer_complete() && tx.xfer_complete()) {
+            core::hint::spin_loop();
+        }
+
+        // Defensively disable channels
+        tx.stop();
+        rx.stop();
+
+        // Check for overflows or DMA errors
+        self.flush_tx_rx()?;
+        self.rx_channel
+            .as_mut()
+            .xfer_success()
+            .and(self.tx_channel.as_mut().xfer_success())?;
+        Ok(())
+    }
+
+    #[inline]
+    pub(super) fn read_dma_master(&mut self, mut words: &mut [C::Word]) -> Result<(), Error> {
+        if words.is_empty() {
+            return Ok(());
+        }
+
+        let mut source_word = self.config.nop_word.as_();
+        let mut source = SinkSourceBuffer::new(&mut source_word, words.len());
+
+        self.transfer_blocking(&mut words, &mut source)
+    }
+}
+
+/// [`SpiBus`] implementation for [`Spi`], using DMA transfers.
+impl<P, M, S, C, R, T> SpiBus<Word<C>> for Spi<Config<P, M, C>, Duplex, R, T>
+where
+    Config<P, M, C>: ValidConfig<Sercom = S>,
+    S: Sercom,
+    P: ValidPads,
+    M: MasterMode,
+    C: Size + 'static,
+    C::Word: PrimInt + AsPrimitive<DataWidth> + Beat,
+    DataWidth: AsPrimitive<C::Word>,
+    R: AnyChannel<Status = Ready>,
+    T: AnyChannel<Status = Ready>,
+{
+    #[hal_macro_helper]
+    #[inline]
+    fn read(&mut self, words: &mut [C::Word]) -> Result<(), Self::Error> {
+        self.read_dma_master(words)
+    }
+
+    #[inline]
+    fn write(&mut self, words: &[C::Word]) -> Result<(), Self::Error> {
+        self.write_dma(words)?;
+        Ok(())
+    }
+
+    #[inline]
+    fn transfer(&mut self, mut read: &mut [C::Word], write: &[C::Word]) -> Result<(), Self::Error> {
+        use core::cmp::Ordering;
+
+        // No work to do here
+        if write.is_empty() && read.is_empty() {
+            return Ok(());
+        }
+
+        // Handle 0-length special cases
+        if write.is_empty() {
+            return self.read_dma_master(read);
+        } else if read.is_empty() {
+            self.write_dma(write)?;
+            return Ok(());
+        }
+
+        // Reserve space for a DMAC SRAM descriptor if we need to make a linked
+        // transfer. Must not be dropped until all transfers have completed
+        // or have been stopped.
+        let mut linked_descriptor = DmacDescriptor::default();
+
+        // If read < write, the incoming words will be written to this memory location;
+        // it will be discarded after. If read > write, all writes after the
+        // buffer has been exhausted will write the nop word to "stimulate" the slave
+        // into sending data. Must not be dropped until all transfers have
+        // completed or have been stopped.
+        let mut source_sink_word = self.config.nop_word.as_();
+        let mut sercom_ptr = self.sercom_ptr();
+
+        let (read_link, write_link) = match read.len().cmp(&write.len()) {
+            Ordering::Equal => {
+                let mut write = SharedSliceBuffer::from_slice(write);
+                return self.transfer_blocking(&mut read, &mut write);
+            }
+
+            // `read` is shorter; link transfer to sink incoming words after the buffer has been
+            // filled.
+            Ordering::Less => {
+                let mut sink =
+                    SinkSourceBuffer::new(&mut source_sink_word, write.len() - read.len());
+                unsafe {
+                    channel::write_descriptor(
+                        &mut linked_descriptor,
+                        &mut sercom_ptr,
+                        &mut sink,
+                        // Add a null descriptor pointer to end the transfer.
+                        core::ptr::null_mut(),
+                    );
+                }
+
+                (Some(&mut linked_descriptor), None)
+            }
+
+            // `write` is shorter; link transfer to send NOP word after the buffer has been
+            // exhausted.
+            Ordering::Greater => {
+                let mut source =
+                    SinkSourceBuffer::new(&mut source_sink_word, read.len() - write.len());
+                unsafe {
+                    channel::write_descriptor(
+                        &mut linked_descriptor,
+                        &mut source,
+                        &mut sercom_ptr,
+                        // Add a null descriptor pointer to end the transfer.
+                        core::ptr::null_mut(),
+                    );
+                }
+
+                (None, Some(&mut linked_descriptor))
+            }
+        };
+
+        let rx = self.rx_channel.as_mut();
+        let tx = self.tx_channel.as_mut();
+
+        let mut write = SharedSliceBuffer::from_slice(write);
+
+        // SAFETY: We make sure that any DMA transfer is complete or stopped before
+        // returning. The order of operations is important; the RX transfer
+        // must be ready to receive before the TX transfer is initiated.
+        unsafe {
+            read_dma_linked::<_, _, S>(rx, sercom_ptr.clone(), &mut read, read_link);
+            write_dma_linked::<_, _, S>(tx, sercom_ptr, &mut write, write_link);
+        }
+
+        while !(rx.xfer_complete() && tx.xfer_complete()) {
+            core::hint::spin_loop();
+        }
+
+        // Defensively disable channels
+        tx.stop();
+        rx.stop();
+
+        // Check for overflows or DMA errors
+        self.flush_tx_rx()?;
+        self.rx_channel
+            .as_mut()
+            .xfer_success()
+            .and(self.tx_channel.as_mut().xfer_success())?;
+        Ok(())
+    }
+
+    #[inline]
+    fn transfer_in_place(&mut self, words: &mut [C::Word]) -> Result<(), Self::Error> {
+        for word in words {
+            let read = self.transfer_word_in_place(*word)?;
+            *word = read;
+        }
+
+        self.flush_tx();
+        Ok(())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> Result<(), Error> {
+        self.flush_tx();
+        Ok(())
+    }
+}
+
+/// [`embedded_io::Write`] implementation for [`Transmit`] [`Spi`]s in either
+/// [`Slave`] or [`MasterMode`], using DMA transfers.
+impl<P, M, Z, D, R, T, S> embedded_io::Write for Spi<Config<P, M, Z>, D, R, T>
+where
+    P: ValidPads,
+    M: OpMode,
+    Z: Size<Word = u8> + 'static,
+    Config<P, M, Z>: ValidConfig<Sercom = S>,
+    D: Transmit,
+    S: Sercom,
+    T: AnyChannel<Status = Ready>,
+{
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        Spi::write_dma(self, buf)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.flush_tx();
+        Ok(())
+    }
+}
+
+/// [`embedded_io::Read`] implementation for [`Receive`] [`Spi`]s in
+/// [`MasterMode`], using DMA transfers.
+impl<P, M, Z, D, R, T, S> embedded_io::Read for Spi<Config<P, M, Z>, D, R, T>
+where
+    P: ValidPads,
+    M: MasterMode,
+    Z: Size<Word = u8> + 'static,
+    Config<P, M, Z>: ValidConfig<Sercom = S>,
+    D: Receive,
+    S: Sercom,
+    R: AnyChannel<Status = Ready>,
+    T: AnyChannel<Status = Ready>,
+{
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.read_dma_master(buf)?;
+        Ok(buf.len())
+    }
+}
+
+/// [`embedded_io::Read`] implementation for [`Receive`] [`Spi`]s in [`Slave`]
+/// mode, using DMA transfers.
+impl<P, Z, D, R, T, S> embedded_io::Read for Spi<Config<P, Slave, Z>, D, R, T>
+where
+    P: ValidPads,
+    Z: Size<Word = u8> + 'static,
+    Config<P, Slave, Z>: ValidConfig<Sercom = S>,
+    D: Receive,
+    S: Sercom,
+    R: AnyChannel<Status = Ready>,
+{
+    fn read(&mut self, mut buf: &mut [u8]) -> Result<usize, Self::Error> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        // In Slave mode, RX words can come in even if we haven't sent anything. This
+        // means some words can arrive asynchronously while we weren't looking (similar
+        // to UART RX). We need to check if we haven't missed any.
+        self.flush_rx()?;
+        let sercom_ptr = self.sercom_ptr();
+        let rx = self.rx_channel.as_mut();
+
+        // SAFETY: We make sure that any DMA transfer is complete or stopped before
+        // returning.
+        unsafe {
+            read_dma::<_, _, S>(rx, sercom_ptr.clone(), &mut buf);
+        }
+
+        while !(rx.xfer_complete()) {
+            core::hint::spin_loop();
+        }
+
+        // Defensively disable channel
+        rx.stop();
+
+        // Check for overflows or DMA errors
+        self.flush_rx()?;
+        self.rx_channel.as_mut().xfer_success()?;
+        Ok(buf.len())
+    }
+}

--- a/hal/src/sercom/spi/impl_ehal/panic_on.rs
+++ b/hal/src/sercom/spi/impl_ehal/panic_on.rs
@@ -1,0 +1,183 @@
+//! [`SpiBus`] implementations for [`PanicOnWrite`] and [`PanicOnRead`]
+
+use num_traits::{AsPrimitive, PrimInt};
+
+use crate::ehal::spi::{ErrorType, SpiBus};
+
+use super::{
+    Config, DataWidth, MasterMode, NoneT, PanicOnRead, PanicOnWrite, Rx, Sercom, Size, Spi, Tx,
+    ValidConfig, ValidPads, Word,
+};
+
+impl<T: ErrorType> ErrorType for PanicOnRead<T> {
+    type Error = <T as ErrorType>::Error;
+}
+
+impl<T: ErrorType> ErrorType for PanicOnWrite<T> {
+    type Error = <T as ErrorType>::Error;
+}
+
+/// [`SpiBus`] implementation for [`PanicOnRead`] using word-by-word transfers
+impl<P, M, C> SpiBus<Word<C>> for PanicOnRead<Spi<Config<P, M, C>, Tx>>
+where
+    Config<P, M, C>: ValidConfig<OpMode = M>,
+    P: ValidPads,
+    M: MasterMode,
+    C: Size + 'static,
+    C::Word: PrimInt + AsPrimitive<DataWidth> + Copy,
+    DataWidth: AsPrimitive<C::Word>,
+{
+    #[inline]
+    fn read(&mut self, _words: &mut [Word<C>]) -> Result<(), Self::Error> {
+        unimplemented!("`PanicOnRead` panics on SPI reads");
+    }
+
+    #[inline]
+    fn write(&mut self, words: &[Word<C>]) -> Result<(), Self::Error> {
+        self.0.write_word_by_word(words)
+    }
+
+    #[inline]
+    fn transfer(&mut self, _read: &mut [Word<C>], _write: &[Word<C>]) -> Result<(), Self::Error> {
+        unimplemented!("`PanicOnRead` panics on SPI reads");
+    }
+
+    #[inline]
+    fn transfer_in_place(&mut self, _words: &mut [Word<C>]) -> Result<(), Self::Error> {
+        unimplemented!("`PanicOnRead` panics on SPI reads");
+    }
+
+    #[inline]
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.0.flush_tx();
+        Ok(())
+    }
+}
+
+/// [`SpiBus`] implementation for [`PanicOnWrite`] using word-by-word transfers
+impl<P, M, C> SpiBus<Word<C>> for PanicOnWrite<Spi<Config<P, M, C>, Rx>>
+where
+    Config<P, M, C>: ValidConfig<OpMode = M>,
+    P: ValidPads,
+    M: MasterMode,
+    C: Size + 'static,
+    C::Word: PrimInt + AsPrimitive<DataWidth> + Copy,
+    DataWidth: AsPrimitive<C::Word>,
+{
+    #[inline]
+    fn read(&mut self, words: &mut [Word<C>]) -> Result<(), Self::Error> {
+        self.0.read_word_by_word(words)
+    }
+
+    #[inline]
+    fn write(&mut self, _words: &[Word<C>]) -> Result<(), Self::Error> {
+        unimplemented!("`PanicOnWrite` panics on SPI writes");
+    }
+
+    #[inline]
+    fn transfer(&mut self, _read: &mut [Word<C>], _write: &[Word<C>]) -> Result<(), Self::Error> {
+        unimplemented!("`PanicOnWrite` panics on SPI writes");
+    }
+
+    #[inline]
+    fn transfer_in_place(&mut self, _words: &mut [Word<C>]) -> Result<(), Self::Error> {
+        unimplemented!("`PanicOnWrite` panics on SPI writes");
+    }
+
+    #[inline]
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        unimplemented!("`PanicOnWrite` panics on SPI writes");
+    }
+}
+
+#[cfg(feature = "dma")]
+mod dma {
+    use super::*;
+    use crate::dmac::{AnyChannel, Beat, Ready};
+
+    /// [`SpiBus`] implementation for [`PanicOnRead`] using DMA transfers
+    impl<P, M, C, T, S> SpiBus<Word<C>> for PanicOnRead<Spi<Config<P, M, C>, Tx, NoneT, T>>
+    where
+        Config<P, M, C>: ValidConfig<Sercom = S, OpMode = M>,
+        P: ValidPads,
+        M: MasterMode,
+        C: Size + 'static,
+        C::Word: PrimInt + AsPrimitive<DataWidth> + Beat,
+        S: Sercom,
+        DataWidth: AsPrimitive<C::Word>,
+        T: AnyChannel<Status = Ready>,
+    {
+        #[inline]
+        fn read(&mut self, _words: &mut [Word<C>]) -> Result<(), Self::Error> {
+            unimplemented!("`PanicOnRead` panics on SPI reads");
+        }
+
+        #[inline]
+        fn write(&mut self, words: &[Word<C>]) -> Result<(), Self::Error> {
+            self.0.write_dma(words)?;
+            Ok(())
+        }
+
+        #[inline]
+        fn transfer(
+            &mut self,
+            _read: &mut [Word<C>],
+            _write: &[Word<C>],
+        ) -> Result<(), Self::Error> {
+            unimplemented!("`PanicOnRead` panics on SPI reads");
+        }
+
+        #[inline]
+        fn transfer_in_place(&mut self, _words: &mut [Word<C>]) -> Result<(), Self::Error> {
+            unimplemented!("`PanicOnRead` panics on SPI reads");
+        }
+
+        #[inline]
+        fn flush(&mut self) -> Result<(), Self::Error> {
+            self.0.flush_tx();
+            Ok(())
+        }
+    }
+
+    /// [`SpiBus`] implementation for [`PanicOnWrite`] using DMA transfers
+    impl<P, M, C, R, T> SpiBus<Word<C>> for PanicOnWrite<Spi<Config<P, M, C>, Rx, R, T>>
+    where
+        Config<P, M, C>: ValidConfig<OpMode = M>,
+        P: ValidPads,
+        M: MasterMode,
+        C: Size + 'static,
+        C::Word: PrimInt + AsPrimitive<DataWidth> + Beat,
+        DataWidth: AsPrimitive<C::Word>,
+        R: AnyChannel<Status = Ready>,
+        T: AnyChannel<Status = Ready>,
+    {
+        #[inline]
+        fn read(&mut self, words: &mut [Word<C>]) -> Result<(), Self::Error> {
+            self.0.read_dma_master(words)
+        }
+
+        #[inline]
+        fn write(&mut self, _words: &[Word<C>]) -> Result<(), Self::Error> {
+            unimplemented!("`PanicOnWrite` panics on SPI writes");
+        }
+
+        #[inline]
+        fn transfer(
+            &mut self,
+            _read: &mut [Word<C>],
+            _write: &[Word<C>],
+        ) -> Result<(), Self::Error> {
+            unimplemented!("`PanicOnWrite` panics on SPI writes");
+        }
+
+        #[inline]
+        fn transfer_in_place(&mut self, _words: &mut [Word<C>]) -> Result<(), Self::Error> {
+            unimplemented!("`PanicOnWrite` panics on SPI writes");
+        }
+
+        #[inline]
+        fn flush(&mut self) -> Result<(), Self::Error> {
+            unimplemented!("`PanicOnWrite` panics on SPI writes");
+        }
+    }
+}

--- a/hal/src/sercom/spi/impl_ehal_thumbv6m.rs
+++ b/hal/src/sercom/spi/impl_ehal_thumbv6m.rs
@@ -73,37 +73,6 @@ use crate::ehal_nb;
 use nb::Error::WouldBlock;
 use num_traits::{AsPrimitive, PrimInt};
 
-impl ehal_nb::serial::Error for Error {
-    fn kind(&self) -> ehal_nb::serial::ErrorKind {
-        match self {
-            Error::Overflow => ehal_nb::serial::ErrorKind::Overrun,
-            Error::LengthError => ehal_nb::serial::ErrorKind::Other,
-        }
-    }
-}
-
-impl<C, D> ehal_nb::serial::ErrorType for Spi<C, D>
-where
-    C: ValidConfig,
-    D: Capability,
-{
-    type Error = Error;
-}
-
-impl embedded_io::Error for Error {
-    fn kind(&self) -> embedded_io::ErrorKind {
-        embedded_io::ErrorKind::Other
-    }
-}
-
-impl<C, D> embedded_io::ErrorType for Spi<C, D>
-where
-    C: ValidConfig,
-    D: Capability,
-{
-    type Error = Error;
-}
-
 //=============================================================================
 // serial::Read
 //=============================================================================

--- a/hal/src/sercom/spi/impl_ehal_thumbv7em.rs
+++ b/hal/src/sercom/spi/impl_ehal_thumbv7em.rs
@@ -93,45 +93,14 @@
 use crate::ehal_02;
 use crate::ehal_nb;
 use crate::sercom::spi::{
-    AtomicSize, Capability, Config, DataWidth, Duplex, DynLength, Error, Flags, GreaterThan4,
-    Length, MasterMode, OpMode, Receive, Rx, Slave, Spi, Status, Tx, ValidConfig, ValidPads, Word,
+    AtomicSize, Config, DataWidth, Duplex, DynLength, Error, Flags, GreaterThan4, Length,
+    MasterMode, OpMode, Receive, Rx, Slave, Spi, Status, Tx, ValidConfig, ValidPads, Word,
 };
 use nb::Error::WouldBlock;
 use num_traits::{AsPrimitive, PrimInt};
 use typenum::{U1, U2, U3, U4};
 
 use crate::pac::sercom0::RegisterBlock;
-
-impl ehal_nb::serial::Error for Error {
-    fn kind(&self) -> ehal_nb::serial::ErrorKind {
-        match self {
-            Error::Overflow => ehal_nb::serial::ErrorKind::Overrun,
-            Error::LengthError => ehal_nb::serial::ErrorKind::Other,
-        }
-    }
-}
-
-impl<C, D> ehal_nb::serial::ErrorType for Spi<C, D>
-where
-    C: ValidConfig,
-    D: Capability,
-{
-    type Error = Error;
-}
-
-impl embedded_io::Error for Error {
-    fn kind(&self) -> embedded_io::ErrorKind {
-        embedded_io::ErrorKind::Other
-    }
-}
-
-impl<C, D> embedded_io::ErrorType for Spi<C, D>
-where
-    C: ValidConfig,
-    D: Capability,
-{
-    type Error = Error;
-}
 
 //=============================================================================
 // serial::Read

--- a/hal/src/sercom/uart/config.rs
+++ b/hal/src/sercom/uart/config.rs
@@ -10,7 +10,7 @@ use crate::{
     pac,
     sercom::Sercom,
     time::Hertz,
-    typelevel::{Is, Sealed},
+    typelevel::{Is, NoneT, Sealed},
 };
 use core::marker::PhantomData;
 use num_traits::{AsPrimitive, PrimInt};
@@ -408,6 +408,8 @@ where
         Uart {
             config: self,
             capability: PhantomData,
+            rx_channel: NoneT,
+            tx_channel: NoneT,
         }
     }
 }

--- a/hal/src/sercom/uart/flags.rs
+++ b/hal/src/sercom/uart/flags.rs
@@ -120,6 +120,9 @@ pub enum Error {
     InconsistentSyncField,
     /// Detected a collision
     CollisionDetected,
+    /// DMA error
+    #[cfg(feature = "dma")]
+    Dma(crate::dmac::Error),
 }
 
 impl From<Error> for Status {
@@ -132,6 +135,8 @@ impl From<Error> for Status {
             Overflow => Status::BUFOVF,
             InconsistentSyncField => Status::ISF,
             CollisionDetected => Status::COLL,
+            #[cfg(feature = "dma")]
+            Dma(_) => unimplemented!(),
         }
     }
 }


### PR DESCRIPTION
## Context

### SPI timing and performance issues
In #657, @Felix-El has pointed out that the blocking SPI implementations were somewhat fragile and prone to race conditions. @ianrrees  also had some similar comments in #751. Essentially, our SPI transfers are done word by word, which might:

* Introduce buffer overflow errors if the SPI is ran at a too high frequency
* Break invariants of some timing-dependent protocols build on top of SPI, such as LCD displays and addressable LEDs.

### SPI transfers using DMA

Currently, the HAL has minimal support for making SPI transfers using DMA. It exposes the `send_with_dma` and `receive_with_dma` methods. However these:
1. Are non-blocking
1. Take exclusively `'static` buffers in order to satisfy memory safety invariants (namely, due to point 1)
1. Most importantly, can not be used to build [`embedded-hal::spi::SpiBus`](https://docs.rs/embedded-hal/latest/embedded_hal/spi/trait.SpiBus.html) trait implementations.

The same points are also true for our UART and I2C drivers.

## Proposal

In this PR, I suggest a new implementation to make DMA-enabled SPI transfers. It provides blocking, safe implementations that don't need to take `'static` buffers. The API to use DMA is as simple as configuring 2 DMA channels, then calling `Spi::with_dma_channels`, and all subsequent transfers will use DMA. 

What I propose is that we encourage users who have strict timing or performance requirements, or need very high frequency transfers, to use the DMA implementations. The word-by-word implementation can therefore remain simple, without the need for us to expend lots of energy trying to optimize it for performance. Users with loose timings or lower frequencies can still use it with reduced configuration complexity (which is really not a lot).

The rationale is that we can probably optimize the word-by-word implementation a bit, but we'll soon hit an upper limit, which we can only exceed using DMA anyways. DMA transfers are also impervious to preemption by higher priority interrupts.

I want to add the same mechanisms for I2C and UART, since most of the effort is already done and reusable there.

## What's included

  - [x] DMA-enabled blocking SpiBus implementation
  - [x] Mark the various `send_with_dma` and `receive_with_dma` methods as deprecated. They should be removed either in this PR or in a subsequent release -- perhaps at the same time as the ehal 0.2 stuff. Keep the UART `send_with_dma` and `receive_with_dma` nonblocking methods, as they can be used on a split UART to do some interesting things.
  - [x] ~~Configurable NOP word for SPI transfers~~ Turns out this was already implemented
  - [x] DMA-enabled blocking I2c implementation
  - [x] DMA-enabled blocking Uart implementation

#### SPI-specific improvements

  - [x] Disable receiver when the only capability is TX - reduces changes of unnecessary overflow errors. Reference: #657 ([see comment](https://github.com/atsamd-rs/atsamd/issues/657#issuecomment-1372199143)).
  - [x] Provide SpiBus implementations for RX-only and TX-only SPIs (DMA and non-DMA), which panic when unsupported operations are attempted. References: #752, #751 ([see comment](https://github.com/atsamd-rs/atsamd/issues/751#issuecomment-2344634018)).

## What's not included

* `embedded-hal-nb` DMA implementations. These would either require the user to pass `'static` buffers everywhere, or require all DMA-enabled methods to be unsafe. Both options are incompatible with the traits `embedded-hal-nb` provides. For non-blocking concurrent code, I would strongly suggest users look at async instead (#635).

* There have also been reports of fragile timing and performance in our blocking `embedded-hal v0.2` implementations. I'm not particularly interested in updating those. In fact, I would like to remove embedded-hal v0.2 from atsamd-hal entirely (perhaps in another PR).  

## Breaking changes

* Bumps MSRV to Rust 1.77.2

## Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment.

## Notes for reviewers:

* This PR is built on top of #764, which should be merged first.

* Please merge this PR using rebase (and not squash) to conserve changelog history.

Closes #657.
