### PR TITLE
Upgrade `pygamer` BSP display driver and graphics dependencies

### DIFF
--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -47,6 +47,8 @@ usbd-serial = "0.2"
 [features]
 # ask the HAL to enable atsamd51j support
 default = ["rt", "atsamd-hal/samd51j"]
+dma = ["atsamd-hal/dma"]
+max-channels = ["dma", "atsamd-hal/max-channels"]
 panic_led = []
 rt = ["cortex-m-rt", "atsamd-hal/samd51j-rt"]
 usb = ["atsamd-hal/usb", "usb-device"]

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -16,7 +16,9 @@ version = "0.11.0"
 
 [dependencies]
 cortex-m = {version = "0.7", features = ["critical-section-single-core"]}
-st7735-lcd = "0.8.1"
+embedded-hal-bus = "0.2.0"
+# This version is pinned as recommended by: https://docs.rs/embedded-hal-bus/0.2.0/embedded_hal_bus/spi/struct.ExclusiveDevice.html#method.new_no_delay
+st7735-lcd = "=0.10.0"
 
 [dependencies.cortex-m-rt]
 optional = true
@@ -29,18 +31,17 @@ version = "0.18.2"
 
 [dependencies.usb-device]
 optional = true
-version = "0.3.1"
+version = "0.3.2"
 
 [dev-dependencies]
-embedded-graphics = "0.7.1"
-embedded-hal-bus = "0.2.0"
+embedded-graphics = "0.8.1"
 embedded-sdmmc = "0.8.0"
 lis3dh = "0.4.3"
 micromath = "2.1"
-panic-halt = "0.2"
+panic-halt = "1"
 rtic = {version = "2.1.1", features = ["thumbv7-backend"]}
 smart-leds = "0.4"
-tinybmp = "0.3.1"
+tinybmp = "0.6"
 usbd-serial = "0.2"
 
 [features]

--- a/boards/pygamer/examples/clock_out.rs
+++ b/boards/pygamer/examples/clock_out.rs
@@ -30,5 +30,7 @@ fn main() -> ! {
         .configure_gclk_divider_and_source(Gclk2, 40, Dpll0, false)
         .unwrap();
     let _clock_out_pin: GclkOut = pins.d5.into();
-    loop {}
+    loop {
+        cortex_m::asm::wfi();
+    }
 }

--- a/boards/pygamer/examples/ferris_img.rs
+++ b/boards/pygamer/examples/ferris_img.rs
@@ -59,5 +59,7 @@ fn main() -> ! {
     let ferris = Image::new(&raw_image, Point::new(32, 32));
 
     ferris.draw(&mut display).unwrap();
-    loop {}
+    loop {
+        cortex_m::asm::wfi();
+    }
 }

--- a/boards/pygamer/examples/qspi.rs
+++ b/boards/pygamer/examples/qspi.rs
@@ -99,7 +99,9 @@ fn main() -> ! {
     flash.read_memory(0, &mut read_buf);
     assert_eq!(read_buf, write_buf);
 
-    loop {}
+    loop {
+        cortex_m::asm::wfi();
+    }
 }
 
 /// Wait for the write-in-progress and suspended write/erase.


### PR DESCRIPTION
# Summary
Most of the `pygamer` BSP dependencies were upgraded with #766, which was merged. The remaining dependencies are upgraded to the latest version with this PR:

- `st7735-lcd` to v0.10.0
-  `embedded-graphics` to v0.8.1
-  `tinybmp` to v0.6

# Important Note
These dependency upgrades depend on #772, which has already been merged into the `pygamer-upgrade-graphics` branch but not yet into `master`. Hence, this PR should probably not be merged until #772 has been merged first.

# Checklist
  - [X] All new or modified code is well documented, especially public items
  - [X] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment.