### PR TITLE
feat: make traits public in the CAN module 

### DIFF
--- a/hal/src/peripherals/can.rs
+++ b/hal/src/peripherals/can.rs
@@ -19,7 +19,7 @@ use crate::{
         Source,
     },
     gpio::*,
-    typelevel::{Decrement, Increment},
+    typelevel::{Decrement, Increment, Sealed},
 };
 use atsamd_hal_macros::hal_cfg;
 
@@ -121,24 +121,30 @@ unsafe impl CanId for Can1 {
     const ADDRESS: *const () = crate::pac::Can1::PTR as *const _;
 }
 
-trait OwnedPeripheral {
+/// Trait representing a CAN peripheral
+pub trait OwnedPeripheral: Sealed {
     type Represents: CanId;
 }
 
+impl Sealed for crate::pac::Can0 {}
 impl OwnedPeripheral for crate::pac::Can0 {
     type Represents = Can0;
 }
 
 #[hal_cfg("can1")]
+impl Sealed for crate::pac::Can1 {}
+#[hal_cfg("can1")]
 impl OwnedPeripheral for crate::pac::Can1 {
     type Represents = Can1;
 }
 
-trait RxPin {
+/// Trait implemented on pins that can be set as RX pins for CAN
+pub trait RxPin: Sealed {
     type ValidFor: CanId;
 }
 
-trait TxPin {
+/// Trait implemented on pins that can be set as TX pins for CAN
+pub trait TxPin: Sealed {
     type ValidFor: CanId;
 }
 


### PR DESCRIPTION
# Summary
Making `OwnedPeripheral`, `RxPin`, `TxPin` public and sealed so they can be used to make abstraction layers in your own application.

# Checklist
  - [X] All new or modified code is well documented, especially public items
  - [X] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 

#### Note
The crate changelogs **should no longer** be manually updated! Changelogs are now automatically generated. Instead:

- If your PR is contained to a single crate, or a single feature:
  - Nothing else to do; your PR will likely be squashed down to a single commit.
  - Please consider using [conventional commmit phrasing](https://www.conventionalcommits.org) in the PR title.
- If your PR brings in large, sweeping changes across multiple crates:
  - Organize your commits such that each commit only touches a single crate, or a single feature across multiple crates. Please don't create commits that span multiple features over multiple crates.
  - Use [conventional commmits](https://www.conventionalcommits.org) for your commit messages.
