### PR TITLE
fix(i2c): Send repeated starts in byte-by-byte I2C transactions

### DIFF
--- a/hal/src/sercom/i2c.rs
+++ b/hal/src/sercom/i2c.rs
@@ -199,10 +199,10 @@
 //! use atsamd_hal::dmac::channel::{AnyChannel, Ready};
 //! use atsand_hal::sercom::i2c::{I2c, AnyConfig, Error};
 //! use atsamd_hal::embedded_hal::i2c::I2c;
-//! fn i2c_send_with_dma<A: AnyConfig, C: AnyChannel<Status = Ready>>(i2c: I2c<A>, channel: C, bytes: &[u8]) -> Result<(), Error>{
+//! fn i2c_write_with_dma<A: AnyConfig, C: AnyChannel<Status = Ready>>(i2c: I2c<A>, channel: C, bytes: &[u8]) -> Result<(), Error>{
 //!     // Attach a DMA channel
 //!     let i2c = i2c.with_dma_channel(channel);
-//!     i2c.send(0x54, bytes)?;
+//!     i2c.write(0x54, bytes)?;
 //! }
 //! ```
 //!
@@ -214,6 +214,13 @@
 //!   adjacent write/read operations of the same type; the total number of bytes
 //!   across all adjacent operations must not exceed 256. If you need continuous
 //!   transfers of 256 bytes or more, use the non-DMA [`I2c`] implementations.
+//!
+//! * When using [`I2c::transaction`] or [`I2c::write_read`], the
+//!   [`embedded_hal::i2c::I2c`] specification mandates that a REPEATED START
+//!   (instead of a STOP+START) is sent between transactions of a different type
+//!   (read/write). Unfortunately, in DMA mode, the hardware is only capable of
+//!   sending STOP+START. If you absolutely need repeated starts, the only
+//!   workaround is to use the I2C without DMA.
 //!
 //! * Using [`I2c::transaction`] consumes significantly more memory than the
 //!   other methods provided by [`embedded_hal::i2c::I2c`] (at least 256 bytes
@@ -239,6 +246,7 @@
 //! [`PinMode`]: crate::gpio::pin::PinMode
 //! [`embedded_hal::i2c::I2c`]: crate::ehal::i2c::I2c
 //! [`I2c::transaction`]: crate::ehal::i2c::I2c::transaction
+//! [`I2c::write_read`]: crate::ehal::i2c::I2c::write_read
 
 use atsamd_hal_macros::hal_module;
 


### PR DESCRIPTION
# Summary

The `embedded_hal::i2c::I2c` specification mandates that a repeated start (instead of a stop+start) is sent between transactions of a different type (read/write) when using `I2c::transaction` or `I2c::read_write`. Currently, the HAL, while it respects not sending a stop+start between two operations of the same type, does send stop+start between transactions of a different type. 

This PR fixes that behavior, and enables sending repeated starts between transactions of different types.

Unfortunately, in DMA mode, the hardware is only capable of sending stop+starts. If a user absolutely needs repeated starts, the only workaround is to use the I2C without DMA.

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced