### PR TITLE
grand_central_m4(feat): Adding i2c example

### DIFF
--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -37,6 +37,7 @@ ws2812-timer-delay = "0.3"
 
 [features]
 default = ["rt", "atsamd-hal/samd51p"]
+dma = ["atsamd-hal/dma"]
 rt = ["cortex-m-rt", "atsamd-hal/samd51p-rt"]
 usb = ["atsamd-hal/usb", "usb-device"]
 
@@ -46,6 +47,10 @@ chip = "ATSAMD51P20A"
 
 [[example]]
 name = "blinky_basic"
+
+[[example]]
+name = "i2c"
+required-features = ["dma"]
 
 [[example]]
 name = "eic"

--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -38,6 +38,7 @@ ws2812-timer-delay = "0.3"
 [features]
 default = ["rt", "atsamd-hal/samd51p"]
 dma = ["atsamd-hal/dma"]
+max-channels = ["dma", "atsamd-hal/max-channels"]
 rt = ["cortex-m-rt", "atsamd-hal/samd51p-rt"]
 usb = ["atsamd-hal/usb", "usb-device"]
 

--- a/boards/grand_central_m4/examples/i2c.rs
+++ b/boards/grand_central_m4/examples/i2c.rs
@@ -1,0 +1,72 @@
+//! This example showcases the i2c module, and uses DMA to perform I2C
+//! transactions.
+
+#![no_std]
+#![no_main]
+
+#[cfg(not(feature = "use_semihosting"))]
+use panic_halt as _;
+#[cfg(feature = "use_semihosting")]
+use panic_semihosting as _;
+
+use grand_central_m4 as bsp;
+
+use bsp::hal;
+use bsp::pac;
+use bsp::{entry, periph_alias, pin_alias};
+
+use cortex_m::asm;
+use pac::Peripherals;
+
+use hal::clock::GenericClockController;
+use hal::dmac::{DmaController, PriorityLevel};
+use hal::ehal::i2c::I2c;
+use hal::fugit::RateExtU32;
+use hal::sercom::i2c;
+
+// This example is based on the BMP388 pressure sensor. Adjust the device and
+// register addresses to your liking
+const ADDRESS: u8 = 0x76;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_external_32kosc(
+        peripherals.gclk,
+        &mut peripherals.mclk,
+        &mut peripherals.osc32kctrl,
+        &mut peripherals.oscctrl,
+        &mut peripherals.nvmctrl,
+    );
+
+    let mclk = peripherals.mclk;
+    let dmac = peripherals.dmac;
+    let pins = bsp::Pins::new(peripherals.port);
+
+    // Take SDA and SCL
+    let (sda, scl) = (pin_alias!(pins.sda), pin_alias!(pins.scl));
+
+    // Setup DMA channels for later use
+    let mut dmac = DmaController::init(dmac, &mut peripherals.pm);
+    let channels = dmac.split();
+    let chan0 = channels.0.init(PriorityLevel::Lvl0);
+
+    let gclk0 = clocks.gclk0();
+    let sercom5_clock = &clocks.sercom5_core(&gclk0).unwrap();
+    let pads = i2c::Pads::new(sda, scl);
+    let i2c_sercom = periph_alias!(peripherals.i2c_sercom);
+    let mut i2c = i2c::Config::new(&mclk, i2c_sercom, pads, sercom5_clock.freq())
+        .baud(100.kHz())
+        .enable()
+        .with_dma_channel(chan0);
+
+    let mut received = [0x00; 1];
+
+    // Test writing then reading from an I2C chip
+    i2c.write_read(ADDRESS, &[0x00; 8], &mut received).unwrap();
+
+    loop {
+        // Go to sleep
+        asm::wfi();
+    }
+}


### PR DESCRIPTION
# Summary
This code won't compile but it would when targeting the new hal version.

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 
