### PR TITLE
chore(grand_central_m4): Remove path dependency to HAL

### DIFF
--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -16,7 +16,6 @@ optional = true
 
 [dependencies.atsamd-hal]
 version = "0.19.0"
-path = "../../hal"
 default-features = false
 
 [dependencies.usb-device]


### PR DESCRIPTION
I previously missed the path dependency on `atsamd-hal` that was introduced. Remove it so the BSP complies with Tier 2 requirements.