### PR TITLE
changed(eic)!: Overhaul the `eic` module

### DIFF
--- a/boards/atsame54_xpro/examples/mcan.rs
+++ b/boards/atsame54_xpro/examples/mcan.rs
@@ -22,7 +22,7 @@
 use atsame54_xpro as bsp;
 use bsp::hal;
 use hal::clock::v2 as clock;
-use hal::eic::pin::*;
+use hal::eic::{Ch15, Eic, ExtInt, Sense};
 use hal::gpio::{Interrupt as GpioInterrupt, *};
 use hal::prelude::*;
 
@@ -87,7 +87,7 @@ type Aux = mcan::bus::Aux<
         bsp::pac::Can1,
     >,
 >;
-type Button = ExtInt15<Pin<PB31, GpioInterrupt<PullUp>>>;
+type Button = ExtInt<Pin<PB31, GpioInterrupt<PullUp>>, Ch15>;
 
 #[rtic::app(device = hal::pac, peripherals = true, dispatchers = [FREQM])]
 mod app {
@@ -140,9 +140,8 @@ mod app {
 
         let (pclk_eic, gclk0) = clock::pclk::Pclk::enable(tokens.pclks.eic, clocks.gclk0);
 
-        let mut eic =
-            hal::eic::init_with_ulp32k(&mut mclk, pclk_eic.into(), ctx.device.eic).finalize();
-        let mut button = bsp::pin_alias!(pins.button).into_pull_up_ei(&mut eic);
+        let eic_channels = Eic::new(&mut mclk, pclk_eic.into(), ctx.device.eic).split();
+        let mut button = bsp::pin_alias!(pins.button).into_pull_up_ei(eic_channels.15);
         button.sense(Sense::Fall);
         button.debounce();
         button.enable_interrupt();

--- a/boards/feather_m0/examples/eic.rs
+++ b/boards/feather_m0/examples/eic.rs
@@ -17,8 +17,7 @@ use feather_m0 as bsp;
 use bsp::entry;
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
-use hal::eic::pin::{ExtInt2, Sense};
-use hal::eic::EIC;
+use hal::eic::{Eic, Sense};
 use hal::gpio::{Pin, PullUpInterrupt};
 use hal::prelude::*;
 use pac::{interrupt, CorePeripherals, Peripherals};
@@ -45,9 +44,10 @@ fn main() -> ! {
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
     let eic_clock = clocks.eic(&gclk0).unwrap();
-    let mut eic = EIC::init(&mut peripherals.pm, eic_clock, peripherals.eic);
+    let eic_channels = Eic::new(&mut peripherals.pm, eic_clock, peripherals.eic).split();
+
     let button: Pin<_, PullUpInterrupt> = pins.d10.into();
-    let mut extint = ExtInt2::new(button, &mut eic);
+    let mut extint = eic_channels.2.with_pin(button);
     extint.sense(Sense::Fall);
     extint.enable_interrupt();
 

--- a/hal/src/dmac/dma_controller.rs
+++ b/hal/src/dmac/dma_controller.rs
@@ -112,7 +112,7 @@ macro_rules! define_channels_struct {
         seq!(N in 0..$num_channels {
             #(
                 /// Type alias for a channel number
-                pub struct Ch~N;
+                pub enum Ch~N {}
 
                 impl ChId for Ch~N {
                     const U8: u8 = N;

--- a/hal/src/peripherals/eic.rs
+++ b/hal/src/peripherals/eic.rs
@@ -50,15 +50,15 @@
 //! * Bind the corresponding `EIC` interrupt source to the SPI
 //!   [`InterruptHandler`] (refer to the module-level
 //!   [`async_hal`](crate::async_hal) documentation for more information).
-//! *
-//!     * SAMD11/SAMD21: Turn an [`Eic`] into an async-enabled [`Eic`] by
-//!       calling [`Eic::into_future`]. Since there is only a single interrupt
-//!       handler for the EIC peripheral, all EXTINT channels must be turned
-//!       into async channels at once.
-//!     * SAMx5x: Turn an individuel [`ExtInt`] into an async-enabled [`ExtInt`]
-//!       by calling [`ExtInt::into_future`]. Each channel has a dedicated
-//!       interrupt source, therefore you must individually choose which
-//!       channels to turn into async channels.
+//!
+//! * SAMD11/SAMD21: Turn an [`Eic`] into an async-enabled [`Eic`] by calling
+//!   [`Eic::into_future`]. Since there is only a single interrupt handler for
+//!   the EIC peripheral, all EXTINT channels must be turned into async channels
+//!   at once.
+//! * SAMx5x: Turn an individuel [`ExtInt`] into an async-enabled [`ExtInt`] by
+//!   calling [`ExtInt::into_future`]. Each channel has a dedicated interrupt
+//!   source, therefore you must individually choose which channels to turn into
+//!   async channels.
 //! * Use the provided [`wait`](ExtInt::wait) method. async-enabled [`ExtInt`]s
 //!   also implement [`embedded_hal_async::digital::Wait`].
 

--- a/hal/src/peripherals/eic.rs
+++ b/hal/src/peripherals/eic.rs
@@ -1,0 +1,276 @@
+use core::marker::PhantomData;
+
+use atsamd_hal_macros::{hal_cfg, hal_module};
+
+use crate::{
+    clock::EicClock,
+    gpio::{AnyPin, Pin},
+    pac,
+    typelevel::{NoneT, Sealed},
+};
+
+#[hal_module(
+    any("eic-d11", "eic-d21") => "eic/d11/mod.rs",
+    "eic-d5x" => "eic/d5x/mod.rs",
+)]
+mod impls {}
+pub use impls::*;
+
+pub type Sense = pac::eic::config::Sense0select;
+
+/// Trait representing a EIC EXTINT channel ID
+pub trait ChId {
+    const ID: usize;
+}
+
+/// Marker struct that represents an EXTINT channel capable of doing async operations.
+#[cfg(feature = "async")]
+pub enum EicFuture {}
+
+/// Trait representing a GPIO pin which can be used as an external interrupt.
+pub trait EicPin: AnyPin + Sealed {
+    type Floating;
+    type PullUp;
+    type PullDown;
+
+    type ChId: ChId;
+
+    #[hal_cfg("eic-d5x")]
+    #[cfg(feature = "async")]
+    type InterruptSource: crate::async_hal::interrupts::InterruptSource;
+
+    /// Configure a pin as a floating external interrupt
+    fn into_floating_ei(self, chan: Channel<Self::ChId>) -> Self::Floating;
+
+    /// Configure a pin as pulled-up external interrupt
+    fn into_pull_up_ei(self, chan: Channel<Self::ChId>) -> Self::PullUp;
+
+    /// Configure a pin as pulled-down external interrupt
+    fn into_pull_down_ei(self, chan: Channel<Self::ChId>) -> Self::PullDown;
+}
+
+/// Represents a numbered external interrupt. The external interrupt is generic
+/// over any pin, only the EicPin implementations in this module make sense.
+pub struct ExtInt<P, Id, F = NoneT>
+where
+    P: EicPin,
+    Id: ChId,
+{
+    chan: Channel<Id, F>,
+    _pin: Pin<P::Id, P::Mode>,
+}
+
+// impl !Send for [<$PadType $num>]<GPIO> {}
+// impl !Sync for [<$PadType $num>]<GPIO> {}
+
+impl<P, Id, F> ExtInt<P, Id, F>
+where
+    P: EicPin,
+    Id: ChId,
+{
+    /// Construct pad from the appropriate pin in any mode.
+    /// You may find it more convenient to use the `into_pad` trait
+    /// and avoid referencing the pad type.
+    fn new(pin: P, chan: Channel<Id, F>) -> Self {
+        ExtInt {
+            _pin: pin.into(),
+            chan,
+        }
+    }
+}
+
+/// EIC channel. Use this struct to create an [`ExtInt`](pins::ExtInt)
+pub struct Channel<Id: ChId, F = NoneT> {
+    eic: core::mem::ManuallyDrop<pac::Eic>,
+    _id: PhantomData<Id>,
+    _irqs: PhantomData<F>,
+}
+
+impl<Id: ChId, F> Channel<Id, F> {
+    /// Assign a pin to this [`Channel`], and turn it into an [`ExtInt`], which is capable of sensing
+    /// state changes on the pin.
+    pub fn with_pin<P: EicPin<ChId = Id>>(self, pin: P) -> ExtInt<P, Id, F> {
+        ExtInt::new(pin, self)
+    }
+
+    fn new(eic: pac::Eic) -> Self {
+        Self {
+            eic: core::mem::ManuallyDrop::new(eic),
+            _id: PhantomData,
+            _irqs: PhantomData,
+        }
+    }
+
+    #[hal_cfg("eic-d5x")]
+    #[cfg(feature = "async")]
+    fn change_mode<N>(self) -> Channel<Id, N> {
+        Channel {
+            eic: self.eic,
+            _id: self._id,
+            _irqs: PhantomData,
+        }
+    }
+}
+
+/// External Interrupt Controller. Use [`split`](Self::split) to split the struct into individual channels, whcih can be used to create [`ExtInt`]s.
+pub struct Eic<I = NoneT> {
+    eic: pac::Eic,
+    _irqs: PhantomData<I>,
+}
+
+impl Eic {
+    /// Create a new [`Eic`] and initialize it.
+    #[hal_cfg(any("eic-d11", "eic-d21"))]
+    pub fn new(pm: &mut pac::Pm, _clock: EicClock, eic: pac::Eic) -> Self {
+        pm.apbamask().modify(|_, w| w.eic_().set_bit());
+
+        // Reset the EIC
+        eic.ctrl().modify(|_, w| w.swrst().set_bit());
+        while eic.ctrl().read().swrst().bit_is_set() {
+            core::hint::spin_loop();
+        }
+
+        eic.ctrl().modify(|_, w| w.enable().set_bit());
+        while eic.status().read().syncbusy().bit_is_set() {
+            cortex_m::asm::nop();
+        }
+        Self {
+            eic,
+            _irqs: PhantomData,
+        }
+    }
+
+    /// Create and initialize a new [`Eic`], and wire it up to the
+    /// ultra-low-power 32kHz clock source.
+    #[hal_cfg("eic-d5x")]
+    pub fn new(mclk: &mut pac::Mclk, _clock: EicClock, eic: pac::Eic) -> Self {
+        mclk.apbamask().modify(|_, w| w.eic_().set_bit());
+
+        // Reset the EIC
+        eic.ctrla().modify(|_, w| w.swrst().set_bit());
+        while eic.syncbusy().read().swrst().bit_is_set() {
+            core::hint::spin_loop();
+        }
+
+        // Use the low-power 32k clock and enable.
+        eic.ctrla().modify(|_, w| {
+            w.cksel().set_bit();
+            w.enable().set_bit()
+        });
+
+        while eic.syncbusy().read().enable().bit_is_set() {
+            core::hint::spin_loop();
+        }
+
+        Self {
+            eic,
+            _irqs: PhantomData,
+        }
+    }
+}
+
+#[hal_cfg("eic-d11")]
+macro_rules! with_num_channels {
+    ($some_macro:ident) => {
+        $some_macro! {8}
+    };
+}
+
+#[hal_cfg(any("eic-d5x", "eic-d21"))]
+macro_rules! with_num_channels {
+    ($some_macro:ident) => {
+        $some_macro! {16}
+    };
+}
+
+macro_rules! get {
+    ($literal:literal) => {
+        $literal
+    };
+}
+
+pub const NUM_CHANNELS: usize = with_num_channels!(get);
+
+macro_rules! define_channels_struct {
+    ($num_channels:literal) => {
+        seq_macro::seq!(N in 0..$num_channels {
+            #(
+                /// Type alias for a channel number
+                pub struct Ch~N;
+
+                impl ChId for Ch~N {
+                    const ID: usize = N;
+                }
+            )*
+
+            /// Struct generating individual handles to each EXTINT channel
+            pub struct Channels(
+                #(
+                    pub Channel<Ch~N>,
+                )*
+            );
+        });
+    };
+}
+
+with_num_channels!(define_channels_struct);
+
+#[cfg(feature = "async")]
+macro_rules! define_channels_struct_future {
+    ($num_channels:literal) => {
+        seq_macro::seq!(N in 0..$num_channels {
+            /// Struct generating individual handles to each EXTINT channel for `async` operation
+            pub struct FutureChannels(
+                #(
+                    pub Channel<Ch~N, EicFuture>,
+                )*
+            );
+        });
+    };
+}
+
+#[cfg(feature = "async")]
+with_num_channels!(define_channels_struct_future);
+
+macro_rules! define_split {
+    ($num_channels:literal) => {
+        seq_macro::seq!(N in 0..$num_channels {
+            /// Split the EIC into individual channels.
+            #[inline]
+            pub fn split(self) -> Channels {
+                Channels(
+                    #(
+                       unsafe { Channel::new(core::ptr::read(&self.eic as *const _)) },
+                    )*
+                )
+            }
+
+        });
+    };
+}
+
+impl Eic {
+    with_num_channels!(define_split);
+}
+
+#[cfg(feature = "async")]
+macro_rules! define_split_future {
+    ($num_channels:literal) => {
+        seq_macro::seq!(N in 0..$num_channels {
+            /// Split the EIC into individual channels
+            #[inline]
+            pub fn split(self) -> FutureChannels {
+                FutureChannels(
+                    #(
+                        unsafe { Channel::new(core::ptr::read(&self.eic as *const _)) },
+                    )*
+                )
+            }
+        });
+    };
+}
+
+#[cfg(feature = "async")]
+impl Eic<EicFuture> {
+    with_num_channels!(define_split_future);
+}

--- a/hal/src/peripherals/eic.rs
+++ b/hal/src/peripherals/eic.rs
@@ -24,7 +24,8 @@ pub trait ChId {
     const ID: usize;
 }
 
-/// Marker struct that represents an EXTINT channel capable of doing async operations.
+/// Marker struct that represents an EXTINT channel capable of doing async
+/// operations.
 #[cfg(feature = "async")]
 pub enum EicFuture {}
 
@@ -82,7 +83,8 @@ where
 
 /// EIC channel.
 ///
-/// Use this struct to create an [`ExtInt`](pins::ExtInt) by calling [`with_pin`](Self::with_pin).
+/// Use this struct to create an [`ExtInt`](pins::ExtInt) by calling
+/// [`with_pin`](Self::with_pin).
 pub struct Channel<Id: ChId, F = NoneT> {
     eic: core::mem::ManuallyDrop<pac::Eic>,
     _id: PhantomData<Id>,
@@ -90,8 +92,8 @@ pub struct Channel<Id: ChId, F = NoneT> {
 }
 
 impl<Id: ChId, F> Channel<Id, F> {
-    /// Assign a pin to this [`Channel`], and turn it into an [`ExtInt`], which is capable of sensing
-    /// state changes on the pin.
+    /// Assign a pin to this [`Channel`], and turn it into an [`ExtInt`], which
+    /// is capable of sensing state changes on the pin.
     pub fn with_pin<P: EicPin<ChId = Id>>(self, pin: P) -> ExtInt<P, Id, F> {
         ExtInt::new(pin, self)
     }
@@ -115,7 +117,9 @@ impl<Id: ChId, F> Channel<Id, F> {
     }
 }
 
-/// External Interrupt Controller. Use [`split`](Self::split) to split the struct into individual channels, whcih can be used to create [`ExtInt`]s.
+/// External Interrupt Controller. Use [`split`](Self::split) to split the
+/// struct into individual channels, which can then be used to create
+/// [`ExtInt`]s, by calling [`Channel::with_pin`].
 pub struct Eic<I = NoneT> {
     eic: pac::Eic,
     _irqs: PhantomData<I>,

--- a/hal/src/peripherals/eic.rs
+++ b/hal/src/peripherals/eic.rs
@@ -1,6 +1,7 @@
 use core::marker::PhantomData;
 
 use atsamd_hal_macros::{hal_cfg, hal_module};
+use seq_macro::seq;
 
 use crate::{
     clock::EicClock,
@@ -79,7 +80,9 @@ where
     }
 }
 
-/// EIC channel. Use this struct to create an [`ExtInt`](pins::ExtInt)
+/// EIC channel.
+///
+/// Use this struct to create an [`ExtInt`](pins::ExtInt) by calling [`with_pin`](Self::with_pin).
 pub struct Channel<Id: ChId, F = NoneT> {
     eic: core::mem::ManuallyDrop<pac::Eic>,
     _id: PhantomData<Id>,
@@ -193,7 +196,7 @@ pub const NUM_CHANNELS: usize = with_num_channels!(get);
 
 macro_rules! define_channels_struct {
     ($num_channels:literal) => {
-        seq_macro::seq!(N in 0..$num_channels {
+        seq!(N in 0..$num_channels {
             #(
                 /// Type alias for a channel number
                 pub struct Ch~N;
@@ -218,7 +221,7 @@ with_num_channels!(define_channels_struct);
 #[cfg(feature = "async")]
 macro_rules! define_channels_struct_future {
     ($num_channels:literal) => {
-        seq_macro::seq!(N in 0..$num_channels {
+        seq!(N in 0..$num_channels {
             /// Struct generating individual handles to each EXTINT channel for `async` operation
             pub struct FutureChannels(
                 #(
@@ -234,7 +237,7 @@ with_num_channels!(define_channels_struct_future);
 
 macro_rules! define_split {
     ($num_channels:literal) => {
-        seq_macro::seq!(N in 0..$num_channels {
+        seq!(N in 0..$num_channels {
             /// Split the EIC into individual channels.
             #[inline]
             pub fn split(self) -> Channels {
@@ -256,7 +259,7 @@ impl Eic {
 #[cfg(feature = "async")]
 macro_rules! define_split_future {
     ($num_channels:literal) => {
-        seq_macro::seq!(N in 0..$num_channels {
+        seq!(N in 0..$num_channels {
             /// Split the EIC into individual channels
             #[inline]
             pub fn split(self) -> FutureChannels {

--- a/hal/src/peripherals/eic/d11/mod.rs
+++ b/hal/src/peripherals/eic/d11/mod.rs
@@ -1,7 +1,7 @@
-pub mod pin;
+mod pin;
 
 #[cfg(feature = "async")]
-mod async_api {
+pub(super) mod async_api {
     use crate::async_hal::interrupts::{Binding, Handler, Interrupt, EIC as EicInterrupt};
     use crate::eic::{Eic, EicFuture, NUM_CHANNELS};
     use crate::pac;
@@ -53,6 +53,3 @@ mod async_api {
     const NEW_WAKER: AtomicWaker = AtomicWaker::new();
     pub(super) static WAKERS: [AtomicWaker; NUM_CHANNELS] = [NEW_WAKER; NUM_CHANNELS];
 }
-
-#[cfg(feature = "async")]
-pub use async_api::*;

--- a/hal/src/peripherals/eic/d11/pin.rs
+++ b/hal/src/peripherals/eic/d11/pin.rs
@@ -142,11 +142,11 @@ where
     type Error = core::convert::Infallible;
     #[inline]
     fn is_high(&self) -> Result<bool, Self::Error> {
-        self._pin.is_high()
+        self.pin.is_high()
     }
     #[inline]
     fn is_low(&self) -> Result<bool, Self::Error> {
-        self._pin.is_low()
+        self.pin.is_low()
     }
 }
 

--- a/hal/src/peripherals/eic/d5x/mod.rs
+++ b/hal/src/peripherals/eic/d5x/mod.rs
@@ -1,7 +1,7 @@
 use super::{ChId, Channel};
 use crate::pac;
 
-pub mod pin;
+mod pin;
 
 impl<Id: ChId, F> Channel<Id, F> {
     /// Run the provided closure with the EIC peripheral disabled. The
@@ -29,13 +29,14 @@ impl<Id: ChId, F> Channel<Id, F> {
 }
 
 #[cfg(feature = "async")]
-mod async_api {
+pub(super) mod async_api {
     use super::*;
     use crate::async_hal::interrupts::Handler;
     use crate::eic::NUM_CHANNELS;
     use crate::util::BitIter;
     use embassy_sync::waitqueue::AtomicWaker;
 
+    /// Interrupt handler used for `async` operations.
     pub struct InterruptHandler {
         _private: (),
     }
@@ -66,6 +67,3 @@ mod async_api {
     const NEW_WAKER: AtomicWaker = AtomicWaker::new();
     pub(super) static WAKERS: [AtomicWaker; NUM_CHANNELS] = [NEW_WAKER; NUM_CHANNELS];
 }
-
-#[cfg(feature = "async")]
-pub use async_api::*;

--- a/hal/src/peripherals/eic/d5x/mod.rs
+++ b/hal/src/peripherals/eic/d5x/mod.rs
@@ -1,67 +1,9 @@
-use crate::{clock::EicClock, pac};
+use super::{ChId, Channel};
+use crate::pac;
 
 pub mod pin;
 
-/// An External Interrupt Controller which is being configured.
-pub struct ConfigurableEIC {
-    eic: pac::Eic,
-}
-
-impl ConfigurableEIC {
-    fn new(eic: pac::Eic) -> Self {
-        Self { eic }
-    }
-
-    /// button_debounce_pins enables debouncing for the
-    /// specified pins, with a configuration appropriate
-    /// for debouncing physical buttons.
-    pub fn button_debounce_pins(&mut self, debounce_pins: &[pin::ExternalInterruptID]) {
-        self.eic.dprescaler().modify(|_, w| {
-            w.tickon().set_bit()    // Use the 32k clock for debouncing.
-            .states0().set_bit()    // Require 7 0 samples to see a falling edge.
-            .states1().set_bit()    // Require 7 1 samples to see a rising edge.
-            .prescaler0().div16()
-            .prescaler1().div16()
-        });
-
-        let mut debounceen: u32 = 0;
-        for pin in debounce_pins {
-            debounceen |= 1 << *pin as u32;
-        }
-        self.eic
-            .debouncen()
-            .write(|w| unsafe { w.bits(debounceen) });
-    }
-
-    /// finalize enables the EIC.
-    pub fn finalize(self) -> EIC {
-        self.into()
-    }
-}
-
-/// init_with_ulp32k initializes the EIC and wires it up to the
-/// ultra-low-power 32kHz clock source. finalize() must be called
-/// before the EIC is ready for use.
-pub fn init_with_ulp32k(mclk: &mut pac::Mclk, _clock: EicClock, eic: pac::Eic) -> ConfigurableEIC {
-    mclk.apbamask().modify(|_, w| w.eic_().set_bit());
-
-    eic.ctrla().modify(|_, w| w.swrst().set_bit());
-    while eic.syncbusy().read().swrst().bit_is_set() {
-        cortex_m::asm::nop();
-    }
-
-    // Use the low-power 32k clock.
-    eic.ctrla().modify(|_, w| w.cksel().set_bit());
-
-    ConfigurableEIC::new(eic)
-}
-
-/// A configured External Interrupt Controller.
-pub struct EIC {
-    eic: pac::Eic,
-}
-
-impl EIC {
+impl<Id: ChId, F> Channel<Id, F> {
     /// Run the provided closure with the EIC peripheral disabled. The
     /// enable-protected registers, such as CONFIGx, should be accessed through
     /// this method.
@@ -86,22 +28,11 @@ impl EIC {
     }
 }
 
-impl From<ConfigurableEIC> for EIC {
-    fn from(eic: ConfigurableEIC) -> Self {
-        eic.eic.ctrla().modify(|_, w| w.enable().set_bit());
-        while eic.eic.syncbusy().read().enable().bit_is_set() {
-            cortex_m::asm::nop();
-        }
-
-        Self { eic: eic.eic }
-    }
-}
-
 #[cfg(feature = "async")]
 mod async_api {
-    use super::pin::NUM_CHANNELS;
     use super::*;
     use crate::async_hal::interrupts::Handler;
+    use crate::eic::NUM_CHANNELS;
     use crate::util::BitIter;
     use embassy_sync::waitqueue::AtomicWaker;
 

--- a/hal/src/peripherals/eic/d5x/pin.rs
+++ b/hal/src/peripherals/eic/d5x/pin.rs
@@ -5,7 +5,6 @@ use crate::eic::*;
 use crate::gpio::{
     self, pin::*, AnyPin, FloatingInterrupt, PinMode, PullDownInterrupt, PullUpInterrupt,
 };
-use crate::typelevel::NoneT;
 
 /// The pad macro defines the given EIC pin and implements EicPin for the
 /// given pins. The EicPin implementation will configure the pin for the
@@ -166,11 +165,11 @@ where
     type Error = core::convert::Infallible;
     #[inline]
     fn is_high(&self) -> Result<bool, Self::Error> {
-        self._pin.is_high()
+        self.pin.is_high()
     }
     #[inline]
     fn is_low(&self) -> Result<bool, Self::Error> {
-        self._pin.is_low()
+        self.pin.is_low()
     }
 }
 
@@ -184,6 +183,7 @@ mod async_impls {
     use crate::{
         async_hal::interrupts::{Binding, Handler, InterruptSource},
         eic::EicFuture,
+        typelevel::NoneT,
     };
 
     use super::{
@@ -207,7 +207,7 @@ mod async_impls {
             unsafe { P::InterruptSource::enable() };
 
             ExtInt {
-                _pin: self._pin,
+                pin: self.pin,
                 chan: self.chan.change_mode(),
             }
         }

--- a/hal/src/peripherals/eic/d5x/pin.rs
+++ b/hal/src/peripherals/eic/d5x/pin.rs
@@ -1,50 +1,11 @@
-use super::EIC;
+use atsamd_hal_macros::hal_cfg;
+
 use crate::ehal_02::digital::v2::InputPin;
+use crate::eic::*;
 use crate::gpio::{
     self, pin::*, AnyPin, FloatingInterrupt, PinMode, PullDownInterrupt, PullUpInterrupt,
 };
-use crate::pac;
-use crate::typelevel::{NoneT, Sealed};
-use atsamd_hal_macros::hal_cfg;
-use core::marker::PhantomData;
-use core::mem::ManuallyDrop;
-
-/// Marker type that signifies an [`ExtInt`] is capable of `async` operations
-pub enum EicFuture {}
-
-/// The EicPin trait makes it more ergonomic to convert a gpio pin into an EIC
-/// pin. You should not implement this trait for yourself; only the
-/// implementations in the EIC module make sense.
-// This is more complicated than it needs to be, due to the ExtInt structs being
-// defined through macros below.
-pub trait EicPin: AnyPin + Sealed {
-    type Floating;
-    type PullUp;
-    type PullDown;
-
-    const EIC_ID: usize;
-
-    #[cfg(feature = "async")]
-    type InterruptSource: crate::async_hal::interrupts::InterruptSource;
-
-    /// Configure a pin as a floating external interrupt
-    fn into_floating_ei(self, eic: &mut EIC) -> Self::Floating;
-
-    /// Configure a pin as pulled-up external interrupt
-    fn into_pull_up_ei(self, eic: &mut EIC) -> Self::PullUp;
-
-    /// Configure a pin as pulled-down external interrupt
-    fn into_pull_down_ei(self, eic: &mut EIC) -> Self::PullDown;
-}
-
-pub type Sense = pac::eic::config::Sense0select;
-
-pub type ExternalInterruptID = usize;
-
-/// ExternalInterrupt describes something with an external interrupt ID.
-pub trait ExternalInterrupt {
-    fn id(&self) -> ExternalInterruptID;
-}
+use crate::typelevel::NoneT;
 
 /// The pad macro defines the given EIC pin and implements EicPin for the
 /// given pins. The EicPin implementation will configure the pin for the
@@ -61,38 +22,28 @@ macro_rules! ei {
     ) => {
 
         crate::paste::item! {
-            pub enum [<Eic $num>] {}
-
             $(
                 $(#[$attr])*
                 impl<M: PinMode> EicPin for Pin<gpio::$PinType, M> {
-                    type Floating = ExtInt<Pin<gpio::$PinType, FloatingInterrupt>>;
-                    type PullUp = ExtInt<Pin<gpio::$PinType, PullUpInterrupt>>;
-                    type PullDown = ExtInt<Pin<gpio::$PinType, PullDownInterrupt>>;
+                    type Floating = ExtInt<Pin<gpio::$PinType, FloatingInterrupt>, Self::ChId>;
+                    type PullUp = ExtInt<Pin<gpio::$PinType, PullUpInterrupt>, Self::ChId>;
+                    type PullDown = ExtInt<Pin<gpio::$PinType, PullDownInterrupt>, Self::ChId>;
 
-                    const EIC_ID: usize = $num;
+                    type ChId = [<Ch $num>];
 
                     #[cfg(feature = "async")]
                     type InterruptSource = crate::async_hal::interrupts::[<EIC_EXTINT_ $num>];
 
-                    fn into_floating_ei(self, eic: &mut EIC) -> Self::Floating {
-                        ExtInt::new(self.into_floating_interrupt(), eic)
+                    fn into_floating_ei(self, channel: Channel<Self::ChId>) -> Self::Floating {
+                        ExtInt::new(self.into_floating_interrupt(), channel)
                     }
 
-                    fn into_pull_up_ei(self, eic: &mut EIC) -> Self::PullUp {
-                        ExtInt::new(self.into_pull_up_interrupt(), eic)
+                    fn into_pull_up_ei(self,channel: Channel<Self::ChId>) -> Self::PullUp {
+                        ExtInt::new(self.into_pull_up_interrupt(), channel)
                     }
 
-                    fn into_pull_down_ei(self, eic: &mut EIC) -> Self::PullDown {
-                        ExtInt::new(self.into_pull_down_interrupt(), eic)
-                    }
-                }
-
-                $(#[$attr])*
-                impl<M: PinMode> ExternalInterrupt for Pin<gpio::$PinType, M>
-                {
-                    fn id(&self) -> ExternalInterruptID {
-                        $num
+                    fn into_pull_down_ei(self, channel: Channel<Self::ChId>) -> Self::PullDown {
+                        ExtInt::new(self.into_pull_down_interrupt(), channel)
                     }
                 }
             )+
@@ -101,80 +52,57 @@ macro_rules! ei {
     };
 }
 
-/// Represents a numbered external interrupt. The external interrupt is generic
-/// over any pin, only the EicPin implementations in this module make sense.
-pub struct ExtInt<P, I = NoneT>
+impl<P, Id, F> ExtInt<P, Id, F>
 where
     P: EicPin,
+    Id: ChId,
 {
-    eic: ManuallyDrop<EIC>,
-    _pin: Pin<P::Id, P::Mode>,
-    _irq: PhantomData<I>,
-}
-
-// impl !Send for [<$PadType $num>]<GPIO> {};
-// impl !Sync for [<$PadType $num>]<GPIO> {}}
-
-impl<P: EicPin, F> ExtInt<P, F> {
-    /// Construct pad from the appropriate pin in any mode.
-    /// You may find it more convenient to use the `into_pad` trait
-    /// and avoid referencing the pad type.
-    pub fn new(pin: P, eic: &mut EIC) -> Self {
-        let eic = unsafe { ManuallyDrop::new(core::ptr::read(eic as *const _)) };
-
-        Self {
-            eic,
-            _pin: pin.into(),
-            _irq: PhantomData,
-        }
-    }
-
     pub fn enable_event(&mut self) {
-        self.eic
+        self.chan
             .eic
             .evctrl()
-            .modify(|_, w| unsafe { w.bits(1 << P::EIC_ID) });
+            .modify(|_, w| unsafe { w.bits(1 << P::ChId::ID) });
     }
 
     pub fn enable_interrupt(&mut self) {
-        self.eic
+        self.chan
             .eic
             .intenset()
-            .write(|w| unsafe { w.bits(1 << P::EIC_ID) })
+            .write(|w| unsafe { w.bits(1 << P::ChId::ID) })
     }
 
     pub fn disable_interrupt(&mut self) {
-        self.eic
+        self.chan
             .eic
             .intenclr()
-            .write(|w| unsafe { w.bits(1 << P::EIC_ID) })
+            .write(|w| unsafe { w.bits(1 << P::ChId::ID) })
     }
 
     pub fn is_interrupt(&mut self) -> bool {
-        let intflag = self.eic.eic.intflag().read().bits();
-        intflag & (1 << P::EIC_ID) != 0
+        let intflag = self.chan.eic.intflag().read().bits();
+        intflag & (1 << P::ChId::ID) != 0
     }
 
     pub fn state(&mut self) -> bool {
-        let state = self.eic.eic.pinstate().read().bits();
-        state & (1 << P::EIC_ID) != 0
+        let state = self.chan.eic.pinstate().read().bits();
+        state & (1 << P::ChId::ID) != 0
     }
 
     pub fn clear_interrupt(&mut self) {
         unsafe {
-            self.eic.eic.intflag().write(|w| w.bits(1 << P::EIC_ID));
+            self.chan.eic.intflag().write(|w| w.bits(1 << P::ChId::ID));
         }
     }
 
     pub fn sense(&mut self, sense: Sense) {
-        self.eic.with_disable(|e| {
+        self.chan.with_disable(|e| {
             // Which of the two config blocks this eic config is in
-            let offset = (P::EIC_ID >> 3) & 0b0001;
+            let offset = (P::ChId::ID >> 3) & 0b0001;
             let config = &e.config(offset);
 
             config.modify(|_, w| unsafe {
                 // Which of the eight eic configs in this config block
-                match P::EIC_ID & 0b111 {
+                match P::ChId::ID & 0b111 {
                     0b000 => w.sense0().bits(sense as u8),
                     0b001 => w.sense1().bits(sense as u8),
                     0b010 => w.sense2().bits(sense as u8),
@@ -190,14 +118,14 @@ impl<P: EicPin, F> ExtInt<P, F> {
     }
 
     pub fn filter(&mut self, filter: bool) {
-        self.eic.with_disable(|e| {
+        self.chan.with_disable(|e| {
             // Which of the two config blocks this eic config is in
-            let offset = (P::EIC_ID >> 3) & 0b0001;
+            let offset = (P::ChId::ID >> 3) & 0b0001;
             let config = &e.config(offset);
 
             config.modify(|_, w| {
                 // Which of the eight eic configs in this config block
-                match P::EIC_ID & 0b111 {
+                match P::ChId::ID & 0b111 {
                     0b000 => w.filten0().bit(filter),
                     0b001 => w.filten1().bit(filter),
                     0b010 => w.filten2().bit(filter),
@@ -214,7 +142,7 @@ impl<P: EicPin, F> ExtInt<P, F> {
 
     /// Enable debouncing for this pin, with a configuration appropriate for debouncing physical buttons.
     pub fn debounce(&mut self) {
-        self.eic.with_disable(|e| {
+        self.chan.with_disable(|e| {
             e.dprescaler().modify(|_, w| {
                 w.tickon().set_bit()    // Use the 32k clock for debouncing.
                 .states0().set_bit()    // Require 7 0 samples to see a falling edge.
@@ -224,82 +152,16 @@ impl<P: EicPin, F> ExtInt<P, F> {
             });
 
             e.debouncen()
-                .modify(|_, w| unsafe { w.bits(P::EIC_ID as u32) });
+                .modify(|_, w| unsafe { w.bits(P::ChId::ID as u32) });
         });
     }
 }
 
-impl<P: EicPin> ExtInt<P, NoneT> {
-    /// Turn an EIC pin into a pin usable as a [`Future`](core::future::Future).
-    /// The correct interrupt source is needed.
-    #[cfg(feature = "async")]
-    pub fn into_future<I>(self, _irq: I) -> ExtInt<P, EicFuture>
-    where
-        I: crate::async_hal::interrupts::Binding<
-            P::InterruptSource,
-            super::async_api::InterruptHandler,
-        >,
-        super::async_api::InterruptHandler:
-            crate::async_hal::interrupts::Handler<P::InterruptSource>,
-    {
-        use crate::async_hal::interrupts::InterruptSource;
-
-        P::InterruptSource::unpend();
-        unsafe { P::InterruptSource::enable() };
-
-        ExtInt {
-            _pin: self._pin,
-            eic: self.eic,
-            _irq: PhantomData,
-        }
-    }
-}
-
-#[cfg(feature = "async")]
-impl<P> ExtInt<P, EicFuture>
-where
-    P: EicPin,
-    Self: InputPin<Error = core::convert::Infallible>,
-{
-    pub async fn wait(&mut self, sense: Sense) {
-        use core::{future::poll_fn, task::Poll};
-        self.disable_interrupt();
-
-        self.sense(sense);
-        poll_fn(|cx| {
-            if self.is_interrupt() {
-                self.clear_interrupt();
-                self.disable_interrupt();
-                self.sense(Sense::None);
-                return Poll::Ready(());
-            }
-
-            super::async_api::WAKERS[P::EIC_ID].register(cx.waker());
-            self.enable_interrupt();
-
-            if self.is_interrupt() {
-                self.clear_interrupt();
-                self.disable_interrupt();
-                self.sense(Sense::None);
-                return Poll::Ready(());
-            }
-
-            Poll::Pending
-        })
-        .await;
-    }
-}
-
-impl<P: EicPin, F> ExternalInterrupt for ExtInt<P, F> {
-    fn id(&self) -> ExternalInterruptID {
-        P::EIC_ID
-    }
-}
-
-impl<P, C, F> InputPin for ExtInt<P, F>
+impl<P, C, Id, F> InputPin for ExtInt<P, Id, F>
 where
     P: EicPin + AnyPin<Mode = Interrupt<C>>,
     C: InterruptConfig,
+    Id: ChId,
 {
     type Error = core::convert::Infallible;
     #[inline]
@@ -313,47 +175,120 @@ where
 }
 
 #[cfg(feature = "async")]
-impl<P> embedded_hal_1::digital::ErrorType for ExtInt<P, EicFuture>
-where
-    P: EicPin,
-    Self: InputPin<Error = core::convert::Infallible>,
-{
-    type Error = core::convert::Infallible;
+mod async_impls {
+    use core::convert::Infallible;
+
+    use embedded_hal_1::digital::ErrorType;
+    use embedded_hal_async::digital::Wait;
+
+    use crate::{
+        async_hal::interrupts::{Binding, Handler, InterruptSource},
+        eic::EicFuture,
+    };
+
+    use super::{
+        super::async_api::{InterruptHandler, WAKERS},
+        *,
+    };
+
+    impl<P, Id> ExtInt<P, Id, NoneT>
+    where
+        P: EicPin,
+        Id: ChId,
+    {
+        /// Turn an EIC pin into a pin usable as a [`Future`](core::future::Future).
+        /// The correct interrupt source is needed.
+        pub fn into_future<I>(self, _irq: I) -> ExtInt<P, Id, EicFuture>
+        where
+            I: Binding<P::InterruptSource, InterruptHandler>,
+            InterruptHandler: Handler<P::InterruptSource>,
+        {
+            P::InterruptSource::unpend();
+            unsafe { P::InterruptSource::enable() };
+
+            ExtInt {
+                _pin: self._pin,
+                chan: self.chan.change_mode(),
+            }
+        }
+    }
+
+    impl<P, Id> ExtInt<P, Id, EicFuture>
+    where
+        P: EicPin,
+        Self: InputPin<Error = Infallible>,
+        Id: ChId,
+    {
+        pub async fn wait(&mut self, sense: Sense) {
+            use core::{future::poll_fn, task::Poll};
+            self.disable_interrupt();
+
+            self.sense(sense);
+            poll_fn(|cx| {
+                if self.is_interrupt() {
+                    self.clear_interrupt();
+                    self.disable_interrupt();
+                    self.sense(Sense::None);
+                    return Poll::Ready(());
+                }
+
+                WAKERS[P::ChId::ID].register(cx.waker());
+                self.enable_interrupt();
+
+                if self.is_interrupt() {
+                    self.clear_interrupt();
+                    self.disable_interrupt();
+                    self.sense(Sense::None);
+                    return Poll::Ready(());
+                }
+
+                Poll::Pending
+            })
+            .await;
+        }
+    }
+
+    impl<P, Id> ErrorType for ExtInt<P, Id, EicFuture>
+    where
+        P: EicPin,
+        Self: InputPin<Error = Infallible>,
+        Id: ChId,
+    {
+        type Error = Infallible;
+    }
+
+    impl<P, Id> Wait for ExtInt<P, Id, EicFuture>
+    where
+        P: EicPin,
+        Self: InputPin<Error = Infallible>,
+        Id: ChId,
+    {
+        async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+            self.wait(Sense::High).await;
+            Ok(())
+        }
+
+        async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+            self.wait(Sense::Low).await;
+            Ok(())
+        }
+
+        async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+            self.wait(Sense::Rise).await;
+            Ok(())
+        }
+
+        async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+            self.wait(Sense::Fall).await;
+            Ok(())
+        }
+
+        async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+            self.wait(Sense::Both).await;
+            Ok(())
+        }
+    }
 }
-
-#[cfg(feature = "async")]
-impl<P> embedded_hal_async::digital::Wait for ExtInt<P, EicFuture>
-where
-    P: EicPin,
-    Self: InputPin<Error = core::convert::Infallible>,
-{
-    async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
-        self.wait(Sense::High).await;
-        Ok(())
-    }
-
-    async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
-        self.wait(Sense::Low).await;
-        Ok(())
-    }
-
-    async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
-        self.wait(Sense::Rise).await;
-        Ok(())
-    }
-
-    async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
-        self.wait(Sense::Fall).await;
-        Ok(())
-    }
-
-    async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
-        self.wait(Sense::Both).await;
-        Ok(())
-    }
-}
-
-pub const NUM_CHANNELS: usize = 16;
 
 ei!(ExtInt[0] {
     #[hal_cfg("pa00")]

--- a/hal/src/peripherals/mod.rs
+++ b/hal/src/peripherals/mod.rs
@@ -18,11 +18,7 @@ pub mod calibration {}
 )]
 pub mod timer {}
 
-#[hal_module(
-    any("eic-d11", "eic-d21") => "eic/d11/mod.rs",
-    "eic-d5x" => "eic/d5x/mod.rs",
-)]
-pub mod eic {}
+pub mod eic;
 
 #[cfg(feature = "usb")]
 #[hal_module(

--- a/hal/src/prelude.rs
+++ b/hal/src/prelude.rs
@@ -1,5 +1,5 @@
 //! Import the prelude to gain convenient access to helper traits
-pub use crate::eic::pin::EicPin;
+pub use crate::eic::EicPin;
 pub use crate::timer_traits::InterruptDrivenTimer;
 pub use fugit::ExtU32 as _;
 pub use fugit::RateExtU32 as _;


### PR DESCRIPTION
# Summary
In light of #781, I realized the `eic` module was in a serious need of an overhaul. Most importantly, in its current state, any EXTINT channel may accept any GPIO pin, which results in configuration errors which are not caught at compile time.

This PR provides a more typesafe API, which does not rely so heavily on macros. Erroneous channel/pin combos are caught at compile time. Additionnally, some types/modules are moved around to make a little more sense, and code is reused where possible, instead of providing two completely separate codebases for D11/D21 and D5x chips.

I figured now was a good time to get this done before the next release, as #635 already has brought in some breaking changes to the `eic` module. 

To note that despite the large changes, the public API is still very reasonably easy to use, and migrating to the new API only takes changes to 2-3 lines of code (check the updated examples). 

Closes #781.

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced
