### PR TITLE
chore: Fix compilation when device feature is off

### DIFF
--- a/hal/src/peripherals/mod.rs
+++ b/hal/src/peripherals/mod.rs
@@ -18,6 +18,7 @@ pub mod calibration {}
 )]
 pub mod timer {}
 
+#[cfg(feature = "device")]
 pub mod eic;
 
 #[cfg(feature = "usb")]


### PR DESCRIPTION
`cargo publish` is failing because it's trying to build the HAL with no device feature enabled, and the `eic` module isn't properly suppressed. Provide a simple fix to enable publishing again.