### PR TITLE
chore(atsamd-hal-macros): Add MSRV to atsamd-hal-macros

### DIFF
--- a/atsamd-hal-macros/Cargo.toml
+++ b/atsamd-hal-macros/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 authors = ["Tethys Svensson"]
 name = "atsamd-hal-macros"
+rust-version = "1.77.2"
 version = "0.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Suppresses clippy lints for unsupported APIs in the standard library.