### PR TITLE
changed(spi): Remove explicit flushes from SpiBus impl

### DIFF
--- a/hal/src/sercom/spi.rs
+++ b/hal/src/sercom/spi.rs
@@ -258,6 +258,24 @@
 //! let rcvd: u16 = block!(spi.read());
 //! ```
 //!
+//! ## Flushing the bus
+//!
+//! The [`SpiBus`](crate::ehal::spi::SpiBus) methods do not flush the bus when a
+//! transaction is complete. This is in part to increase performance and allow
+//! for pipelining SPI transactions. This is true for both sync and async
+//! operation. As such, you should ensure you manually call
+//! [`flush`](crate::ehal::spi::SpiBus::flush) when:
+//! * You must synchronize SPI activity and GPIO activity, for example before
+//!   deasserting a CS pin.
+//! * Before deinitializing the SPI peripheral.
+//!
+//! Take note that the [`SpiDevice`](crate::ehal::spi::SpiDevice)
+//! implementations automatically take care of flushing, so no further flushing
+//! is needed.
+//!
+//! [See the embedded-hal spec](https://docs.rs/embedded-hal/latest/embedded_hal/spi/index.html#flushing)
+//! for more information.
+//!
 //! # [`PanicOnRead`] and [`PanicOnWrite`]
 //!
 //! Some driver libraries take a type implementing [`embedded_hal::spi::SpiBus`]

--- a/hal/src/sercom/spi/async_api/dma.rs
+++ b/hal/src/sercom/spi/async_api/dma.rs
@@ -194,7 +194,6 @@ where
             self.spi.config.as_mut().regs.rx_enable();
         }
 
-        self.flush_tx().await;
         tx_result?;
         Ok(words.len())
     }
@@ -229,7 +228,7 @@ where
         );
 
         // Check for overflows or DMA errors
-        self.flush_tx_rx().await?;
+        self.spi.read_status().check_bus_error()?;
         rx_result.and(tx_result)?;
         Ok(())
     }
@@ -365,7 +364,7 @@ where
         };
 
         // Check for overflows or DMA errors
-        self.flush_tx_rx().await?;
+        self.spi.read_status().check_bus_error()?;
         rx_result.and(tx_result)?;
         Ok(())
     }

--- a/hal/src/sercom/spi/async_api/mod.rs
+++ b/hal/src/sercom/spi/async_api/mod.rs
@@ -283,13 +283,6 @@ where
     async fn flush_rx(&mut self) -> Result<(), Error> {
         self.wait_flags(Flags::RXC).await
     }
-
-    /// Wait on TXC and RXC flags
-    #[inline]
-    #[cfg(feature = "dma")]
-    async fn flush_tx_rx(&mut self) -> Result<(), Error> {
-        self.wait_flags(Flags::TXC | Flags::RXC).await
-    }
 }
 
 impl<C, A, R, T> AsRef<Spi<C, A, R, T>> for SpiFuture<C, A, R, T>

--- a/hal/src/sercom/spi/impl_ehal/dma.rs
+++ b/hal/src/sercom/spi/impl_ehal/dma.rs
@@ -74,7 +74,6 @@ where
         }
 
         self._tx_channel.as_mut().xfer_success()?;
-        self.flush_tx();
         Ok(buf.len())
     }
 }
@@ -119,7 +118,7 @@ where
         rx.stop();
 
         // Check for overflows or DMA errors
-        self.flush_tx_rx()?;
+        self.read_status().check_bus_error()?;
         self._rx_channel
             .as_mut()
             .xfer_success()
@@ -259,7 +258,7 @@ where
         rx.stop();
 
         // Check for overflows or DMA errors
-        self.flush_tx_rx()?;
+        self.read_status().check_bus_error()?;
         self._rx_channel
             .as_mut()
             .xfer_success()
@@ -368,7 +367,7 @@ where
         rx.stop();
 
         // Check for overflows or DMA errors
-        self.flush_rx()?;
+        self.read_status().check_bus_error()?;
         self._rx_channel.as_mut().xfer_success()?;
         Ok(buf.len())
     }

--- a/hal/src/sercom/spi/impl_ehal/mod.rs
+++ b/hal/src/sercom/spi/impl_ehal/mod.rs
@@ -113,7 +113,6 @@ where
             *r = self.transfer_word_in_place(*w)?;
         }
 
-        self.flush_tx();
         Ok(())
     }
 
@@ -128,13 +127,6 @@ where
     #[inline]
     fn flush_rx(&mut self) -> Result<(), Error> {
         self.block_on_flags(Flags::RXC)
-    }
-
-    /// Wait on TXC and RXC flags
-    #[inline]
-    #[cfg(feature = "dma")]
-    fn flush_tx_rx(&mut self) -> Result<(), Error> {
-        self.block_on_flags(Flags::TXC | Flags::RXC)
     }
 }
 
@@ -156,7 +148,6 @@ where
         for word in words.iter_mut() {
             *word = self.transfer_word_in_place(self.config.nop_word.as_())?;
         }
-        self.flush_tx();
         Ok(())
     }
 
@@ -171,7 +162,6 @@ where
                 self.write_data(word.as_());
             }
         }
-        self.flush_tx();
 
         // Reenable receiver only if necessary
         if D::RX_ENABLE {
@@ -213,7 +203,6 @@ where
             *word = read;
         }
 
-        self.flush_tx();
         Ok(())
     }
 


### PR DESCRIPTION
# Summary
Removes explicit flushes from SpiBus implementation, allowing for better pipelining of SPI transactions while still adhering to the [embedded-hal spec](https://docs.rs/embedded-hal/latest/embedded_hal/spi/index.html#flushing).

Incidentally, also makes neopixels work again with the SPI peripheral (in release mode, and when DMA is **not** enabled) - tested on a Metro M4.

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced