### PR TITLE
Allow the construction of Delay using the clock::v2 API

### DIFF
--- a/hal/src/delay.rs
+++ b/hal/src/delay.rs
@@ -8,6 +8,8 @@ use crate::clock::GenericClockController;
 use crate::ehal::delay::DelayNs;
 use crate::ehal_02;
 use crate::time::Hertz;
+
+#[hal_cfg("rtc-d5x")]
 use crate::typelevel::Increment;
 
 #[hal_cfg("rtc-d5x")]

--- a/hal/src/delay.rs
+++ b/hal/src/delay.rs
@@ -13,9 +13,7 @@ use crate::time::Hertz;
 use crate::typelevel::Increment;
 
 #[hal_cfg("rtc-d5x")]
-use crate::clock::v2::{
-    Source, gclk::Gclk0Id
-};
+use crate::clock::v2::{gclk::Gclk0Id, Source};
 
 /// System timer (SysTick) as a delay provider
 pub struct Delay {
@@ -38,14 +36,16 @@ impl Delay {
     /// Configures the system timer (SysTick) as a delay provide, compatible
     /// with the V2 clocking API
     pub fn new_with_source<S>(mut syst: SYST, gclk0: S) -> (Self, S::Inc)
-    where S: Source<Id = Gclk0Id> + Increment {
+    where
+        S: Source<Id = Gclk0Id> + Increment,
+    {
         syst.set_clock_source(SystClkSource::Core);
         (
             Delay {
                 syst,
                 sysclock: gclk0.freq(),
             },
-            gclk0.inc()
+            gclk0.inc(),
         )
     }
 

--- a/hal/src/delay.rs
+++ b/hal/src/delay.rs
@@ -7,6 +7,8 @@ use crate::clock::GenericClockController;
 use crate::ehal::delay::DelayNs;
 use crate::ehal_02;
 use crate::time::Hertz;
+use crate::typelevel::Increment;
+use crate::clock::v2::Source;
 
 /// System timer (SysTick) as a delay provider
 pub struct Delay {
@@ -23,6 +25,18 @@ impl Delay {
             syst,
             sysclock: clocks.gclk0().into(),
         }
+    }
+
+    pub fn new_with_source<S>(mut syst: SYST, source: S) -> (Self, S::Inc)
+    where S: Source + Increment {
+        syst.set_clock_source(SystClkSource::Core);
+        (
+            Delay {
+                syst,
+                sysclock: source.freq(),
+            },
+            source.inc()
+        )
     }
 
     /// Releases the system timer (SysTick) resource


### PR DESCRIPTION
This PR introduces `Delay::new_with_source` function, which is compatible with the V2 clocking API, allowing the usage of Delay after calling `clock_system_at_reset` (Which is required for MCAN)

Example usage:

```rust
let (pclk_can0, gclk0) = pclk::Pclk::enable(tokens.pclks.can0, clocks.gclk0);
let (mut delay, gclk0) = Delay::new_with_source(cpu_core.SYST, gclk0);
```

