### PR TITLE
Allow USB to work with V2 clocking API

### DIFF
--- a/hal/src/delay.rs
+++ b/hal/src/delay.rs
@@ -8,6 +8,8 @@ use crate::clock::GenericClockController;
 use crate::ehal::delay::DelayNs;
 use crate::ehal_02;
 use crate::time::Hertz;
+
+#[hal_cfg("rtc-d5x")]
 use crate::typelevel::Increment;
 
 #[hal_cfg("rtc-d5x")]

--- a/hal/src/delay.rs
+++ b/hal/src/delay.rs
@@ -13,9 +13,7 @@ use crate::time::Hertz;
 use crate::typelevel::Increment;
 
 #[hal_cfg("rtc-d5x")]
-use crate::clock::v2::{
-    Source, gclk::Gclk0Id
-};
+use crate::clock::v2::{gclk::Gclk0Id, Source};
 
 /// System timer (SysTick) as a delay provider
 pub struct Delay {
@@ -38,14 +36,16 @@ impl Delay {
     /// Configures the system timer (SysTick) as a delay provide, compatible
     /// with the V2 clocking API
     pub fn new_with_source<S>(mut syst: SYST, gclk0: S) -> (Self, S::Inc)
-    where S: Source<Id = Gclk0Id> + Increment {
+    where
+        S: Source<Id = Gclk0Id> + Increment,
+    {
         syst.set_clock_source(SystClkSource::Core);
         (
             Delay {
                 syst,
                 sysclock: gclk0.freq(),
             },
-            gclk0.inc()
+            gclk0.inc(),
         )
     }
 

--- a/hal/src/delay.rs
+++ b/hal/src/delay.rs
@@ -7,6 +7,8 @@ use crate::clock::GenericClockController;
 use crate::ehal::delay::DelayNs;
 use crate::ehal_02;
 use crate::time::Hertz;
+use crate::typelevel::Increment;
+use crate::clock::v2::Source;
 
 /// System timer (SysTick) as a delay provider
 pub struct Delay {
@@ -23,6 +25,18 @@ impl Delay {
             syst,
             sysclock: clocks.gclk0().into(),
         }
+    }
+
+    pub fn new_with_source<S>(mut syst: SYST, source: S) -> (Self, S::Inc)
+    where S: Source + Increment {
+        syst.set_clock_source(SystClkSource::Core);
+        (
+            Delay {
+                syst,
+                sysclock: source.freq(),
+            },
+            source.inc()
+        )
     }
 
     /// Releases the system timer (SysTick) resource


### PR DESCRIPTION
# Summary

Continuing my work to allow more peripherals to work with the V2 clocking API, this PR adds a new method (Maybe name should be changed to something more permanent), that allows the UsbBus to be constructed with the new V2 clocking API. 

I've left the original constructor untouched in order to maintain compatibility.

Now, in the BSPs, USB can be constructed like so:

```rust
pub fn usb(
    usb: pac::Usb,
    pclk_usb: Pclk<Usb, Gclk0Id>, // Can use any Gclk here
    mclk: &mut pac::Mclk,
    d_minus: impl Into<UsbDm>,
    d_plus: impl Into<UsbDp>,
) -> UsbBusAllocator<UsbBus> {
    UsbBusAllocator::new(UsbBus::new_with_v2_clock(pclk_usb, mclk, d_minus.into(), d_plus.into(), usb))
}
```
