### PR TITLE
DRAFT - Rewrite of ADC code

### DIFF
--- a/boards/atsame54_xpro/CHANGELOG.md
+++ b/boards/atsame54_xpro/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.1](https://github.com/atsamd-rs/atsamd/compare/atsame54_xpro-0.10.0...atsame54_xpro-0.10.1) - 2024-12-11
+
+### Other
+
+- updated the following local packages: atsamd-hal
+
 ## [0.10.0](https://github.com/atsamd-rs/atsamd/compare/atsame54_xpro-0.9.0...atsame54_xpro-0.10.0) - 2024-11-28
 
 ### Added

--- a/boards/atsame54_xpro/Cargo.toml
+++ b/boards/atsame54_xpro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atsame54_xpro"
-version = "0.10.0"
+version = "0.10.1"
 authors = [
     "Karsten Große <karsten.grosse@sympatron.de>",
     "John Little <johngigantic@gmail.com>"
@@ -23,7 +23,7 @@ features = ["critical-section-single-core"]
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.20.0"
+version = "0.20.2"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/feather_m0/CHANGELOG.md
+++ b/boards/feather_m0/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1](https://github.com/atsamd-rs/atsamd/compare/feather_m0-0.17.0...feather_m0-0.17.1) - 2024-12-11
+
+### Other
+
+- updated the following local packages: atsamd-hal
+
 ## [0.17.0](https://github.com/atsamd-rs/atsamd/compare/feather_m0-0.16.0...feather_m0-0.17.0) - 2024-11-28
 
 ### Added

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feather_m0"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit Feather M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
@@ -21,7 +21,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.20.0"
+version = "0.20.2"
 default-features = false
 
 [dependencies.cortex-m]

--- a/boards/feather_m4/CHANGELOG.md
+++ b/boards/feather_m4/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1](https://github.com/atsamd-rs/atsamd/compare/feather_m4-0.15.0...feather_m4-0.15.1) - 2024-12-11
+
+### Other
+
+- updated the following local packages: atsamd-hal
+
 ## [0.15.0](https://github.com/atsamd-rs/atsamd/compare/feather_m4-0.14.0...feather_m4-0.15.0) - 2024-11-28
 
 ### Added

--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "feather_m4"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 authors = ["Theodore DeRego <tderego94@gmail.com>"]
 description = "Board Support crate for the Adafruit Feather M4"
@@ -25,7 +25,7 @@ features = ["critical-section-single-core"]
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.20.0"
+version = "0.20.2"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/metro_m0/CHANGELOG.md
+++ b/boards/metro_m0/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1](https://github.com/atsamd-rs/atsamd/compare/metro_m0-0.17.0...metro_m0-0.17.1) - 2024-12-11
+
+### Other
+
+- updated the following local packages: atsamd-hal
+
 ## [0.17.0](https://github.com/atsamd-rs/atsamd/compare/metro_m0-0.16.0...metro_m0-0.17.0) - 2024-11-28
 
 ### Added

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metro_m0"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Wez Furlong <wez@wezfurlong.org>"]
 description = "Board Support crate for the Adafruit Metro M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
@@ -24,7 +24,7 @@ features = ["critical-section-single-core"]
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.20.0"
+version = "0.20.2"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/metro_m0/examples/blinky_rtic.rs
+++ b/boards/metro_m0/examples/blinky_rtic.rs
@@ -19,7 +19,7 @@ mod app {
     use hal::clock::{ClockGenId, ClockSource, GenericClockController};
     use hal::pac::Peripherals;
     use hal::prelude::*;
-    use hal::rtc::{Count32Mode, Duration, Rtc};
+    use hal::rtc::{rtic::v1::Duration, Count32Mode, Rtc};
 
     #[local]
     struct Local {}

--- a/boards/metro_m4/CHANGELOG.md
+++ b/boards/metro_m4/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1](https://github.com/atsamd-rs/atsamd/compare/metro_m4-0.16.0...metro_m4-0.16.1) - 2024-12-11
+
+### Other
+
+- updated the following local packages: atsamd-hal
+
 ## [0.16.0](https://github.com/atsamd-rs/atsamd/compare/metro_m4-0.15.0...metro_m4-0.16.0) - 2024-11-28
 
 ### Added

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metro_m4"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Paul Sajna <sajattack@gmail.com>", "Wez Furlong <wez@wezfurlong.org>"]
 description = "Board Support crate for the Adafruit Metro M4"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
@@ -20,7 +20,7 @@ optional = true
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.20.0"
+version = "0.20.2"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/pygamer/CHANGELOG.md
+++ b/boards/pygamer/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1](https://github.com/atsamd-rs/atsamd/compare/pygamer-0.13.0...pygamer-0.13.1) - 2024-12-11
+
+### Examples
+
+- *(pygamer)* Restore neopixel examples using SPI driver
+
 ## [0.13.0](https://github.com/atsamd-rs/atsamd/compare/pygamer-0.12.0...pygamer-0.13.0) - 2024-11-28
 
 ### Added

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 name = "pygamer"
 readme = "README.md"
 repository = "https://github.com/atsamd-rs/atsamd"
-version = "0.13.0"
+version = "0.13.1"
 
 [dependencies]
 cortex-m = {version = "0.7", features = ["critical-section-single-core"]}
@@ -27,7 +27,7 @@ version = "0.7"
 [dependencies.atsamd-hal]
 default-features = false
 path = "../../hal"
-version = "0.20.0"
+version = "0.20.2"
 
 [dependencies.usb-device]
 optional = true

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -33,6 +33,11 @@ version = "0.20.0"
 optional = true
 version = "0.3.2"
 
+[dependencies.ws2812-spi]
+version = "0.5.0"
+features = ["mosi_idle_high"]
+optional = true
+
 [dev-dependencies]
 embedded-graphics = "0.8.1"
 embedded-sdmmc = "0.8.0"
@@ -52,6 +57,7 @@ max-channels = ["dma", "atsamd-hal/max-channels"]
 panic_led = []
 rt = ["cortex-m-rt", "atsamd-hal/samd51j-rt"]
 usb = ["atsamd-hal/usb", "usb-device"]
+neopixel-spi = ["dep:ws2812-spi"]
 # Enable async support from atsamd-hal
 async = ["atsamd-hal/async"]
 
@@ -89,3 +95,23 @@ name = "timer"
 [[example]]
 name = "usb_poll"
 required-features = ["usb"]
+
+[[example]]
+name = "neopixel_adc_battery"
+required-features = ["neopixel-spi"]
+
+[[example]]
+name = "neopixel_adc_light"
+required-features = ["neopixel-spi"]
+
+[[example]]
+name = "neopixel_button"
+required-features = ["neopixel-spi"]
+
+[[example]]
+name = "neopixel_easing"
+required-features = ["neopixel-spi"]
+
+[[example]]
+name = "neopixel_rainbow"
+required-features = ["neopixel-spi"]

--- a/boards/pygamer/examples/neopixel_adc_battery.rs
+++ b/boards/pygamer/examples/neopixel_adc_battery.rs
@@ -1,0 +1,89 @@
+//! Display battery percentage on the neopixels.
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
+
+#![no_std]
+#![no_main]
+
+#[cfg(not(feature = "panic_led"))]
+use panic_halt as _;
+use pygamer::{entry, hal, pac, Pins};
+
+use hal::adc::Adc;
+use hal::{clock::GenericClockController, delay::Delay};
+
+use pac::gclk::pchctrl::Genselect::Gclk11;
+
+use hal::ehal::delay::DelayNs;
+
+use pac::{CorePeripherals, Peripherals};
+use smart_leds::{brightness, SmartLedsWrite, RGB8};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.gclk,
+        &mut peripherals.mclk,
+        &mut peripherals.osc32kctrl,
+        &mut peripherals.oscctrl,
+        &mut peripherals.nvmctrl,
+    );
+    let pins = Pins::new(peripherals.port).split();
+
+    let mut adc0 = Adc::adc0(peripherals.adc0, &mut peripherals.mclk, &mut clocks, Gclk11);
+    let mut battery = pins.battery.init();
+
+    // neopixels
+    let mut neopixel = pins.neopixel.init_spi(
+        &mut clocks,
+        // Unfortunately, the SPI driver requires a clock pin, even though it's not used by the
+        // neopixels.
+        pins.i2c.scl,
+        peripherals.sercom2,
+        &mut peripherals.mclk,
+    );
+
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    //todo put this on a .. 10minute, 30min, update timer
+    loop {
+        let battery_data = battery.read(&mut adc0);
+
+        let mut colors = [
+            RGB8::default(),
+            RGB8::default(),
+            RGB8::default(),
+            RGB8::default(),
+            RGB8::default(),
+        ];
+
+        if battery_data < 3.6 {
+            enable_leds(1, &mut colors);
+        } else if (3.6..3.8).contains(&battery_data) {
+            enable_leds(2, &mut colors);
+        } else if (3.8..3.9).contains(&battery_data) {
+            enable_leds(3, &mut colors);
+        } else if (3.9..4.0).contains(&battery_data) {
+            enable_leds(4, &mut colors);
+        } else {
+            enable_leds(5, &mut colors);
+        };
+
+        neopixel
+            .write(brightness(colors.iter().cloned(), 1))
+            .unwrap();
+
+        // Reset the LEDs
+        delay.delay_ms(10);
+    }
+}
+
+/// Turn on the specified number of LEDs and set the color to red.
+fn enable_leds(num_leds: usize, colors: &mut [RGB8]) {
+    for color in colors.iter_mut().take(num_leds) {
+        *color = RGB8::from((255, 0, 0));
+    }
+}

--- a/boards/pygamer/examples/neopixel_adc_light.rs
+++ b/boards/pygamer/examples/neopixel_adc_light.rs
@@ -1,0 +1,88 @@
+//! Display light sensor reading on the neopixels.
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
+
+#![no_std]
+#![no_main]
+
+#[cfg(not(feature = "panic_led"))]
+use panic_halt as _;
+use pygamer::{entry, hal, pac, Pins};
+
+use hal::adc::Adc;
+use hal::prelude::*;
+use hal::{clock::GenericClockController, delay::Delay};
+use pac::gclk::pchctrl::Genselect::Gclk11;
+use pac::{CorePeripherals, Peripherals};
+use smart_leds::SmartLedsWrite;
+use smart_leds::{
+    hsv::{hsv2rgb, Hsv},
+    RGB8,
+};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.gclk,
+        &mut peripherals.mclk,
+        &mut peripherals.osc32kctrl,
+        &mut peripherals.oscctrl,
+        &mut peripherals.nvmctrl,
+    );
+    let pins = Pins::new(peripherals.port).split();
+
+    let mut adc1 = Adc::adc1(peripherals.adc1, &mut peripherals.mclk, &mut clocks, Gclk11);
+    let mut light = pins.light_pin.into_alternate();
+
+    // neopixels
+    let mut neopixel = pins.neopixel.init_spi(
+        &mut clocks,
+        // Unfortunately, the SPI driver requires a clock pin, even though it's not used by the
+        // neopixels.
+        pins.i2c.scl,
+        peripherals.sercom2,
+        &mut peripherals.mclk,
+    );
+
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    const NUM_LEDS: usize = 5;
+    let mut j: u8 = 0;
+
+    loop {
+        let light_data: u16 = adc1.read(&mut light).unwrap();
+
+        let pos: usize = if light_data < 100 {
+            0
+        } else if (147..1048).contains(&light_data) {
+            1
+        } else if (1048..3048).contains(&light_data) {
+            2
+        } else if (3048..3948).contains(&light_data) {
+            3
+        } else {
+            4
+        };
+
+        //finally paint the one led wherever the position is
+        let _ = neopixel.write((0..NUM_LEDS).map(|i| {
+            if i == pos {
+                hsv2rgb(Hsv {
+                    hue: j,
+                    sat: 255,
+                    val: 32,
+                })
+            } else {
+                RGB8::default()
+            }
+        }));
+
+        //incremement the hue easing
+        j = j.wrapping_add(1);
+
+        delay.delay_ms(10u8);
+    }
+}

--- a/boards/pygamer/examples/neopixel_button.rs
+++ b/boards/pygamer/examples/neopixel_button.rs
@@ -1,0 +1,115 @@
+//! Joystick y controls the color of a neopixel while Joystick x moves it
+//! left and right around the center neopixel
+//! Select and Start control a second neopixel left and right while it is
+//! automatically rotating through the color wheel
+//! When they overlap, joystick takes precedence
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
+
+#![no_std]
+#![no_main]
+
+#[cfg(not(feature = "panic_led"))]
+use panic_halt as _;
+use pygamer::{self as bsp, entry, hal, pac, pins::Keys, Pins};
+
+use bsp::util::map_from;
+use hal::adc::Adc;
+use hal::{clock::GenericClockController, delay::Delay};
+
+use pac::gclk::pchctrl::Genselect::Gclk11;
+use pac::{CorePeripherals, Peripherals};
+
+use hal::ehal::delay::DelayNs;
+
+use smart_leds::SmartLedsWrite;
+use smart_leds::{
+    hsv::{hsv2rgb, Hsv},
+    RGB8,
+};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core_peripherals = CorePeripherals::take().unwrap();
+
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.gclk,
+        &mut peripherals.mclk,
+        &mut peripherals.osc32kctrl,
+        &mut peripherals.oscctrl,
+        &mut peripherals.nvmctrl,
+    );
+
+    let mut delay = Delay::new(core_peripherals.SYST, &mut clocks);
+    let pins = Pins::new(peripherals.port).split();
+
+    let mut buttons = pins.buttons.init();
+
+    let mut adc1 = Adc::adc1(peripherals.adc1, &mut peripherals.mclk, &mut clocks, Gclk11);
+    let mut joystick = pins.joystick.init();
+
+    // neopixels
+    let mut neopixel = pins.neopixel.init_spi(
+        &mut clocks,
+        // Unfortunately, the SPI driver requires a clock pin, even though it's not used by the
+        // neopixels.
+        pins.i2c.scl,
+        peripherals.sercom2,
+        &mut peripherals.mclk,
+    );
+
+    const NUM_LEDS: usize = 5;
+    let mut pos_button: usize = 2;
+    let mut color_button: u8 = 0;
+    loop {
+        let (x, y) = joystick.read(&mut adc1);
+
+        // map up/down to control rainbow color 0-255
+        let color_joy = map_from(y as i16, (0, 4095), (0, 255)) as u8;
+
+        // map left/right to neopixel position 0-4
+        // joystick is not quite linear, rests at second pixel
+        // shifting up by 500 seems to help
+        let pos_joy = map_from(x as i16 + 500, (0, 4595), (0, 4)) as usize;
+
+        for event in buttons.events() {
+            match event {
+                Keys::SelectDown => {
+                    pos_button = pos_button.saturating_sub(1);
+                }
+                Keys::StartDown => {
+                    if pos_button < 4 {
+                        pos_button += 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        //finally paint the two leds at position, accel priority
+        let _ = neopixel.write((0..NUM_LEDS).map(|i| {
+            if i == pos_joy {
+                hsv2rgb(Hsv {
+                    hue: color_joy,
+                    sat: 255,
+                    val: 32,
+                })
+            } else if i == pos_button {
+                hsv2rgb(Hsv {
+                    hue: color_button,
+                    sat: 255,
+                    val: 32,
+                })
+            } else {
+                RGB8::default()
+            }
+        }));
+
+        //incremement the hue easing
+        color_button = color_button.wrapping_add(1);
+
+        delay.delay_ms(5);
+    }
+}

--- a/boards/pygamer/examples/neopixel_easing.rs
+++ b/boards/pygamer/examples/neopixel_easing.rs
@@ -1,0 +1,102 @@
+//! Randomly choose and led and color to breath in and out
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
+
+#![no_std]
+#![no_main]
+
+#[cfg(not(feature = "panic_led"))]
+use panic_halt as _;
+use pygamer::{entry, hal, pac, Pins};
+
+use core::f32::consts::FRAC_PI_2;
+
+use hal::clock::GenericClockController;
+use hal::delay::Delay;
+use hal::trng::Trng;
+
+use pac::{CorePeripherals, Peripherals};
+
+use hal::ehal::delay::DelayNs;
+
+use micromath::F32Ext;
+use smart_leds::SmartLedsWrite;
+use smart_leds::{
+    hsv::{hsv2rgb, Hsv},
+    RGB8,
+};
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.gclk,
+        &mut peripherals.mclk,
+        &mut peripherals.osc32kctrl,
+        &mut peripherals.oscctrl,
+        &mut peripherals.nvmctrl,
+    );
+
+    let pins = Pins::new(peripherals.port).split();
+
+    // neopixels
+    let mut neopixel = pins.neopixel.init_spi(
+        &mut clocks,
+        // Unfortunately, the SPI driver requires a clock pin, even though it's not used by the
+        // neopixels.
+        pins.i2c.scl,
+        peripherals.sercom2,
+        &mut peripherals.mclk,
+    );
+
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    let trng = Trng::new(&mut peripherals.mclk, peripherals.trng);
+
+    const NUM_LEDS: usize = 5;
+
+    loop {
+        let rand = trng.random_u8();
+        let pos: usize = rand.wrapping_rem(5) as usize; //random led
+
+        //slowly enable led
+        for j in 0..255u8 {
+            let _ = neopixel.write((0..NUM_LEDS).map(|i| {
+                if i == pos {
+                    hsv2rgb(Hsv {
+                        hue: rand,
+                        sat: 255,
+                        val: sine_ease_in(j as f32, 0.0, 32.0, 255.0) as u8,
+                    })
+                } else {
+                    RGB8::default()
+                }
+            }));
+            delay.delay_ms(5);
+        }
+
+        //slowly disable led - note the reverse .rev()
+        for j in (0..255u8).rev() {
+            let _ = neopixel.write((0..NUM_LEDS).map(|i| {
+                if i == pos {
+                    hsv2rgb(Hsv {
+                        hue: rand,
+                        sat: 255,
+                        val: sine_ease_in(j as f32, 0.0, 32.0, 255.0) as u8,
+                    })
+                } else {
+                    RGB8::default()
+                }
+            }));
+            delay.delay_ms(5);
+        }
+    }
+}
+
+#[inline]
+// current step, where oputput starts, where output ends, last step
+fn sine_ease_in(t: f32, b: f32, c: f32, d: f32) -> f32 {
+    -c * (t / d * FRAC_PI_2).cos() + c + b
+}

--- a/boards/pygamer/examples/neopixel_rainbow.rs
+++ b/boards/pygamer/examples/neopixel_rainbow.rs
@@ -1,0 +1,84 @@
+//! Rotate all neopixel leds through a rainbow. Uses a luckily placed set of SPI
+//! pins as a timer source.
+//!
+//! Note leds may appear white during debug. Either build for release or add
+//! opt-level = 2 to profile.dev in Cargo.toml
+
+#![no_std]
+#![no_main]
+
+#[cfg(not(feature = "panic_led"))]
+use panic_halt as _;
+use pygamer::{entry, hal, pac, Pins};
+
+use hal::{clock::GenericClockController, delay::Delay};
+
+use pac::{CorePeripherals, Peripherals};
+
+use hal::ehal::delay::DelayNs;
+
+use smart_leds::hsv::{hsv2rgb, Hsv};
+use smart_leds::SmartLedsWrite;
+
+#[entry]
+fn main() -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.gclk,
+        &mut peripherals.mclk,
+        &mut peripherals.osc32kctrl,
+        &mut peripherals.oscctrl,
+        &mut peripherals.nvmctrl,
+    );
+    let pins = Pins::new(peripherals.port).split();
+
+    // neopixels
+    let mut neopixel = pins.neopixel.init_spi(
+        &mut clocks,
+        // Unfortunately, the SPI driver requires a clock pin, even though it's not used by the
+        // neopixels.
+        pins.i2c.scl,
+        peripherals.sercom2,
+        &mut peripherals.mclk,
+    );
+
+    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    loop {
+        for j in 0..255u8 {
+            let colors = [
+                // split the color changes across all 5 leds evenly, 255/5=51
+                // and have them safely wrap over when they go above 255
+                hsv2rgb(Hsv {
+                    hue: j,
+                    sat: 255,
+                    val: 32,
+                }),
+                hsv2rgb(Hsv {
+                    hue: j.wrapping_add(51),
+                    sat: 255,
+                    val: 32,
+                }),
+                hsv2rgb(Hsv {
+                    hue: j.wrapping_add(102),
+                    sat: 255,
+                    val: 32,
+                }),
+                hsv2rgb(Hsv {
+                    hue: j.wrapping_add(153),
+                    sat: 255,
+                    val: 32,
+                }),
+                hsv2rgb(Hsv {
+                    hue: j.wrapping_add(204),
+                    sat: 255,
+                    val: 32,
+                }),
+            ];
+
+            neopixel.write(colors.iter().cloned()).unwrap();
+            delay.delay_ms(5);
+        }
+    }
+}

--- a/boards/samd11_bare/CHANGELOG.md
+++ b/boards/samd11_bare/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1](https://github.com/atsamd-rs/atsamd/compare/samd11_bare-0.13.0...samd11_bare-0.13.1) - 2024-12-11
+
+### Other
+
+- updated the following local packages: atsamd-hal
+
 ## [0.13.0](https://github.com/atsamd-rs/atsamd/compare/samd11_bare-0.12.0...samd11_bare-0.13.0) - 2024-11-28
 
 ### Added

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "samd11_bare"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Jesse Braham <jesse@beta7.io>"]
 description = "Support crate for the ATSAMD11C"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
@@ -23,7 +23,7 @@ features = ["critical-section-single-core"]
 
 [dependencies.atsamd-hal]
 path = "../../hal"
-version = "0.20.0"
+version = "0.20.2"
 default-features = false
 
 [dev-dependencies]

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.2](https://github.com/atsamd-rs/atsamd/compare/atsamd-hal-0.20.1...atsamd-hal-0.20.2) - 2024-12-11
+
+### Changed
+
+- *(spi)* Remove explicit flushes from SpiBus impl
+
 ## [0.20.1](https://github.com/atsamd-rs/atsamd/compare/atsamd-hal-0.20.0...atsamd-hal-0.20.1) - 2024-12-05
 
 ### Added

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -20,7 +20,7 @@ name = "atsamd-hal"
 readme = "README.md"
 repository = "https://github.com/atsamd-rs/atsamd"
 rust-version = "1.77.2"
-version = "0.20.1"
+version = "0.20.2"
 
 [package.metadata.docs.rs]
 features = ["samd21g", "samd21g-rt", "usb", "dma", "async"]

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -23,7 +23,7 @@ rust-version = "1.77.2"
 version = "0.20.2"
 
 [package.metadata.docs.rs]
-features = ["samd21g", "samd21g-rt", "usb", "dma", "async"]
+features = ["samd21g", "samd21g-rt", "usb", "dma", "async", "rtic"]
 
 #===============================================================================
 # Required depdendencies
@@ -48,7 +48,7 @@ nb = "1.1"
 num-traits = {version = "0.2.19", default-features = false}
 opaque-debug = "0.3.0"
 paste = "1.0.15"
-portable-atomic = {version = "1.9.0", optional = true, default-features = false, features = ["critical-section"]}
+portable-atomic = {version = "1.10.0", optional = true, features = ["critical-section"]}
 rand_core = "0.6"
 seq-macro = "0.3"
 typenum = "1.12.0"
@@ -69,6 +69,7 @@ jlink_rtt = {version = "0.2", optional = true}
 mcan-core = {version = "0.2", optional = true}
 rtic-monotonic = {version = "1.0", optional = true}
 usb-device = {version = "0.3.2", optional = true}
+rtic-time = {version = "2.0", optional = true}
 
 #===============================================================================
 # PACs
@@ -80,27 +81,27 @@ usb-device = {version = "0.3.2", optional = true}
 # users should specify a corresponding variant (see below). The variant features
 # will select the correct PAC, as well as other configuration features.
 
-atsamd11c = { version = "0.14.1", path = "../pac/atsamd11c", optional = true}
-atsamd11d = { version = "0.14.1", path = "../pac/atsamd11d", optional = true}
+atsamd11c = {version = "0.14.1", path = "../pac/atsamd11c", optional = true}
+atsamd11d = {version = "0.14.1", path = "../pac/atsamd11d", optional = true}
 
-atsamd21e = { version = "0.14.1", path = "../pac/atsamd21e", optional = true}
-atsamd21g = { version = "0.14.1", path = "../pac/atsamd21g", optional = true}
-atsamd21j = { version = "0.14.1", path = "../pac/atsamd21j", optional = true}
+atsamd21e = {version = "0.14.1", path = "../pac/atsamd21e", optional = true}
+atsamd21g = {version = "0.14.1", path = "../pac/atsamd21g", optional = true}
+atsamd21j = {version = "0.14.1", path = "../pac/atsamd21j", optional = true}
 
-atsamd51g = { version = "0.14.1", path = "../pac/atsamd51g", optional = true}
-atsamd51j = { version = "0.14.1", path = "../pac/atsamd51j", optional = true}
-atsamd51n = { version = "0.14.1", path = "../pac/atsamd51n", optional = true}
-atsamd51p = { version = "0.14.1", path = "../pac/atsamd51p", optional = true}
+atsamd51g = {version = "0.14.1", path = "../pac/atsamd51g", optional = true}
+atsamd51j = {version = "0.14.1", path = "../pac/atsamd51j", optional = true}
+atsamd51n = {version = "0.14.1", path = "../pac/atsamd51n", optional = true}
+atsamd51p = {version = "0.14.1", path = "../pac/atsamd51p", optional = true}
 
-atsame51g = { version = "0.14.1", path = "../pac/atsame51g", optional = true}
-atsame51j = { version = "0.14.1", path = "../pac/atsame51j", optional = true}
-atsame51n = { version = "0.14.1", path = "../pac/atsame51n", optional = true}
+atsame51g = {version = "0.14.1", path = "../pac/atsame51g", optional = true}
+atsame51j = {version = "0.14.1", path = "../pac/atsame51j", optional = true}
+atsame51n = {version = "0.14.1", path = "../pac/atsame51n", optional = true}
 
-atsame53j = { version = "0.14.1", path = "../pac/atsame53j", optional = true}
-atsame53n = { version = "0.14.1", path = "../pac/atsame53n", optional = true}
+atsame53j = {version = "0.14.1", path = "../pac/atsame53j", optional = true}
+atsame53n = {version = "0.14.1", path = "../pac/atsame53n", optional = true}
 
-atsame54n = { version = "0.14.1", path = "../pac/atsame54n", optional = true}
-atsame54p = { version = "0.14.1", path = "../pac/atsame54p", optional = true}
+atsame54n = {version = "0.14.1", path = "../pac/atsame54n", optional = true}
+atsame54p = {version = "0.14.1", path = "../pac/atsame54p", optional = true}
 
 #===============================================================================
 # Features
@@ -182,11 +183,11 @@ same54p-rt = ["same54p", "atsame54p/rt"]
 # These features are user-selectable and enable additional features within the
 # HAL, like USB or DMA support.
 can = ["mcan-core"]
-dma = []
 defmt = ["dep:defmt"]
+dma = []
 enable_unsafe_aes_newblock_cipher = []
 max-channels = ["dma"]
-rtic = ["rtic-monotonic"]
+rtic = ["rtic-monotonic", "rtic-time", "portable-atomic"]
 sdmmc = ["embedded-sdmmc"]
 usb = ["usb-device"]
 use_rtt = ["jlink_rtt"]

--- a/hal/src/async_hal/interrupts.rs
+++ b/hal/src/async_hal/interrupts.rs
@@ -1,7 +1,7 @@
 //! # Async interrupts
 //!
-//! This module provides APIs for working with interrupts, tailored towards
-//! async peripherals.
+//! This module provides APIs specific to working with interrupts in an async
+//! peripheral context.
 //!
 //! Asynchronous programming relies on tasks that can be paused and resumed
 //! without blocking the entire program. When an async task is waiting for a
@@ -34,14 +34,10 @@
 //! [`InterruptExt`]: crate::async_hal::interrupts::InterruptExt
 //! [`pac`]: crate::pac
 
+pub use crate::interrupt::*;
+
 use crate::typelevel::Sealed;
-use atsamd_hal_macros::{hal_cfg, hal_macro_helper};
-use core::{
-    mem,
-    sync::atomic::{compiler_fence, Ordering},
-};
-use cortex_m::{interrupt::InterruptNumber, peripheral::NVIC};
-use critical_section::CriticalSection;
+use atsamd_hal_macros::hal_cfg;
 
 /// Marker trait indicating that an interrupt source has one binding and
 /// one handler.
@@ -355,170 +351,3 @@ pub trait Handler<I: InterruptSource>: Sealed {
 ///
 /// This allows drivers to check bindings at compile-time.
 pub unsafe trait Binding<I: InterruptSource, H: Handler<I>> {}
-
-/// An interrupt type that can be configured by the HAL to handle
-/// interrupts.
-///
-/// The PAC defined enum-level interrupts implement this trait.
-pub trait InterruptExt: InterruptNumber + Copy {
-    /// Enable the interrupt.
-    ///
-    /// # Safety
-    ///
-    /// Do not enable any interrupt inside a critical section.
-    #[inline]
-    unsafe fn enable(self) {
-        compiler_fence(Ordering::SeqCst);
-        NVIC::unmask(self)
-    }
-
-    /// Disable the interrupt.
-    #[inline]
-    fn disable(self) {
-        NVIC::mask(self);
-        compiler_fence(Ordering::SeqCst);
-    }
-
-    /// Check if interrupt is enabled.
-    #[inline]
-    fn is_enabled(self) -> bool {
-        NVIC::is_enabled(self)
-    }
-
-    /// Check if interrupt is pending.
-    #[inline]
-    fn is_pending(self) -> bool {
-        NVIC::is_pending(self)
-    }
-
-    /// Set interrupt pending.
-    #[inline]
-    fn pend(self) {
-        NVIC::pend(self)
-    }
-
-    /// Unset interrupt pending.
-    #[inline]
-    fn unpend(self) {
-        NVIC::unpend(self)
-    }
-
-    /// Get the priority of the interrupt.
-    #[inline]
-    fn get_priority(self) -> Priority {
-        Priority::hw2logical(NVIC::get_priority(self))
-    }
-
-    /// Set the interrupt priority.
-    #[inline]
-    #[hal_macro_helper]
-    fn set_priority(self, prio: Priority) {
-        unsafe {
-            let mut nvic = steal_nvic();
-
-            // On thumbv6, set_priority must do a RMW to change 8bit in a 32bit reg.
-            #[hal_cfg(any("nvic-d11", "nvic-d21"))]
-            critical_section::with(|_| nvic.set_priority(self, prio.logical2hw()));
-            // On thumbv7+, set_priority does an atomic 8bit write, so no CS needed.
-            #[hal_cfg("nvic-d5x")]
-            nvic.set_priority(self, prio.logical2hw());
-        }
-    }
-
-    /// Set the interrupt priority with an already-acquired critical section.
-    ///
-    /// Equivalent to [`set_priority`](Self::set_priority), except you pass a
-    /// [`CriticalSection`] to prove you've already acquired a critical
-    /// section. This prevents acquiring another one, which saves code size.
-    #[inline]
-    fn set_priority_with_cs(self, _cs: CriticalSection, prio: Priority) {
-        unsafe {
-            let mut nvic = steal_nvic();
-            nvic.set_priority(self, prio.logical2hw());
-        }
-    }
-}
-
-impl<T: InterruptNumber + Copy> InterruptExt for T {}
-
-#[hal_cfg(any("nvic-d11", "nvic-d21"))]
-const NVIC_PRIO_BITS: u8 = 2;
-#[hal_cfg("nvic-d5x")]
-const NVIC_PRIO_BITS: u8 = 3;
-
-/// Logical interrupt priority level.
-///
-/// P4 is the most urgent, and P1 is the least urgent priority.
-#[hal_cfg(any("nvic-d11", "nvic-d21"))]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[repr(u8)]
-#[allow(missing_docs)]
-pub enum Priority {
-    P1 = 1,
-    P2 = 2,
-    P3 = 3,
-    P4 = 4,
-}
-
-/// Logical interrupt priority level.
-///
-/// P8 is the most urgent, and P1 is the least urgent priority.
-#[hal_cfg("nvic-d5x")]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[repr(u8)]
-#[allow(missing_docs)]
-pub enum Priority {
-    P1 = 1,
-    P2 = 2,
-    P3 = 3,
-    P4 = 4,
-    P5 = 5,
-    P6 = 6,
-    P7 = 7,
-    P8 = 8,
-}
-
-impl Priority {
-    /// Convert a logical priority (where higher priority number = higher
-    /// priority level) to a hardware priority level (where lower priority
-    /// number = higher priority level).
-    ///
-    /// Taken from [`cortex-m-interrupt`]
-    ///
-    /// See LICENSE-MIT for the license.
-    ///
-    /// [`cortex-m-interrupt`]: https://github.com/datdenkikniet/cortex-m-interrupt
-    #[inline]
-    #[must_use]
-    pub const fn logical2hw(self) -> u8 {
-        ((1 << NVIC_PRIO_BITS) - self as u8) << (8 - NVIC_PRIO_BITS)
-    }
-
-    /// Convert a hardware priority level (where lower priority number = higher
-    /// priority level) to a logical priority (where a higher priority number =
-    /// higher priority level).
-    ///
-    /// # Panics
-    ///
-    /// This method may only be used with allowed hardware priority levels. Ie,
-    /// * 0x00,
-    /// * 0x20,
-    /// * 0x40,
-    /// * and so on.
-    ///
-    /// Any other value will cause a panic. To save yourself some
-    /// trouble, use this method only with hardware priority values gotten
-    /// directly from the NVIC.
-    #[inline]
-    #[must_use]
-    pub const fn hw2logical(prio: u8) -> Self {
-        assert!(prio % 0x20 == 0);
-        unsafe { mem::transmute((1 << NVIC_PRIO_BITS) - (prio >> (8 - NVIC_PRIO_BITS))) }
-    }
-}
-
-unsafe fn steal_nvic() -> NVIC {
-    cortex_m::peripheral::Peripherals::steal().NVIC
-}

--- a/hal/src/async_hal/interrupts.rs
+++ b/hal/src/async_hal/interrupts.rs
@@ -199,6 +199,10 @@ seq_macro::seq!(N in 0..= 15 {
     }
 });
 
+// ----------  ADC Interrupt ---------- //
+declare_multiple_interrupts!(ADC0: [ADC0_RESRDY, ADC0_OTHER]);
+declare_multiple_interrupts!(ADC1: [ADC1_RESRDY, ADC1_OTHER]);
+
 /// An interrupt source that may have one or many interrupt bindings.
 ///
 /// This trait may implemented directly when multiple interrupt sources are

--- a/hal/src/delay.rs
+++ b/hal/src/delay.rs
@@ -8,6 +8,8 @@ use crate::clock::GenericClockController;
 use crate::ehal::delay::DelayNs;
 use crate::ehal_02;
 use crate::time::Hertz;
+
+#[hal_cfg("rtc-d5x")]
 use crate::typelevel::Increment;
 
 #[hal_cfg("rtc-d5x")]

--- a/hal/src/delay.rs
+++ b/hal/src/delay.rs
@@ -13,9 +13,7 @@ use crate::time::Hertz;
 use crate::typelevel::Increment;
 
 #[hal_cfg("rtc-d5x")]
-use crate::clock::v2::{
-    Source, gclk::Gclk0Id
-};
+use crate::clock::v2::{gclk::Gclk0Id, Source};
 
 /// System timer (SysTick) as a delay provider
 pub struct Delay {
@@ -38,14 +36,16 @@ impl Delay {
     /// Configures the system timer (SysTick) as a delay provide, compatible
     /// with the V2 clocking API
     pub fn new_with_source<S>(mut syst: SYST, gclk0: S) -> (Self, S::Inc)
-    where S: Source<Id = Gclk0Id> + Increment {
+    where
+        S: Source<Id = Gclk0Id> + Increment,
+    {
         syst.set_clock_source(SystClkSource::Core);
         (
             Delay {
                 syst,
                 sysclock: gclk0.freq(),
             },
-            gclk0.inc()
+            gclk0.inc(),
         )
     }
 

--- a/hal/src/delay.rs
+++ b/hal/src/delay.rs
@@ -7,6 +7,8 @@ use crate::clock::GenericClockController;
 use crate::ehal::delay::DelayNs;
 use crate::ehal_02;
 use crate::time::Hertz;
+use crate::typelevel::Increment;
+use crate::clock::v2::Source;
 
 /// System timer (SysTick) as a delay provider
 pub struct Delay {
@@ -23,6 +25,18 @@ impl Delay {
             syst,
             sysclock: clocks.gclk0().into(),
         }
+    }
+
+    pub fn new_with_source<S>(mut syst: SYST, source: S) -> (Self, S::Inc)
+    where S: Source + Increment {
+        syst.set_clock_source(SystClkSource::Core);
+        (
+            Delay {
+                syst,
+                sysclock: source.freq(),
+            },
+            source.inc()
+        )
     }
 
     /// Releases the system timer (SysTick) resource

--- a/hal/src/interrupt.rs
+++ b/hal/src/interrupt.rs
@@ -1,0 +1,179 @@
+//! Primitives for manipulating interrupts
+
+use core::sync::atomic::{compiler_fence, Ordering};
+
+use crate::pac::NVIC;
+use atsamd_hal_macros::{hal_cfg, hal_macro_helper};
+
+pub use crate::pac::NVIC_PRIO_BITS;
+
+/// Logical interrupt priority level.
+///
+/// P4 is the most urgent, and P1 is the least urgent priority.
+#[hal_cfg(any("nvic-d11", "nvic-d21"))]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+#[allow(missing_docs)]
+pub enum Priority {
+    P1 = 1,
+    P2 = 2,
+    P3 = 3,
+    P4 = 4,
+}
+
+/// Logical interrupt priority level.
+///
+/// P8 is the most urgent, and P1 is the least urgent priority.
+#[hal_cfg("nvic-d5x")]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+#[allow(missing_docs)]
+pub enum Priority {
+    P1 = 1,
+    P2 = 2,
+    P3 = 3,
+    P4 = 4,
+    P5 = 5,
+    P6 = 6,
+    P7 = 7,
+    P8 = 8,
+}
+
+impl Priority {
+    /// Creates the `Priority` from a numeric priority if possible.
+    pub const fn from_numeric(prio: u8) -> Option<Self> {
+        if prio >= 1 && prio <= 8 {
+            Some(unsafe { core::mem::transmute::<u8, Self>(prio) })
+        } else {
+            None
+        }
+    }
+
+    /// Convert a logical priority (where higher priority number = higher
+    /// priority level) to a hardware priority level (where lower priority
+    /// number = higher priority level).
+    ///
+    /// Taken from [`cortex-m-interrupt`]
+    ///
+    /// See LICENSE-MIT for the license.
+    ///
+    /// [`cortex-m-interrupt`]: https://github.com/datdenkikniet/cortex-m-interrupt
+    #[inline]
+    #[must_use]
+    pub const fn logical2hw(self) -> u8 {
+        ((1 << NVIC_PRIO_BITS) - self as u8) << (8 - NVIC_PRIO_BITS)
+    }
+
+    /// Convert a hardware priority level (where lower priority number = higher
+    /// priority level) to a logical priority (where a higher priority number =
+    /// higher priority level).
+    ///
+    /// # Panics
+    ///
+    /// This method may only be used with allowed hardware priority levels. Ie,
+    /// * 0x00,
+    /// * 0x20,
+    /// * 0x40,
+    /// * and so on.
+    ///
+    /// Any other value will cause a panic. To save yourself some
+    /// trouble, use this method only with hardware priority values gotten
+    /// directly from the NVIC.
+    #[inline]
+    #[must_use]
+    pub const fn hw2logical(prio: u8) -> Self {
+        assert!(prio % 0x20 == 0);
+        unsafe { core::mem::transmute((1 << NVIC_PRIO_BITS) - (prio >> (8 - NVIC_PRIO_BITS))) }
+    }
+}
+
+/// An interrupt type that can be configured by the HAL to handle
+/// interrupts.
+///
+/// The PAC defined enum-level interrupts implement this trait.
+pub trait InterruptExt: cortex_m::interrupt::InterruptNumber + Copy {
+    /// Enable the interrupt.
+    ///
+    /// # Safety
+    ///
+    /// Do not enable any interrupt inside a critical section.
+    #[inline]
+    unsafe fn enable(self) {
+        compiler_fence(Ordering::SeqCst);
+        NVIC::unmask(self)
+    }
+
+    /// Disable the interrupt.
+    #[inline]
+    fn disable(self) {
+        NVIC::mask(self);
+        compiler_fence(Ordering::SeqCst);
+    }
+
+    /// Check if interrupt is enabled.
+    #[inline]
+    fn is_enabled(self) -> bool {
+        NVIC::is_enabled(self)
+    }
+
+    /// Check if interrupt is pending.
+    #[inline]
+    fn is_pending(self) -> bool {
+        NVIC::is_pending(self)
+    }
+
+    /// Set interrupt pending.
+    #[inline]
+    fn pend(self) {
+        NVIC::pend(self)
+    }
+
+    /// Unset interrupt pending.
+    #[inline]
+    fn unpend(self) {
+        NVIC::unpend(self)
+    }
+
+    /// Get the priority of the interrupt.
+    #[inline]
+    fn get_priority(self) -> Priority {
+        Priority::hw2logical(NVIC::get_priority(self))
+    }
+
+    /// Set the interrupt priority.
+    #[inline]
+    #[hal_macro_helper]
+    fn set_priority(self, prio: Priority) {
+        unsafe {
+            let mut nvic = steal_nvic();
+
+            // On thumbv6, set_priority must do a RMW to change 8bit in a 32bit reg.
+            #[hal_cfg(any("nvic-d11", "nvic-d21"))]
+            critical_section::with(|_| nvic.set_priority(self, prio.logical2hw()));
+            // On thumbv7+, set_priority does an atomic 8bit write, so no CS needed.
+            #[hal_cfg("nvic-d5x")]
+            nvic.set_priority(self, prio.logical2hw());
+        }
+    }
+
+    /// Set the interrupt priority with an already-acquired critical section.
+    ///
+    /// Equivalent to [`set_priority`](Self::set_priority), except you pass a
+    /// [`CriticalSection`] to prove you've already acquired a critical
+    /// section. This prevents acquiring another one, which saves code size.
+    #[inline]
+    fn set_priority_with_cs(self, _cs: critical_section::CriticalSection, prio: Priority) {
+        unsafe {
+            let mut nvic = steal_nvic();
+            nvic.set_priority(self, prio.logical2hw());
+        }
+    }
+}
+
+impl<T: cortex_m::interrupt::InterruptNumber + Copy> InterruptExt for T {}
+
+unsafe fn steal_nvic() -> NVIC {
+    cortex_m::peripheral::Peripherals::steal().NVIC
+}

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -14,6 +14,9 @@ pub use embedded_hal_async as ehal_async;
 #[cfg(feature = "async")]
 pub use embedded_io_async;
 
+#[cfg(feature = "rtic")]
+pub use rtic_time;
+
 pub mod typelevel;
 mod util;
 
@@ -75,6 +78,8 @@ pub mod async_hal;
 pub mod delay;
 #[cfg(feature = "device")]
 pub mod gpio;
+#[cfg(feature = "device")]
+pub mod interrupt;
 #[cfg(feature = "device")]
 pub mod prelude;
 #[cfg(feature = "device")]

--- a/hal/src/peripherals/adc/adc_settings.rs
+++ b/hal/src/peripherals/adc/adc_settings.rs
@@ -1,0 +1,159 @@
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum AdcSampleCount {
+    Count1 = 1,
+    Count2 = 2,
+    Count4 = 4,
+    Count8 = 8,
+    Count16 = 16,
+    Count32 = 32,
+    Count64 = 64,
+    Count128 = 128,
+    Count256 = 256,
+    Count512 = 512,
+    Count1024 = 1024
+}
+
+#[derive(Copy, Clone)]
+pub enum AdcBitWidth {
+    Eight = 8,
+    Ten = 10,
+    Twelve = 12,
+}
+
+/// Result accumulation strategy for the ADC
+pub enum AdcAccumulation {
+    /// The ADC will read once and then the result is ready
+    Single,
+    /// The ADC will read [AdcSampleCount] samples, average them out
+    /// into a 16 bit wide value, and then the result is ready
+    Average(AdcSampleCount),
+    /// The ADC will read [AdcSampleCount] samples, sum them
+    /// into a 16 bit wide value, and then the result is ready
+    Summed(AdcSampleCount)
+}
+
+#[derive(Copy, Clone)]
+pub enum AdcDivider {
+    Div2 = 2,
+    Div4 = 4,
+    Div8 = 8,
+    Div16 = 16,
+    Div32 = 32,
+    Div64 = 64,
+    Div128 = 128,
+    Div256 = 256
+}
+
+/// # ADC sampling rate settings
+/// 
+/// Multiple factors can affect the ADCs overall sampling rate, and this structure
+/// allows for the configuring of the majority of factors that affect the sample rate of the ADC
+/// 
+/// To begin with, the ADC Clock is driven by the peripheral clock divided with a divider ([AdcDivider]).
+/// 
+/// Each sample is read by the ADC over [AdcSettingsBuilder::sample_clock_cycles] clock cycles, and then
+/// transmitted to the ADC register over [AdcSettingsBuilder::bit_width] clock cycles (1 clock cycle per bit)
+/// 
+/// The ADC can also be configured to combine multiple simultaneous readings in either an average or summed mode
+/// (See [AdcAccumulation]), this also affects the overall sample rate of the ADC as the ADC has to do multiple
+/// samples before a result is ready.
+/// 
+/// Therefore, the overall formula for calculating Sample rate (SPS) can be calculated like so:
+/// 
+/// ## For single sample
+/// ```
+/// SPS = (GCLK_ADC / clk_divider) / (sample_clock_cycles + bit_width)
+/// ```
+/// ## For multiple samples (Averaging or Summed)
+/// ```
+/// SPS = (GCLK_ADC / clk_divider) / (n * (sample_clock_cycles + bit_width))
+/// ```
+pub struct AdcSettingsBuilder {
+    pub clk_divider: AdcDivider,
+    pub sample_clock_cycles: u8,
+    pub bit_width: AdcBitWidth,
+    pub accumulation: AdcAccumulation
+}
+
+impl AdcSettingsBuilder {
+    /// 
+    /// Configure the ADC to sample at 250_000 SPS (Assuming the clock source is 48_000_000) using the following settings:
+    /// * clock divider factor of 32
+    /// * 5 clock cycles per sample
+    /// * 12bit sampling
+    /// * Single accumulation (No averaging or summing)
+    /// 
+    pub fn new() -> Self {
+        Self {
+            clk_divider: AdcDivider::Div32,
+            sample_clock_cycles: 5,
+            bit_width: AdcBitWidth::Twelve,
+            accumulation: AdcAccumulation::Single
+        }
+    }
+
+    /// 
+    /// This setting adjusts the ADC clock frequency by dividing the input clock for the ADC.
+    /// 
+    /// ## Example:
+    /// * Input clock 48MHz, div 32 => ADC Clock is 1.5MHz
+    /// 
+    pub fn clock_divider(mut self, div: AdcDivider) -> Self {
+        self.clk_divider = div;
+        self
+    }
+
+    /// This setting adjusts the bit width of each ADC sample
+    pub fn sample_bit_width(mut self, bit_width: AdcBitWidth) -> Self {
+        self.bit_width = bit_width;
+        self
+    }
+
+    /// Sets how the ADC will accumulate values before actually returning a value.
+    /// 
+    /// The default is single (ADC will return a sample as soon as it is measured)
+    /// 
+    /// Setting [AdcAccumulation::Summed] will make the ADC take 'n' samples, and sum the 
+    /// total before returning it
+    /// 
+    /// Setting [AdcAccumulation::Average] will make the ADC take 'n' samples, and average the 
+    /// total before returning it
+    /// 
+    /// NOTE: Selecting [AdcAccumulation::Summed] or [AdcAccumulation::Average] will reduce the overall
+    /// ADC sample rate by a factor of 1/n, and the returned value will be 16bits long no matter
+    /// what the sample Bit width was selected as
+    pub fn accumulation_method(mut self, method: AdcAccumulation) -> Self {
+        self.accumulation = method;
+        self
+    }
+
+    /// This adjusts the number of ADC clock cycles taken to sample a single sample.
+    /// The higher this number, the longer it will take the ADC to sample each sample.
+    /// 
+    /// ## Safety
+    /// Internally, this function will clamp the minimum input value to 1 to avoid 0
+    /// 
+    pub fn clock_cycles_per_sample(mut self, num: u8) -> Self {
+        self.sample_clock_cycles = 1.max(num); // Prevent 0
+        self
+    }
+
+    /// 
+    /// Returns a calculated sample rate of the ADC with these settings
+    /// 
+    pub fn calculate_sps(&self, clock_freq: u32) -> u32 {
+        let div = self.clk_divider as u32;
+        let adc_clk_freq = clock_freq / div;
+
+        let mut clocks_per_sample = self.sample_clock_cycles as u32 + (self.bit_width as u32);
+
+        let multi = match self.accumulation {
+            AdcAccumulation::Single => 1,
+            AdcAccumulation::Average(adc_sample_count) => adc_sample_count as u32,
+            AdcAccumulation::Summed(adc_sample_count) => adc_sample_count as u32,
+        };
+        clocks_per_sample *= multi as u32;
+        adc_clk_freq / clocks_per_sample
+    }
+}

--- a/hal/src/peripherals/adc/async_api.rs
+++ b/hal/src/peripherals/adc/async_api.rs
@@ -1,0 +1,37 @@
+use core::marker::PhantomData;
+
+use crate::async_hal::interrupts::Handler;
+
+
+pub(super) mod waker {
+    use embassy_sync::waitqueue::AtomicWaker;
+
+    #[allow(clippy::declare_interior_mutable_const)]
+    const NEW_WAKER: AtomicWaker = AtomicWaker::new();
+    pub static ADC_WAKERS: [AtomicWaker; super::super::NUM_ADC] = [NEW_WAKER; super::super::NUM_ADC];
+}
+
+/// Interrupt handler for the ADC peripheral.
+pub struct InterruptHandler<A: super::Adc> {
+    _private: (),
+    _adc: PhantomData<A>
+}
+
+impl<A: super::Adc> crate::typelevel::Sealed for InterruptHandler<A>{}
+
+impl<A: super::Adc> Handler<A::Interrupt> for InterruptHandler<A> {
+    unsafe fn on_interrupt() {
+        let mut peripherals = unsafe { crate::pac::Peripherals::steal() };
+        let adc = A::reg_block(&mut peripherals);
+        critical_section::with(|_| {
+            // Just check if result ready is set. Todo - Handle overrun and other interrupt reasons
+            if adc.intflag().read().resrdy().bit_is_set() {
+                adc.intflag().modify(|_, w| w.resrdy().set_bit());
+                // Wake up!
+                A::waker().wake();
+            } else {
+                // Handle other cases
+            }
+        })
+    }
+}

--- a/hal/src/peripherals/eic/d11/pin.rs
+++ b/hal/src/peripherals/eic/d11/pin.rs
@@ -55,7 +55,7 @@ where
         self.chan
             .eic
             .evctrl()
-            .modify(|r, w| unsafe { w.bits(r.bits() | 1 << P::ChId::ID) });
+            .modify(|r, w| unsafe { w.bits(r.bits() | (1 << P::ChId::ID)) });
     }
 
     pub fn enable_interrupt(&mut self) {
@@ -69,7 +69,7 @@ where
         self.chan
             .eic
             .wakeup()
-            .modify(|r, w| unsafe { w.bits(r.bits() | 1 << P::ChId::ID) })
+            .modify(|r, w| unsafe { w.bits(r.bits() | (1 << P::ChId::ID)) })
     }
 
     pub fn disable_interrupt(&mut self) {

--- a/hal/src/prelude.rs
+++ b/hal/src/prelude.rs
@@ -11,3 +11,9 @@ pub use crate::ehal_02::digital::v2::OutputPin as _atsamd_hal_embedded_hal_digit
 pub use crate::ehal_02::digital::v2::ToggleableOutputPin as _atsamd_hal_embedded_hal_digital_v2_ToggleableOutputPin;
 
 pub use crate::ehal_02::prelude::*;
+
+#[cfg(feature = "rtic")]
+pub use rtic_time::Monotonic as _;
+
+#[cfg(feature = "rtic")]
+pub use fugit::{ExtU64, ExtU64Ceil};

--- a/hal/src/rtc/modes.rs
+++ b/hal/src/rtc/modes.rs
@@ -1,0 +1,405 @@
+//! Provides low-level access to the [Real Time Clock (RTC)](https://onlinedocs.microchip.com/oxy/GUID-F5813793-E016-46F5-A9E2-718D8BCED496-en-US-14/GUID-E17D8859-D42B-4B0E-9B81-76168A0C38AC.html) peripheral on ATSAMD chips.
+//!
+//! The main abstraction is the [`RtcMode`] trait, which exposes
+//! static/associated functions to use the RTC in in a particular mode. All functions are marked as [`inline`](https://matklad.github.io/2021/07/09/inline-in-rust.html)
+//! so that this should be a zero cost abstraction.
+//!
+//! This module is intended to serve as the basis for the safe
+//! [`Rtc`](crate::rtc::Rtc) abstraction as well as RTIC and embassy time
+//! drivers.
+//!
+//! Abstraction benefits:
+//! - Handles all RTC register accesses.
+//! - Handles RTC [register synchronization](https://onlinedocs.microchip.com/oxy/GUID-F5813793-E016-46F5-A9E2-718D8BCED496-en-US-14/GUID-ABE2D37F-8125-4279-9955-BC3900046CFF.html).
+//! - Handles ATSAMD chip variations.
+//!
+//! The idea is that various higher-level users of these abstractions will not
+//! have to handle these low-level aspects of using the RTC. However, this
+//! module does not present a safe interface. For example, many of the methods
+//! in [`RtcMode`] assume that the RTC has already been put into the correct
+//! mode (using [`RtcMode::set_mode`]), but without enforcing this in any way.
+
+// As explained in the [datasheets](https://onlinedocs.microchip.com/oxy/GUID-F5813793-E016-46F5-A9E2-718D8BCED496-en-US-14/GUID-ABE2D37F-8125-4279-9955-BC3900046CFF.html),
+// reading a read-synced register may result in
+// an old value, which we try to avoid by ensuring that SYNCBUSY is clear
+// before reading. A write to a write-synced register will be discarded if
+// syncing is happening during the write. As such, we also ensure that SYNCBUSY
+// is clear before writing to a synced register. Throughout the crate, every
+// register access should be prefaced by a `SYNC` comment indicating the
+// required synchronization. The presence of this comment signals that this
+// access was checked in the datasheet and accounted for.
+
+use crate::pac;
+use atsamd_hal_macros::{hal_cfg, hal_macro_helper};
+use pac::Rtc;
+
+/// Type-level enum for RTC interrupts.
+pub trait RtcInterrupt {
+    /// Enable this interrupt.
+    fn enable(rtc: &Rtc);
+    /// Returns whether the interrupt has been triggered.
+    fn check_flag(rtc: &Rtc) -> bool;
+    /// Clears the interrupt flag so the ISR will not be called again
+    /// immediately.
+    fn clear_flag(rtc: &Rtc);
+}
+
+/// Macro to easily declare an RTC interrupt.
+macro_rules! create_rtc_interrupt {
+    ($mode:ident, $name:ident, $bit:ident) => {
+        #[doc = concat!("Type-level variant for the ", stringify!($name), " interrupt in ", stringify!($mode))]
+        pub enum $name {}
+        impl RtcInterrupt for $name {
+            #[inline]
+            fn enable(rtc: &Rtc) {
+                // SYNC: None
+                rtc.$mode().intenset().write(|w| w.$bit().set_bit());
+            }
+
+            #[inline]
+            fn check_flag(rtc: &Rtc) -> bool {
+                // SYNC: None
+                rtc.$mode().intflag().read().$bit().bit_is_set()
+            }
+
+            #[inline]
+            fn clear_flag(rtc: &Rtc) {
+                // SYNC: None
+                rtc.$mode().intflag().write(|w| w.$bit().set_bit());
+            }
+        }
+    };
+}
+
+/// An abstraction of an RTC in a particular mode that provides low-level
+/// access and handles all register syncing issues using only associated
+/// functions.
+pub trait RtcMode {
+    /// The type of the COUNT register.
+    type Count: Copy + PartialEq + Eq;
+
+    /// Sets this mode in the CTRL register.
+    ///
+    /// # Safety
+    ///
+    /// This can be called any time but is typically only called once before
+    /// calling most other methods.
+    fn set_mode(rtc: &Rtc);
+
+    /// Sets a compare value.
+    ///
+    /// # Safety
+    ///
+    /// Should be called only after setting the RTC mode using
+    /// [`set_mode`](RtcMode::set_mode).
+    fn set_compare(rtc: &Rtc, number: usize, value: Self::Count);
+
+    /// Retrieves a compare from the register.
+    ///
+    /// # Safety
+    ///
+    /// Should be called only after setting the RTC mode using
+    /// [`set_mode`](RtcMode::set_mode).
+    fn get_compare(rtc: &Rtc, number: usize) -> Self::Count;
+
+    /// Returns the current synced COUNT value.
+    ///
+    /// # Safety
+    ///
+    /// Should be called only after setting the RTC mode using
+    /// [`set_mode`](RtcMode::set_mode).
+    fn count(rtc: &Rtc) -> Self::Count;
+
+    /// Returns whether register syncing is currently happening.
+    ///
+    /// # Safety
+    ///
+    /// Can be called any time.
+    #[inline]
+    #[hal_macro_helper]
+    fn sync_busy(rtc: &Rtc) -> bool {
+        // NOTE: This register and field are the same in all modes.
+        // SYNC: None
+        #[hal_cfg(any("rtc-d11", "rtc-d21"))]
+        return rtc.mode0().status().read().syncbusy().bit_is_set();
+        // SYNC: None
+        #[hal_cfg("rtc-d5x")]
+        return rtc.mode0().syncbusy().read().bits() != 0;
+    }
+
+    /// Resets the RTC, leaving it disabled in MODE0.
+    ///
+    /// # Safety
+    ///
+    /// Can be called any time.
+    #[inline]
+    #[hal_macro_helper]
+    fn reset(rtc: &Rtc) {
+        // Reset RTC back to initial settings, which disables it and enters mode 0.
+        // NOTE: This register and field are the same in all modes.
+        // SYNC: Write
+        Self::sync(rtc);
+        #[hal_cfg(any("rtc-d11", "rtc-d21"))]
+        rtc.mode0().ctrl().modify(|_, w| w.swrst().set_bit());
+        #[hal_cfg("rtc-d5x")]
+        rtc.mode0().ctrla().modify(|_, w| w.swrst().set_bit());
+
+        // Wait for the reset to complete
+        // SYNC: Write (we just read though)
+        #[hal_cfg(any("rtc-d11", "rtc-d21"))]
+        while rtc.mode0().ctrl().read().swrst().bit_is_set() {}
+        #[hal_cfg("rtc-d5x")]
+        while rtc.mode0().ctrla().read().swrst().bit_is_set() {}
+    }
+
+    /// Starts the RTC and does any required initialization for this mode.
+    ///
+    /// # Safety
+    ///
+    /// Should be called only after setting the RTC mode using
+    /// [`set_mode`](RtcMode::set_mode).
+    #[inline]
+    #[hal_macro_helper]
+    fn start_and_initialize(rtc: &Rtc) {
+        Self::enable(rtc);
+
+        // Enable counter sync on SAMx5x, the counter cannot be read otherwise.
+        #[hal_cfg("rtc-d5x")]
+        {
+            // Enable counter synchronization
+            // NOTE: This register and field are the same in all modes.
+            // SYNC: Write
+            Self::sync(rtc);
+            rtc.mode0().ctrla().modify(|_, w| w.countsync().set_bit());
+
+            // Errata: The first read of the count is incorrect so we need to read it
+            // then wait for it to change.
+            Self::_wait_for_count_change(rtc);
+        }
+    }
+
+    /// Enables an RTC interrupt.
+    ///
+    /// # Safety
+    ///
+    /// Should be called only after setting the RTC mode using
+    /// [`set_mode`](RtcMode::set_mode).
+    #[inline]
+    fn enable_interrupt<I: RtcInterrupt>(rtc: &Rtc) {
+        I::enable(rtc);
+    }
+
+    /// Returns whether an RTC interrupt has been triggered.
+    ///
+    /// # Safety
+    ///
+    /// Should be called only after setting the RTC mode using
+    /// [`set_mode`](RtcMode::set_mode).
+    #[inline]
+    fn check_interrupt_flag<I: RtcInterrupt>(rtc: &Rtc) -> bool {
+        I::check_flag(rtc)
+    }
+
+    /// Clears an RTC interrupt flag so the ISR will not be called again
+    /// immediately.
+    ///
+    /// # Safety
+    ///
+    /// Should be called only after setting the RTC mode using
+    /// [`set_mode`](RtcMode::set_mode).
+    #[inline]
+    fn clear_interrupt_flag<I: RtcInterrupt>(rtc: &Rtc) {
+        I::clear_flag(rtc);
+    }
+
+    /// Waits for any register syncing to be completed, or returns immediately
+    /// if not currently syncing.
+    ///
+    /// # Safety
+    ///
+    /// Can be called any time.
+    #[inline]
+    fn sync(rtc: &Rtc) {
+        while Self::sync_busy(rtc) {}
+    }
+
+    /// Disables the RTC.
+    ///
+    /// # Safety
+    ///
+    /// Can be called any time.
+    #[inline]
+    #[hal_macro_helper]
+    fn disable(rtc: &Rtc) {
+        // SYNC: Write
+        Self::sync(rtc);
+        // NOTE: This register and field are the same in all modes.
+        #[hal_cfg(any("rtc-d11", "rtc-d21"))]
+        rtc.mode0().ctrl().modify(|_, w| w.enable().clear_bit());
+        #[hal_cfg("rtc-d5x")]
+        rtc.mode0().ctrla().modify(|_, w| w.enable().clear_bit());
+    }
+
+    /// Enables the RTC.
+    ///
+    /// # Safety
+    ///
+    /// Can be called any time.
+    #[inline]
+    #[hal_macro_helper]
+    fn enable(rtc: &Rtc) {
+        // SYNC: Write
+        Self::sync(rtc);
+        // NOTE: This register and field are the same in all modes.
+        #[hal_cfg(any("rtc-d11", "rtc-d21"))]
+        rtc.mode0().ctrl().modify(|_, w| w.enable().set_bit());
+        #[hal_cfg("rtc-d5x")]
+        rtc.mode0().ctrla().modify(|_, w| w.enable().set_bit());
+    }
+
+    /// Waits until the COUNT register changes.
+    ///
+    /// Note that this may not necessarily be the next tick numerically due sync
+    /// delay.
+    ///
+    /// # Safety
+    ///
+    /// Should be called only after setting the RTC mode using
+    /// [`set_mode`](RtcMode::set_mode). This will halt forever if called when
+    /// the RTC is disabled.
+    #[inline]
+    fn _wait_for_count_change(rtc: &Rtc) -> Self::Count {
+        let mut last_count = Self::count(rtc);
+
+        loop {
+            let count = Self::count(rtc);
+
+            if count != last_count {
+                break count;
+            }
+
+            last_count = count;
+        }
+    }
+}
+
+/// Interface for using the RTC in MODE0 (32-bit COUNT)
+pub mod mode0 {
+    use super::*;
+
+    create_rtc_interrupt!(mode0, Compare0, cmp0);
+    #[hal_cfg("rtc-d5x")]
+    create_rtc_interrupt!(mode0, Compare1, cmp1);
+    #[hal_cfg("rtc-d5x")]
+    create_rtc_interrupt!(mode0, Overflow, ovf);
+
+    /// The RTC operating in MODE0 (32-bit COUNT)
+    pub struct RtcMode0;
+
+    impl RtcMode for RtcMode0 {
+        type Count = u32;
+
+        #[inline]
+        #[hal_macro_helper]
+        fn set_mode(rtc: &Rtc) {
+            // SYNC: Write
+            Self::sync(rtc);
+            // NOTE: This register and field are the same in all modes.
+            #[hal_cfg(any("rtc-d11", "rtc-d21"))]
+            rtc.mode0().ctrl().modify(|_, w| w.mode().count32());
+            #[hal_cfg("rtc-d5x")]
+            rtc.mode0().ctrla().modify(|_, w| w.mode().count32());
+        }
+
+        #[inline]
+        fn set_compare(rtc: &Rtc, number: usize, value: Self::Count) {
+            // SYNC: Write
+            Self::sync(rtc);
+            unsafe {
+                rtc.mode0().comp(number).write(|w| w.comp().bits(value));
+            }
+        }
+
+        #[inline]
+        fn get_compare(rtc: &Rtc, number: usize) -> Self::Count {
+            // SYNC: Write (we just read though)
+            rtc.mode0().comp(number).read().bits()
+        }
+
+        #[inline]
+        #[hal_macro_helper]
+        fn count(rtc: &Rtc) -> Self::Count {
+            #[hal_cfg(any("rtc-d11", "rtc-d21"))]
+            {
+                // Request syncing of the COUNT register.
+                // SYNC: None
+                rtc.mode0().readreq().modify(|_, w| w.rreq().set_bit());
+            }
+
+            // SYNC: Read/Write
+            Self::sync(rtc);
+            rtc.mode0().count().read().bits()
+        }
+    }
+}
+
+/// Interface for using the RTC in MODE1 (16-bit COUNT)
+pub mod mode1 {
+    use super::*;
+
+    create_rtc_interrupt!(mode1, Compare0, cmp0);
+    create_rtc_interrupt!(mode1, Compare1, cmp1);
+    create_rtc_interrupt!(mode1, Overflow, ovf);
+
+    /// The RTC operating in MODE1 (16-bit COUNT)
+    pub struct RtcMode1;
+
+    impl RtcMode for RtcMode1 {
+        type Count = u16;
+
+        #[inline]
+        #[hal_macro_helper]
+        fn set_mode(rtc: &Rtc) {
+            // SYNC: Write
+            Self::sync(rtc);
+            // NOTE: This register and field are the same in all modes.
+            #[hal_cfg(any("rtc-d11", "rtc-d21"))]
+            rtc.mode0().ctrl().modify(|_, w| w.mode().count16());
+            #[hal_cfg("rtc-d5x")]
+            rtc.mode0().ctrla().modify(|_, w| w.mode().count16());
+
+            // Set the mode 1 period
+            // SYNC: Write
+            Self::sync(rtc);
+            unsafe { rtc.mode1().per().write(|w| w.bits(0xFFFF)) };
+        }
+
+        #[inline]
+        fn set_compare(rtc: &Rtc, number: usize, value: Self::Count) {
+            // SYNC: Write
+            Self::sync(rtc);
+            unsafe { rtc.mode1().comp(number).write(|w| w.comp().bits(value)) };
+        }
+
+        #[inline]
+        fn get_compare(rtc: &Rtc, number: usize) -> Self::Count {
+            // SYNC: Write (we just read though)
+            rtc.mode1().comp(number).read().bits()
+        }
+
+        #[inline]
+        #[hal_macro_helper]
+        fn count(rtc: &Rtc) -> Self::Count {
+            #[hal_cfg(any("rtc-d11", "rtc-d21"))]
+            {
+                // Request syncing of the COUNT register.
+                // SYNC: None
+                rtc.mode1().readreq().modify(|_, w| w.rreq().set_bit());
+            }
+
+            // SYNC: Read/Write
+            Self::sync(rtc);
+            rtc.mode1().count().read().bits()
+        }
+    }
+}

--- a/hal/src/rtc/rtic/backends.rs
+++ b/hal/src/rtc/rtic/backends.rs
@@ -1,0 +1,323 @@
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __internal_backend_methods {
+    {
+        mode = $mode:ty;
+        rtic_int = $rtic_int:ty;
+        rtc_pac = $rtc_pac: ident;
+        init_compares = $init_compares:block
+        statics = $statics:block
+        enable_interrupts = $enable_interrupts:block
+    }
+    => {
+        /// RTC interrupt handler called before control passes to the
+        /// [`TimerQueue`
+        /// handler`](rtic_time::timer_queue::TimerQueue::on_monotonic_interrupt).
+        ///
+        /// # Safety
+        /// This should only be called from the RTC interrupt handler.
+        #[inline]
+        pub unsafe fn interrupt_handler() {
+            let rtc = pac::Rtc::steal();
+
+            /// Returns whether a < b, taking wrapping into account and assuming
+            /// that the difference is less than a half period.
+            #[inline]
+            fn less_than_with_wrap(
+                a: <$mode as RtcMode>::Count,
+                b: <$mode as RtcMode>::Count,
+            ) -> bool {
+                let d = a.wrapping_sub(b);
+
+                d >= <$mode>::HALF_PERIOD
+            }
+
+            // Ensure that the COUNT is at least the compare value
+            // Due to syncing delay this may not be the case initially
+            // Note that this has to be done here because RTIC will clear the cmp0 flag
+            // before `RtcBackend::on_interrupt` is called.
+            if <$mode>::check_interrupt_flag::<$rtic_int>(&rtc) {
+                let compare = <$mode>::get_compare(&rtc, 0);
+
+                while less_than_with_wrap(<$mode>::count(&rtc), compare) {}
+            }
+
+            Self::timer_queue().on_monotonic_interrupt();
+        }
+
+        /// Starts the clock.
+        ///
+        /// **Do not use this function directly.**
+        ///
+        /// Use the crate level macros instead, then call `start` on the monotonic.
+        pub fn _start($rtc_pac: pac::Rtc) {
+            // Disable the RTC.
+            <$mode>::disable(&$rtc_pac);
+
+            // Reset RTC back to initial settings, which disables it and enters mode 0.
+            <$mode>::reset(&$rtc_pac);
+
+            // Set the RTC mode
+            <$mode>::set_mode(&$rtc_pac);
+
+            $init_compares
+
+            // Timing critical, make sure we don't get interrupted.
+            critical_section::with(|_| {
+                // Start the timer and initialize it
+                <$mode>::start_and_initialize(&$rtc_pac);
+
+                // Clear the triggered compare flag
+                <$mode>::clear_interrupt_flag::<$rtic_int>(&$rtc_pac);
+
+                // Enable the compare interrupt
+                <$mode>::enable_interrupt::<$rtic_int>(&$rtc_pac);
+
+                $statics
+
+                $enable_interrupts
+
+                // Enable the RTC interrupt in the NVIC and set its priority.
+                // SAFETY: We take full ownership of the peripheral and interrupt vector,
+                // plus we are not using any external shared resources so we won't impact
+                // basepri/source masking based critical sections.
+                unsafe {
+                    $crate::rtc::rtic::set_monotonic_prio(pac::Interrupt::RTC);
+                    pac::NVIC::unmask(pac::Interrupt::RTC);
+                }
+            });
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __internal_basic_backend {
+    ($name:ident, $mode:ty, $mode_num:literal, $rtic_int:ty) => {
+        use atsamd_hal_macros::hal_cfg;
+        use rtic_time::timer_queue::{TimerQueue, TimerQueueBackend};
+        use $crate::pac;
+        use $crate::rtc::modes::RtcMode;
+
+        #[doc = concat!("Basic RTC-based [`TimerQueueBackend`] without period counting that uses the RTC in mode ", stringify!($mode_num), ".")]
+        pub struct $name;
+
+        static RTC_TQ: TimerQueue<$name> = TimerQueue::new();
+
+        impl $name {
+            $crate::__internal_backend_methods! {
+                mode = $mode;
+                rtic_int = $rtic_int;
+                rtc_pac = rtc;
+                init_compares = {
+                    // Set the the initial compare
+                    <$mode>::set_compare(&rtc, 0, 0);
+                }
+                statics = {
+                    // Initialize the timer queue
+                    RTC_TQ.initialize(Self);
+                }
+                enable_interrupts = {
+                    // Enable the compare interrupt
+                    <$mode>::enable_interrupt::<$rtic_int>(&rtc);
+                }
+            }
+        }
+
+        impl TimerQueueBackend for $name {
+            type Ticks = <$mode as RtcMode>::Count;
+
+            fn now() -> Self::Ticks {
+                <$mode>::count(unsafe { &pac::Rtc::steal() })
+            }
+
+            fn enable_timer() {
+                <$mode>::enable(unsafe { &pac::Rtc::steal() });
+            }
+
+            fn disable_timer() {
+                <$mode>::disable(unsafe { &pac::Rtc::steal() });
+            }
+
+            fn on_interrupt() {
+                // There is nothing we need to do here
+            }
+
+            fn set_compare(mut instant: Self::Ticks) {
+                let rtc = unsafe { pac::Rtc::steal() };
+
+                // Evidently the compare interrupt will not trigger if the instant is within a
+                // couple of ticks, so delay it a bit if it is too close.
+                // This is not mentioned in the documentation or errata, but is known to be an
+                // issue for other microcontrollers as well (e.g. nRF family).
+                if instant.saturating_sub(Self::now())
+                    < <$mode>::MIN_COMPARE_TICKS
+                {
+                    instant = instant.wrapping_add(<$mode>::MIN_COMPARE_TICKS)
+                }
+
+                unsafe { <$mode>::set_compare(&rtc, 0, instant) };
+            }
+
+            fn clear_compare_flag() {
+                <$mode>::clear_interrupt_flag::<$rtic_int>(unsafe { &pac::Rtc::steal() });
+            }
+
+            fn pend_interrupt() {
+                pac::NVIC::pend(pac::Interrupt::RTC);
+            }
+
+            fn timer_queue() -> &'static TimerQueue<Self> {
+                &RTC_TQ
+            }
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __internal_half_period_counting_backend {
+    ($name:ident, $mode:ty, $mode_num:literal, $rtic_int:ty, $half_period_int:ty, $overflow_int:ty) => {
+        use atsamd_hal_macros::hal_cfg;
+        use core::sync::atomic::Ordering;
+        use portable_atomic::AtomicU64;
+        use rtic_time::{
+            half_period_counter::calculate_now,
+            timer_queue::{TimerQueue, TimerQueueBackend},
+        };
+        use $crate::pac;
+
+        struct TimerValue(<$mode as RtcMode>::Count);
+        impl rtic_time::half_period_counter::TimerValue for TimerValue {
+            const BITS: u32 = <$mode as RtcMode>::Count::BITS;
+        }
+        impl From<TimerValue> for u64 {
+            fn from(value: TimerValue) -> Self {
+                Self::from(value.0)
+            }
+        }
+
+        #[doc = concat!("An RTC-based [`TimerQueueBackend`] using [half-period counting](rtic_time::half_period_counter) that uses the RTC in mode ", stringify!($mode_num), ".")]
+        pub struct $name;
+
+        static RTC_PERIOD_COUNT: AtomicU64 = AtomicU64::new(0);
+        static RTC_TQ: TimerQueue<$name> = TimerQueue::new();
+
+        impl $name {
+            $crate::__internal_backend_methods! {
+                mode = $mode;
+                rtic_int = $rtic_int;
+                rtc_pac = rtc;
+                init_compares = {
+                    // Configure the compare registers
+                    <$mode>::set_compare(&rtc, 0, 0);
+                    <$mode>::set_compare(&rtc, 1, <$mode>::HALF_PERIOD);
+                }
+                statics = {
+                    // Make sure period counter is synced with the timer value
+                    RTC_PERIOD_COUNT.store(0, Ordering::SeqCst);
+
+                    // Initialize the timer queue
+                    RTC_TQ.initialize(Self);
+                }
+                enable_interrupts = {
+                    // Enable the compare and overflow interrupts.
+                    <$mode>::enable_interrupt::<$rtic_int>(&rtc);
+                    <$mode>::enable_interrupt::<$half_period_int>(&rtc);
+                    <$mode>::enable_interrupt::<$overflow_int>(&rtc);
+                }
+            }
+        }
+
+        impl TimerQueueBackend for RtcBackend {
+            type Ticks = u64;
+
+            fn now() -> Self::Ticks {
+                calculate_now(
+                    || RTC_PERIOD_COUNT.load(Ordering::Relaxed),
+                    || TimerValue(<$mode>::count(unsafe { &pac::Rtc::steal() })),
+                )
+            }
+
+            fn enable_timer() {
+                <$mode>::enable(unsafe { &pac::Rtc::steal() });
+            }
+
+            fn disable_timer() {
+                <$mode>::disable(unsafe { &pac::Rtc::steal() });
+            }
+
+            fn on_interrupt() {
+                let rtc: pac::Rtc = unsafe { pac::Rtc::steal() };
+
+                // NOTE: The cmp0 flag is cleared when RTIC calls `clear_compare_flag`.
+                if <$mode>::check_interrupt_flag::<$half_period_int>(&rtc) {
+                    <$mode>::clear_interrupt_flag::<$half_period_int>(&rtc);
+                    let prev = RTC_PERIOD_COUNT.fetch_add(1, Ordering::Relaxed);
+                    assert!(prev % 2 == 0, "Monotonic must have skipped an interrupt!");
+
+                    // Ensure that the COUNT has crossed
+                    // Due to syncing delay this may not be the case initially
+                    while <$mode>::count(&rtc) < <$mode>::HALF_PERIOD {}
+                }
+                if <$mode>::check_interrupt_flag::<$overflow_int>(&rtc) {
+                    <$mode>::clear_interrupt_flag::<$overflow_int>(&rtc);
+                    let prev = RTC_PERIOD_COUNT.fetch_add(1, Ordering::Relaxed);
+                    assert!(prev % 2 == 1, "Monotonic must have skipped an interrupt!");
+
+                    // Ensure that the COUNT has wrapped
+                    // Due to syncing delay this may not be the case initially
+                    while <$mode>::count(&rtc) > <$mode>::HALF_PERIOD {}
+                }
+            }
+
+            fn set_compare(mut instant: Self::Ticks) {
+                let rtc = unsafe { pac::Rtc::steal() };
+
+                const MAX: u64 = <$mode as RtcMode>::Count::MAX as u64;
+
+                // Disable interrupts because this section is timing critical.
+                // We rely on the fact that this entire section runs within one
+                // RTC clock tick. (which it will do easily if it doesn't get
+                // interrupted)
+                critical_section::with(|_| {
+                    let now = Self::now();
+
+                    // Wrapping_sub deals with the u64 overflow corner case
+                    let diff = instant.wrapping_sub(now);
+                    let val = if diff <= MAX {
+                        // Now we know `instant` will happen within one `MAX` time duration.
+
+                        // Evidently the compare interrupt will not trigger if the instant is within a
+                        // couple of ticks, so delay it a bit if it is too close.
+                        // This is not mentioned in the documentation or errata, but is known to be an
+                        // issue for other microcontrollers as well (e.g. nRF family).
+                        if diff < <$mode>::MIN_COMPARE_TICKS.into() {
+                            instant = instant
+                                .wrapping_add(<$mode>::MIN_COMPARE_TICKS.into());
+                        }
+
+                        (instant & MAX) as <$mode as RtcMode>::Count
+                    } else {
+                        // Just wait a full hardware counter period
+                        <$mode>::count(&rtc).wrapping_sub(1)
+                    };
+
+                    <$mode>::set_compare(&rtc, 0, val);
+                });
+            }
+
+            fn clear_compare_flag() {
+                <$mode>::clear_interrupt_flag::<$rtic_int>(unsafe { &pac::Rtc::steal() });
+            }
+
+            fn pend_interrupt() {
+                pac::NVIC::pend(pac::Interrupt::RTC);
+            }
+
+            fn timer_queue() -> &'static TimerQueue<Self> {
+                &RTC_TQ
+            }
+        }
+    };
+}

--- a/hal/src/rtc/rtic/mod.rs
+++ b/hal/src/rtc/rtic/mod.rs
@@ -1,0 +1,340 @@
+//! [`Monotonic`](rtic_time::Monotonic) implementations using the Real Time
+//! Clock (RTC).
+//!
+//! Enabling the `rtic` feature is required to use this module.
+//!
+//! For RTIC v1, the old [`rtic_monotonic::Monotonic`] trait is implemented for
+//! [`Rtc`](crate::rtc::Rtc) in [`Count32Mode`](crate::rtc::Count32Mode) in the
+//! [`v1`] module. A monotonic for RTIC v2 is provided here.
+//!
+//! # RTC clock selection
+//!
+//! Prior to starting the monotonic, the RTC clock source must be configured
+//! using [`clocks`](crate::clock). On SAMD11/21 platforms, the RTC clock must
+//! be setup as a [generic clock](crate::clock::GenericClockController).
+//! On SAMx5x platforms the RTC clock must be selected from either the 1.1024
+//! kHz clock or the 32.768 kHz clock, either of which can be internal or
+//! external.
+//!
+//! **NOTE: Eventually, starting the monotonic will require proof that the RTC
+//! clock has been configured. However, this requires v2 of the clock API for
+//! SAMx5x chips, which is not yet fully supported in the rest of the HAL.**
+//!
+//! # RTC modes
+//!
+//! The RTC on all chip variants has two counter modes: mode 0 features a 32-bit
+//! hardware counter, and mode 1 features a a 16-bit hardware counter but some
+//! additional features. Part of the [`Monotonic`](rtic_time::Monotonic)
+//! contract is that the monotonic should always count up and never roll over
+//! back to time zero. However, even the 32-bit hardware counter will overflow
+//! after about 36 hours using the faster clock rate, which is not acceptable.
+//!
+//! A technique known as [half-period counting
+//! (HPC)](rtic_time::half_period_counter) is used to effectively increase the
+//! montononic counter to be 64 bits wide in either mode. The result is a
+//! monotonic that effectively counts up forever without rolling over. This
+//! technique requires two compare registers, one for waking RTIC tasks and one
+//! for HPC. The number of compare registers available on ATSAMD chips is as
+//! follows:
+//!
+//! |            | SAMD11/21 | SAMx5x |
+//! | -----------| --------- | ------ |
+//! | **Mode 0** | 1         | 2      |
+//! | **Mode 1** | 2         | 4      |
+//!
+//! As a result, HPC can be done in mode 0 for SAMx5x chips but requires mode 1
+//! for SAMD11/21 variants. The monotonic provided for each variant uses the
+//! appropriate RTC mode.
+//!
+//! The monotonics have the following specifications:
+//!
+//! |                                      | 1 kHz clock        | 32 kHz clock        |
+//! | ------------------------------------ | ------------------ | ------------------- |
+//! | **Rollover period**                  | ~571 million years | ~17.8 million years |
+//! | **HPC interrupt period (SAMD11/21)** | 32 seconds         | 1 second            |
+//! | **HPC interrupt period (SAMx5x)**    | ~24 days           | ~18 hours           |
+//! | **Time resolution**                  | ~977 μs            | ~31 μs              |
+//!
+//! # Usage
+//!
+//! The monotonic should be created using the
+//! [macro](crate::rtc_monotonic). The first macro argument is the name of
+//! the global structure that will implement
+//! [`Monotonic`](rtic_time::Monotonic). The RTC clock rate must be
+//! known at compile time, and so the appropriate type from [`rtc_clock`] must
+//! be passed to the macro as the second argument.
+//!
+//! Sometime during initialization, the monotonic also must be started by
+//! calling the `start` method on the created monotonic. The
+//! [`Rtc`](crate::pac::Rtc) peripheral struct must be passed to `start` to
+//! ensure that the monotonic has complete control of the RTC.
+//!
+//! Note that the macro creates the RTC interrupt handler, and starting the
+//! monotonic enables RTC interrupts in the NVIC, so that this does not need to
+//! be done manually.
+//!
+//! # Example
+//!
+//! ```
+//! use atsamd_hal::prelude::*;
+//! use atsamd_hal::rtc::rtic::rtc_clock;
+//!
+//! // Create the monotonic struct named `Mono`
+//! rtc_monotonic!(Mono, rtc_clock::Clock32k);
+//!
+//! // Uncomment if not using the RTIC RTOS:
+//! // #[no_mangle]
+//! // static RTIC_ASYNC_MAX_LOGICAL_PRIO: u8 = 1;
+//! //
+//! // This tells the monotonic driver the maximum interrupt
+//! // priority it's allowed to use. RTIC sets it automatically,
+//! // but you need to set it manually if you're writing
+//! // a RTIC-less app.
+//!
+//! fn init() {
+//!     # // This is normally provided by the selected PAC
+//!     # let rtc = unsafe { core::mem::transmute(()) };
+//!     # let mut mclk = unsafe { core::mem::transmute(()) };
+//!     # let mut osc32kctrl = unsafe { core::mem::transmute(()) };
+//!     // Here the RTC clock source should be configured using the clocks API
+//!
+//!     // Start the monotonic
+//!     Mono::start(rtc);
+//! }
+//!
+//! async fn usage() {
+//!     loop {
+//!          // Use the monotonic
+//!          let timestamp = Mono::now();
+//!
+//!          Mono::delay_until(timestamp + 2u32.secs()).await;
+//!          Mono::delay(100u32.millis()).await;
+//!     }
+//! }
+//! ```
+//!
+//! # Other notes
+//!
+//! The number returned by
+//! [`Monotonic::now().ticks()`](rtic_monotonic::Monotonic::now) will always
+//! increase (barring monotonic rollover). However, due to the register
+//! [synchronization delay](https://onlinedocs.microchip.com/oxy/GUID-F5813793-E016-46F5-A9E2-718D8BCED496-en-US-14/GUID-0C52DB00-4BF6-4F41-85B5-B76529875364.html),
+//! the number returned may not always increment by one every time it changes.
+//! In fact, testing shows that it typically increments by four every time it
+//! changes. This is true regardless of the clock rate used, as the
+//! synchronization delay scales along with the clock period.
+
+/// Items for RTIC v1.
+///
+/// This mainly implements [`rtic_monotonic::Monotonic`] for
+/// [`Rtc<Count32Mode>`](crate::rtc::Rtc).
+///
+/// This will be removed in a future release, users should migrate to RTIC v2.
+#[deprecated]
+pub mod v1 {
+    use crate::rtc::{Count32Mode, Rtc};
+    use rtic_monotonic::Monotonic;
+
+    /// The RTC clock frequency in Hz.
+    pub const CLOCK_FREQ: u32 = 32_768;
+
+    /// The [`fugit`] time instant.
+    pub type Instant = fugit::Instant<u32, 1, CLOCK_FREQ>;
+    /// The [`fugit`] time duration.
+    pub type Duration = fugit::Duration<u32, 1, CLOCK_FREQ>;
+
+    impl Monotonic for Rtc<Count32Mode> {
+        type Instant = Instant;
+        type Duration = Duration;
+        unsafe fn reset(&mut self) {
+            // Since reset is only called once, we use it to enable the interrupt generation
+            // bit.
+            self.mode0().intenset().write(|w| w.cmp0().set_bit());
+        }
+
+        fn now(&mut self) -> Self::Instant {
+            Self::Instant::from_ticks(self.count32())
+        }
+
+        fn zero() -> Self::Instant {
+            Self::Instant::from_ticks(0)
+        }
+
+        fn set_compare(&mut self, instant: Self::Instant) {
+            unsafe {
+                self.mode0()
+                    .comp(0)
+                    .write(|w| w.comp().bits(instant.ticks()))
+            }
+        }
+
+        fn clear_compare_flag(&mut self) {
+            self.mode0().intflag().write(|w| w.cmp0().set_bit());
+        }
+    }
+}
+
+mod backends;
+
+use super::modes::{mode0::RtcMode0, mode1::RtcMode1, RtcMode};
+use crate::interrupt::{Priority, NVIC_PRIO_BITS};
+use atsamd_hal_macros::hal_cfg;
+
+/// Types used to specify the RTC clock rate at compile time when creating the
+/// monotonics.
+///
+/// These types utilize [type-level programming](crate::typelevel)
+/// techniques and are passed to the [monotonic creation
+/// macro](crate::rtc_monotonic).
+/// The RTC clock rate must be specified at compile time so that the `Instant`
+/// and `Duration` types in
+/// [`TimerQueueBasedMonotonic`](rtic_time::monotonic::TimerQueueBasedMonotonic)
+/// can be specified.
+pub mod rtc_clock {
+    /// Type-level enum for available RTC clock rates.
+    pub trait RtcClockRate {
+        const RATE_HZ: u32;
+    }
+
+    /// Type level [`RtcClockRate`] variant for the 32.768 kHz clock rate.
+    pub enum Clock32k {}
+    impl RtcClockRate for Clock32k {
+        const RATE_HZ: u32 = 32_768;
+    }
+
+    /// Type level [`RtcClockRate`] variant for the 1.024 kHz clock rate.
+    pub enum Clock1k {}
+    impl RtcClockRate for Clock1k {
+        const RATE_HZ: u32 = 1_024;
+    }
+
+    /// Type level [`RtcClockRate`] variant for a custom clock rate
+    pub enum ClockCustom<const RATE_HZ: u32> {}
+    impl<const RATE_HZ: u32> RtcClockRate for ClockCustom<RATE_HZ> {
+        const RATE_HZ: u32 = RATE_HZ;
+    }
+}
+
+trait RtcModeMonotonic: RtcMode {
+    /// The COUNT value representing a half period.
+    const HALF_PERIOD: Self::Count;
+    /// The minimum number of ticks that compares need to be ahead of the COUNT
+    /// in order to trigger.
+    const MIN_COMPARE_TICKS: Self::Count;
+}
+impl RtcModeMonotonic for RtcMode0 {
+    const HALF_PERIOD: Self::Count = 0x8000_0000;
+    const MIN_COMPARE_TICKS: Self::Count = 8;
+}
+impl RtcModeMonotonic for RtcMode1 {
+    const HALF_PERIOD: Self::Count = 0x8000;
+    const MIN_COMPARE_TICKS: Self::Count = 8;
+}
+
+mod backend {
+    use super::*;
+
+    // For SAMD11/21 chips mode 1 is the only sensible option
+    #[hal_cfg(any("rtc-d11", "rtc-d21"))]
+    use crate::rtc::modes::mode1::{Compare0, Compare1, Overflow};
+
+    #[hal_cfg(any("rtc-d11", "rtc-d21"))]
+    crate::__internal_half_period_counting_backend!(
+        RtcBackend, RtcMode1, 1, Compare0, Compare1, Overflow
+    );
+
+    // For SAMx5x mode 0 is the best option
+    #[hal_cfg("rtc-d5x")]
+    use crate::rtc::modes::mode0::{Compare0, Compare1, Overflow};
+
+    #[hal_cfg("rtc-d5x")]
+    crate::__internal_half_period_counting_backend!(
+        RtcBackend, RtcMode0, 0, Compare0, Compare1, Overflow
+    );
+}
+
+pub use backend::RtcBackend;
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __internal_create_rtc_interrupt {
+    ($backend:ident) => {
+        #[no_mangle]
+        #[allow(non_snake_case)]
+        unsafe extern "C" fn RTC() {
+            $crate::rtc::rtic::$backend::interrupt_handler();
+        }
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __internal_create_rtc_struct {
+    ($name:ident, $backend:ident, $clock_rate:ty) => {
+        /// A `Monotonic` based on the RTC peripheral.
+        pub struct $name;
+
+        impl $name {
+            /// This method must be called only once.
+            pub fn start(rtc: $crate::pac::Rtc) {
+                use $crate::rtc::rtic::rtc_clock::*;
+                $crate::__internal_create_rtc_interrupt!($backend);
+
+                $crate::rtc::rtic::$backend::_start(rtc);
+            }
+        }
+
+        use $crate::rtc::rtic::rtc_clock::RtcClockRate;
+
+        impl $crate::rtic_time::monotonic::TimerQueueBasedMonotonic for $name {
+            type Backend = $crate::rtc::rtic::$backend;
+            type Instant = $crate::fugit::Instant<
+                <Self::Backend as $crate::rtic_time::timer_queue::TimerQueueBackend>::Ticks,
+                1,
+                { <$clock_rate>::RATE_HZ },
+            >;
+            type Duration = $crate::fugit::Duration<
+                <Self::Backend as $crate::rtic_time::timer_queue::TimerQueueBackend>::Ticks,
+                1,
+                { <$clock_rate>::RATE_HZ },
+            >;
+        }
+
+        $crate::rtic_time::impl_embedded_hal_delay_fugit!($name);
+        $crate::rtic_time::impl_embedded_hal_async_delay_fugit!($name);
+    };
+}
+
+/// Create an RTIC v2 monotonic that uses the RTC.
+///
+/// See the [`rtic`](crate::rtc::rtic) module for details.
+#[macro_export]
+macro_rules! rtc_monotonic {
+    ($name:ident, $clock_rate: ty) => {
+        $crate::__internal_create_rtc_struct!($name, RtcBackend, $clock_rate);
+    };
+}
+
+/// This function was modified from the private function in `rtic-monotonics`,
+/// part of the [`rtic`](https://github.com/rtic-rs/rtic) project.
+///
+/// Note that this depends on the static variable `RTIC_ASYNC_MAX_LOGICAL_PRIO`
+/// defined as part of RTIC. Refer to the example in the [`rtic`
+/// module](crate::rtc::rtic) documentation for more details.
+///
+/// See LICENSE-MIT and LICENSE-APACHE for the licenses.
+unsafe fn set_monotonic_prio(interrupt: impl cortex_m::interrupt::InterruptNumber) {
+    extern "C" {
+        static RTIC_ASYNC_MAX_LOGICAL_PRIO: u8;
+    }
+
+    let max_prio = RTIC_ASYNC_MAX_LOGICAL_PRIO.clamp(1, 1 << NVIC_PRIO_BITS);
+    let hw_prio = Priority::from_numeric(max_prio).unwrap().logical2hw();
+
+    // We take ownership of the entire IRQ and all settings to it, we only change
+    // settings for the IRQ we control.
+    // This will also compile-error in case the NVIC changes in size.
+    let mut nvic: cortex_m::peripheral::NVIC = core::mem::transmute(());
+
+    nvic.set_priority(interrupt, hw_prio);
+}

--- a/hal/src/sercom/i2c/reg.rs
+++ b/hal/src/sercom/i2c/reg.rs
@@ -543,5 +543,5 @@ fn encode_write_address(addr_7_bits: u8) -> u16 {
 }
 
 fn encode_read_address(addr_7_bits: u8) -> u16 {
-    (addr_7_bits as u16) << 1 | 1
+    ((addr_7_bits as u16) << 1) | 1
 }


### PR DESCRIPTION
# Draft PR - Don't merge

As mentioned in #796 , the ADC code requires a re-write in order to make it compatible with Clock V2 API, and to give it an async API. 

This Draft PR will track progress I'm making towards this goal.

I've so far created a settings builder type that should be compatible with both 21 and 51 series chips, it allows the user to configure more parameters on how the ADC will sample its data (Along with some good defaults). This is required since due to Clock V2, the ADC clock might not be running at 48Mhz, meaning there is no way to assume the actual sample rate of the ADC at the HAL level, therefore this settings builder also has a `calculate_sps` method so that the user can get an estimated sample rate of the ADC with their desired settings.

