### PR TITLE
chore(wio_terminal): Fix arrow in examples/buttons

### DIFF
--- a/boards/wio_terminal/examples/buttons.rs
+++ b/boards/wio_terminal/examples/buttons.rs
@@ -114,9 +114,9 @@ where
                 .draw(display)
                 .ok();
             Triangle::new(
-                Point::new(90, 115),
-                Point::new(85, 120),
-                Point::new(90, 125),
+                Point::new(100, 115),
+                Point::new(95, 120),
+                Point::new(100, 125),
             )
             .into_styled(style)
             .draw(display)


### PR DESCRIPTION
# Summary

Fix issue that the arrow head and tail were separated.

The left arrow tail was moved in #645 but the head was not. This PR moves the arrow head to align with the tail.

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 
