### PR TITLE
Changes durations in the `time` module to use `u64` instead of `u32`

### DIFF
--- a/boards/feather_m0/examples/async_timer.rs
+++ b/boards/feather_m0/examples/async_timer.rs
@@ -1,6 +1,7 @@
 #![no_std]
 #![no_main]
 
+use atsamd_hal::time::Milliseconds;
 #[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;
 #[cfg(feature = "use_semihosting")]
@@ -11,7 +12,6 @@ use feather_m0 as bsp;
 use hal::{
     clock::{enable_internal_32kosc, ClockGenId, ClockSource, GenericClockController},
     ehal::digital::StatefulOutputPin,
-    fugit::MillisDurationU32,
     pac::Tc4,
     timer::TimerCounter,
 };
@@ -48,9 +48,7 @@ async fn main(_s: embassy_executor::Spawner) {
     let mut timer = timer.into_future(Irqs);
 
     loop {
-        timer
-            .delay(MillisDurationU32::from_ticks(500).convert())
-            .await;
+        timer.delay(Milliseconds::from_ticks(500).convert()).await;
         red_led.toggle().unwrap();
     }
 }

--- a/boards/metro_m4/examples/async_timer.rs
+++ b/boards/metro_m4/examples/async_timer.rs
@@ -1,13 +1,13 @@
 #![no_std]
 #![no_main]
 
+use atsamd_hal::time::Milliseconds;
 #[cfg(not(feature = "use_semihosting"))]
 use panic_halt as _;
 #[cfg(feature = "use_semihosting")]
 use panic_semihosting as _;
 
 use bsp::{hal, pac, pin_alias};
-use hal::fugit::MillisDurationU32;
 use hal::{
     clock::GenericClockController, ehal::digital::StatefulOutputPin, pac::Tc4, timer::TimerCounter,
 };
@@ -41,9 +41,7 @@ async fn main(_s: embassy_executor::Spawner) {
     let mut timer = timer.into_future(Irqs);
 
     loop {
-        timer
-            .delay(MillisDurationU32::from_ticks(500).convert())
-            .await;
+        timer.delay(Milliseconds::from_ticks(500).convert()).await;
         red_led.toggle().unwrap();
     }
 }

--- a/hal/src/peripherals/timer/async_api.rs
+++ b/hal/src/peripherals/timer/async_api.rs
@@ -6,6 +6,7 @@
 use crate::{
     async_hal::interrupts::{Binding, Handler, Interrupt},
     pac,
+    time::Nanoseconds,
     timer_traits::InterruptDrivenTimer,
     typelevel::Sealed,
 };
@@ -17,7 +18,6 @@ use core::{
     task::{Poll, Waker},
 };
 use embassy_sync::waitqueue::AtomicWaker;
-use fugit::NanosDurationU32;
 use portable_atomic::AtomicBool;
 
 use crate::peripherals::timer;
@@ -186,7 +186,7 @@ where
 {
     /// Delay asynchronously
     #[inline]
-    pub async fn delay(&mut self, count: NanosDurationU32) {
+    pub async fn delay(&mut self, count: Nanoseconds) {
         self.timer.start(count);
         self.timer.enable_interrupt();
 
@@ -217,7 +217,8 @@ where
     T: AsyncCount16,
 {
     async fn delay_ns(&mut self, ns: u32) {
-        self.delay(NanosDurationU32::from_ticks(ns).convert()).await;
+        self.delay(Nanoseconds::from_ticks(ns.into()).convert())
+            .await;
     }
 }
 

--- a/hal/src/peripherals/timer/d11.rs
+++ b/hal/src/peripherals/timer/d11.rs
@@ -2,7 +2,6 @@
 use core::convert::Infallible;
 
 use atsamd_hal_macros::hal_cfg;
-use fugit::NanosDurationU32;
 
 use crate::ehal_02::timer::{CountDown, Periodic};
 use crate::pac::Pm;
@@ -86,7 +85,7 @@ where
         self.tc.count_16().intenset().write(|w| w.ovf().set_bit());
     }
 
-    fn start<T: Into<NanosDurationU32>>(&mut self, timeout: T) {
+    fn start<T: Into<Nanoseconds>>(&mut self, timeout: T) {
         let params = TimerParams::new_ns(timeout.into(), self.freq);
         let divider = params.divider;
         let cycles = params.cycles;

--- a/hal/src/peripherals/timer/d5x.rs
+++ b/hal/src/peripherals/timer/d5x.rs
@@ -2,7 +2,6 @@
 use core::convert::Infallible;
 
 use atsamd_hal_macros::hal_cfg;
-use fugit::NanosDurationU32;
 
 use crate::ehal_02::timer::{CountDown, Periodic};
 use crate::pac::tc0::Count16 as Count16Reg;
@@ -85,7 +84,7 @@ where
 
     fn start<T>(&mut self, timeout: T)
     where
-        T: Into<NanosDurationU32>,
+        T: Into<Nanoseconds>,
     {
         let params = TimerParams::new_ns(timeout.into(), self.freq);
         let divider = params.divider;

--- a/hal/src/prelude.rs
+++ b/hal/src/prelude.rs
@@ -1,7 +1,8 @@
 //! Import the prelude to gain convenient access to helper traits
 pub use crate::eic::EicPin;
 pub use crate::timer_traits::InterruptDrivenTimer;
-pub use fugit::ExtU32 as _;
+pub use fugit::ExtU64 as _;
+pub use fugit::ExtU64Ceil as _;
 pub use fugit::RateExtU32 as _;
 
 // embedded-hal doesn’t yet have v2 in its prelude, so we need to
@@ -14,6 +15,3 @@ pub use crate::ehal_02::prelude::*;
 
 #[cfg(feature = "rtic")]
 pub use rtic_time::Monotonic as _;
-
-#[cfg(feature = "rtic")]
-pub use fugit::{ExtU64, ExtU64Ceil};

--- a/hal/src/rtc/mod.rs
+++ b/hal/src/rtc/mod.rs
@@ -1,6 +1,5 @@
 //! Real-time clock/counter
 use atsamd_hal_macros::{hal_cfg, hal_macro_helper};
-use fugit::NanosDurationU32;
 
 use crate::ehal_02;
 use crate::pac;
@@ -383,7 +382,7 @@ impl InterruptDrivenTimer for Rtc<Count32Mode> {
 
     fn start<T>(&mut self, timeout: T)
     where
-        T: Into<NanosDurationU32>,
+        T: Into<Nanoseconds>,
     {
         let params = TimerParams::new_us(timeout, self.rtc_clock_freq);
         let divider = params.divider;
@@ -458,8 +457,7 @@ impl TimerParams {
     pub fn new_us(timeout: impl Into<Nanoseconds>, src_freq: impl Into<Hertz>) -> Self {
         let timeout = timeout.into();
         let src_freq = src_freq.into();
-        let ticks: u32 =
-            (timeout.to_nanos() as u64 * src_freq.to_Hz() as u64 / 1_000_000_000_u64) as u32;
+        let ticks: u32 = (timeout.to_nanos() * src_freq.to_Hz() as u64 / 1_000_000_000_u64) as u32;
         Self::new_from_ticks(ticks)
     }
 

--- a/hal/src/time.rs
+++ b/hal/src/time.rs
@@ -14,13 +14,13 @@ pub type MegaHertz = fugit::MegahertzU32;
 // Period based
 
 /// Seconds
-pub type Seconds = fugit::SecsDurationU32;
+pub type Seconds = fugit::SecsDurationU64;
 
 /// Milliseconds
-pub type Milliseconds = fugit::MillisDurationU32;
+pub type Milliseconds = fugit::MillisDurationU64;
 
 /// Microseconds
-pub type Microseconds = fugit::MicrosDurationU32;
+pub type Microseconds = fugit::MicrosDurationU64;
 
 /// Nanoseconds
-pub type Nanoseconds = fugit::NanosDurationU32;
+pub type Nanoseconds = fugit::NanosDurationU64;

--- a/hal/src/timer_params.rs
+++ b/hal/src/timer_params.rs
@@ -17,8 +17,7 @@ impl TimerParams {
 
     /// calculates TimerParams from a given period based timeout.
     pub fn new_ns(timeout: Nanoseconds, src_freq: Hertz) -> Self {
-        let ticks: u32 =
-            (timeout.to_nanos() as u64 * src_freq.to_Hz() as u64 / 1_000_000_000_u64) as u32;
+        let ticks: u32 = (timeout.to_nanos() * src_freq.to_Hz() as u64 / 1_000_000_000_u64) as u32;
         Self::new_from_ticks(ticks)
     }
 
@@ -51,7 +50,7 @@ impl TimerParams {
 
 #[cfg(test)]
 mod tests {
-    use crate::fugit::{ExtU32, RateExtU32};
+    use crate::fugit::{ExtU64, RateExtU32};
     use crate::timer_params::TimerParams;
 
     #[test]

--- a/hal/src/timer_traits.rs
+++ b/hal/src/timer_traits.rs
@@ -1,6 +1,6 @@
 use core::convert::Infallible;
 
-use fugit::NanosDurationU32;
+use crate::time::Nanoseconds;
 
 /// Specifies a timer that can enable & disable an interrupt that fires
 /// when the timer expires
@@ -9,7 +9,7 @@ pub trait InterruptDrivenTimer {
     fn enable_interrupt(&mut self);
 
     /// Start the timer with a given timeout in nanoseconds
-    fn start<T: Into<NanosDurationU32>>(&mut self, timeout: T);
+    fn start<T: Into<Nanoseconds>>(&mut self, timeout: T);
 
     /// Wait for the timer to finish counting down **without blocking**.
     fn wait(&mut self) -> nb::Result<(), Infallible>;


### PR DESCRIPTION
# Summary

Currently many time durations pass/stored throughout the HAL use nanoseconds for maximum precision. However these are stored using a `u32` for a maximum of about 4 seconds. Since delays/times longer than this could be useful and should be possible, this changes all type defs in the `time` module to use `u64` instead, extending the maximum time (when stored as nanoseconds) to over 584 years.

There were also several places in the HAL that import `fugit` duration types directly. These were changed to use the type defs in the `time` time module instead so that the entire HAL uses these exclusively.

See the commit message for more details.

Note that the rate/frequency types defined in `time` still use `u32` as rates above 4 GHz are not likely to be useful.

Also note that this _is_ a breaking change.

# Checklist
  - [X] All new or modified code is well documented, especially public items
  - [X] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 