### PR TITLE
feat: Add new EHAL InputPin traits to EIC

### DIFF
--- a/hal/src/peripherals/eic/d11/mod.rs
+++ b/hal/src/peripherals/eic/d11/mod.rs
@@ -1,4 +1,5 @@
 mod pin;
+mod pin2;
 
 #[cfg(feature = "async")]
 pub(super) mod async_api {

--- a/hal/src/peripherals/eic/d11/pin2.rs
+++ b/hal/src/peripherals/eic/d11/pin2.rs
@@ -1,0 +1,31 @@
+use crate::ehal::digital::{InputPin,ErrorType};
+use crate::eic::*;
+
+
+// This conflicts with async path already implementing it
+#[cfg(not(feature = "async"))]
+impl<P, Id> ErrorType for ExtInt<P, Id, EicFuture>
+where
+    P: EicPin,
+    Id: ChId,
+    Self: InputPin<Error = Infallible>,
+{
+    type Error = Infallible;
+}
+
+
+impl<P, Id, F> InputPin for ExtInt<P, Id, F>
+ where Self: ErrorType,
+       P: EicPin,
+       Id: ChId,
+{
+    #[inline]
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.pin._is_high())
+    }
+
+    #[inline]
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.pin._is_low())
+    }
+}

--- a/hal/src/peripherals/eic/d5x/mod.rs
+++ b/hal/src/peripherals/eic/d5x/mod.rs
@@ -2,6 +2,7 @@ use super::{ChId, Channel};
 use crate::pac;
 
 mod pin;
+mod pin2;
 
 impl<Id: ChId, F> Channel<Id, F> {
     /// Run the provided closure with the EIC peripheral disabled. The

--- a/hal/src/peripherals/eic/d5x/pin2.rs
+++ b/hal/src/peripherals/eic/d5x/pin2.rs
@@ -1,0 +1,30 @@
+use crate::ehal::digital::{InputPin,ErrorType};
+use crate::eic::*;
+
+// This conflicts with async path already implementing it
+#[cfg(not(feature = "async"))]
+impl<P, Id> ErrorType for ExtInt<P, Id, EicFuture>
+where
+    P: EicPin,
+    Id: ChId,
+    Self: InputPin<Error = Infallible>,
+{
+    type Error = Infallible;
+}
+
+
+impl<P, Id, F> InputPin for ExtInt<P, Id, F>
+ where Self: ErrorType,
+       P: EicPin,
+       Id: ChId,
+{
+    #[inline]
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.pin._is_high())
+    }
+
+    #[inline]
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.pin._is_low())
+    }
+}


### PR DESCRIPTION
# Summary
Adding Ehal 1.0 InputPin trait implementations. I'm not sure if this is the cleanest / expected way to implement them. Can also put them back in `pin` modules.

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 
