### PR TITLE
Tidy, mainly documentation links

### DIFF
--- a/atsamd-hal-macros/src/generation.rs
+++ b/atsamd-hal-macros/src/generation.rs
@@ -77,6 +77,13 @@ pub fn hal_expr_to_devices(expr: &HalExpr) -> Result<BTreeSet<&'static str>, Err
             }
             Ok(devices)
         }
+        HalExpr::Not(arg) => {
+            let mut devices = all_devices();
+            for device in hal_expr_to_devices(arg)? {
+                devices.remove(device);
+            }
+            Ok(devices)
+        }
         HalExpr::Peripheral(lit) => Ok(lookup_peripheral(lit)?.iter().copied().collect()),
     }
 }

--- a/atsamd-hal-macros/src/lib.rs
+++ b/atsamd-hal-macros/src/lib.rs
@@ -71,7 +71,7 @@ fn hal_cfg_impl(args: TokenStream) -> Result<Group, Error> {
 /// )]
 /// pub mod calibration {}
 ///
-/// #[hal_module("aes")
+/// #[hal_module("aes")]
 /// pub mod aes {}
 /// ```
 ///

--- a/atsamd-hal-macros/src/lib.rs
+++ b/atsamd-hal-macros/src/lib.rs
@@ -22,6 +22,8 @@
 //!   `any("pm-d11", "pm-d21", "rstc-d5x")`.
 //! - An expression of the form `all([peripheral expression], ...)`. Example:
 //!   `all("tc4", "tc5")`.
+//! - An expression of the form `not([peripheral expression])`. Example:
+//!   `not("dmac-d5x")`.
 
 use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
 

--- a/boards/matrix_portal_m4/examples/blinky_basic.rs
+++ b/boards/matrix_portal_m4/examples/blinky_basic.rs
@@ -2,7 +2,6 @@
 #![no_main]
 
 use matrix_portal_m4::{entry, hal, pac, Pins};
-#[cfg(not(feature = "panic_led"))]
 use panic_halt as _;
 
 use hal::clock::GenericClockController;

--- a/hal/src/async_hal/interrupts.rs
+++ b/hal/src/async_hal/interrupts.rs
@@ -321,6 +321,8 @@ pub trait Interrupt: crate::typelevel::Sealed {
     /// Equivalent to [`set_priority`](Self::set_priority), except you pass a
     /// [`CriticalSection`] to prove you've already acquired a critical
     /// section. This prevents acquiring another one, which saves code size.
+    ///
+    /// [`CriticalSection`]: critical_section::CriticalSection
     #[inline]
     fn set_priority_with_cs(cs: critical_section::CriticalSection, prio: Priority) {
         Self::IRQ.set_priority_with_cs(cs, prio)

--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -401,6 +401,14 @@ where
             .modify(|_, w| w.threshold().variant(threshold));
     }
 
+    #[cfg(doc)]
+    #[hal_cfg(not("dmac-d5x"))]
+    /// This method is not present with the selected feature set, defined for
+    /// documentation only
+    pub fn fifo_threshold(&mut self) {
+        unimplemented!()
+    }
+
     /// Set burst length for the channel, in number of beats. A burst transfer
     /// is an atomic, uninterruptible operation.
     #[hal_cfg("dmac-d5x")]
@@ -409,6 +417,14 @@ where
         self.regs
             .chctrla
             .modify(|_, w| w.burstlen().variant(burst_length));
+    }
+
+    #[cfg(doc)]
+    #[hal_cfg(not("dmac-d5x"))]
+    /// This method is not present with the selected feature set, defined for
+    /// documentation only
+    pub fn burst_length(&mut self) {
+        unimplemented!()
     }
 
     /// Start the transfer.

--- a/hal/src/gpio/mod.rs
+++ b/hal/src/gpio/mod.rs
@@ -1,7 +1,7 @@
 //! # GPIO
 //!
 //! The GPIO module is used to configure GPIO pins through the
-//! [PORT](crate::pac::PORT) interface.
+//! [Port](crate::pac::Port) interface.
 //!
 //! ## Versions
 //!

--- a/hal/src/gpio/pin.rs
+++ b/hal/src/gpio/pin.rs
@@ -91,6 +91,7 @@
 //! [type classes]: crate::typelevel#type-classes
 //! [type-level enum]: crate::typelevel#type-level-enum
 //! [`OptionalKind`]: crate::typelevel#optionalkind-trait-pattern
+//! [`ToggleableOutputPin`]: crate::ehal_02::digital::v2::ToggleableOutputPin
 //! [`AnyKind`]: crate::typelevel#anykind-trait-pattern
 
 #![allow(clippy::zero_prefixed_literal)]

--- a/hal/src/interrupt.rs
+++ b/hal/src/interrupt.rs
@@ -163,6 +163,8 @@ pub trait InterruptExt: cortex_m::interrupt::InterruptNumber + Copy {
     /// Equivalent to [`set_priority`](Self::set_priority), except you pass a
     /// [`CriticalSection`] to prove you've already acquired a critical
     /// section. This prevents acquiring another one, which saves code size.
+    ///
+    /// [`CriticalSection`]: critical_section::CriticalSection
     #[inline]
     fn set_priority_with_cs(self, _cs: critical_section::CriticalSection, prio: Priority) {
         unsafe {

--- a/hal/src/peripherals/clock/d5x/v2.rs
+++ b/hal/src/peripherals/clock/d5x/v2.rs
@@ -768,10 +768,10 @@
 //! ```
 //!
 //! [PAC]: crate::pac
-//! [`OSCCTRL`]: crate::pac::OSCCTRL
-//! [`OSC32KCTRL`]: crate::pac::OSC32KCTRL
-//! [`GCLK`]: crate::pac::GCLK
-//! [`MCLK`]: crate::pac::MCLK
+//! [`OSCCTRL`]: crate::pac::Oscctrl
+//! [`OSC32KCTRL`]: crate::pac::Osc32kctrl
+//! [`GCLK`]: crate::pac::Gclk
+//! [`MCLK`]: crate::pac::Mclk
 //! [`Peripherals::steal`]: crate::pac::Peripherals::steal
 //!
 //! [`Ahb`]: ahb::Ahb
@@ -783,7 +783,6 @@
 //! [`Apb::enable`]: apb::Apb::enable
 //! [`ApbClk`]: apb::ApbClk
 //! [`ApbClk<A>`]: apb::ApbClk
-//! [`ApbClk::enable`]: apb::ApbClk::enable
 //! [`ApbClks`]: apb::ApbClks
 //! [`ApbToken`]: apb::ApbToken
 //!

--- a/hal/src/peripherals/eic.rs
+++ b/hal/src/peripherals/eic.rs
@@ -146,6 +146,14 @@ where
             chan,
         }
     }
+
+    #[cfg(all(doc, feature = "async"))]
+    #[hal_cfg(not("eic-d5x"))]
+    /// This method is not present with the selected feature set, defined for
+    /// documentation only
+    pub fn into_future(self) {
+        unimplemented!()
+    }
 }
 
 /// EIC channel.
@@ -241,6 +249,14 @@ impl Eic {
         }
 
         eic
+    }
+
+    #[cfg(all(doc, feature = "async"))]
+    #[hal_cfg(not(any("eic-d11", "eic-d21")))]
+    /// This method is not present with the selected feature set, defined for
+    /// documentation only
+    pub fn into_future(self) {
+        unimplemented!()
     }
 
     /// Release the EIC and return the register block.

--- a/hal/src/peripherals/eic.rs
+++ b/hal/src/peripherals/eic.rs
@@ -150,7 +150,7 @@ where
 
 /// EIC channel.
 ///
-/// Use this struct to create an [`ExtInt`](pins::ExtInt) by calling
+/// Use this struct to create an [`ExtInt`] by calling
 /// [`with_pin`](Self::with_pin).
 pub struct Channel<Id: ChId, F = NoneT> {
     eic: core::mem::ManuallyDrop<pac::Eic>,

--- a/hal/src/sercom/i2c.rs
+++ b/hal/src/sercom/i2c.rs
@@ -3,16 +3,16 @@
 //! Configuring an I2C peripheral occurs in three steps. First, you must create
 //! a set of [`Pads`] for use by the peripheral. Next, you assemble pieces into
 //! a [`Config`] struct. After configuring the peripheral, you then [`enable`]
-//! it, yielding a functional [`I2c`] struct.
-//! Transactions are performed using the [`i2c`](embedded_hal::blocking::i2c)
-//! traits from embedded HAL.
+//! it, yielding a functional [`I2c`] struct. Transactions are performed using
+//! traits from embedded-hal ([v1.0](crate::ehal) and blocking traits from
+//! [v0.2](`crate::ehal_02`)).
 //!
 //! # [`Pads`]
 //!
-//! A [`Sercom`] uses two [`Pin`]s as peripheral [`Pad`]s, but only
-//! certain [`Pin`] combinations are acceptable. In particular, all [`Pin`]s
-//! must be mapped to the same [`Sercom`], and SDA is always [`Pad0`], while SCL
-//! is always [`Pad1`] (see the datasheet). This HAL makes it impossible to use
+//! A [`Sercom`] uses two [`Pin`]s as peripheral [`Pad`]s, but only certain
+//! [`Pin`] combinations are acceptable. In particular, all [`Pin`]s must be
+//! mapped to the same [`Sercom`], and SDA is always [`Pad0`], while SCL is
+//! always [`Pad1`] (see the datasheet). This HAL makes it impossible to use
 //! invalid [`Pin`]/[`Pad`] combinations, and the [`Pads`] struct is responsible
 //! for enforcing these constraints.
 //!
@@ -74,8 +74,8 @@
 //!
 //! # [`Config`]
 //!
-//! Next, create a [`Config`] struct, which represents the I2C peripheral in
-//! its disabled state. A [`Config`] is specified with one type parameters, the
+//! Next, create a [`Config`] struct, which represents the I2C peripheral in its
+//! disabled state. A [`Config`] is specified with one type parameters, the
 //! [`Pads`] type.
 //!
 //! Upon creation, the [`Config`] takes ownership of both the [`Pads`] struct
@@ -135,8 +135,8 @@
 //! [`I2c`] structs can only be created from a [`Config`]. They have one type
 //! parameter, representing the underlying [`Config`].
 //!
-//! Only the [`I2c`] struct can actually perform
-//! transactions. To do so, use the [`embedded_hal::i2c::I2c`] trait.
+//! Only the [`I2c`] struct can actually perform transactions. To do so, use the
+//! [`embedded_hal::i2c::I2c`] trait.
 //!
 //! ```
 //! use embedded_hal::i2c::I2c;
@@ -146,9 +146,9 @@
 //!
 //! # Reading the current configuration
 //!
-//! The `AsRef<Config<P>>` trait is implemented for `I2c<Config<P>>`.
-//! This means you can use the `get_` methods implemented for `Config`, since
-//! they take an `&self` argument.
+//! The `AsRef<Config<P>>` trait is implemented for `I2c<Config<P>>`. This means
+//! you can use the `get_` methods implemented for `Config`, since they take an
+//! `&self` argument.
 //!
 //! ```no_run
 //! // Assume i2c is a I2c<C<P>>
@@ -191,8 +191,8 @@
 //! [`I2c::with_dma_channel`] to attach a DMA channel to the [`I2c`] struct. A
 //! DMA-enabled [`I2c`] implements the blocking
 //! [`embedded_hal::i2c::I2c`](crate::ehal::i2c::I2c) trait, which can be used
-//! to perform I2C transfers which are fast, continuous and low jitter, even
-//! if they are preemped by a higher priority interrupt.
+//! to perform I2C transfers which are fast, continuous and low jitter, even if
+//! they are preemped by a higher priority interrupt.
 //!
 //!
 //! ```no_run
@@ -236,9 +236,8 @@
 //!
 //! # `async` operation <span class="stab portability" title="Available on crate feature `async` only"><code>async</code></span>
 //!
-//! An [`I2c`] can be used for
-//! `async` operations. Configuring an [`I2c`] in async mode is relatively
-//! simple:
+//! An [`I2c`] can be used for `async` operations. Configuring an [`I2c`] in
+//! async mode is relatively simple:
 //!
 //! * Bind the corresponding `SERCOM` interrupt source to the SPI
 //!   [`InterruptHandler`] (refer to the module-level [`async_hal`]
@@ -250,8 +249,8 @@
 //! * Use the provided async methods for reading or writing to the I2C
 //!   peripheral. [`I2cFuture`] implements [`embedded_hal_async::i2c::I2c`].
 //!
-//! `I2cFuture` implements `AsRef<I2c>` and `AsMut<I2c>` so
-//! that it can be reconfigured using the regular [`I2c`] methods.
+//! `I2cFuture` implements `AsRef<I2c>` and `AsMut<I2c>` so that it can be
+//! reconfigured using the regular [`I2c`] methods.
 //!
 //! ## Considerations when using `async` [`I2c`] with DMA <span class="stab portability" title="Available on crate feature `async` only"><code>async</code></span> <span class="stab portability" title="Available on crate feature `dma` only"><code>dma</code></span>
 //!
@@ -288,9 +287,9 @@
 //! This means that using functions like [`futures::select_biased`] to implement
 //! timeouts is safe; transfers will be safely cancelled if the timeout expires.
 //!
-//! This also means that should you [`forget`] this [`Future`] after its
-//! first [`poll`] call, the transfer will keep running, ruining the
-//! now-reclaimed memory, as well as the rest of your day.
+//! This also means that should you [`forget`] this [`Future`] after its first
+//! [`poll`] call, the transfer will keep running, ruining the now-reclaimed
+//! memory, as well as the rest of your day.
 //!
 //! * `await`ing is fine: the [`Future`] will run to completion.
 //! * Dropping an incomplete transfer is also fine. Dropping can happen, for

--- a/hal/src/sercom/pad.rs
+++ b/hal/src/sercom/pad.rs
@@ -356,3 +356,27 @@ mod ioset {
 
 #[hal_cfg("sercom0-d5x")]
 pub use ioset::*;
+
+#[cfg(doc)]
+#[hal_cfg(not("sercom0-d5x"))]
+/// This trait is not present with the selected feature set, defined for
+/// documentation only
+pub trait IoSet {}
+
+#[cfg(doc)]
+#[hal_cfg(not("sercom0-d5x"))]
+/// This trait is not present with the selected feature set, defined for
+/// documentation only
+pub trait InIoSet {}
+
+#[cfg(doc)]
+#[hal_cfg(not("sercom0-d5x"))]
+/// This type is not present with the selected feature set, defined for
+/// documentation only
+pub enum UndocIoSet1 {}
+
+#[cfg(doc)]
+#[hal_cfg(not("sercom0-d5x"))]
+/// This type is not present with the selected feature set, defined for
+/// documentation only
+pub enum UndocIoSet2 {}

--- a/hal/src/sercom/spi.rs
+++ b/hal/src/sercom/spi.rs
@@ -480,6 +480,34 @@ pub use pads::*;
 )]
 pub mod size {}
 
+#[cfg(doc)]
+#[hal_cfg(not(any("sercom0-d11", "sercom0-d21")))]
+/// This type is not present with the selected feature set, defined for
+/// documentation only
+pub enum NineBit {}
+
+#[cfg(doc)]
+#[hal_cfg(not(any("sercom0-d11", "sercom0-d21")))]
+/// This type is not present with the selected feature set, defined for
+/// documentation only
+pub enum EightBit {}
+
+#[cfg(doc)]
+#[hal_cfg(not(any("sercom0-d11", "sercom0-d21")))]
+/// This trait is not present with the selected feature set, defined for
+/// documentation only
+pub trait CharSize {
+    /// This type is not present with the selected feature set, defined for
+    /// documentation only
+    type Word;
+}
+
+#[cfg(doc)]
+#[hal_cfg(not("sercom0-d5x"))]
+/// This trait is not present with the selected feature set, defined for
+/// documentation only
+pub trait Length {}
+
 pub use size::*;
 
 /// Valid transaction [`Length`]s from the [`typenum`] crate
@@ -1777,6 +1805,16 @@ where
     #[inline]
     pub fn set_dyn_length(&mut self, length: u8) {
         self.config.set_dyn_length(length);
+    }
+}
+
+#[cfg(doc)]
+#[hal_cfg(not("sercom0-d5x"))]
+impl<C: ValidConfig, R, T> Spi<C, Tx, R, T> {
+    /// This method is not present with the selected feature set, defined for
+    /// documentation only
+    pub fn get_dyn_length(&self) -> u8 {
+        unimplemented!()
     }
 }
 

--- a/hal/src/sercom/spi.rs
+++ b/hal/src/sercom/spi.rs
@@ -1,22 +1,21 @@
 //! Use a SERCOM peripheral for SPI transactions
 //!
 //! Using an SPI peripheral occurs in three steps. First, you must supply
-//! [`gpio`] [`Pin`]s to create a set of [`Pads`]. Next, you combine the
-//! `Pads` with other pieces to form a [`Config`] struct. Finally, after
-//! configuring the peripheral, you [`enable`] it to yield a functional
-//! [`Spi`] struct. Transactions are performed using traits from the
-//! [`embedded_hal`] crate, specifically those from the
-//! [`spi`](embedded_hal::spi), [`serial`](embedded_hal::serial), and
-//! [`blocking`](embedded_hal::blocking) modules.
+//! [`gpio`] [`Pin`]s to create a set of [`Pads`]. Next, you combine the `Pads`
+//! with other pieces to form a [`Config`] struct. Finally, after configuring
+//! the peripheral, you [`enable`] it to yield a functional [`Spi`] struct.
+//! Transactions are performed using traits from the Embedded HAL crates,
+//! specifically those from the [`spi`](ehal::spi),
+//! [`serial`](embedded_hal_02::serial), and
+//! [`blocking`](embedded_hal_02::blocking) modules.
 //!
 //! # Crating a set of [`Pads`]
 //!
 //! An SPI peripheral can use up to four [`Pin`]s as [`Sercom`] pads. However,
 //! only certain `Pin` combinations are acceptable. All `Pin`s must be mapped to
 //! the same `Sercom`, and for SAMx5x chips, they must also belong to the same
-//! `IoSet`.
-//! This HAL makes it impossible to use invalid `Pin` combinations, and the
-//! [`Pads`] struct is responsible for enforcing these constraints.
+//! `IoSet`. This HAL makes it impossible to use invalid `Pin` combinations, and
+//! the [`Pads`] struct is responsible for enforcing these constraints.
 //!
 //! A `Pads` type takes five or six type parameters, depending on the chip. The
 //! first type always specifies the `Sercom`. On SAMx5x chips, the second type
@@ -51,9 +50,9 @@
 //! [`PinMode`]: crate::gpio::pin::PinMode
 //!
 //!
-//! Alternatively, you can use the `PadsFromIds` alias to define a set of
-//! `Pads` in terms of [`PinId`]s instead of [`Pin`]s. This is useful when you
-//! don't have [`Pin`] aliases pre-defined.
+//! Alternatively, you can use the `PadsFromIds` alias to define a set of `Pads`
+//! in terms of [`PinId`]s instead of [`Pin`]s. This is useful when you don't
+//! have [`Pin`] aliases pre-defined.
 //!
 //! ```
 //! use atsamd_hal::gpio::{PA08, PA09};
@@ -108,16 +107,13 @@
 //!
 //! Next, create a [`Config`] struct, which represents the SPI peripheral in its
 //! disabled state. A `Config` is specified with three type parameters: the
-//! [`Pads`] type; an [`OpMode`], which defaults to [`Master`]; and a
-//! [`Size`] type that varies by chip. [`Size`] essentially acts as a trait
-//! alias. On SAMD11 and SAMD21 chips, it represents the
-//! `CharSize`, which can either be `EightBit` or `NineBit`.
-//! While on SAMx5x chips, it represents the transaction
-//! `Length`
-//! in bytes, using type-level numbers provided by the [`typenum`] crate. Valid
-//! transaction lengths, from `U1` to `U255`, are re-exported in the
-//! `lengths`
-//! sub-module.
+//! [`Pads`] type; an [`OpMode`], which defaults to [`Master`]; and a [`Size`]
+//! type that varies by chip. [`Size`] essentially acts as a trait alias. On
+//! SAMD11 and SAMD21 chips, it represents the `CharSize`, which can either be
+//! `EightBit` or `NineBit`. While on SAMx5x chips, it represents the
+//! transaction `Length` in bytes, using type-level numbers provided by the
+//! [`typenum`] crate. Valid transaction lengths, from `U1` to `U255`, are
+//! re-exported in the `lengths` sub-module.
 //!
 //! ```
 //! use atsamd_hal::gpio::{PA08, PA09};
@@ -241,14 +237,12 @@
 //! ```
 //!
 //! Only [`Spi`] structs can actually perform transactions. To do so, use the
-//! various embedded HAL traits, like
-//! [`spi::SpiBus`](crate::ehal::spi::SpiBus),
+//! various embedded HAL traits, like [`spi::SpiBus`](crate::ehal::spi::SpiBus),
 //! [`embedded_io::Read`], [`embedded_io::Write`],
 //! [`embedded_hal_nb::serial::Read`](crate::ehal_nb::serial::Read), or
-//! [`embedded_hal_nb::serial::Write`](crate::ehal_nb::serial::Write).
-//! See the [`impl_ehal`] module documentation for more details about the
-//! specific trait implementations, which vary based on [`Size`] and
-//! [`Capability`].
+//! [`embedded_hal_nb::serial::Write`](crate::ehal_nb::serial::Write). See the
+//! [`impl_ehal`] module documentation for more details about the specific trait
+//! implementations, which vary based on [`Size`] and [`Capability`].
 //!
 //! ```
 //! use nb::block;
@@ -273,7 +267,8 @@
 //! implementations automatically take care of flushing, so no further flushing
 //! is needed.
 //!
-//! [See the embedded-hal spec](https://docs.rs/embedded-hal/latest/embedded_hal/spi/index.html#flushing)
+//! [See the embedded-hal
+//! spec](https://docs.rs/embedded-hal/latest/embedded_hal/spi/index.html#flushing)
 //! for more information.
 //!
 //! # [`PanicOnRead`] and [`PanicOnWrite`]
@@ -299,8 +294,8 @@
 //! This HAL includes support for DMA-enabled SPI transfers. Use
 //! [`Spi::with_dma_channels`] ([`Duplex`] and [`Rx`]), and
 //! [`Spi::with_tx_channel`] ([`Tx`]-only) to attach DMA channels to the [`Spi`]
-//! struct. A DMA-enabled [`Spi`] implements the
-//! blocking [`embedded_hal::spi::SpiBus`], [`embedded_io::Write`] and/or
+//! struct. A DMA-enabled [`Spi`] implements the blocking
+//! [`embedded_hal::spi::SpiBus`], [`embedded_io::Write`] and/or
 //! [`embedded_io::Read`] traits, which can be used to perform SPI transactions
 //! which are fast, continuous and low jitter, even if they are preemped by a
 //! higher priority interrupt.
@@ -321,9 +316,8 @@
 //!
 //! # `async` operation <span class="stab portability" title="Available on crate feature `async` only"><code>async</code></span>
 //!
-//! An [`Spi`] can be used for
-//! `async` operations. Configuring a [`Spi`] in async mode is relatively
-//! simple:
+//! An [`Spi`] can be used for `async` operations. Configuring a [`Spi`] in
+//! async mode is relatively simple:
 //!
 //! * Bind the corresponding `SERCOM` interrupt source to the SPI
 //!   [`InterruptHandler`] (refer to the module-level [`async_hal`]
@@ -336,8 +330,8 @@
 //! * Use the provided async methods for reading or writing to the SPI
 //!   peripheral. [`SpiFuture`] implements [`embedded_hal_async::spi::SpiBus`].
 //!
-//! `SpiFuture` implements `AsRef<Spi>` and `AsMut<Spi>` so
-//! that it can be reconfigured using the regular [`Spi`] methods.
+//! `SpiFuture` implements `AsRef<Spi>` and `AsMut<Spi>` so that it can be
+//! reconfigured using the regular [`Spi`] methods.
 //!
 //! ## Considerations when using `async` [`Spi`] with DMA <span class="stab portability" title="Available on crate feature `async` only"><code>async</code></span> <span class="stab portability" title="Available on crate feature `dma` only"><code>dma</code></span>
 //!
@@ -374,9 +368,9 @@
 //! This means that using functions like [`futures::select_biased`] to implement
 //! timeouts is safe; transfers will be safely cancelled if the timeout expires.
 //!
-//! This also means that should you [`forget`] this [`Future`] after its
-//! first [`poll`] call, the transfer will keep running, ruining the
-//! now-reclaimed memory, as well as the rest of your day.
+//! This also means that should you [`forget`] this [`Future`] after its first
+//! [`poll`] call, the transfer will keep running, ruining the now-reclaimed
+//! memory, as well as the rest of your day.
 //!
 //! * `await`ing is fine: the [`Future`] will run to completion.
 //! * Dropping an incomplete transfer is also fine. Dropping can happen, for
@@ -434,6 +428,9 @@
 //!
 //! [`enable`]: Config::enable
 //! [`gpio`]: crate::gpio
+//! [`IsPad`]: super::pad::IsPad
+//! [`OptionalPad`]: super::pad::OptionalPad
+//! [`PadNum`]: super::pad::PadNum
 //! [`Pin`]: crate::gpio::pin::Pin
 //! [`PinId`]: crate::gpio::pin::PinId
 //! [`PinMode`]: crate::gpio::pin::PinMode
@@ -1425,11 +1422,11 @@ where
     ///
     /// Only the ERROR, SSL and TXC flags can be cleared.
     ///
-    /// **Note:** The implementation of of [`serial::Write::flush`] waits on and
-    /// clears the `TXC` flag. Manually clearing this flag could cause it to
-    /// hang indefinitely.
+    /// **Note:** Implementations of `flush` methods (eg [`SpiBus::flush`]) wait
+    /// on and clear the `TXC` flag. Manually clearing this flag could cause
+    /// them to hang indefinitely.
     ///
-    /// [`serial::Write::flush`]: embedded_hal::serial::Write::flush
+    /// [`SpiBus::flush`]: ehal::spi::SpiBus::flush
     #[inline]
     pub fn clear_flags(&mut self, flags: Flags) {
         self.config.as_mut().regs.clear_flags(flags);
@@ -1686,8 +1683,8 @@ where
 /// panic if any write-adjacent method is used (ie, `write`, `transfer`,
 /// `transfer_in_place`, and `flush`).
 ///
-/// Also implements `Into<Spi>, `AsRef<Spi>` and `AsMut<Spi>` if you need to use
-/// `Spi` methods.
+/// Also implements `Into<Spi>`, `AsRef<Spi>` and `AsMut<Spi>` if you need to
+/// use `Spi` methods.
 ///
 /// [`embedded_hal::spi::SpiBus`]: crate::ehal::spi::SpiBus
 pub struct PanicOnWrite<T: crate::ehal::spi::ErrorType>(T);
@@ -1721,8 +1718,8 @@ impl<C: ValidConfig, R, T> Spi<C, Tx, R, T> {
 /// panic if any write-adjacent method is used (ie, `read`, `transfer`, and
 /// `transfer_in_place`).
 ///
-/// Also implements `Into<Spi>, `AsRef<Spi>` and `AsMut<Spi>` if you need to use
-/// `Spi` methods.
+/// Also implements `Into<Spi>`, `AsRef<Spi>` and `AsMut<Spi>` if you need to
+/// use `Spi` methods.
 ///
 /// [`embedded_hal::spi::SpiBus`]: crate::ehal::spi::SpiBus
 pub struct PanicOnRead<T: crate::ehal::spi::ErrorType>(T);

--- a/hal/src/sercom/spi/async_api/mod.rs
+++ b/hal/src/sercom/spi/async_api/mod.rs
@@ -69,8 +69,7 @@ where
     ///
     /// In cases where the underlying [`Spi`] is [`Duplex`], reading words need
     /// to be accompanied with sending a no-op word. By default it is set to
-    /// 0x00, but you can configure it by using the
-    /// [`nop_word`](crate::sercom::spi::Config::nop_word) method.
+    /// 0x00, but you can configure it using [`Config::set_nop_word`].
     #[inline]
     pub fn into_future<I>(self, _interrupts: I) -> SpiFuture<C, A>
     where
@@ -210,8 +209,8 @@ where
     /// Read words into a buffer asynchronously, word by word.
     ///
     /// Since we are using a [`Duplex`] [`SpiFuture`], we need to send a word
-    /// simultaneously while receiving one. This `no-op` word is
-    /// configurable via the [`nop_word`](Self::nop_word) method.
+    /// simultaneously while receiving one. This `no-op` word is configurable
+    /// via [`Config::set_nop_word`].
     #[inline]
     pub async fn read(&mut self, buffer: &mut [C::Word]) -> Result<(), Error> {
         if buffer.is_empty() {

--- a/hal/src/sercom/spi/impl_ehal/thumbv6m.rs
+++ b/hal/src/sercom/spi/impl_ehal/thumbv6m.rs
@@ -1,4 +1,5 @@
-//! Implement [`embedded_hal`] traits for [`Spi`] structs
+//! Implement Embedded HAL ([v0.2](crate::ehal_02) and [nb](ehal_nb)) traits for
+//! [`Spi`] structs
 //!
 //! As noted in the [spi module](super) documentation, the embedded-hal trait
 //! implementations vary by both [`Size`] and [`Capability`]. Each
@@ -21,7 +22,7 @@
 //! non-blocking fashion, but this can be done using
 #![cfg_attr(feature = "dma", doc = "[`DMA`](crate::dmac)")]
 #![cfg_attr(not(feature = "dma"), doc = "`DMA`")]
-//! or using interrupts and the [`spi_future`](super::super::spi_future) module.
+//! or using interrupts and the [`spi_future`](crate::sercom::spi_future) module.
 //!
 //! # Variations by [`Capability`]
 //!
@@ -331,11 +332,13 @@ where
 // spi::FullDuplex
 //=============================================================================
 
-/// Implement [`spi::FullDuplex`] for [`Spi`] structs with [`AtomicSize`]
+/// Implement embedded-hal-nb [`spi::FullDuplex`] for [`Spi`] structs with [`AtomicSize`]
 ///
 /// `spi::FullDuplex` is only implemented when the `Spi` struct has [`Duplex`]
 /// [`Capability`]. The [`Word`] size used in the implementation depends on the
 /// corresponding [`CharSize`].
+///
+/// [`spi::FullDuplex`]: ehal_nb::spi::FullDuplex
 impl<C> ehal_nb::spi::FullDuplex<C::Word> for Spi<C, Duplex>
 where
     C: ValidConfig,
@@ -364,11 +367,13 @@ where
     }
 }
 
-/// Implement [`spi::FullDuplex`] for [`Spi`] structs with [`AtomicSize`]
+/// Implement embedded-hal 0.2 [`spi::FullDuplex`] for [`Spi`] structs with [`AtomicSize`]
 ///
 /// `spi::FullDuplex` is only implemented when the `Spi` struct has [`Duplex`]
 /// [`Capability`]. The [`Word`] size used in the implementation depends on the
 /// corresponding [`CharSize`].
+///
+/// [`spi::FullDuplex`]: crate::ehal_02::spi::FullDuplex
 impl<C> crate::ehal_02::spi::FullDuplex<C::Word> for Spi<C, Duplex>
 where
     C: ValidConfig,

--- a/hal/src/sercom/spi_future.rs
+++ b/hal/src/sercom/spi_future.rs
@@ -183,11 +183,13 @@ use crate::typelevel::NoneT;
 
 use super::spi::{AnySpi, Error, Flags};
 
+#[allow(unused_imports)]
+// This isn't used in the `d11` or `d21` builds, but is for `doc` and `d5x`
+use super::spi::Spi;
+
 #[hal_cfg("sercom0-d5x")]
 use {
-    super::spi::{
-        Capability, Config, DynLength, OpMode, Spi, StaticLength, ValidConfig, ValidPads,
-    },
+    super::spi::{Capability, Config, DynLength, OpMode, StaticLength, ValidConfig, ValidPads},
     typenum::Unsigned,
 };
 

--- a/hal/src/sercom/spi_future.rs
+++ b/hal/src/sercom/spi_future.rs
@@ -202,6 +202,12 @@ type Data = u16;
 #[hal_cfg("sercom0-d5x")]
 type Data = u32;
 
+#[cfg(doc)]
+#[hal_cfg(not("sercom0-d5x"))]
+/// This type is not present with the selected feature set, defined for
+/// documentation only
+pub enum DynLength {}
+
 //=============================================================================
 // CheckBufLen
 //=============================================================================

--- a/hal/src/sercom/uart.rs
+++ b/hal/src/sercom/uart.rs
@@ -3,10 +3,10 @@
 //! Configuring an UART peripheral occurs in three steps. First, you must create
 //! a set of [`Pads`] for use by the peripheral. Next, you assemble pieces into
 //! a [`Config`] struct. After configuring the peripheral, you then [`enable`]
-//! it, yielding a functional [`Uart`] struct.
-//! Transactions are performed using the [`embedded_io::Write`],
-//! [`embedded_io::Read`], [`embedded_hal_nb::serial::Write`], and
-//! [`embedded_hal_nb::serial::Read`] traits.
+//! it, yielding a functional [`Uart`] struct. Transactions are performed using
+//! the [`embedded_io::Write`], [`embedded_io::Read`],
+//! [`embedded_hal_nb::serial::Write`], and [`embedded_hal_nb::serial::Read`]
+//! traits.
 //!
 //! # [`Pads`]
 //!
@@ -23,8 +23,8 @@
 //! represent the Data In, Data Out, Sclk and SS pads respectively. Each of the
 //! remaining type parameters is an [`OptionalPad`] and defaults to [`NoneT`]. A
 //! [`Pad`] is just a [`Pin`] configured in the correct [`PinMode`] that
-//! implements [`IsPad`]. The [`bsp_pins!`](crate::bsp_pins) macro can be
-//! used to define convenient type aliases for [`Pad`] types.
+//! implements [`IsPad`]. The [`bsp_pins!`](crate::bsp_pins) macro can be used
+//! to define convenient type aliases for [`Pad`] types.
 //!
 //! ```
 //! use atsamd_hal::gpio::{PA08, PA09, AlternateC};
@@ -92,15 +92,16 @@
 //! ```
 //!
 //! Upon creation, the [`Config`] takes ownership of both the [`Pads`] struct
-//! and the PAC [`Sercom`] struct. It takes a reference to the PM, so that it
-//! can enable the APB clock, and it takes a frequency to indicate the GCLK
-//! configuration. Users are responsible for correctly configuring the GCLK.
+//! and the PAC `SercomN` struct (eg [`Sercom0`]). It takes a reference to the
+//! PM, so that it can enable the APB clock, and it takes a frequency to
+//! indicate the GCLK configuration. Users are responsible for correctly
+//! configuring the GCLK.
 //!
 //! ```
 //! use atsamd_hal::time::U32Ext;
 //!
 //! let pm = peripherals.PM;
-//! let sercom = peripherals.SERCOM0;
+//! let sercom = peripherals.Sercom0;
 //! // Configure GCLK for 10 MHz
 //! let freq = 10.mhz();
 //! let config = uart::Config::new(&pm, sercom, pads, freq);
@@ -199,10 +200,10 @@
 //! type UartTx = uart::UartTx<Config, RxDuples>;
 //! ```
 //!
-//! Only the [`Uart`] struct can actually perform
-//! transactions. To do so, use the embedded HAL traits, like
-//! [`embedded_hal_nb::serial::Read`], [`embedded_hal_nb::serial::Write`],
-//! [`embedded_io::Read`], and [`embedded_io::Write`].
+//! Only the [`Uart`] struct can actually perform transactions. To do so, use
+//! the embedded HAL traits, like [`embedded_hal_nb::serial::Read`],
+//! [`embedded_hal_nb::serial::Write`], [`embedded_io::Read`], and
+//! [`embedded_io::Write`].
 //!
 //! ```
 //! use nb::block;
@@ -228,7 +229,8 @@
 //! [`Config`] has a `CTS` pad specified. The
 //! [`disable_ctsic`](Uart::disable_ctsic) and
 //! [`clear_ctsic`](Uart::clear_ctsic) methods are also available under the same
-//! conditions. [This application note](https://www.silabs.com/documents/public/application-notes/an0059.0-uart-flow-control.pdf)
+//! conditions. [This application
+//! note](https://www.silabs.com/documents/public/application-notes/an0059.0-uart-flow-control.pdf)
 //! provides more information about UART hardware flow control.
 //!
 //! # Splitting
@@ -291,8 +293,8 @@
 //! Some methods, such as [`disable`] and [`reconfigure`], need to operate on
 //! all parts of a UART at once. In practice, this means that these methods
 //! operate on the type that was returned by [`enable`]. This can be `Uart<C,
-//! Rx>`, `Uart<C, Tx>`, or `Uart<C, Duplex>`, depending on how the
-//! peripheral was configured.
+//! Rx>`, `Uart<C, Tx>`, or `Uart<C, Duplex>`, depending on how the peripheral
+//! was configured.
 //!
 //! The [`reconfigure`] method gives out an `&mut Config` reference, which can
 //! then use the `set_*` methods.
@@ -339,7 +341,7 @@
 //!
 //! ```no_run
 //! use atsamd_hal::dmac::channel::{AnyChannel, Ready};
-//! use atsand_hal::sercom::Uart::{I2c, ValidConfig, Error, TxDuplex};
+//! use atsamd_hal::sercom::Uart::{I2c, ValidConfig, Error, TxDuplex};
 //! use atsamd_hal::embedded_io::Write;
 //! fn uart_send_with_dma<A: ValidConfig, C: AnyChannel<Status = Ready>>(uart: Uart<A, TxDuplex>, channel: C, bytes: &[u8]) -> Result<(), Error>{
 //!     // Attach a DMA channel
@@ -352,15 +354,13 @@
 //!
 //! Non-blocking DMA transfers are also supported.
 //!
-//! The provided [`send_with_dma`] and
-//! [`receive_with_dma`] build and begin a
-//! [`dmac::Transfer`], thus starting the UART
-//! in a non-blocking way. Note that these methods require `'static` buffers in
-//! order to remain memory-safe.
+//! The provided [`send_with_dma`] and [`receive_with_dma`] build and begin a
+//! [`Transfer`], thus starting the UART in a non-blocking way. Note that these
+//! methods require `'static` buffers in order to remain memory-safe.
 //!
-//! Optionally, interrupts can be enabled on the provided
-//! [`Channel`]. Please refer to the [`dmac`](crate::dmac) module-level
-//! documentation for more information.
+//! Optionally, interrupts can be enabled on the provided [`Channel`]. Please
+//! refer to the [`dmac`](crate::dmac) module-level documentation for more
+//! information.
 //!
 //! ```
 //! // Assume channel0 and channel1 are configured `dmac::Channel`s,
@@ -398,15 +398,11 @@
 //! * Use the provided async methods for reading or writing to the UART
 //!   peripheral.
 //!
-//! `UartFuture` implements `AsRef<Uart>` and `AsMut<Uart>` so
-//! that it can be reconfigured using the regular [`Uart`] methods. It also
-//! exposes a [`split`](UartFuture::split) method to split it into its RX and TX
-//! parts.
+//!  `UartFuture` implements `AsRef<Uart>` and `AsMut<Uart>` so that it can be
+//!  reconfigured using the regular [`Uart`] methods. It also exposes a
+//!  [`split`](UartFuture::split) method to split it into its RX and TX parts.
 //!
-//!  ## Considerations when using `async` [`Uart`] with DMA <span class="stab
-//! portability" title="Available on crate feature `async`
-//! only"><code>async</code></span> <span class="stab portability"
-//! title="Available on crate feature `dma` only"><code>dma</code></span>
+//! ## Considerations when using `async` [`Uart`] with DMA <span class="stab portability" title="Available on crate feature `async` only"> <code>async</code></span> <span class="stab portability" title="Available on crate feature `dma` only"><code>dma</code></span>
 //!
 //! * An [`Uart`] struct must be turned into an [`UartFuture`] by calling
 //!   [`Uart::into_future`] before calling `with_dma_channel`. The DMA channel
@@ -441,9 +437,9 @@
 //! This means that using functions like [`futures::select_biased`] to implement
 //! timeouts is safe; transfers will be safely cancelled if the timeout expires.
 //!
-//! This also means that should you [`forget`] this [`Future`] after its
-//! first [`poll`] call, the transfer will keep running, ruining the
-//! now-reclaimed memory, as well as the rest of your day.
+//! This also means that should you [`forget`] this [`Future`] after its first
+//! [`poll`] call, the transfer will keep running, ruining the now-reclaimed
+//! memory, as well as the rest of your day.
 //!
 //! * `await`ing is fine: the [`Future`] will run to completion.
 //! * Dropping an incomplete transfer is also fine. Dropping can happen, for
@@ -510,17 +506,21 @@
 //! [`split`]: Uart::split
 //! [`join`]: Uart::join
 //! [`NoneT`]: crate::typelevel::NoneT
-//! [`serial::Write`]: embedded_hal::serial::Write
-//! [`serial::Read`]: embedded_hal::serial::Read
-//! [`receive_with_dma`]: Self::receive_with_dma
-//! [`send_with_dma`]: Self::send_with_dma
-//! [`dmac::Transfer`]: crate::dmac::Transfer
+//! [`receive_with_dma`]: Uart::receive_with_dma
+//! [`send_with_dma`]: Uart::send_with_dma
+//! [`Transfer`]: crate::dmac::Transfer
 //! [`Channel`]: crate::dmac::Channel
 //! [`async_hal`]: crate::async_hal
 //! [`forget`]: core::mem::forget
 //! [`ManuallyDrop`]: core::mem::ManuallyDrop
 //! [`Future`]: core::future::Future
 //! [`poll`]: core::future::Future::poll
+//! [`Sercom`]: crate::sercom::Sercom
+//! [`Sercom0`]: crate::pac::Sercom0
+//! [`PadNum`]: crate::sercom::pad::PadNum
+//! [`Pad`]: crate::sercom::pad::Pad
+//! [`IsPad`]: crate::sercom::pad::IsPad
+//! [`OptionalPad`]: crate::sercom::pad::OptionalPad
 
 use atsamd_hal_macros::{hal_cfg, hal_module};
 


### PR DESCRIPTION
# Summary
Mostly warning cleanup, a few typos etc.

I'm finding the documentation of feature-gated APIs to be quite awkward...  Wondering if it might be easier to add dummy methods/types that are conditional on documentation builds with the feature not enabled, so that rustdoc has something to link to.  Eg
```Rust
#[cfg(all(doc, not(feature = "dma")))]
/// Documentation was built without `dma` feature enabled
pub mod dmac {}
```