### PR TITLE
Update ItsyBitsy M4 BSP to use 'atsamd-hal 0.21.0'

### DIFF
--- a/boards/itsybitsy_m4/Cargo.toml
+++ b/boards/itsybitsy_m4/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.17"
+version = "0.21"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/itsybitsy_m4/examples/blinky_basic.rs
+++ b/boards/itsybitsy_m4/examples/blinky_basic.rs
@@ -21,18 +21,18 @@ fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
     let mut clocks = GenericClockController::with_internal_32kosc(
-        peripherals.GCLK,
-        &mut peripherals.MCLK,
-        &mut peripherals.OSC32KCTRL,
-        &mut peripherals.OSCCTRL,
-        &mut peripherals.NVMCTRL,
+        peripherals.gclk,
+        &mut peripherals.mclk,
+        &mut peripherals.osc32kctrl,
+        &mut peripherals.oscctrl,
+        &mut peripherals.nvmctrl,
     );
     let mut delay = Delay::new(core.SYST, &mut clocks);
     delay.delay_ms(400u16);
 
-    let pins = bsp::Pins::new(peripherals.PORT);
+    let pins = bsp::Pins::new(peripherals.port);
     let mut red_led = pins.d13.into_push_pull_output();
-    let mut wdt = Watchdog::new(peripherals.WDT);
+    let mut wdt = Watchdog::new(peripherals.wdt);
     wdt.start(WatchdogTimeout::Cycles256 as u8);
 
     loop {

--- a/boards/itsybitsy_m4/examples/dotstar.rs
+++ b/boards/itsybitsy_m4/examples/dotstar.rs
@@ -27,18 +27,18 @@ fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
     let mut clocks = GenericClockController::with_internal_32kosc(
-        peripherals.GCLK,
-        &mut peripherals.MCLK,
-        &mut peripherals.OSC32KCTRL,
-        &mut peripherals.OSCCTRL,
-        &mut peripherals.NVMCTRL,
+        peripherals.gclk,
+        &mut peripherals.mclk,
+        &mut peripherals.osc32kctrl,
+        &mut peripherals.oscctrl,
+        &mut peripherals.nvmctrl,
     );
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
-    let pins = bsp::Pins::new(peripherals.PORT);
+    let pins = bsp::Pins::new(peripherals.port);
     let gclk0 = clocks.gclk0();
     let tc2_3 = clocks.tc2_tc3(&gclk0).unwrap();
-    let mut timer = TimerCounter::tc3_(&tc2_3, peripherals.TC3, &mut peripherals.MCLK);
+    let mut timer = TimerCounter::tc3_(&tc2_3, peripherals.tc3, &mut peripherals.mclk);
     InterruptDrivenTimer::start(&mut timer, Hertz::MHz(4).into_duration());
     let mut rgb = bsp::dotstar_bitbang(
         pins.dotstar_miso.into(),

--- a/boards/itsybitsy_m4/examples/sercom_interrupt.rs
+++ b/boards/itsybitsy_m4/examples/sercom_interrupt.rs
@@ -55,8 +55,8 @@ type Uart0 = uart::Uart<uart::Config<UartPads0>, uart::Duplex>;
 pub fn uart0(
     clocks: &mut GenericClockController,
     baud: impl Into<Hertz>,
-    sercom0: pac::SERCOM0,
-    mclk: &mut pac::MCLK,
+    sercom0: pac::Sercom0,
+    mclk: &mut pac::Mclk,
     uart_rx: impl Into<IoSet3Sercom0Pad2>,
     uart_tx: impl Into<IoSet3Sercom0Pad0>,
 ) -> Uart0 {
@@ -80,22 +80,22 @@ fn main() -> ! {
     let mut dp = Peripherals::take().unwrap();
     let mut core = CorePeripherals::take().unwrap();
     let mut clocks = GenericClockController::with_internal_32kosc(
-        dp.GCLK,
-        &mut dp.MCLK,
-        &mut dp.OSC32KCTRL,
-        &mut dp.OSCCTRL,
-        &mut dp.NVMCTRL,
+        dp.gclk,
+        &mut dp.mclk,
+        &mut dp.osc32kctrl,
+        &mut dp.oscctrl,
+        &mut dp.nvmctrl,
     );
 
-    let pins = bsp::Pins::new(dp.PORT);
+    let pins = bsp::Pins::new(dp.port);
     let mut delay = Delay::new(core.SYST, &mut clocks);
 
     // custom sercom uart configuration
     let mut serial_sercom0 = uart0(
         &mut clocks,
         115200.Hz(),
-        dp.SERCOM0,
-        &mut dp.MCLK,
+        dp.sercom0,
+        &mut dp.mclk,
         pins.a5,
         pins.a4,
     );
@@ -104,8 +104,8 @@ fn main() -> ! {
     let mut serial_sercom3 = bsp::uart(
         &mut clocks,
         115200.Hz(),
-        dp.SERCOM3,
-        &mut dp.MCLK,
+        dp.sercom3,
+        &mut dp.mclk,
         pins.d0_rx,
         pins.d1_tx,
     );

--- a/boards/itsybitsy_m4/examples/spi.rs
+++ b/boards/itsybitsy_m4/examples/spi.rs
@@ -31,27 +31,27 @@ fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
     let mut clocks = GenericClockController::with_internal_32kosc(
-        peripherals.GCLK,
-        &mut peripherals.MCLK,
-        &mut peripherals.OSC32KCTRL,
-        &mut peripherals.OSCCTRL,
-        &mut peripherals.NVMCTRL,
+        peripherals.gclk,
+        &mut peripherals.mclk,
+        &mut peripherals.osc32kctrl,
+        &mut peripherals.oscctrl,
+        &mut peripherals.nvmctrl,
     );
-    let pins = bsp::Pins::new(peripherals.PORT);
+    let pins = bsp::Pins::new(peripherals.port);
     let mut delay = Delay::new(core.SYST, &mut clocks);
     let mut serial = bsp::uart(
         &mut clocks,
         115200.Hz(),
-        peripherals.SERCOM3,
-        &mut peripherals.MCLK,
+        peripherals.sercom3,
+        &mut peripherals.mclk,
         pins.d0_rx,
         pins.d1_tx,
     );
     let mut spi1 = spi_master(
         &mut clocks,
         4.MHz(),
-        peripherals.SERCOM1,
-        &mut peripherals.MCLK,
+        peripherals.sercom1,
+        &mut peripherals.mclk,
         pins.sck,
         pins.mosi,
         pins.miso,

--- a/boards/itsybitsy_m4/examples/usb_serial.rs
+++ b/boards/itsybitsy_m4/examples/usb_serial.rs
@@ -39,16 +39,16 @@ fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let mut core = CorePeripherals::take().unwrap();
     let mut clocks = GenericClockController::with_internal_32kosc(
-        peripherals.GCLK,
-        &mut peripherals.MCLK,
-        &mut peripherals.OSC32KCTRL,
-        &mut peripherals.OSCCTRL,
-        &mut peripherals.NVMCTRL,
+        peripherals.gclk,
+        &mut peripherals.mclk,
+        &mut peripherals.osc32kctrl,
+        &mut peripherals.oscctrl,
+        &mut peripherals.nvmctrl,
     );
-    let pins = bsp::Pins::new(peripherals.PORT);
+    let pins = bsp::Pins::new(peripherals.port);
     let gclk0 = clocks.gclk0();
     let tc2_3 = clocks.tc2_tc3(&gclk0).unwrap();
-    let mut timer = TimerCounter::tc3_(&tc2_3, peripherals.TC3, &mut peripherals.MCLK);
+    let mut timer = TimerCounter::tc3_(&tc2_3, peripherals.tc3, &mut peripherals.mclk);
     timer.start(Hertz::MHz(4).into_duration());
     let mut rgb = bsp::dotstar_bitbang(
         pins.dotstar_miso.into(),
@@ -65,14 +65,14 @@ fn main() -> ! {
     );
     dbgprint!(
         "Last reset was from {:?}\n",
-        hal::reset_cause(&peripherals.RSTC)
+        hal::reset_cause(&peripherals.rstc)
     );
 
     let bus_allocator = unsafe {
         USB_ALLOCATOR = Some(bsp::usb_allocator(
-            peripherals.USB,
+            peripherals.usb,
             &mut clocks,
-            &mut peripherals.MCLK,
+            &mut peripherals.mclk,
             pins.usb_dm,
             pins.usb_dp,
         ));

--- a/boards/itsybitsy_m4/rust-toolchain.toml
+++ b/boards/itsybitsy_m4/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+targets = [ "thumbv7em-none-eabihf" ]

--- a/boards/itsybitsy_m4/src/lib.rs
+++ b/boards/itsybitsy_m4/src/lib.rs
@@ -19,7 +19,6 @@ pub use hal::{
     },
     time::Hertz,
 };
-use pac::MCLK;
 
 #[cfg(feature = "usb")]
 use hal::usb::usb_device::bus::UsbBusAllocator;
@@ -27,9 +26,9 @@ use hal::usb::usb_device::bus::UsbBusAllocator;
 pub use hal::usb::UsbBus;
 
 hal::bsp_peripherals!(
-    SERCOM1 { SpiSercom }
-    SERCOM2 { I2cSercom }
-    SERCOM3 { UartSercom }
+    Sercom1 { SpiSercom }
+    Sercom2 { I2cSercom }
+    Sercom3 { UartSercom }
 );
 
 hal::bsp_pins!(
@@ -263,8 +262,8 @@ hal::bsp_pins!(
 /// Enables the clocks for the QSPI peripheral in single data rate mode
 /// assuming 120MHz system clock, for 4MHz QSPI mode 0 operation.
 pub fn qspi_master(
-    mclk: &mut MCLK,
-    qspi: pac::QSPI,
+    mclk: &mut pac::Mclk,
+    qspi: pac::Qspi,
     sck: impl Into<QspiSck>,
     cs: impl Into<QspiCs>,
     data: (
@@ -304,7 +303,7 @@ pub fn i2c_master(
     clocks: &mut GenericClockController,
     baud: impl Into<Hertz>,
     sercom: I2cSercom,
-    mclk: &mut pac::MCLK,
+    mclk: &mut pac::Mclk,
     sda: impl Into<Sda>,
     scl: impl Into<Scl>,
 ) -> I2c {
@@ -330,7 +329,7 @@ pub fn uart(
     clocks: &mut GenericClockController,
     baud: impl Into<Hertz>,
     sercom3: UartSercom,
-    mclk: &mut pac::MCLK,
+    mclk: &mut pac::Mclk,
     uart_rx: impl Into<UartRx>,
     uart_tx: impl Into<UartTx>,
 ) -> Uart {
@@ -346,16 +345,16 @@ pub fn uart(
 /// Convenience for setting up the USB Bus allocator
 #[cfg(feature = "usb")]
 pub fn usb_allocator(
-    usb: pac::USB,
+    usb: pac::Usb,
     clocks: &mut GenericClockController,
-    mclk: &mut pac::MCLK,
+    mclk: &mut pac::Mclk,
     dm: impl Into<UsbDm>,
     dp: impl Into<UsbDp>,
 ) -> UsbBusAllocator<UsbBus> {
-    use pac::gclk::{genctrl::SRCSELECT_A, pchctrl::GENSELECT_A};
+    use pac::gclk::{genctrl::Srcselect, pchctrl::Genselect};
 
-    clocks.configure_gclk_divider_and_source(GENSELECT_A::GCLK2, 1, SRCSELECT_A::DFLL, false);
-    let usb_gclk = clocks.get_gclk(GENSELECT_A::GCLK2).unwrap();
+    clocks.configure_gclk_divider_and_source(Genselect::Gclk2, 1, Srcselect::Dfll, false);
+    let usb_gclk = clocks.get_gclk(Genselect::Gclk2).unwrap();
     let usb_clock = &clocks.usb(&usb_gclk).unwrap();
     let (dm, dp) = (dm.into(), dp.into());
     UsbBusAllocator::new(UsbBus::new(usb_clock, mclk, dm, dp, usb))
@@ -391,7 +390,7 @@ pub fn spi_master(
     baud: impl Into<Hertz>,
     sercom1: SpiSercom,
 
-    mclk: &mut pac::MCLK,
+    mclk: &mut pac::Mclk,
     sck: impl Into<Sck>,
     mosi: impl Into<Mosi>,
     miso: impl Into<Miso>,


### PR DESCRIPTION
# Summary
This PR updates the ItsyBitsy M4 BSP to use 'atsamd-hal 0.21.0'.

### Changes;
- Updated 'Cargo.toml'
- Updated field names to reflect new HAL syntax
- verified that all examples still build successfully
- added rust-toolchain.toml

### Comments
I needed newer functions of atsamd-hal in a project (eic) so I had to patch it. Changes are mostly limited to changing uppercase to lowercase fields.