### PR TITLE
fix CI: Remove gen-docs dependency on matrix

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Install Rust
         run: |
           rustup set profile minimal
-          rustup override set ${{ matrix.toolchain }}
           rustup target add thumbv6m-none-eabi
           rustup target add thumbv7em-none-eabihf
 


### PR DESCRIPTION
Presumably we can just use the default Rust channel to generate docs

# Summary
The HAL documentation that we publish is quite old, because the CI job that produces it is broken.  This change appears to get past the first failure in the limited testing I've been able to do on my GitHub account.