### PR TITLE
Fix CI docs and publish to atsamd-rs/atsamd GitHub Pages

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Install Rust
         run: |
           rustup set profile minimal
-          rustup override set ${{ matrix.toolchain }}
           rustup target add thumbv6m-none-eabi
           rustup target add thumbv7em-none-eabihf
 

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           set -ex
 
-          docs_path="$(pwd)/docs_repo"
+          docs_path="$(pwd)/docs"
           mkdir -pv "${docs_path}"
           (cd "$docs_path" && git init && git checkout -b main)
 
@@ -40,10 +40,6 @@ jobs:
               cd hal
 
               cargo doc --features "${feature_str}" --target "${target}" --release --target-dir "${docs_path}/${variant}"
-
-              rm -rf "${docs_path}/${variant}/${target}/doc/typenum"
-              find "${docs_path}/${variant}/" -type f -exec sed -i 's|../typenum/|https://docs.rs/typenum/1.12.0/typenum/|g' {} +
-              sed -i '/"typenum"/d' "${docs_path}/${variant}/${target}/doc/search-index.js"
 
               rm -rf "${docs_path}/${variant}/${target}/release/deps"
               rm -rf "${docs_path}/${variant}/release"
@@ -83,37 +79,18 @@ jobs:
           echo '    </table>' >> "${docs_path}/index.html"
           echo '  </body>' >> "${docs_path}/index.html"
           echo '</html>' >> "${docs_path}/index.html"
-
-      - name: Upload
-        if: github.event.inputs.gen_hal_docs == 'yes'
-        shell: bash
+      - name: Checkout pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+      - name: Commit documentation changes
         run: |
-          set -ex
-
-          docs_path="$(pwd)/docs_repo"
-          cd "${docs_path}"
-          git add -A
-          git config author.name atsamd-bot
-          git config author.email 'atsamd-bot@users.noreply.github.com'
-          git config committer.name atsamd-bot
-          git config committer.email 'atsamd-bot@users.noreply.github.com'
-          git commit -m 'Generate HAL documentation'
-
-          git remote add upstream https://github.com/atsamd-rs/docs.git
-
-          # Disable command echoing and compute the base64 header in a wrapper
-          # function, to avoid the token or the base64-encoded token from
-          # hitting the logs.
-          set +x
-          gen_basic_header() {
-            local gat=$1
-            echo -n "$(echo -n "x-access-token:${gat}"|base64 --wrap=0)"
-          }
-          auth="$(gen_basic_header '${{ secrets.ATSAMD_BOT }}')"
-
-          git \
-            -c "http.https://github.com.extraheader=Authorization: basic ${auth}" \
-            -c 'author.name=atsamd-bot' \
-            -c 'author.email=atsamd-bot@users.noreply.github.com' \
-            push -q upstream main -f
-          set -x
+          rsync --archive --delete --exclude .git docs/ gh-pages/
+          cd gh-pages
+          touch .nojekyll
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "Update documentation" -a || true
+          git push

--- a/README.md
+++ b/README.md
@@ -10,25 +10,25 @@ This repository holds various crates that support/enable working with Microchip 
 
 The Hardware Abstraction Layer (HAL - [![Crates.io](https://img.shields.io/crates/v/atsamd_hal.svg)](https://crates.io/crates/atsamd_hal)) crate encodes a type-safe layer over the raw PACs. This crate implements traits specified by the [embedded-hal](https://github.com/rust-embedded/embedded-hal) project, making it compatible with various drivers in the embedded Rust ecosystem.  Cargo features are used to enable support for specific hardware variations and features.  Online documentation for commonly-used feature sets is provided:
 
-| Chip family | Documented features   |
-|:------------|:----------------------|
-| [samd11c]   | samd11c               |
-| [samd11d]   | samd11d               |
-| [samd21g]   | samd21g usb           |
-| [samd21j]   | samd21j usb           |
-| [samd51g]   | samd51g usb           |
-| [samd51j]   | samd51j usb           |
-| [samd51n]   | samd51n usb           |
-| [samd51p]   | samd51p usb           |
+| Chip family | Documented features               |
+|:------------|:----------------------------------|
+| [samd11c]   | samd11c dma defmt async           |
+| [samd11d]   | samd11d dma defmt async           |
+| [samd21g]   | samd21g usb dma defmt async       |
+| [samd21j]   | samd21j usb dma defmt async       |
+| [samd51g]   | samd51g usb sdmmc dma defmt async |
+| [samd51j]   | samd51j usb sdmmc dma defmt async |
+| [samd51n]   | samd51n usb sdmmc dma defmt async |
+| [samd51p]   | samd51p usb sdmmc dma defmt async |
 
-[samd11c]: https://atsamd-rs.github.io/docs/samd11c/thumbv6m-none-eabi/doc/atsamd_hal/index.html
-[samd11d]: https://atsamd-rs.github.io/docs/samd11d/thumbv6m-none-eabi/doc/atsamd_hal/index.html
-[samd21g]: https://atsamd-rs.github.io/docs/samd21g/thumbv6m-none-eabi/doc/atsamd_hal/index.html
-[samd21j]: https://atsamd-rs.github.io/docs/samd21j/thumbv6m-none-eabi/doc/atsamd_hal/index.html
-[samd51g]: https://atsamd-rs.github.io/docs/samd51g/thumbv7em-none-eabihf/doc/atsamd_hal/index.html
-[samd51j]: https://atsamd-rs.github.io/docs/samd51j/thumbv7em-none-eabihf/doc/atsamd_hal/index.html
-[samd51n]: https://atsamd-rs.github.io/docs/samd51n/thumbv7em-none-eabihf/doc/atsamd_hal/index.html
-[samd51p]: https://atsamd-rs.github.io/docs/samd51p/thumbv7em-none-eabihf/doc/atsamd_hal/index.html
+[samd11c]: https://atsamd-rs.github.io/atsamd/samd11c/thumbv6m-none-eabi/doc/atsamd_hal/index.html
+[samd11d]: https://atsamd-rs.github.io/atsamd/samd11d/thumbv6m-none-eabi/doc/atsamd_hal/index.html
+[samd21g]: https://atsamd-rs.github.io/atsamd/samd21g/thumbv6m-none-eabi/doc/atsamd_hal/index.html
+[samd21j]: https://atsamd-rs.github.io/atsamd/samd21j/thumbv6m-none-eabi/doc/atsamd_hal/index.html
+[samd51g]: https://atsamd-rs.github.io/atsamd/samd51g/thumbv7em-none-eabihf/doc/atsamd_hal/index.html
+[samd51j]: https://atsamd-rs.github.io/atsamd/samd51j/thumbv7em-none-eabihf/doc/atsamd_hal/index.html
+[samd51n]: https://atsamd-rs.github.io/atsamd/samd51n/thumbv7em-none-eabihf/doc/atsamd_hal/index.html
+[samd51p]: https://atsamd-rs.github.io/atsamd/samd51p/thumbv7em-none-eabihf/doc/atsamd_hal/index.html
 
 ## PAC and BSP - Peripheral Access Crate and Board Support Package
 


### PR DESCRIPTION
# Summary
The first commit gets the docs builds going again.  The second is a bigger change which I'm less confident about; in the old scheme docs were published to a separate repo atsamd-rs/docs, but that required some auth shenanigans which this removes by just using a gh-pages branch in this repo.  We've got some very old docs in the gh-pages branch already, I'm not sure on the history there but there is some precedent. 