### PR TITLE
Add TC6/7 for applicable chips

### DIFF
--- a/hal/src/async_hal/interrupts.rs
+++ b/hal/src/async_hal/interrupts.rs
@@ -185,6 +185,12 @@ declare_interrupts!(TC4);
 #[hal_cfg("tc5")]
 declare_interrupts!(TC5);
 
+#[hal_cfg("tc6")]
+declare_interrupts!(TC6);
+
+#[hal_cfg("tc7")]
+declare_interrupts!(TC7);
+
 // ----------  EIC Interrupt ---------- //
 #[hal_cfg(any("eic-d11", "eic-d21"))]
 declare_interrupts!(EIC);

--- a/hal/src/peripherals/timer/d5x.rs
+++ b/hal/src/peripherals/timer/d5x.rs
@@ -9,6 +9,8 @@ use crate::pac::tc0::Count16 as Count16Reg;
 use crate::pac::{Mclk, Tc2, Tc3};
 #[hal_cfg(all("tc4", "tc5"))]
 use crate::pac::{Tc4, Tc5};
+#[hal_cfg(all("tc6", "tc7"))]
+use crate::pac::{Tc6, Tc7};
 use crate::timer_params::TimerParams;
 use crate::timer_traits::InterruptDrivenTimer;
 
@@ -203,4 +205,10 @@ tc! {
 tc! {
     TimerCounter4: (Tc4, tc4_, Tc4Tc5Clock, apbcmask),
     TimerCounter5: (Tc5, tc5_, Tc4Tc5Clock, apbcmask),
+}
+
+#[hal_cfg(all("tc6", "tc7"))]
+tc! {
+    TimerCounter6: (Tc6, tc6_, Tc6Tc7Clock, apbdmask),
+    TimerCounter7: (Tc7, tc7_, Tc6Tc7Clock, apbdmask),
 }


### PR DESCRIPTION
# Summary
For ATSAME54P20A, It has 2 extra timers (TC6, TC7), which were not present in the HAL (The HAL maxed out at TC5)

This PR adds these extra 2 timers.

