### PR TITLE
EIC Fixes for D5X

### DIFF
--- a/hal/src/peripherals/eic.rs
+++ b/hal/src/peripherals/eic.rs
@@ -218,6 +218,17 @@ impl Eic {
 
     /// Create and initialize a new [`Eic`], and wire it up to the
     /// ultra-low-power 32kHz clock source.
+    ///
+    /// Due to the way the EIC peripheral is implemented, the EIC Clock MUST
+    /// be driven by the OSC32K clock, this can be done with the V2 clocking API as follows:
+    ///
+    /// ```no_run
+    /// let (osc32k, base) = OscUlp32k::enable(tokens.osculp32k.osculp32k, clocks.osculp32k_base);
+    /// let (gclk2, _osc32k) = Gclk::from_source(tokens.gclks.gclk2, osc32k);
+    /// let gclk2_32k = gclk2.enable();
+    /// let (pclk_eic, gclk2_32k) = Pclk::enable(tokens.pclks.eic, gclk2_32k);
+    /// let eic = Eic::new(&mut mclk, pclk_eic.into(), cx.device.eic).split();
+    /// ```
     #[hal_cfg("eic-d5x")]
     pub fn new(mclk: &mut pac::Mclk, _clock: EicClock, eic: pac::Eic) -> Self {
         mclk.apbamask().modify(|_, w| w.eic_().set_bit());

--- a/hal/src/peripherals/eic.rs
+++ b/hal/src/peripherals/eic.rs
@@ -220,7 +220,8 @@ impl Eic {
     /// ultra-low-power 32kHz clock source.
     ///
     /// Due to the way the EIC peripheral is implemented, the EIC Clock MUST
-    /// be driven by the OSC32K clock, this can be done with the V2 clocking API as follows:
+    /// be driven by the OSC32K clock, this can be done with the V2 clocking 
+    /// API as follows:
     ///
     /// ```no_run
     /// let (osc32k, base) = OscUlp32k::enable(tokens.osculp32k.osculp32k, clocks.osculp32k_base);

--- a/hal/src/peripherals/eic.rs
+++ b/hal/src/peripherals/eic.rs
@@ -220,7 +220,7 @@ impl Eic {
     /// ultra-low-power 32kHz clock source.
     ///
     /// Due to the way the EIC peripheral is implemented, the EIC Clock MUST
-    /// be driven by the OSC32K clock, this can be done with the V2 clocking 
+    /// be driven by the OSC32K clock, this can be done with the V2 clocking
     /// API as follows:
     ///
     /// ```no_run

--- a/hal/src/peripherals/eic/d11/pin.rs
+++ b/hal/src/peripherals/eic/d11/pin.rs
@@ -57,13 +57,13 @@ where
     /// Note that this function does disable the EIC peripheral briefely in order
     /// to write to the evctrl register.
     pub fn enable_event(&mut self) {
-        self.chan.eic.ctrla().write(|w| w.enable().clear_bit());
+        self.chan.eic.ctrl().write(|w| w.enable().clear_bit());
         self.sync();
         self.chan
             .eic
             .evctrl()
             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << P::ChId::ID)) });
-        self.chan.eic.ctrla().write(|w| w.enable().set_bit());
+        self.chan.eic.ctrl().write(|w| w.enable().set_bit());
         self.sync();
     }
 
@@ -142,7 +142,7 @@ where
     }
 
     fn sync(&self) {
-        while self.chan.eic.syncbusy().read().bits() != 0 {
+        while self.chan.eic.status().read().syncbusy().bit_is_set() {
             core::hint::spin_loop();
         }
     }


### PR DESCRIPTION
# Summary

As part of my work for implementing the Event system for pulse counting, I noticed that there was some issues with the EIC implementation. This PR fixes them.

1. Document the fact that when using the V2 clocking API, the user must enable the OSC32K clock and wire it up to the EIC Clock, since the HAL assumes that the OSC32K clock will drive the EIC peripheral. Later, I will possibly create a new constructor for the EIC peripheral that can take in a much faster clock source if the user wishes for it.

2. Create a constructor for the EIC peripheral that does not assume that OSC32K clock source is used. This allows the EIC peripheral to be driven by a much faster clock source, thus, have a faster event detection frequency

3. The enable_event method on an EIC channel does not actually function, as the EIC peripheral is enabled when the function is called, but the evctrl register is locked due to the peripheral being enabled. So the method now disables the EIC before enabling the bit, and then re-enables the peripheral. This is noted in the function documentation
