### PR TITLE
Fix evsys user[m] register locations

### DIFF
--- a/pac/atsamd51g/src/evsys.rs
+++ b/pac/atsamd51g/src/evsys.rs
@@ -61,13 +61,13 @@ impl RegisterBlock {
     pub fn channels_iter(&self) -> impl Iterator<Item = &Channels> {
         self.channels.iter()
     }
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub const fn user(&self, n: usize) -> &User {
         &self.user[n]
     }
     #[doc = "Iterator for array of:"]
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub fn user_iter(&self) -> impl Iterator<Item = &User> {
         self.user.iter()

--- a/pac/atsamd51g/src/evsys/user.rs
+++ b/pac/atsamd51g/src/evsys/user.rs
@@ -10,7 +10,7 @@ impl R {
     #[doc = "Bits 0:5 - Channel Event Selection"]
     #[inline(always)]
     pub fn channel(&self) -> ChannelR {
-        ChannelR::new((self.bits & 0x3f) as u8)
+        ChannelR::new(self.bits & 0x3f)
     }
 }
 impl W {
@@ -24,18 +24,18 @@ impl W {
 #[doc = "User Multiplexer n\n\nYou can [`read`](crate::Reg::read) this register and get [`user::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`user::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct UserSpec;
 impl crate::RegisterSpec for UserSpec {
-    type Ux = u32;
+    type Ux = u8;
 }
 #[doc = "`read()` method returns [`user::R`](R) reader structure"]
 impl crate::Readable for UserSpec {}
 #[doc = "`write(|w| ..)` method takes [`user::W`](W) writer structure"]
 impl crate::Writable for UserSpec {
     type Safety = crate::Unsafe;
-    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
-    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
 }
 #[doc = "`reset()` method sets USER[%s]
 to value 0"]
 impl crate::Resettable for UserSpec {
-    const RESET_VALUE: u32 = 0;
+    const RESET_VALUE: u8 = 0;
 }

--- a/pac/atsamd51j/src/evsys.rs
+++ b/pac/atsamd51j/src/evsys.rs
@@ -61,13 +61,13 @@ impl RegisterBlock {
     pub fn channels_iter(&self) -> impl Iterator<Item = &Channels> {
         self.channels.iter()
     }
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub const fn user(&self, n: usize) -> &User {
         &self.user[n]
     }
     #[doc = "Iterator for array of:"]
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub fn user_iter(&self) -> impl Iterator<Item = &User> {
         self.user.iter()

--- a/pac/atsamd51j/src/evsys/user.rs
+++ b/pac/atsamd51j/src/evsys/user.rs
@@ -10,7 +10,7 @@ impl R {
     #[doc = "Bits 0:5 - Channel Event Selection"]
     #[inline(always)]
     pub fn channel(&self) -> ChannelR {
-        ChannelR::new((self.bits & 0x3f) as u8)
+        ChannelR::new(self.bits & 0x3f)
     }
 }
 impl W {
@@ -24,18 +24,18 @@ impl W {
 #[doc = "User Multiplexer n\n\nYou can [`read`](crate::Reg::read) this register and get [`user::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`user::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct UserSpec;
 impl crate::RegisterSpec for UserSpec {
-    type Ux = u32;
+    type Ux = u8;
 }
 #[doc = "`read()` method returns [`user::R`](R) reader structure"]
 impl crate::Readable for UserSpec {}
 #[doc = "`write(|w| ..)` method takes [`user::W`](W) writer structure"]
 impl crate::Writable for UserSpec {
     type Safety = crate::Unsafe;
-    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
-    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
 }
 #[doc = "`reset()` method sets USER[%s]
 to value 0"]
 impl crate::Resettable for UserSpec {
-    const RESET_VALUE: u32 = 0;
+    const RESET_VALUE: u8 = 0;
 }

--- a/pac/atsamd51n/src/evsys.rs
+++ b/pac/atsamd51n/src/evsys.rs
@@ -61,13 +61,13 @@ impl RegisterBlock {
     pub fn channels_iter(&self) -> impl Iterator<Item = &Channels> {
         self.channels.iter()
     }
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub const fn user(&self, n: usize) -> &User {
         &self.user[n]
     }
     #[doc = "Iterator for array of:"]
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub fn user_iter(&self) -> impl Iterator<Item = &User> {
         self.user.iter()

--- a/pac/atsamd51n/src/evsys/user.rs
+++ b/pac/atsamd51n/src/evsys/user.rs
@@ -10,7 +10,7 @@ impl R {
     #[doc = "Bits 0:5 - Channel Event Selection"]
     #[inline(always)]
     pub fn channel(&self) -> ChannelR {
-        ChannelR::new((self.bits & 0x3f) as u8)
+        ChannelR::new(self.bits & 0x3f)
     }
 }
 impl W {
@@ -24,18 +24,18 @@ impl W {
 #[doc = "User Multiplexer n\n\nYou can [`read`](crate::Reg::read) this register and get [`user::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`user::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct UserSpec;
 impl crate::RegisterSpec for UserSpec {
-    type Ux = u32;
+    type Ux = u8;
 }
 #[doc = "`read()` method returns [`user::R`](R) reader structure"]
 impl crate::Readable for UserSpec {}
 #[doc = "`write(|w| ..)` method takes [`user::W`](W) writer structure"]
 impl crate::Writable for UserSpec {
     type Safety = crate::Unsafe;
-    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
-    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
 }
 #[doc = "`reset()` method sets USER[%s]
 to value 0"]
 impl crate::Resettable for UserSpec {
-    const RESET_VALUE: u32 = 0;
+    const RESET_VALUE: u8 = 0;
 }

--- a/pac/atsamd51p/src/evsys.rs
+++ b/pac/atsamd51p/src/evsys.rs
@@ -61,13 +61,13 @@ impl RegisterBlock {
     pub fn channels_iter(&self) -> impl Iterator<Item = &Channels> {
         self.channels.iter()
     }
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub const fn user(&self, n: usize) -> &User {
         &self.user[n]
     }
     #[doc = "Iterator for array of:"]
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub fn user_iter(&self) -> impl Iterator<Item = &User> {
         self.user.iter()

--- a/pac/atsamd51p/src/evsys/user.rs
+++ b/pac/atsamd51p/src/evsys/user.rs
@@ -10,7 +10,7 @@ impl R {
     #[doc = "Bits 0:5 - Channel Event Selection"]
     #[inline(always)]
     pub fn channel(&self) -> ChannelR {
-        ChannelR::new((self.bits & 0x3f) as u8)
+        ChannelR::new(self.bits & 0x3f)
     }
 }
 impl W {
@@ -24,18 +24,18 @@ impl W {
 #[doc = "User Multiplexer n\n\nYou can [`read`](crate::Reg::read) this register and get [`user::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`user::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct UserSpec;
 impl crate::RegisterSpec for UserSpec {
-    type Ux = u32;
+    type Ux = u8;
 }
 #[doc = "`read()` method returns [`user::R`](R) reader structure"]
 impl crate::Readable for UserSpec {}
 #[doc = "`write(|w| ..)` method takes [`user::W`](W) writer structure"]
 impl crate::Writable for UserSpec {
     type Safety = crate::Unsafe;
-    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
-    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
 }
 #[doc = "`reset()` method sets USER[%s]
 to value 0"]
 impl crate::Resettable for UserSpec {
-    const RESET_VALUE: u32 = 0;
+    const RESET_VALUE: u8 = 0;
 }

--- a/pac/atsame51g/src/evsys.rs
+++ b/pac/atsame51g/src/evsys.rs
@@ -61,13 +61,13 @@ impl RegisterBlock {
     pub fn channels_iter(&self) -> impl Iterator<Item = &Channels> {
         self.channels.iter()
     }
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub const fn user(&self, n: usize) -> &User {
         &self.user[n]
     }
     #[doc = "Iterator for array of:"]
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub fn user_iter(&self) -> impl Iterator<Item = &User> {
         self.user.iter()

--- a/pac/atsame51g/src/evsys/user.rs
+++ b/pac/atsame51g/src/evsys/user.rs
@@ -10,7 +10,7 @@ impl R {
     #[doc = "Bits 0:5 - Channel Event Selection"]
     #[inline(always)]
     pub fn channel(&self) -> ChannelR {
-        ChannelR::new((self.bits & 0x3f) as u8)
+        ChannelR::new(self.bits & 0x3f)
     }
 }
 impl W {
@@ -24,18 +24,18 @@ impl W {
 #[doc = "User Multiplexer n\n\nYou can [`read`](crate::Reg::read) this register and get [`user::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`user::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct UserSpec;
 impl crate::RegisterSpec for UserSpec {
-    type Ux = u32;
+    type Ux = u8;
 }
 #[doc = "`read()` method returns [`user::R`](R) reader structure"]
 impl crate::Readable for UserSpec {}
 #[doc = "`write(|w| ..)` method takes [`user::W`](W) writer structure"]
 impl crate::Writable for UserSpec {
     type Safety = crate::Unsafe;
-    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
-    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
 }
 #[doc = "`reset()` method sets USER[%s]
 to value 0"]
 impl crate::Resettable for UserSpec {
-    const RESET_VALUE: u32 = 0;
+    const RESET_VALUE: u8 = 0;
 }

--- a/pac/atsame51j/src/evsys.rs
+++ b/pac/atsame51j/src/evsys.rs
@@ -61,13 +61,13 @@ impl RegisterBlock {
     pub fn channels_iter(&self) -> impl Iterator<Item = &Channels> {
         self.channels.iter()
     }
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub const fn user(&self, n: usize) -> &User {
         &self.user[n]
     }
     #[doc = "Iterator for array of:"]
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub fn user_iter(&self) -> impl Iterator<Item = &User> {
         self.user.iter()

--- a/pac/atsame51j/src/evsys/user.rs
+++ b/pac/atsame51j/src/evsys/user.rs
@@ -10,7 +10,7 @@ impl R {
     #[doc = "Bits 0:5 - Channel Event Selection"]
     #[inline(always)]
     pub fn channel(&self) -> ChannelR {
-        ChannelR::new((self.bits & 0x3f) as u8)
+        ChannelR::new(self.bits & 0x3f)
     }
 }
 impl W {
@@ -24,18 +24,18 @@ impl W {
 #[doc = "User Multiplexer n\n\nYou can [`read`](crate::Reg::read) this register and get [`user::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`user::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct UserSpec;
 impl crate::RegisterSpec for UserSpec {
-    type Ux = u32;
+    type Ux = u8;
 }
 #[doc = "`read()` method returns [`user::R`](R) reader structure"]
 impl crate::Readable for UserSpec {}
 #[doc = "`write(|w| ..)` method takes [`user::W`](W) writer structure"]
 impl crate::Writable for UserSpec {
     type Safety = crate::Unsafe;
-    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
-    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
 }
 #[doc = "`reset()` method sets USER[%s]
 to value 0"]
 impl crate::Resettable for UserSpec {
-    const RESET_VALUE: u32 = 0;
+    const RESET_VALUE: u8 = 0;
 }

--- a/pac/atsame51n/src/evsys.rs
+++ b/pac/atsame51n/src/evsys.rs
@@ -61,13 +61,13 @@ impl RegisterBlock {
     pub fn channels_iter(&self) -> impl Iterator<Item = &Channels> {
         self.channels.iter()
     }
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub const fn user(&self, n: usize) -> &User {
         &self.user[n]
     }
     #[doc = "Iterator for array of:"]
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub fn user_iter(&self) -> impl Iterator<Item = &User> {
         self.user.iter()

--- a/pac/atsame51n/src/evsys/user.rs
+++ b/pac/atsame51n/src/evsys/user.rs
@@ -10,7 +10,7 @@ impl R {
     #[doc = "Bits 0:5 - Channel Event Selection"]
     #[inline(always)]
     pub fn channel(&self) -> ChannelR {
-        ChannelR::new((self.bits & 0x3f) as u8)
+        ChannelR::new(self.bits & 0x3f)
     }
 }
 impl W {
@@ -24,18 +24,18 @@ impl W {
 #[doc = "User Multiplexer n\n\nYou can [`read`](crate::Reg::read) this register and get [`user::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`user::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct UserSpec;
 impl crate::RegisterSpec for UserSpec {
-    type Ux = u32;
+    type Ux = u8;
 }
 #[doc = "`read()` method returns [`user::R`](R) reader structure"]
 impl crate::Readable for UserSpec {}
 #[doc = "`write(|w| ..)` method takes [`user::W`](W) writer structure"]
 impl crate::Writable for UserSpec {
     type Safety = crate::Unsafe;
-    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
-    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
 }
 #[doc = "`reset()` method sets USER[%s]
 to value 0"]
 impl crate::Resettable for UserSpec {
-    const RESET_VALUE: u32 = 0;
+    const RESET_VALUE: u8 = 0;
 }

--- a/pac/atsame53j/src/evsys.rs
+++ b/pac/atsame53j/src/evsys.rs
@@ -61,13 +61,13 @@ impl RegisterBlock {
     pub fn channels_iter(&self) -> impl Iterator<Item = &Channels> {
         self.channels.iter()
     }
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub const fn user(&self, n: usize) -> &User {
         &self.user[n]
     }
     #[doc = "Iterator for array of:"]
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub fn user_iter(&self) -> impl Iterator<Item = &User> {
         self.user.iter()

--- a/pac/atsame53j/src/evsys/user.rs
+++ b/pac/atsame53j/src/evsys/user.rs
@@ -10,7 +10,7 @@ impl R {
     #[doc = "Bits 0:5 - Channel Event Selection"]
     #[inline(always)]
     pub fn channel(&self) -> ChannelR {
-        ChannelR::new((self.bits & 0x3f) as u8)
+        ChannelR::new(self.bits & 0x3f)
     }
 }
 impl W {
@@ -24,18 +24,18 @@ impl W {
 #[doc = "User Multiplexer n\n\nYou can [`read`](crate::Reg::read) this register and get [`user::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`user::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct UserSpec;
 impl crate::RegisterSpec for UserSpec {
-    type Ux = u32;
+    type Ux = u8;
 }
 #[doc = "`read()` method returns [`user::R`](R) reader structure"]
 impl crate::Readable for UserSpec {}
 #[doc = "`write(|w| ..)` method takes [`user::W`](W) writer structure"]
 impl crate::Writable for UserSpec {
     type Safety = crate::Unsafe;
-    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
-    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
 }
 #[doc = "`reset()` method sets USER[%s]
 to value 0"]
 impl crate::Resettable for UserSpec {
-    const RESET_VALUE: u32 = 0;
+    const RESET_VALUE: u8 = 0;
 }

--- a/pac/atsame53n/src/evsys.rs
+++ b/pac/atsame53n/src/evsys.rs
@@ -61,13 +61,13 @@ impl RegisterBlock {
     pub fn channels_iter(&self) -> impl Iterator<Item = &Channels> {
         self.channels.iter()
     }
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub const fn user(&self, n: usize) -> &User {
         &self.user[n]
     }
     #[doc = "Iterator for array of:"]
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub fn user_iter(&self) -> impl Iterator<Item = &User> {
         self.user.iter()

--- a/pac/atsame53n/src/evsys/user.rs
+++ b/pac/atsame53n/src/evsys/user.rs
@@ -10,7 +10,7 @@ impl R {
     #[doc = "Bits 0:5 - Channel Event Selection"]
     #[inline(always)]
     pub fn channel(&self) -> ChannelR {
-        ChannelR::new((self.bits & 0x3f) as u8)
+        ChannelR::new(self.bits & 0x3f)
     }
 }
 impl W {
@@ -24,18 +24,18 @@ impl W {
 #[doc = "User Multiplexer n\n\nYou can [`read`](crate::Reg::read) this register and get [`user::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`user::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct UserSpec;
 impl crate::RegisterSpec for UserSpec {
-    type Ux = u32;
+    type Ux = u8;
 }
 #[doc = "`read()` method returns [`user::R`](R) reader structure"]
 impl crate::Readable for UserSpec {}
 #[doc = "`write(|w| ..)` method takes [`user::W`](W) writer structure"]
 impl crate::Writable for UserSpec {
     type Safety = crate::Unsafe;
-    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
-    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
 }
 #[doc = "`reset()` method sets USER[%s]
 to value 0"]
 impl crate::Resettable for UserSpec {
-    const RESET_VALUE: u32 = 0;
+    const RESET_VALUE: u8 = 0;
 }

--- a/pac/atsame54n/src/evsys.rs
+++ b/pac/atsame54n/src/evsys.rs
@@ -61,13 +61,13 @@ impl RegisterBlock {
     pub fn channels_iter(&self) -> impl Iterator<Item = &Channels> {
         self.channels.iter()
     }
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub const fn user(&self, n: usize) -> &User {
         &self.user[n]
     }
     #[doc = "Iterator for array of:"]
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub fn user_iter(&self) -> impl Iterator<Item = &User> {
         self.user.iter()

--- a/pac/atsame54n/src/evsys/user.rs
+++ b/pac/atsame54n/src/evsys/user.rs
@@ -10,7 +10,7 @@ impl R {
     #[doc = "Bits 0:5 - Channel Event Selection"]
     #[inline(always)]
     pub fn channel(&self) -> ChannelR {
-        ChannelR::new((self.bits & 0x3f) as u8)
+        ChannelR::new(self.bits & 0x3f)
     }
 }
 impl W {
@@ -24,18 +24,18 @@ impl W {
 #[doc = "User Multiplexer n\n\nYou can [`read`](crate::Reg::read) this register and get [`user::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`user::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct UserSpec;
 impl crate::RegisterSpec for UserSpec {
-    type Ux = u32;
+    type Ux = u8;
 }
 #[doc = "`read()` method returns [`user::R`](R) reader structure"]
 impl crate::Readable for UserSpec {}
 #[doc = "`write(|w| ..)` method takes [`user::W`](W) writer structure"]
 impl crate::Writable for UserSpec {
     type Safety = crate::Unsafe;
-    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
-    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
 }
 #[doc = "`reset()` method sets USER[%s]
 to value 0"]
 impl crate::Resettable for UserSpec {
-    const RESET_VALUE: u32 = 0;
+    const RESET_VALUE: u8 = 0;
 }

--- a/pac/atsame54p/src/evsys.rs
+++ b/pac/atsame54p/src/evsys.rs
@@ -61,13 +61,13 @@ impl RegisterBlock {
     pub fn channels_iter(&self) -> impl Iterator<Item = &Channels> {
         self.channels.iter()
     }
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub const fn user(&self, n: usize) -> &User {
         &self.user[n]
     }
     #[doc = "Iterator for array of:"]
-    #[doc = "0x120..0x22c - User Multiplexer n"]
+    #[doc = "0x120..0x163 - User Multiplexer n"]
     #[inline(always)]
     pub fn user_iter(&self) -> impl Iterator<Item = &User> {
         self.user.iter()

--- a/pac/atsame54p/src/evsys/user.rs
+++ b/pac/atsame54p/src/evsys/user.rs
@@ -10,7 +10,7 @@ impl R {
     #[doc = "Bits 0:5 - Channel Event Selection"]
     #[inline(always)]
     pub fn channel(&self) -> ChannelR {
-        ChannelR::new((self.bits & 0x3f) as u8)
+        ChannelR::new(self.bits & 0x3f)
     }
 }
 impl W {
@@ -24,18 +24,18 @@ impl W {
 #[doc = "User Multiplexer n\n\nYou can [`read`](crate::Reg::read) this register and get [`user::R`](R). You can [`reset`](crate::Reg::reset), [`write`](crate::Reg::write), [`write_with_zero`](crate::Reg::write_with_zero) this register using [`user::W`](W). You can also [`modify`](crate::Reg::modify) this register. See [API](https://docs.rs/svd2rust/#read--modify--write-api)."]
 pub struct UserSpec;
 impl crate::RegisterSpec for UserSpec {
-    type Ux = u32;
+    type Ux = u8;
 }
 #[doc = "`read()` method returns [`user::R`](R) reader structure"]
 impl crate::Readable for UserSpec {}
 #[doc = "`write(|w| ..)` method takes [`user::W`](W) writer structure"]
 impl crate::Writable for UserSpec {
     type Safety = crate::Unsafe;
-    const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
-    const ONE_TO_MODIFY_FIELDS_BITMAP: u32 = 0;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: u8 = 0;
 }
 #[doc = "`reset()` method sets USER[%s]
 to value 0"]
 impl crate::Resettable for UserSpec {
-    const RESET_VALUE: u32 = 0;
+    const RESET_VALUE: u8 = 0;
 }

--- a/svd/devices/include/atsamd5x.xsl
+++ b/svd/devices/include/atsamd5x.xsl
@@ -5,7 +5,18 @@
     actual values expected for this field. -->
   <xsl:template match="/device/peripherals/peripheral[name='NVMCTRL']/registers/register[name='PARAM']/fields/field[name='SEE']/enumeratedValues">
   </xsl:template>
-
+  
+  <!-- EVSYS USER[m] registers have the wrong width (4 bytes vs actual 1)-->
+  <xsl:template match="/device/peripherals/peripheral[name='EVSYS']/registers/register[name='USER[%s]']/dimIncrement">
+    <dimIncrement>1</dimIncrement>
+  </xsl:template>
+  <xsl:template match="/device/peripherals/peripheral[name='EVSYS']/registers/register[name='USER[%s]']/size">
+    <size>8</size>
+  </xsl:template>
+  <xsl:template match="/device/peripherals/peripheral[name='EVSYS']/registers/register[name='USER[%s]']/resetValue">
+    <resetValue>0x00</resetValue>
+  </xsl:template>
+  
   <!-- The SDHC0 peripheral on some devices contains reset values for certain
     fields that are wider than their corresponding storage. Replace the invalid
     values with the ones from the datasheet. -->


### PR DESCRIPTION
# Summary

This patch fixes the length of the SAM5x evsys user[m] channel registers. The registers are 1 byte long, whilst the SVD had them as 4 bytes long, causing numerous issues when dealing with the EVSYS multiplexer. 
