### PR TITLE
FT: EVSYS peripheral implementation and pulse counting

### DIFF
--- a/hal/src/peripherals/eic.rs
+++ b/hal/src/peripherals/eic.rs
@@ -218,6 +218,17 @@ impl Eic {
 
     /// Create and initialize a new [`Eic`], and wire it up to the
     /// ultra-low-power 32kHz clock source.
+    ///
+    /// Due to the way the EIC peripheral is implemented, the EIC Clock MUST
+    /// be driven by the OSC32K clock, this can be done with the V2 clocking API as follows:
+    ///
+    /// ```no_run
+    /// let (osc32k, base) = OscUlp32k::enable(tokens.osculp32k.osculp32k, clocks.osculp32k_base);
+    /// let (gclk2, _osc32k) = Gclk::from_source(tokens.gclks.gclk2, osc32k);
+    /// let gclk2_32k = gclk2.enable();
+    /// let (pclk_eic, gclk2_32k) = Pclk::enable(tokens.pclks.eic, gclk2_32k);
+    /// let eic = Eic::new(&mut mclk, pclk_eic.into(), cx.device.eic).split();
+    /// ```
     #[hal_cfg("eic-d5x")]
     pub fn new(mclk: &mut pac::Mclk, _clock: EicClock, eic: pac::Eic) -> Self {
         mclk.apbamask().modify(|_, w| w.eic_().set_bit());

--- a/hal/src/peripherals/eic.rs
+++ b/hal/src/peripherals/eic.rs
@@ -118,12 +118,13 @@ pub trait EicPin: AnyPin + Sealed {
 
 /// A numbered external interrupt, which can be used to sense state changes on
 /// its pin.
-pub struct ExtInt<P, Id, F = NoneT>
+pub struct ExtInt<P, Id, F = NoneT, EvId = NoneT>
 where
     P: EicPin,
     Id: ChId,
 {
     chan: Channel<Id, F>,
+    evchan: PhantomData<EvId>,
     pin: Pin<P::Id, P::Mode>,
 }
 
@@ -143,6 +144,7 @@ where
     fn new(pin: P, chan: Channel<Id, F>) -> Self {
         ExtInt {
             pin: pin.into(),
+            evchan: PhantomData::default(),
             chan,
         }
     }

--- a/hal/src/peripherals/eic.rs
+++ b/hal/src/peripherals/eic.rs
@@ -220,7 +220,8 @@ impl Eic {
     /// ultra-low-power 32kHz clock source.
     ///
     /// Due to the way the EIC peripheral is implemented, the EIC Clock MUST
-    /// be driven by the OSC32K clock, this can be done with the V2 clocking API as follows:
+    /// be driven by the OSC32K clock, this can be done with the V2 clocking 
+    /// API as follows:
     ///
     /// ```no_run
     /// let (osc32k, base) = OscUlp32k::enable(tokens.osculp32k.osculp32k, clocks.osculp32k_base);

--- a/hal/src/peripherals/eic.rs
+++ b/hal/src/peripherals/eic.rs
@@ -220,7 +220,7 @@ impl Eic {
     /// ultra-low-power 32kHz clock source.
     ///
     /// Due to the way the EIC peripheral is implemented, the EIC Clock MUST
-    /// be driven by the OSC32K clock, this can be done with the V2 clocking 
+    /// be driven by the OSC32K clock, this can be done with the V2 clocking
     /// API as follows:
     ///
     /// ```no_run

--- a/hal/src/peripherals/eic/d11/pin.rs
+++ b/hal/src/peripherals/eic/d11/pin.rs
@@ -3,6 +3,7 @@ use atsamd_hal_macros::hal_cfg;
 use crate::ehal::digital::{ErrorType, InputPin};
 use crate::ehal_02::digital::v2::InputPin as InputPin_02;
 use crate::eic::*;
+use crate::evsys::EvSysChannel;
 use crate::gpio::{
     self, pin::*, AnyPin, FloatingInterrupt, PinMode, PullDownInterrupt, PullUpInterrupt,
 };
@@ -52,6 +53,15 @@ where
     P: EicPin,
     Id: ChId,
 {
+    pub fn enable_evsys_src<EvId: crate::evsys::ChId>(
+        &mut self,
+        chan: EvSysChannel<EvId, crate::evsys::Uninitialized>,
+    ) -> EvSysChannel<EvId, crate::evsys::GenReady> {
+        // EIC External ISR 0..15 = 0x12 - 0x21
+        self.enable_event();
+        chan.register_generator((P::ChId::ID as u8) + 0x0C)
+    }
+
     /// Enables event output for the event system for this channel.
     ///
     /// Note that this function does disable the EIC peripheral briefely in order

--- a/hal/src/peripherals/eic/d11/pin.rs
+++ b/hal/src/peripherals/eic/d11/pin.rs
@@ -57,13 +57,13 @@ where
     /// Note that this function does disable the EIC peripheral briefely in order
     /// to write to the evctrl register.
     pub fn enable_event(&mut self) {
-        self.chan.eic.ctrla().write(|w| w.enable().clear_bit());
+        self.chan.eic.ctrl().write(|w| w.enable().clear_bit());
         self.sync();
         self.chan
             .eic
             .evctrl()
             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << P::ChId::ID)) });
-        self.chan.eic.ctrla().write(|w| w.enable().set_bit());
+        self.chan.eic.ctrl().write(|w| w.enable().set_bit());
         self.sync();
     }
 
@@ -142,7 +142,7 @@ where
     }
 
     fn sync(&self) {
-        while self.chan.eic.syncbusy().read().bits() != 0 {
+        while self.chan.eic.status().read().syncbusy().bit_is_set() {
             core::hint::spin_loop();
         }
     }

--- a/hal/src/peripherals/eic/d5x/pin.rs
+++ b/hal/src/peripherals/eic/d5x/pin.rs
@@ -1,5 +1,4 @@
 use atsamd_hal_macros::hal_cfg;
-use atsame54p::evsys;
 
 use crate::ehal::digital::{ErrorType, InputPin};
 use crate::ehal_02::digital::v2::InputPin as InputPin_02;

--- a/hal/src/peripherals/evsys.rs
+++ b/hal/src/peripherals/evsys.rs
@@ -1,0 +1,251 @@
+//! # Event system controller
+//!
+//! This peripheral allows for the chips peripherals to exchange events with eachother
+//! without needing the CPU.
+//!
+//! The event system contains a number of channels, that can be wired between peripherals.
+//! The number of channels available varies per chip:
+//! * SAM5x: 32 channels
+//! * SAMD21: 12 channels
+//! * SAMD11: 6 channels
+//!
+//! The channels destinations are configured using a multiplexor register, which directs events to
+//! a destination peripherals. Destination peripherals can support 1 or more supported path modes:
+//! * Asynchronous
+//! * Synchronous
+//! * Resynchronized
+//!
+//! A peripheral can only be the receiver of 1 channel, however, a peripheral can generate
+//! events on multiple channels at the same time.
+//!
+//! ## Usage
+//!
+//! 1. Create the [`EvSysController`]
+//! 2. Split the controller into a tuple of its channels, using [`EvSysController::split`]
+//! 3. Pass a channel into a generator peripheral to enable it to output to the provided channel
+//! 4. Pass the channel into the receiving peripheral to complete wiring the peripheral up.
+//!
+//! ### Example setup using TC pulse counter and EIC
+//! ```no_run
+//! // Splitting EIC channels (See EIC peripheral)
+//! let eic_channels = Eic::new(&mut peripherals.mclk, eic_clock, peripherals.eic).split();
+//! let speed_sensor: Pin<_, PullDownInterrupt> = pins.speed_sensor.into();
+//! let extint_speed_sensor = eic_channels.0.with_pin(speed_sensor); // Our generator channel
+//!
+//! // Initialize the evsys controller and split into channels
+//! let evsys_channels = EvSysController::new(&mut peripherals.mclk, evsys_clock, peripherals.evsys).split();
+//! // Take a channel and provide it to an EIC channel to generate our events
+//! let evsys_chan0 = extint_speed_sensor.enable_evsys_src(evsys_channels.0); // Channel with generator wired up
+//!
+//! // Create our pulse counter, using the evsys channel to provide the trigger to count!
+//! let pc_settings = CounterSettings::default();
+//! let pc_speed_sensor: PulseCounter<Tc2PulseCounter, evsys::Ch0> = PulseCounter::new(cx.device.tc2, &tc2_3_pclk, pc_settings, &mut peripherals.mclk, evsys_chan0);
+//!
+//!
+//! loop {
+//!    let pulses = pc_speed_sensor.count();
+//!    pc_speed_sensor.reset(); // Set pulse counter back to 0 after each read!
+//! }
+//! ```
+//! ## Notes
+//! At the moment, the event system channels will only run using Asynchronous paths,
+//! which is not supported by all receiving peripherals.
+
+use atsamd_hal_macros::hal_cfg;
+use core::marker::PhantomData;
+
+use crate::pac::{Evsys, Mclk};
+use crate::typelevel::Sealed;
+use seq_macro::seq;
+
+pub trait Status: Sealed {}
+
+pub enum Uninitialized {}
+impl Sealed for Uninitialized {}
+impl Status for Uninitialized {}
+
+pub enum GenReady {}
+impl Sealed for GenReady {}
+impl Status for GenReady {}
+
+pub enum Ready {}
+impl Sealed for Ready {}
+impl Status for Ready {}
+
+pub trait ChId {
+    const ID: usize;
+}
+
+pub struct EvSysChannel<Id: ChId, S: Status> {
+    evsys: core::mem::ManuallyDrop<Evsys>,
+    _id: PhantomData<Id>,
+    _state: PhantomData<S>,
+    generator_id: u8,
+}
+
+// Create a new Uninitialized channel
+fn new_evsys_channel<Id: ChId>(evsys: Evsys) -> EvSysChannel<Id, Uninitialized> {
+    EvSysChannel {
+        evsys: core::mem::ManuallyDrop::new(evsys),
+        _id: PhantomData,
+        _state: PhantomData,
+        generator_id: 0,
+    }
+}
+
+// Impl for channels of any state
+impl<Id: ChId, S: Status> EvSysChannel<Id, S> {
+    fn change_status<N: Status>(self) -> EvSysChannel<Id, N> {
+        EvSysChannel {
+            evsys: self.evsys,
+            _id: PhantomData,
+            _state: PhantomData,
+            generator_id: self.generator_id,
+        }
+    }
+}
+
+// Methods that can only be used on a channel that is uninitialized
+impl<Id: ChId> EvSysChannel<Id, Uninitialized> {
+    pub fn register_generator(mut self, generator_id: u8) -> EvSysChannel<Id, GenReady> {
+        self.generator_id = generator_id;
+        self.change_status()
+    }
+}
+
+// Methods that can only be used on a channel with just a connected generator
+impl<Id: ChId> EvSysChannel<Id, GenReady> {
+    pub fn remove_generator(mut self) -> EvSysChannel<Id, Uninitialized> {
+        self.generator_id = 0;
+        self.change_status()
+    }
+
+    pub fn register_user(self, user_id: usize) -> EvSysChannel<Id, Ready> {
+        // Now wire up the generator
+        // Multiplexor MUST be wired before the channel
+        self.evsys
+            .user(user_id)
+            .write(|w| unsafe { w.channel().bits(Id::ID as u8 + 1) }); // +1 since 0 means no channel
+
+        self.evsys.channels(Id::ID as usize).channel().write(|w| {
+            w.path().asynchronous();
+            w.edgsel().no_evt_output();
+            unsafe { w.evgen().bits(self.generator_id) }
+        });
+        self.change_status()
+    }
+}
+
+// Methods that can only be used on a channel that has both ends connected
+impl<Id: ChId> EvSysChannel<Id, Ready> {
+    pub fn deregister_user(self, user_id: usize) -> EvSysChannel<Id, GenReady> {
+        // Unhook the channel generator
+        let reg = self.evsys.channels(Id::ID as usize);
+        reg.channel().reset();
+        // Then unhook the user
+        self.evsys
+            .user(user_id)
+            .write(|w| unsafe { w.channel().bits(0) });
+        self.change_status()
+    }
+
+    pub fn busy(&self) -> bool {
+        self.evsys
+            .channels(Id::ID as usize)
+            .chstatus()
+            .read()
+            .busych()
+            .bit()
+    }
+}
+
+/// Event system controller peripheral
+pub struct EvSysController {
+    evsys: crate::pac::Evsys,
+}
+
+impl EvSysController {
+    pub fn new(mclk: &mut Mclk, evsys: crate::pac::Evsys) -> Self {
+        mclk.apbbmask().write(|w| w.evsys_().set_bit()); // Enable EVSYS clock
+        evsys.ctrla().write(|w| w.swrst().set_bit());
+        Self { evsys }
+    }
+
+    pub fn free(self, _channels: Channels) -> Evsys {
+        self.evsys.ctrla().write(|w| w.swrst().set_bit());
+        self.evsys
+    }
+}
+
+#[hal_cfg("eic-d11")]
+macro_rules! with_num_channels {
+    ($some_macro:ident) => {
+        $some_macro! {6}
+    };
+}
+
+#[hal_cfg(any("eic-d21"))]
+macro_rules! with_num_channels {
+    ($some_macro:ident) => {
+        $some_macro! {12}
+    };
+}
+
+#[hal_cfg(any("eic-d5x"))]
+macro_rules! with_num_channels {
+    ($some_macro:ident) => {
+        $some_macro! {32}
+    };
+}
+
+macro_rules! get {
+    ($literal:literal) => {
+        $literal
+    };
+}
+
+pub const NUM_CHANNELS: usize = with_num_channels!(get);
+
+macro_rules! define_channels_struct {
+    ($num_channels:literal) => {
+        seq!(N in 0..$num_channels {
+            #(
+                /// Type alias for a channel number
+                pub enum Ch~N {}
+
+                impl ChId for Ch~N {
+                    const ID: usize = N;
+                }
+            )*
+
+            /// Struct generating individual handles to each EXTINT channel
+            pub struct Channels(
+                #(
+                    pub EvSysChannel<Ch~N, Uninitialized>,
+                )*
+            );
+        });
+    };
+}
+with_num_channels!(define_channels_struct);
+
+macro_rules! define_split {
+    ($num_channels:literal) => {
+        seq!(N in 0..$num_channels {
+            /// Split the EIC into individual channels.
+            #[inline]
+            pub fn split(self) -> Channels {
+                Channels(
+                    #(
+                       unsafe { new_evsys_channel(core::ptr::read(&self.evsys as *const _)) },
+                    )*
+                )
+            }
+
+        });
+    };
+}
+
+impl EvSysController {
+    with_num_channels!(define_split);
+}

--- a/hal/src/peripherals/mod.rs
+++ b/hal/src/peripherals/mod.rs
@@ -18,8 +18,17 @@ pub mod calibration {}
 )]
 pub mod timer {}
 
+#[hal_module(
+    any("clock-d11", "clock-d21") => "pulse_counter/d11.rs",
+    "clock-d5x" => "pulse_counter/d5x.rs",
+)]
+pub mod pulse_counter {}
+
 #[cfg(feature = "device")]
 pub mod eic;
+
+#[cfg(feature = "device")]
+pub mod evsys;
 
 #[cfg(feature = "usb")]
 #[hal_module(

--- a/hal/src/peripherals/pulse_counter/d11.rs
+++ b/hal/src/peripherals/pulse_counter/d11.rs
@@ -1,0 +1,209 @@
+use core::ops::Deref;
+
+#[hal_cfg("clock-d11")]
+use crate::pac::tc1 as tc;
+#[hal_cfg("clock-d21")]
+use crate::pac::tc3 as tc;
+
+use crate::pac::Pm;
+use atsamd_hal_macros::hal_cfg;
+use tc::count16::evctrl::Evactselect;
+
+use super::evsys::{EvSysChannel, GenReady};
+
+/// Counter settings
+/// Default options
+///
+/// * Stop counting on max value reached (65535), and do not overflow
+/// * Allow running in standby mode
+pub struct CounterSettings {
+    stop_on_overflow: bool,
+    run_in_standby: bool,
+}
+
+impl Default for CounterSettings {
+    fn default() -> Self {
+        Self {
+            stop_on_overflow: true,
+            run_in_standby: true,
+        }
+    }
+}
+
+impl CounterSettings {
+    pub fn run_in_standby(mut self, b: bool) -> Self {
+        self.run_in_standby = b;
+        self
+    }
+
+    pub fn stop_on_overflow(mut self, b: bool) -> Self {
+        self.stop_on_overflow = b;
+        self
+    }
+}
+
+pub trait CounterInstance {
+    const EVSYS_USR_EVT_ID: usize;
+    type Instance: Deref<Target = tc::RegisterBlock>;
+    type Clock;
+    fn enable_pm(pm: &mut Pm);
+    fn disable_pm(pm: &mut Pm);
+}
+
+pub struct PulseCounter<T: CounterInstance, EvId: crate::evsys::ChId> {
+    instance: T::Instance,
+    evsys_channel: EvSysChannel<EvId, crate::evsys::Ready>,
+}
+
+impl<T: CounterInstance, EvId: crate::evsys::ChId> PulseCounter<T, EvId> {
+    /// Creates a new pulse counter out of a TC peripheral
+    ///
+    /// This consumes the evsys channel that monitors the GPIO that is to be monitored
+    ///
+    /// Once created, call [`PulseCounter::start`] to start monitoring
+    ///
+    /// ## Limitations
+    /// 1. Can only work in 16 bit mode, so when monitoring very high frequency signals,
+    ///    you will need to query the counter very frequently
+    ///
+    /// Returns the pulse counter instance
+    pub fn new(
+        tc: T::Instance,
+        _clock: &T::Clock,
+        settings: CounterSettings,
+        pm: &mut Pm,
+        evsys_channel: EvSysChannel<EvId, GenReady>,
+    ) -> Self {
+        // !!IMPORTANT!!
+        // It is undocumented, but the peripherals user register MUST be set BEFORE enabling
+        // the peripherals mclk - otherwise the user register becomes locked!
+        let ready_channel = evsys_channel.register_user(T::EVSYS_USR_EVT_ID);
+        T::enable_pm(pm);
+        // Register the evsys channel to this peripheral's receiver
+        {
+            // Scoped whilst we are modifying count16
+            let instance = tc.count16();
+            // Then trigger SWRST
+            instance.ctrla().write(|w| w.swrst().set_bit());
+            while instance.status().read().syncbusy().bit_is_set() {}
+
+            // Enable reading off the EVSYS channel
+            instance.evctrl().write(|w| {
+                w.tcei().set_bit(); // Enable incomming events
+                w.evact().variant(Evactselect::Count) // Count up on event
+            });
+            instance.count().reset();
+            if settings.stop_on_overflow {
+                instance.ctrlbclr().write(|w| w.oneshot().set_bit()); // Clear oneshot (Allow overflow)
+            } else {
+                instance.ctrlbset().write(|w| w.oneshot().set_bit()); // Set oneshhot (Stop on overflow)
+            }
+            while instance.status().read().syncbusy().bit_is_set() {}
+            instance.ctrla().write(|w| {
+                if settings.run_in_standby {
+                    w.runstdby().set_bit();
+                }
+                w.prescaler().div1()
+            });
+        }
+        let s = Self {
+            instance: tc,
+            evsys_channel: ready_channel,
+        };
+        s
+    }
+
+    /// Stop pulse counting and release the TC peripheral and EVSYS channel
+    pub fn release(self, pm: &mut Pm) -> (T::Instance, EvSysChannel<EvId, GenReady>) {
+        T::disable_pm(pm);
+        let instance = self.instance.count16();
+        instance.ctrla().modify(|_, w| w.enable().clear_bit());
+        while instance.status().read().syncbusy().bit_is_set() {}
+        instance.ctrla().modify(|_, w| w.swrst().set_bit());
+        while instance.status().read().syncbusy().bit_is_set() {}
+        let unhooked = self.evsys_channel.deregister_user(T::EVSYS_USR_EVT_ID);
+        (self.instance, unhooked)
+    }
+
+    /// Retreives the current number of pulses counted.
+    ///
+    /// This does not clear the counted value, to do that, call [PulseCounter::clear]
+    pub fn count(&self) -> u16 {
+        let instance = self.instance.count16();
+        instance.count().read().bits()
+    }
+
+    /// Set the counter value back to 0
+    pub fn clear(&self) {
+        let instance = self.instance.count16();
+        instance.count().reset();
+        self.sync();
+    }
+
+    fn sync(&self) {
+        let count16 = self.instance.count16();
+        while count16.status().read().syncbusy().bit_is_set() {
+            core::hint::spin_loop();
+        }
+    }
+
+    /// Stop pulse counting
+    pub fn stop(&self) {
+        self.instance
+            .count16()
+            .ctrla()
+            .write(|w| w.enable().clear_bit());
+    }
+
+    /// Start pulse counting
+    pub fn start(&self) {
+        self.instance
+            .count16()
+            .ctrla()
+            .write(|w| w.enable().set_bit());
+    }
+}
+
+macro_rules! tc_pulse_counter {
+    ($($TYPE:ident: ($TC:ident, $mclk:ident, $clock:ident, $apmask:ident, $evsysuser:literal),)+) => {
+        $(
+        pub struct $TYPE;
+
+        impl CounterInstance for $TYPE {
+            const EVSYS_USR_EVT_ID: usize = $evsysuser;
+            type Clock = crate::clock::$clock;
+            type Instance = crate::pac::$TC;
+
+            fn enable_pm(pm: &mut Pm) {
+                pm.$apmask().write(|w| w.$mclk().set_bit());
+            }
+
+            fn disable_pm(pm: &mut Pm) {
+                pm.$apmask().write(|w| w.$mclk().clear_bit());
+            }
+        }
+        )+
+    };
+}
+
+// D11
+#[hal_cfg(all("clock-d11", "tc1"))]
+tc_pulse_counter! {Tc1PulseCounter: (Tc1, tc1_, Tc1Tc2Clock, apbcmask, 0x0A),}
+#[hal_cfg(all("clock-d11", "tc2"))]
+tc_pulse_counter! {Tc2PulseCounter: (Tc2, tc2_, Tc1Tc2Clock, apbcmask, 0x0B),}
+
+// D21
+#[hal_cfg(all("clock-d21", "tc3"))]
+tc_pulse_counter! {Tc3PulseCounter: (Tc3, tc3_, Tcc2Tc3Clock, apbcmask, 0x12),}
+
+#[hal_cfg(all("clock-d21", "tc4"))]
+tc_pulse_counter! {Tc4PulseCounter: (Tc4, tc4_, Tc4Tc5Clock, apbcmask, 0x13),}
+
+#[hal_cfg(all("clock-d21", "tc5"))]
+tc_pulse_counter! {Tc5PulseCounter: (Tc5, tc5_, Tc4Tc5Clock, apbcmask, 0x14),}
+
+#[hal_cfg(all("clock-d21", "tc6"))]
+tc_pulse_counter! {Tc6PulseCounter: (Tc6, tc6_, Tc6Tc7Clock, apbcmask, 0x15),}
+
+#[hal_cfg(all("clock-d21", "tc7"))]
+tc_pulse_counter! {Tc7PulseCounter: (Tc7, tc7_, Tc6Tc7Clock, apbcmask, 0x16),}

--- a/hal/src/peripherals/pulse_counter/d5x.rs
+++ b/hal/src/peripherals/pulse_counter/d5x.rs
@@ -135,7 +135,7 @@ impl<T: CounterInstance, EvId: crate::evsys::ChId> PulseCounter<T, EvId> {
         while instance.ctrlbset().read().cmd().bits() != 0 {
             core::hint::spin_loop();
         }
-        let res = instance.count().read().bits() + self.evsys_channel.busy() as u16;
+        let res = instance.count().read().bits();
         res
     }
 

--- a/hal/src/peripherals/pulse_counter/d5x.rs
+++ b/hal/src/peripherals/pulse_counter/d5x.rs
@@ -1,10 +1,10 @@
 use core::ops::Deref;
 
-use atsamd_hal_macros::hal_cfg;
-use atsame54p::{
+use crate::pac::{
     tc0::{self, count16::evctrl::Evactselect},
     Mclk,
 };
+use atsamd_hal_macros::hal_cfg;
 
 use super::{
     clock::v2::pclk::Pclk,

--- a/hal/src/peripherals/pulse_counter/d5x.rs
+++ b/hal/src/peripherals/pulse_counter/d5x.rs
@@ -1,0 +1,211 @@
+use core::ops::Deref;
+
+use atsamd_hal_macros::hal_cfg;
+use atsame54p::{
+    tc0::{self, count16::evctrl::Evactselect},
+    Mclk,
+};
+
+use super::{
+    clock::v2::pclk::Pclk,
+    evsys::{EvSysChannel, GenReady},
+};
+
+/// Counter settings
+/// Default options
+///
+/// * Stop counting on max value reached (65535), and do not overflow
+/// * Allow running in standby mode
+pub struct CounterSettings {
+    stop_on_overflow: bool,
+    run_in_standby: bool,
+}
+
+impl Default for CounterSettings {
+    fn default() -> Self {
+        Self {
+            stop_on_overflow: true,
+            run_in_standby: true,
+        }
+    }
+}
+
+impl CounterSettings {
+    pub fn run_in_standby(mut self, b: bool) -> Self {
+        self.run_in_standby = b;
+        self
+    }
+
+    pub fn stop_on_overflow(mut self, b: bool) -> Self {
+        self.stop_on_overflow = b;
+        self
+    }
+}
+
+pub trait CounterInstance {
+    const EVSYS_USR_EVT_ID: usize;
+    type ClockId: crate::clock::v2::pclk::PclkId;
+    type Instance: Deref<Target = tc0::RegisterBlock>;
+    fn enable_mclk(mclk: &mut Mclk);
+    fn disable_mclk(mclk: &mut Mclk);
+}
+
+pub struct PulseCounter<T: CounterInstance, EvId: crate::evsys::ChId> {
+    instance: T::Instance,
+    evsys_channel: EvSysChannel<EvId, crate::evsys::Ready>,
+}
+
+impl<T: CounterInstance, EvId: crate::evsys::ChId> PulseCounter<T, EvId> {
+    /// Creates a new pulse counter out of a TC peripheral
+    ///
+    /// This consumes the evsys channel that monitors the GPIO that is to be monitored
+    ///
+    /// Once created, call [`PulseCounter::start`] to start monitoring
+    ///
+    /// ## Limitations
+    /// 1. Can only work in 16 bit mode, so when monitoring very high frequency signals,
+    ///    you will need to query the counter very frequently
+    ///
+    /// Returns the pulse counter instance
+    pub fn new<PS: crate::clock::v2::pclk::PclkSourceId>(
+        tc: T::Instance,
+        _clock: &Pclk<T::ClockId, PS>,
+        settings: CounterSettings,
+        mclk: &mut Mclk,
+        evsys_channel: EvSysChannel<EvId, GenReady>,
+    ) -> Self {
+        // !!IMPORTANT!!
+        // It is undocumented, but the peripherals user register MUST be set BEFORE enabling
+        // the peripherals mclk - otherwise the user register becomes locked!
+        let ready_channel = evsys_channel.register_user(T::EVSYS_USR_EVT_ID);
+        T::enable_mclk(mclk);
+        // Register the evsys channel to this peripheral's receiver
+        {
+            // Scoped whilst we are modifying count16
+            let instance = tc.count16();
+            // Then trigger SWRST
+            instance.ctrla().write(|w| w.swrst().set_bit());
+            while instance.syncbusy().read().bits() != 0 {}
+
+            // Enable reading off the EVSYS channel
+            instance.evctrl().write(|w| {
+                w.tcei().set_bit(); // Enable incomming events
+                w.evact().variant(Evactselect::Count) // Count up on event
+            });
+            instance.count().reset();
+            if settings.stop_on_overflow {
+                instance.ctrlbclr().write(|w| w.oneshot().set_bit()); // Clear oneshot (Allow overflow)
+            } else {
+                instance.ctrlbset().write(|w| w.oneshot().set_bit()); // Set oneshhot (Stop on overflow)
+            }
+            while instance.syncbusy().read().bits() != 0 {}
+            instance.ctrla().write(|w| {
+                if settings.run_in_standby {
+                    w.runstdby().set_bit();
+                }
+                w.prescaler().div1()
+            });
+        }
+        let s = Self {
+            instance: tc,
+            evsys_channel: ready_channel,
+        };
+        s
+    }
+
+    /// Stop pulse counting and release the TC peripheral and EVSYS channel
+    pub fn release(self, mclk: &mut Mclk) -> (T::Instance, EvSysChannel<EvId, GenReady>) {
+        T::disable_mclk(mclk);
+        let instance = self.instance.count16();
+        instance.ctrla().modify(|_, w| w.enable().clear_bit());
+        while instance.syncbusy().read().bits() != 0 {}
+        instance.ctrla().modify(|_, w| w.swrst().set_bit());
+        while instance.syncbusy().read().bits() != 0 {}
+        let unhooked = self.evsys_channel.deregister_user(T::EVSYS_USR_EVT_ID);
+        (self.instance, unhooked)
+    }
+
+    /// Retreives the current number of pulses counted.
+    ///
+    /// This does not clear the counted value, to do that, call [PulseCounter::clear]
+    pub fn count(&self) -> u16 {
+        let instance = self.instance.count16();
+        instance.ctrlbset().write(|w| w.cmd().readsync());
+        self.sync();
+        while instance.ctrlbset().read().cmd().bits() != 0 {
+            core::hint::spin_loop();
+        }
+        let res = instance.count().read().bits() + self.evsys_channel.busy() as u16;
+        res
+    }
+
+    /// Set the counter value back to 0
+    pub fn clear(&self) {
+        let instance = self.instance.count16();
+        instance.count().reset();
+        self.sync();
+    }
+
+    fn sync(&self) {
+        let count16 = self.instance.count16();
+        while count16.syncbusy().read().bits() != 0 {
+            core::hint::spin_loop();
+        }
+    }
+
+    /// Stop pulse counting
+    pub fn stop(&self) {
+        self.instance
+            .count16()
+            .ctrla()
+            .write(|w| w.enable().clear_bit());
+    }
+
+    /// Start pulse counting
+    pub fn start(&self) {
+        self.instance
+            .count16()
+            .ctrla()
+            .write(|w| w.enable().set_bit());
+    }
+}
+
+macro_rules! tc_pulse_counter {
+    ($($TYPE:ident: ($TC:ident, $mclk:ident, $clock:ident, $apmask:ident, $evsysuser:literal),)+) => {
+        $(
+        pub struct $TYPE;
+
+        impl CounterInstance for $TYPE {
+            const EVSYS_USR_EVT_ID: usize = $evsysuser;
+            type ClockId = crate::clock::v2::pclk::ids::$clock;
+            type Instance = crate::pac::$TC;
+
+            fn enable_mclk(mclk: &mut Mclk) {
+                mclk.$apmask().write(|w| w.$mclk().set_bit());
+            }
+
+            fn disable_mclk(mclk: &mut Mclk) {
+                mclk.$apmask().write(|w| w.$mclk().clear_bit());
+            }
+        }
+        )+
+    };
+}
+
+tc_pulse_counter! {
+    Tc0PulseCounter: (Tc0, tc0_, Tc0Tc1, apbamask, 44),
+    Tc1PulseCounter: (Tc1, tc1_, Tc0Tc1, apbamask, 45),
+    Tc2PulseCounter: (Tc2, tc2_, Tc2Tc3, apbbmask, 46),
+    Tc3PulseCounter: (Tc3, tc3_, Tc2Tc3, apbbmask, 47),
+}
+
+#[hal_cfg(all("tc4", "tc5"))]
+tc_pulse_counter! {
+    Tc4PulseCounter: (Tc4, tc4_, Tc4Tc5, apbcmask, 48),
+    Tc5PulseCounter: (Tc5, tc5_, Tc4Tc5, apbcmask, 49),
+}
+#[hal_cfg(all("tc6", "tc7"))]
+tc_pulse_counter! {
+    Tc6PulseCounter: (Tc6, tc6_, Tc6Tc7, apbdmask, 50),
+    Tc7PulseCounter: (Tc7, tc7_, Tc6Tc7, apbdmask, 51),
+}


### PR DESCRIPTION
# Summary

**This PR is a Work in progress!**

This adds a basic channel based implementation for the EVSYS peripheral found on SAMx controllers. Along with a new PulseCounter struct that utilizes the EVSYS, TC and EIC peripheral to count pulses on an EIC channel without any CPU intervention. I had created this in order to monitor hall effect speed sensors. 

A huge benefit here is that you can use any TC to monitor any EIC Extint with this method, so the monitored pins do not have to actually be connected to a TC peripheral, making it a lot more flexible.

Apologies for some overlap with #837, as that was needed to get EIC working, but I think this PR should be aimed at reviewing the EVSYS implementation and PulseCounter.

There is still a fair bit more to add to the evsys system (Automatic path type configuration, multiple channels from 1 generator, ...)

## Future plans with this
* Pulse-width and period monitoring using TC for more accurate signal monitoring features