### PR TITLE
fix(tc): wait for `syncbusy` bits to clear instead of `perbufv`

### DIFF
--- a/hal/src/peripherals/timer/d5x.rs
+++ b/hal/src/peripherals/timer/d5x.rs
@@ -96,16 +96,12 @@ where
 
         // Disable the timer while we reconfigure it
         count.ctrla().modify(|_, w| w.enable().clear_bit());
-        while count.status().read().perbufv().bit_is_set() {}
+        while count.syncbusy().read().enable().bit_is_set() {}
 
         // Now that we have a clock routed to the peripheral, we
         // can ask it to perform a reset.
         count.ctrla().write(|w| w.swrst().set_bit());
-
-        while count.status().read().perbufv().bit_is_set() {}
-        // the SVD erroneously marks swrst as write-only, so we
-        // need to manually read the bit here
-        while count.ctrla().read().bits() & 1 != 0 {}
+        while count.syncbusy().read().swrst().bit_is_set() {}
 
         count.ctrlbset().write(|w| {
             // Count up when the direction bit is zero
@@ -184,7 +180,7 @@ impl TimerCounter<$TC>
 
             // Disable the timer while we reconfigure it
             count.ctrla().modify(|_, w| w.enable().clear_bit());
-            while count.status().read().perbufv().bit_is_set()  {}
+            while count.syncbusy().read().enable().bit_is_set()  {}
         }
         Self {
             freq: clock.freq(),


### PR DESCRIPTION
# Summary

The [ATSAM D5x/E5x datasheet](https://ww1.microchip.com/downloads/aemDocuments/documents/MCU32/ProductDocuments/DataSheets/SAM-D5x-E5x-Family-Data-Sheet-DS60001507.pdf) mentions that the PERBUFV bit is only available in 8-bit mode (and will always read back 0 in 16/32-bit modes). 

<img src="https://github.com/user-attachments/assets/cfce5752-e310-4c06-b0d7-2f8a90fbacc7" height="300px"/>

The prescribed way to check that the timer has finished enabling/resetting is through the SYNCBUSY register

<table>
<tr>
<td><img src="https://github.com/user-attachments/assets/5d1abaad-e513-4d36-88a3-8f7efb778465"   /> </td>
<td><img src="https://github.com/user-attachments/assets/54e2e1b2-3632-4244-bf1a-844c89602307" />
</td>
</tr>
</table>



# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 

#### Note
The crate changelogs **should no longer** be manually updated! Changelogs are now automatically generated. Instead:

- If your PR is contained to a single crate, or a single feature:
  - Nothing else to do; your PR will likely be squashed down to a single commit.
  - Please consider using [conventional commmit phrasing](https://www.conventionalcommits.org) in the PR title.
- If your PR brings in large, sweeping changes across multiple crates:
  - Organize your commits such that each commit only touches a single crate, or a single feature across multiple crates. Please don't create commits that span multiple features over multiple crates.
  - Use [conventional commmits](https://www.conventionalcommits.org) for your commit messages.
