### PR TITLE
Refactored IoSet

### DIFF
--- a/boards/atsame54_xpro/src/devices.rs
+++ b/boards/atsame54_xpro/src/devices.rs
@@ -9,7 +9,6 @@ use super::pins::*;
 use hal::clock::GenericClockController;
 use hal::pac;
 use hal::sercom::{i2c, spi, uart};
-use hal::sercom::{IoSet1, IoSet2, IoSet3, IoSet4};
 use hal::time::Hertz;
 use uart::{BaudMode, Oversampling};
 
@@ -32,7 +31,7 @@ hal::bsp_peripherals!(
 );
 
 /// UART pads for the extension 1 connection
-pub type Ext1UartPads = uart::Pads<Ext1UartSercom, IoSet3, Ext1UartRx, Ext1UartTx>;
+pub type Ext1UartPads = uart::Pads<Ext1UartSercom, Ext1UartRx, Ext1UartTx>;
 
 /// Extension 1 UART device
 pub type Ext1Uart = uart::Uart<uart::Config<Ext1UartPads>, uart::Duplex>;
@@ -56,7 +55,7 @@ pub fn ext1_uart(
 
 /// UART pads for the extension 1 connection with flow control
 pub type Ext1FlowControlUartPads =
-    uart::Pads<Ext1UartSercom, IoSet3, Ext1UartRx, Ext1UartTx, Ext1UartRts, Ext1UartCts>;
+    uart::Pads<Ext1UartSercom, Ext1UartRx, Ext1UartTx, Ext1UartRts, Ext1UartCts>;
 
 /// Extension 1 UART device with flow control
 pub type Ext1FlowControlUart = uart::Uart<uart::Config<Ext1FlowControlUartPads>, uart::Duplex>;
@@ -86,7 +85,7 @@ pub fn ext1_flow_control_uart(
 }
 
 /// UART pads for the extension 3 connection
-pub type Ext3UartPads = uart::Pads<Ext3UartSercom, IoSet2, Ext3UartRx, Ext3UartTx>;
+pub type Ext3UartPads = uart::Pads<Ext3UartSercom, Ext3UartRx, Ext3UartTx>;
 
 /// Extension 3 UART device
 pub type Ext3Uart = uart::Uart<uart::Config<Ext3UartPads>, uart::Duplex>;
@@ -109,7 +108,7 @@ pub fn ext3_uart(
 }
 
 /// UART pads for the EDBG connection
-pub type EdbgUartPads = uart::Pads<EdbgUartSercom, IoSet4, EdbgUartRx, EdbgUartTx>;
+pub type EdbgUartPads = uart::Pads<EdbgUartSercom, EdbgUartRx, EdbgUartTx>;
 
 /// EDBG connection UART device
 pub type EdbgUart = uart::Uart<uart::Config<EdbgUartPads>, uart::Duplex>;
@@ -132,7 +131,7 @@ pub fn edbg_uart(
 }
 
 /// I2C pads for the extension 1 connection
-pub type Ext1I2cPads = i2c::Pads<Ext1I2cSercom, IoSet1, Ext1I2cSda, Ext1I2cScl>;
+pub type Ext1I2cPads = i2c::Pads<Ext1I2cSercom, Ext1I2cSda, Ext1I2cScl>;
 
 /// Extension 1 I2C device
 pub type Ext1I2c = i2c::I2c<i2c::Config<Ext1I2cPads>>;
@@ -156,7 +155,7 @@ pub fn ext1_i2c(
 }
 
 /// SPI pads for the extension 1 connection
-pub type Ext1SpiPads = spi::Pads<Ext1SpiSercom, IoSet4, Ext1SpiMiso, Ext1SpiMosi, Ext1SpiSck>;
+pub type Ext1SpiPads = spi::Pads<Ext1SpiSercom, Ext1SpiMiso, Ext1SpiMosi, Ext1SpiSck>;
 
 /// Extension 1 SPI device
 pub type Ext1Spi = spi::Spi<spi::Config<Ext1SpiPads>, spi::Duplex>;
@@ -183,7 +182,7 @@ pub fn ext1_spi(
 }
 
 /// UART pads for the extension 2 connection
-pub type Ext2UartPads = uart::Pads<Ext2UartSercom, IoSet1, Ext2UartRx, Ext2UartTx>;
+pub type Ext2UartPads = uart::Pads<Ext2UartSercom, Ext2UartRx, Ext2UartTx>;
 
 /// Extension 2 UART device
 pub type Ext2Uart = uart::Uart<uart::Config<Ext2UartPads>, uart::Duplex>;
@@ -206,7 +205,7 @@ pub fn ext2_uart(
 }
 
 /// SPI pads for the extension 2 connection
-pub type Ext2SpiPads = spi::Pads<Ext2SpiSercom, IoSet2, Ext2SpiMiso, Ext2SpiMosi, Ext2SpiSck>;
+pub type Ext2SpiPads = spi::Pads<Ext2SpiSercom, Ext2SpiMiso, Ext2SpiMosi, Ext2SpiSck>;
 
 /// Extension 1 SPI device
 pub type Ext2Spi = spi::Spi<spi::Config<Ext2SpiPads>, spi::Duplex>;
@@ -233,7 +232,7 @@ pub fn ext2_spi(
 }
 
 /// SPI pads for the extension 3 connection
-pub type Ext3SpiPads = spi::Pads<Ext3SpiSercom, IoSet2, Ext3SpiMiso, Ext3SpiMosi, Ext3SpiSck>;
+pub type Ext3SpiPads = spi::Pads<Ext3SpiSercom, Ext3SpiMiso, Ext3SpiMosi, Ext3SpiSck>;
 
 /// Extension 3 SPI device
 pub type Ext3Spi = spi::Spi<spi::Config<Ext3SpiPads>, spi::Duplex>;
@@ -260,7 +259,7 @@ pub fn ext3_spi(
 }
 
 /// SPI pads for the DGI connection
-pub type DgiSpiPads = spi::Pads<DgiSpiSercom, IoSet2, DgiSpiMiso, DgiSpiMosi, DgiSpiSck>;
+pub type DgiSpiPads = spi::Pads<DgiSpiSercom, DgiSpiMiso, DgiSpiMosi, DgiSpiSck>;
 
 /// DGI SPI device
 pub type DgiSpi = spi::Spi<spi::Config<DgiSpiPads>, spi::Duplex>;
@@ -287,7 +286,7 @@ pub fn dgi_spi(
 }
 
 /// I2C pads for the extension 2 connection
-pub type Ext2I2cPads = i2c::Pads<Ext2I2cSercom, IoSet2, Ext2I2cSda, Ext2I2cScl>;
+pub type Ext2I2cPads = i2c::Pads<Ext2I2cSercom, Ext2I2cSda, Ext2I2cScl>;
 
 /// Extension 2 I2C device
 pub type Ext2I2c = i2c::I2c<i2c::Config<Ext2I2cPads>>;
@@ -311,7 +310,7 @@ pub fn ext2_i2c(
 }
 
 /// I2C pads for the extension 3 connection
-pub type Ext3I2cPads = i2c::Pads<Ext3I2cSercom, IoSet2, Ext3I2cSda, Ext3I2cScl>;
+pub type Ext3I2cPads = i2c::Pads<Ext3I2cSercom, Ext3I2cSda, Ext3I2cScl>;
 
 /// Extension 3 I2C device
 pub type Ext3I2c = i2c::I2c<i2c::Config<Ext3I2cPads>>;
@@ -335,7 +334,7 @@ pub fn ext3_i2c(
 }
 
 /// I2C pads for the DGI connection
-pub type DgiI2cPads = i2c::Pads<DgiI2cSercom, IoSet2, Ext3I2cSda, Ext3I2cScl>;
+pub type DgiI2cPads = i2c::Pads<DgiI2cSercom, Ext3I2cSda, Ext3I2cScl>;
 
 /// DGI I2C device
 pub type DgiI2c = i2c::I2c<i2c::Config<DgiI2cPads>>;

--- a/boards/feather_m4/examples/clocking_v2.rs
+++ b/boards/feather_m4/examples/clocking_v2.rs
@@ -19,13 +19,13 @@ use atsamd_hal::{
     rtc::{ClockMode, Rtc},
     sercom::{
         uart::{self, BaudMode, Flags, Oversampling},
-        IoSet3, Sercom0,
+        Sercom0,
     },
 };
 
 use rtic::app;
 
-type Pads = uart::PadsFromIds<Sercom0, IoSet3, PA05, PA04>;
+type Pads = uart::PadsFromIds<Sercom0, PA05, PA04>;
 type Uart = uart::Uart<uart::Config<Pads>, uart::Duplex>;
 
 #[app(device = atsamd_hal::pac)]

--- a/boards/feather_m4/src/lib.rs
+++ b/boards/feather_m4/src/lib.rs
@@ -15,7 +15,6 @@ use hal::clock::GenericClockController;
 use hal::sercom::{
     i2c, spi,
     uart::{self, BaudMode, Oversampling},
-    IoSet1, UndocIoSet1,
 };
 use hal::time::Hertz;
 
@@ -170,7 +169,7 @@ hal::bsp_pins!(
 /// SPI pads for the labelled SPI peripheral
 ///
 /// You can use these pads with other, user-defined [`spi::Config`]urations.
-pub type SpiPads = spi::Pads<SpiSercom, UndocIoSet1, Miso, Mosi, Sclk>;
+pub type SpiPads = spi::Pads<SpiSercom, Miso, Mosi, Sclk>;
 
 /// SPI master for the labelled SPI peripheral
 ///
@@ -203,7 +202,7 @@ pub fn spi_master(
 /// I2C pads for the labelled I2C peripheral
 ///
 /// You can use these pads with other, user-defined [`i2c::Config`]urations.
-pub type I2cPads = i2c::Pads<I2cSercom, IoSet1, Sda, Scl>;
+pub type I2cPads = i2c::Pads<I2cSercom, Sda, Scl>;
 
 /// I2C master for the labelled I2C peripheral
 ///
@@ -233,7 +232,7 @@ pub fn i2c_master(
 }
 
 /// UART pads for the labelled RX & TX pins
-pub type UartPads = uart::Pads<UartSercom, IoSet1, UartRx, UartTx>;
+pub type UartPads = uart::Pads<UartSercom, UartRx, UartTx>;
 
 /// UART device for the labelled RX & TX pins
 pub type Uart = uart::Uart<uart::Config<UartPads>, uart::Duplex>;

--- a/boards/metro_m4/src/lib.rs
+++ b/boards/metro_m4/src/lib.rs
@@ -18,7 +18,6 @@ use hal::{
     sercom::{
         i2c, spi,
         uart::{self, BaudMode, Oversampling},
-        IoSet1, IoSet6,
     },
     time::Hertz,
 };
@@ -238,7 +237,7 @@ hal::bsp_pins!(
 /// SPI pads for the labelled SPI peripheral
 ///
 /// You can use these pads with other, user-defined [`spi::Config`]urations.
-pub type SpiPads = spi::Pads<SpiSercom, IoSet1, Miso, Mosi, Sclk>;
+pub type SpiPads = spi::Pads<SpiSercom, Miso, Mosi, Sclk>;
 
 /// SPI master for the labelled SPI peripheral
 ///
@@ -297,7 +296,7 @@ pub fn qspi_master(
 /// I2C pads for the labelled I2C peripheral
 ///
 /// You can use these pads with other, user-defined [`i2c::Config`]urations.
-pub type I2cPads = i2c::Pads<I2cSercom, IoSet6, Sda, Scl>;
+pub type I2cPads = i2c::Pads<I2cSercom, Sda, Scl>;
 
 /// I2C master for the labelled I2C peripheral
 ///
@@ -327,7 +326,7 @@ pub fn i2c_master(
 }
 
 /// UART Pads for the labelled UART peripheral
-pub type UartPads = uart::Pads<UartSercom, IoSet1, UartRx, UartTx>;
+pub type UartPads = uart::Pads<UartSercom, UartRx, UartTx>;
 
 /// UART device for the labelled RX & TX pins
 pub type Uart = uart::Uart<uart::Config<UartPads>, uart::Duplex>;

--- a/boards/pygamer/src/pins.rs
+++ b/boards/pygamer/src/pins.rs
@@ -10,7 +10,7 @@ use hal::gpio::PA01;
 use hal::pwm;
 use hal::qspi;
 use hal::sercom::uart::{self, BaudMode, Oversampling};
-use hal::sercom::{i2c, spi, IoSet1, Sercom1, Sercom4, UndocIoSet1};
+use hal::sercom::{i2c, spi, Sercom1, Sercom4};
 use hal::time::Hertz;
 use hal::typelevel::NoneT;
 
@@ -602,7 +602,7 @@ impl From<()> for DisplayError {
     }
 }
 
-pub type TftPads = spi::Pads<Sercom4, IoSet1, NoneT, TftMosi, TftSclk>;
+pub type TftPads = spi::Pads<Sercom4, NoneT, TftMosi, TftSclk>;
 pub type TftSpi = bspi::ExclusiveDevice<
     spi::PanicOnRead<spi::Spi<spi::Config<TftPads>, spi::Tx>>,
     TftCs,
@@ -668,7 +668,7 @@ pub struct Neopixel {
 
 /// Pads for the neopixel SPI driver
 #[cfg(feature = "neopixel-spi")]
-pub type NeopixelSpiPads = spi::Pads<hal::sercom::Sercom2, IoSet1, NoneT, NeopixelPinSpi, Scl>;
+pub type NeopixelSpiPads = spi::Pads<hal::sercom::Sercom2, NoneT, NeopixelPinSpi, Scl>;
 
 /// SPI master neopixel driver
 #[cfg(feature = "neopixel-spi")]
@@ -719,7 +719,7 @@ pub struct SPI {
 /// According to the datasheet, the combination of PA17, PB22 & PB23 shouldn't
 /// work, even though it does. We have added an undocumented `UndocIoSet1` to
 /// `Sercom1` for this combination.
-pub type SpiPads = spi::Pads<Sercom1, UndocIoSet1, SpiMiso, SpiMosi, SpiSclk>;
+pub type SpiPads = spi::Pads<Sercom1, SpiMiso, SpiMosi, SpiSclk>;
 
 /// SPI master for the labelled pins
 pub type Spi = spi::Spi<spi::Config<SpiPads>, spi::Duplex>;
@@ -756,7 +756,7 @@ pub struct I2C {
 /// I2C pads for the labelled I2C peripheral
 ///
 /// You can use these pads with other, user-defined [`i2c::Config`]urations.
-pub type I2cPads = i2c::Pads<I2cSercom, IoSet1, Sda, Scl>;
+pub type I2cPads = i2c::Pads<I2cSercom, Sda, Scl>;
 
 /// I2C master for the labelled I2C peripheral
 ///
@@ -824,7 +824,7 @@ pub struct UART {
 }
 
 /// UART Pads for the labelled UART peripheral
-pub type UartPads = uart::Pads<UartSercom, IoSet1, UartRx, UartTx>;
+pub type UartPads = uart::Pads<UartSercom, UartRx, UartTx>;
 
 /// UART device for the labelled RX & TX pins
 pub type Uart = uart::Uart<uart::Config<UartPads>, uart::Duplex>;

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -51,6 +51,7 @@ paste = "1.0.15"
 portable-atomic = {version = "1.10.0", optional = true, features = ["critical-section"]}
 rand_core = "0.6"
 seq-macro = "0.3"
+sorted-hlist = "0.2.0"
 typenum = "1.12.0"
 vcell = "0.1"
 void = {version = "1.0", default-features = false}

--- a/hal/src/sercom/i2c.rs
+++ b/hal/src/sercom/i2c.rs
@@ -10,36 +10,28 @@
 //! # [`Pads`]
 //!
 //! A [`Sercom`] uses two [`Pin`]s as peripheral [`Pad`]s, but only certain
-//! [`Pin`] combinations are acceptable. In particular, all [`Pin`]s must be
-//! mapped to the same [`Sercom`], and SDA is always [`Pad0`], while SCL is
-//! always [`Pad1`] (see the datasheet). This HAL makes it impossible to use
-//! invalid [`Pin`]/[`Pad`] combinations, and the [`Pads`] struct is responsible
-//! for enforcing these constraints.
+//! [`Pin`] combinations are acceptable. All [`Pin`]s must be mapped to the same
+//! [`Sercom`], and SDA is always [`Pad0`], while SCL is always [`Pad1`] (see
+//! the datasheet). SAMx5x chips have an additional constraint that [`Pin`]s
+//! must be in the same [`IoSet`].  This HAL makes it impossible to use invalid
+//! [`Pin`]/[`Pad`] combinations, and the [`Pads`] struct is responsible for
+//! enforcing these constraints.
 //!
-//!
-//! A [`Pads`] type takes three or four type parameters, depending on the chip.
-//! The first type always specifies the [`Sercom`]. On SAMx5x chips, the second
-//! type specifies the `IoSet`. The remaining two, `SDA` and `SCL` represent the
-//! SDA and SCL pads respectively. A [`Pad`] is just a [`Pin`] configured in the
-//! correct [`PinMode`] that implements [`IsPad`]. The
-//! [`bsp_pins!`](crate::bsp_pins) macro can be used to define convenient type
-//! aliases for [`Pad`] types.
+//! A [`Pads`] type takes three type parameters. The first type specifies the
+//! [`Sercom`], `SDA` and `SCL` represent the SDA and SCL pads respectively. A
+//! [`Pad`] is just a [`Pin`] configured in the correct [`PinMode`] that
+//! implements [`IsPad`]. The [`bsp_pins!`](crate::bsp_pins) macro can be used
+//! to define convenient type aliases for [`Pad`] types.
 //!
 //! ```no_run
 //! use atsamd_hal::gpio::{PA08, PA09, AlternateC};
 //! use atsamd_hal::sercom::{Sercom0, i2c};
 //! use atsamd_hal::typelevel::NoneT;
 //!
-//! // SAMx5x-specific imports
-//! use atsamd_hal::sercom::pad::IoSet1;
-//!
 //! type Sda = Pin<PA08, AlternateC>;
 //! type Scl = Pin<PA09, AlternateC>;
 //!
-//! // SAMD11/SAMD21 version
 //! type Pads = i2c::Pads<Sercom0, Sda, Scl>;
-//! // SAMx5x version
-//! type Pads = i2c::Pads<Sercom0, IoSet1, Sda, Scl>;
 //! ```
 //!
 //! Alternatively, you can use the [`PadsFromIds`] alias to define a set of
@@ -353,6 +345,7 @@
 //! [`Pad0`]: crate::sercom::pad::Pad0
 //! [`Pad1`]: crate::sercom::pad::Pad1
 //! [`Pad`]: crate::sercom::pad::Pad
+//! [`IoSet`]: crate::sercom::pad::IoSet
 //! [`IsPad`]: crate::sercom::pad::IsPad
 //! [`PadNum`]: crate::sercom::pad::PadNum
 //! [`Pin`]: crate::gpio::pin::Pin

--- a/hal/src/sercom/pad.rs
+++ b/hal/src/sercom/pad.rs
@@ -272,9 +272,21 @@ mod ioset {
 
     /// Type-level enum representing a SERCOM IOSET
     ///
+    /// The SAM D5x/E5x has particular sets of [`Pin`]s that are allowed to be
+    /// used together for each [`Sercom`], and `Pin`s from different sets cannot
+    /// be used together.  The valid combinations of `Pin`s are called IOSETs
+    /// (or IO SETs) in the datasheet.  Additionally, some undocumented sets are
+    /// used in commercially available boards (such as Adafruit's PyGamer and
+    /// Feather M4).  This `IoSet` trait is used to constrain the various `Pads`
+    /// types ([`spi::Pads`], [`uart::Pads`], and [`i2c::Pads`]) to only contain
+    /// valid documented or undocumented sets of `Pin`s.
+    ///
     /// See the [type-level enum] documentation for more details on the pattern.
     /// Typenum unsigned integers are used to make IoSets comparable
     ///
+    /// [`spi::Pads`]: crate::sercom::spi::Pads
+    /// [`uart::Pads`]: crate::sercom::uart::Pads
+    /// [`i2c::Pads`]: crate::sercom::i2c::Pads
     /// [type-level enum]: crate::typelevel#type-level-enum
     pub trait IoSet: Sealed {
         type Order;

--- a/hal/src/sercom/pad/impl_pad_thumbv7em.rs
+++ b/hal/src/sercom/pad/impl_pad_thumbv7em.rs
@@ -3,6 +3,8 @@
 use crate::gpio::*;
 use crate::sercom::*;
 
+use sorted_hlist::mk_hlist;
+
 //==============================================================================
 //  Pad definitions
 //==============================================================================
@@ -49,6 +51,9 @@ macro_rules! pad_info {
         impl IsPad for Pin<$PinId, Alternate<$Cfg>> {
             type Sercom = $Sercom;
             type PadNum = $PadNum;
+        }
+        impl IoSets for Pin<$PinId, Alternate<$Cfg>> {
+            type SetList = mk_hlist!($( <$IoSet as IoSet>::Order ),+);
         }
     };
 }
@@ -107,16 +112,24 @@ macro_rules! pad_table {
     };
 }
 
+// Implement an undocumented `IoSet` for PA16, PA17, PB22 & PB23 configured for
+// `Sercom1`. The pygamer & feather_m4 uses this combination, but it is not
+// listed as valid in the datasheet.
+
+// Implement an undocumented `IoSet` for PA00, PA01, PB22 & PB23 configured for
+// `Sercom1`. The itsybitsy_m4 uses this combination, but it is not
+// listed as valid in the datasheet.
+
 pad_table!(
     #[hal_cfg("pa00")]
     PA00 {
         #[hal_cfg("sercom1")]
-        D: (Sercom1, Pad0, IoSet4),
+        D: (Sercom1, Pad0, IoSet4, UndocIoSet2),
     }
     #[hal_cfg("pa01")]
     PA01 {
         #[hal_cfg("sercom1")]
-        D: (Sercom1, Pad1, IoSet4),
+        D: (Sercom1, Pad1, IoSet4, UndocIoSet2),
     }
     #[hal_cfg("pa04")]
     PA04 {
@@ -197,14 +210,14 @@ pad_table!(
     #[hal_cfg("pa16")]
     PA16 {
         #[hal_cfg("sercom1")]
-        C: (Sercom1, Pad0, IoSet1) + I2C,
+        C: (Sercom1, Pad0, IoSet1, UndocIoSet1) + I2C,
         #[hal_cfg("sercom3")]
         D: (Sercom3, Pad1, IoSet3) + I2C,
     }
     #[hal_cfg("pa17")]
     PA17 {
         #[hal_cfg("sercom1")]
-        C: (Sercom1, Pad1, IoSet1) + I2C,
+        C: (Sercom1, Pad1, IoSet1, UndocIoSet1) + I2C,
         #[hal_cfg("sercom3")]
         D: (Sercom3, Pad0, IoSet3) + I2C,
     }
@@ -387,14 +400,14 @@ pad_table!(
     #[hal_cfg("pb22")]
     PB22 {
         #[hal_cfg("sercom1")]
-        C: (Sercom1, Pad2, IoSet3),
+        C: (Sercom1, Pad2, IoSet3, UndocIoSet1, UndocIoSet2),
         #[hal_cfg("sercom5")]
         D: (Sercom5, Pad2, IoSet4),
     }
     #[hal_cfg("pb23")]
     PB23 {
         #[hal_cfg("sercom1")]
-        C: (Sercom1, Pad3, IoSet3),
+        C: (Sercom1, Pad3, IoSet3, UndocIoSet1, UndocIoSet2),
         #[hal_cfg("sercom5")]
         D: (Sercom5, Pad3, IoSet4),
     }
@@ -627,19 +640,3 @@ pad_table!(
         D: (Sercom3, Pad3, IoSet4),
     }
 );
-
-// Implement an undocumented `IoSet` for PA16, PA17, PB22 & PB23 configured for
-// `Sercom1`. The pygamer & feather_m4 uses this combination, but it is not
-// listed as valid in the datasheet.
-impl InIoSet<UndocIoSet1> for Pin<PA16, Alternate<C>> {}
-impl InIoSet<UndocIoSet1> for Pin<PA17, Alternate<C>> {}
-impl InIoSet<UndocIoSet1> for Pin<PB22, Alternate<C>> {}
-impl InIoSet<UndocIoSet1> for Pin<PB23, Alternate<C>> {}
-
-// Implement an undocumented `IoSet` for PA00, PA01, PB22 & PB23 configured for
-// `Sercom1`. The itsybitsy_m4 uses this combination, but it is not
-// listed as valid in the datasheet.
-impl InIoSet<UndocIoSet2> for Pin<PA00, Alternate<D>> {}
-impl InIoSet<UndocIoSet2> for Pin<PA01, Alternate<D>> {}
-impl InIoSet<UndocIoSet2> for Pin<PB22, Alternate<C>> {}
-impl InIoSet<UndocIoSet2> for Pin<PB23, Alternate<C>> {}

--- a/hal/src/sercom/spi.rs
+++ b/hal/src/sercom/spi.rs
@@ -13,38 +13,32 @@
 //!
 //! An SPI peripheral can use up to four [`Pin`]s as [`Sercom`] pads. However,
 //! only certain `Pin` combinations are acceptable. All `Pin`s must be mapped to
-//! the same `Sercom`, and for SAMx5x chips, they must also belong to the same
-//! `IoSet`. This HAL makes it impossible to use invalid `Pin` combinations, and
-//! the [`Pads`] struct is responsible for enforcing these constraints.
+//! the same `Sercom`, and for SAMx5x chips they must also belong to the same
+//! [`IoSet`]. This HAL makes it impossible to use invalid `Pin` combinations,
+//! and the [`Pads`] struct is responsible for enforcing these constraints.
 //!
-//! A `Pads` type takes five or six type parameters, depending on the chip. The
-//! first type always specifies the `Sercom`. On SAMx5x chips, the second type
-//! specifies the `IoSet`. The remaining four type parameters, `DI`, `DO`, `CK`
-//! and `SS`, represent the Data In, Data Out, Sclk and SS pads respectively.
-//! Each of these type parameters is an [`OptionalPad`] and defaults to
-//! [`NoneT`]. A `Pad` is just a `Pin` configured in the correct [`PinMode`]
-//! that implements [`IsPad`]. The [`bsp_pins!`](crate::bsp_pins) macro can be
-//! used to define convenient type aliases for `Pad` types.
+//! A `Pads` type takes five parameters: the first specifies the `Sercom`, and
+//! the remaining four type parameters, `DI`, `DO`, `CK` and `SS`, represent the
+//! Data In, Data Out, Sclk and SS pads respectively. Each of these type
+//! parameters is an [`OptionalPad`] and defaults to [`NoneT`]. A `Pad` is just
+//! a `Pin` configured in the correct [`PinMode`] that implements [`IsPad`]. The
+//! [`bsp_pins!`](crate::bsp_pins) macro can be used to define convenient type
+//! aliases for `Pad` types.
 //!
 //! ```
 //! use atsamd_hal::gpio::{PA08, PA09, AlternateC};
 //! use atsamd_hal::sercom::{Sercom0, spi};
 //! use atsamd_hal::typelevel::NoneT;
 //!
-//! // SAMx5x-specific imports
-//! use atsamd_hal::sercom::pad::IoSet1;
-//!
 //! type Miso = Pin<PA08, AlternateC>;
 //! type Sclk = Pin<PA09, AlternateC>;
 //!
-//! // SAMD11/SAMD21 version
 //! type Pads = spi::Pads<Sercom0, Miso, NoneT, Sclk>;
-//! // SAMx5x version
-//! type Pads = spi::Pads<Sercom0, IoSet1, Miso, NoneT, Sclk>;
 //! ```
 //!
 //! [`enable`]: Config::enable
 //! [`gpio`]: crate::gpio
+//! [`IoSet`]: crate::sercom::pad::IoSet
 //! [`Pin`]: crate::gpio::pin::Pin
 //! [`PinId`]: crate::gpio::pin::PinId
 //! [`PinMode`]: crate::gpio::pin::PinMode
@@ -59,13 +53,7 @@
 //! use atsamd_hal::sercom::{Sercom0, spi};
 //! use atsamd_hal::typelevel::NoneT;
 //!
-//! // SAMx5x-specific imports
-//! use atsamd_hal::sercom::pad::IoSet1;
-//!
-//! // SAMD21 version
 //! type Pads = spi::PadsFromIds<Sercom0, PA08, NoneT, PA09>;
-//! // SAMx5x version
-//! type Pads = spi::PadsFromIds<Sercom0, IoSet1, PA08, NoneT, PA09>;
 //! ```
 //!
 //! Instances of `Pads` are created using the builder pattern. Start by creating
@@ -80,18 +68,10 @@
 //! use atsamd_hal::gpio::Pins;
 //! use atsamd_hal::sercom::{Sercom0, spi};
 //!
-//! // SAMx5x-specific imports
-//! use atsamd_hal::sercom::pad::IoSet1;
-//!
 //! let mut peripherals = Peripherals::take().unwrap();
 //! let pins = Pins::new(peripherals.PORT);
-//! // SAMD21 version
+//!
 //! let pads = spi::Pads::<Sercom0>::default()
-//!     .sclk(pins.pa09)
-//!     .data_in(pins.pa08)
-//!     .data_out(pins.pa11);
-//! // SAMx5x version
-//! let pads = spi::Pads::<Sercom0, IoSet1>::default()
 //!     .sclk(pins.pa09)
 //!     .data_in(pins.pa08)
 //!     .data_out(pins.pa11);
@@ -126,14 +106,13 @@
 //!
 //! // SAMx5x-specific imports
 //! use atsamd_hal::sercom::spi::lengths::U2;
-//! use atsamd_hal::sercom::pad::IoSet1;
+//!
+//! type Pads = spi::PadsFromIds<Sercom0, PA08, NoneT, PA09>;
 //!
 //! // SAMD11/SAMD21 version
-//! type Pads = spi::PadsFromIds<Sercom0, PA08, NoneT, PA09>;
 //! type Config = spi::Config<Pads, Master, NineBit>;
 //!
 //! // SAMx5x version
-//! type Pads = spi::PadsFromIds<Sercom0, IoSet1, PA08, NoneT, PA09>;
 //! type Config = spi::Config<Pads, Master, U2>;
 //! ```
 //!
@@ -223,16 +202,15 @@
 //!
 //! // SAMx5x-specific imports
 //! use atsamd_hal::sercom::spi::lengths::U2;
-//! use atsamd_hal::sercom::pad::IoSet1;
+//!
+//! type Pads = spi::PadsFromIds<Sercom0, PA08, NoneT, PA09>;
 //!
 //! // SAMD11/SAMD21 version
-//! type Pads = spi::PadsFromIds<Sercom0, PA08, NoneT, PA09>;
 //! type Config = spi::Config<Pads, Master, NineBit>;
-//! type Spi = spi::Spi<Config, Rx>;
 //!
 //! // SAMx5x version
-//! type Pads = spi::PadsFromIds<Sercom0, IoSet1, PA08, NoneT, PA09>;
 //! type Config = spi::Config<Pads, Master, U2>;
+//!
 //! type Spi = spi::Spi<Config, Rx>;
 //! ```
 //!

--- a/hal/src/sercom/uart.rs
+++ b/hal/src/sercom/uart.rs
@@ -11,20 +11,20 @@
 //! # [`Pads`]
 //!
 //! A [`Sercom`] can use up to four [`Pin`]s as peripheral [`Pad`]s, but only
-//! certain [`Pin`] combinations are acceptable. In particular, all [`Pin`]s
-//! must be mapped to the same `Sercom` (see the datasheet). This HAL makes it
-//! impossible to use invalid [`Pin`]/[`Pad`] combinations, and the [`Pads`]
-//! struct is responsible for enforcing these constraints.
+//! certain [`Pin`] combinations are acceptable. All [`Pin`]s must be mapped to
+//! the same `Sercom` (see the datasheet). SAMx5x chips also require that
+//! [`Pin`]s must be in the same [`IoSet`]. This HAL makes it impossible to use
+//! invalid [`Pin`]/[`Pad`] combinations, and the [`Pads`] struct is responsible
+//! for enforcing these constraints.
 //!
 //!
-//! A `Pads` type takes five or six type parameters, depending on the chip.The
-//! first type always specifies the `Sercom`. On SAMx5x chips, the second type
-//! specifies the `IoSet`. The remaining four, `DI`, `DO`, `CK` and `SS`,
-//! represent the Data In, Data Out, Sclk and SS pads respectively. Each of the
-//! remaining type parameters is an [`OptionalPad`] and defaults to [`NoneT`]. A
-//! [`Pad`] is just a [`Pin`] configured in the correct [`PinMode`] that
-//! implements [`IsPad`]. The [`bsp_pins!`](crate::bsp_pins) macro can be used
-//! to define convenient type aliases for [`Pad`] types.
+//! A `Pads` type takes five type parameters, the first type specifies the
+//! `Sercom`, `DI`, `DO`, `CK` and `SS`, represent the Data In, Data Out, Sclk
+//! and SS pads respectively. Each of the pad type parameters is an
+//! [`OptionalPad`] and defaults to [`NoneT`]. A [`Pad`] is just a [`Pin`]
+//! configured in the correct [`PinMode`] that implements [`IsPad`]. The
+//! [`bsp_pins!`](crate::bsp_pins) macro can be used to define convenient type
+//! aliases for [`Pad`] types.
 //!
 //! ```
 //! use atsamd_hal::gpio::{PA08, PA09, AlternateC};
@@ -500,7 +500,7 @@
 //! [`disable`]: Uart::disable
 //! [`reconfigure`]: Uart::reconfigure
 //! [`bsp_pins`]: crate::bsp_pins
-//! [`Pin`]: crate::gpio::pin::Pin
+//! [`IoSet`]: crate::sercom::pad::IoSet
 //! [`Pin`]: crate::gpio::pin::Pin
 //! [`PinId`]: crate::gpio::pin::PinId
 //! [`PinMode`]: crate::gpio::pin::PinMode


### PR DESCRIPTION
# Summary
Before this commit all sercom Pads structs for thumbv7 required an IoSet parameter. The purpose of the parameter is to check that all Pins of a Pads struct lay in the same IoSet. This puts additional work into the hands of users of this library by making them choose a specific IoSet value, while conceptually the compiler can check if a set of Pins share at least one IoSet on its own. This commit adds a simple heterogeneous list type level class to solve this issue. Each pin receives a sorted HList of all possible corresponding IoSets. A helper trait "ShareIoSet" is implemented for some tuples of pins, where the sorted intersection of all IoSets HLists return a NonEmpty list (NoneT is a wildcard). This trait is used to replace the IoSet parameter in all sercom thumbv7 modes.

The itsybitsy_m4 crate is modified to test the new features by changing the dependencies.atsamd-hal in Cargo.toml to path = "../../hal".