### PR TITLE
ci: Check for doc warnings

### DIFF
--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -1,0 +1,24 @@
+name: Check docs
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install Rust
+        run: |
+          rustup set profile minimal
+      - name: rustdoc
+        run: |
+          RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps -F samd21g,dma,async,usb,defmt,rtic
+          RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps -F samd51j,dma,async,usb,defmt,rtic,can

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  format:
+  check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  format:
+  check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources


### PR DESCRIPTION
# Summary
Add a CI check to ensure the docs pass without warning. Currently, two feature sets are checked:

* `samd21g,dma,async,usb,defmt,rtic`, and
* `samd51j,dma,async,usb,defmt,rtic,can`

Ideally this list should be expanded to encompass all supported chips, but this is at least a good start.