### PR TITLE
Fix bugs with EIC and allow clock provider switching (D5X)

### DIFF
--- a/boards/atsame54_xpro/examples/mcan.rs
+++ b/boards/atsame54_xpro/examples/mcan.rs
@@ -147,7 +147,7 @@ mod app {
 
         let (pclk_eic, gclk0) = clock::pclk::Pclk::enable(tokens.pclks.eic, clocks.gclk0);
 
-        let eic_channels = Eic::new(&mut mclk, pclk_eic.into(), device.eic).split();
+        let eic_channels = Eic::new(&mut mclk, &pclk_eic.into(), device.eic).split();
         let mut button = bsp::pin_alias!(pins.button).into_pull_up_ei(eic_channels.15);
         button.sense(Sense::Fall);
         button.debounce();

--- a/boards/metro_m4/examples/async_eic.rs
+++ b/boards/metro_m4/examples/async_eic.rs
@@ -42,7 +42,7 @@ async fn main(_s: embassy_executor::Spawner) {
     let gclk2 = clocks.get_gclk(ClockGenId::Gclk2).unwrap();
     let eic_clock = clocks.eic(&gclk2).unwrap();
 
-    let eic_channels = Eic::new(&mut peripherals.mclk, eic_clock, peripherals.eic).split();
+    let eic_channels = Eic::new(&mut peripherals.mclk, &eic_clock, peripherals.eic).split();
 
     let button: Pin<_, PullUpInterrupt> = pins.d0.into();
     let mut extint = eic_channels.7.with_pin(button).into_future(Irqs);

--- a/hal/src/peripherals/eic/d11/pin.rs
+++ b/hal/src/peripherals/eic/d11/pin.rs
@@ -96,44 +96,48 @@ where
     }
 
     pub fn sense(&mut self, sense: Sense) {
-        // Which of the two config blocks this eic config is in
-        let offset = (P::ChId::ID >> 3) & 0b0001;
-        let config = &self.chan.eic.config(offset);
+        self.chan.with_disable(|e| {
+            // Which of the two config blocks this eic config is in
+            let offset = (P::ChId::ID >> 3) & 0b0001;
+            let config = &e.config(offset);
 
-        config.modify(|_, w| unsafe {
-            // Which of the eight eic configs in this config block
-            match P::ChId::ID & 0b111 {
-                0b000 => w.sense0().bits(sense as u8),
-                0b001 => w.sense1().bits(sense as u8),
-                0b010 => w.sense2().bits(sense as u8),
-                0b011 => w.sense3().bits(sense as u8),
-                0b100 => w.sense4().bits(sense as u8),
-                0b101 => w.sense5().bits(sense as u8),
-                0b110 => w.sense6().bits(sense as u8),
-                0b111 => w.sense7().bits(sense as u8),
-                _ => unreachable!(),
-            }
+            config.modify(|_, w| unsafe {
+                // Which of the eight eic configs in this config block
+                match P::ChId::ID & 0b111 {
+                    0b000 => w.sense0().bits(sense as u8),
+                    0b001 => w.sense1().bits(sense as u8),
+                    0b010 => w.sense2().bits(sense as u8),
+                    0b011 => w.sense3().bits(sense as u8),
+                    0b100 => w.sense4().bits(sense as u8),
+                    0b101 => w.sense5().bits(sense as u8),
+                    0b110 => w.sense6().bits(sense as u8),
+                    0b111 => w.sense7().bits(sense as u8),
+                    _ => unreachable!(),
+                }
+            });
         });
     }
 
     pub fn filter(&mut self, filter: bool) {
-        // Which of the two config blocks this eic config is in
-        let offset = (P::ChId::ID >> 3) & 0b0001;
-        let config = &self.chan.eic.config(offset);
+        self.chan.with_disable(|e| {
+            // Which of the two config blocks this eic config is in
+            let offset = (P::ChId::ID >> 3) & 0b0001;
+            let config = &e.config(offset);
 
-        config.modify(|_, w| {
-            // Which of the eight eic configs in this config block
-            match P::ChId::ID & 0b111 {
-                0b000 => w.filten0().bit(filter),
-                0b001 => w.filten1().bit(filter),
-                0b010 => w.filten2().bit(filter),
-                0b011 => w.filten3().bit(filter),
-                0b100 => w.filten4().bit(filter),
-                0b101 => w.filten5().bit(filter),
-                0b110 => w.filten6().bit(filter),
-                0b111 => w.filten7().bit(filter),
-                _ => unreachable!(),
-            }
+            config.modify(|_, w| {
+                // Which of the eight eic configs in this config block
+                match P::ChId::ID & 0b111 {
+                    0b000 => w.filten0().bit(filter),
+                    0b001 => w.filten1().bit(filter),
+                    0b010 => w.filten2().bit(filter),
+                    0b011 => w.filten3().bit(filter),
+                    0b100 => w.filten4().bit(filter),
+                    0b101 => w.filten5().bit(filter),
+                    0b110 => w.filten6().bit(filter),
+                    0b111 => w.filten7().bit(filter),
+                    _ => unreachable!(),
+                }
+            });
         });
     }
 }

--- a/hal/src/peripherals/eic/d11/pin.rs
+++ b/hal/src/peripherals/eic/d11/pin.rs
@@ -57,12 +57,10 @@ where
     /// Note that whilst this function is executed, the EIC peripheral is disabled
     /// in order to write to the evctrl register
     pub fn enable_event(&mut self) {
-        self.chan.eic.ctrl().modify(|_, w| w.enable().clear_bit());
-        self.chan
-            .eic
-            .evctrl()
-            .modify(|r, w| unsafe { w.bits(r.bits() | (1 << P::ChId::ID)) });
-        self.chan.eic.ctrl().modify(|_, w| w.enable().set_bit());
+        self.chan.with_disable(|e| {
+            e.evctrl()
+                .modify(|_, w| unsafe { w.bits(1 << P::ChId::ID) });
+        });
     }
 
     pub fn enable_interrupt(&mut self) {

--- a/hal/src/peripherals/eic/d11/pin.rs
+++ b/hal/src/peripherals/eic/d11/pin.rs
@@ -1,12 +1,12 @@
 use atsamd_hal_macros::hal_cfg;
 
-use core::convert::Infallible;
-use crate::ehal_02::digital::v2::InputPin as InputPin_02;
 use crate::ehal::digital::{ErrorType, InputPin};
+use crate::ehal_02::digital::v2::InputPin as InputPin_02;
 use crate::eic::*;
 use crate::gpio::{
     self, pin::*, AnyPin, FloatingInterrupt, PinMode, PullDownInterrupt, PullUpInterrupt,
 };
+use core::convert::Infallible;
 
 /// The pad macro defines the given EIC pin and implements EicPin for the
 /// given pins. The EicPin implementation will configure the pin for the
@@ -52,12 +52,17 @@ where
     P: EicPin,
     Id: ChId,
 {
-    /// Configure the eic with options for this external interrupt
+    /// Enables the event output of the channel for the event system.
+    ///
+    /// Note that whilst this function is executed, the EIC peripheral is disabled
+    /// in order to write to the evctrl register
     pub fn enable_event(&mut self) {
+        self.chan.eic.ctrl().modify(|_, w| w.enable().clear_bit());
         self.chan
             .eic
             .evctrl()
             .modify(|r, w| unsafe { w.bits(r.bits() | (1 << P::ChId::ID)) });
+        self.chan.eic.ctrl().modify(|_, w| w.enable().set_bit());
     }
 
     pub fn enable_interrupt(&mut self) {
@@ -153,7 +158,8 @@ where
 }
 
 impl<P, Id, F> InputPin for ExtInt<P, Id, F>
-where Self: ErrorType,
+where
+    Self: ErrorType,
     P: EicPin,
     Id: ChId,
 {

--- a/hal/src/peripherals/eic/d5x/pin.rs
+++ b/hal/src/peripherals/eic/d5x/pin.rs
@@ -63,12 +63,10 @@ where
     /// Note that whilst this function is executed, the EIC peripheral is disabled
     /// in order to write to the evctrl register
     pub fn enable_event(&mut self) {
-        self.chan.eic.ctrla().write(|w| w.enable().clear_bit());
-        self.chan
-            .eic
-            .evctrl()
-            .modify(|_, w| unsafe { w.bits(1 << P::ChId::ID) });
-        self.chan.eic.ctrla().write(|w| w.enable().set_bit());
+        self.chan.with_disable(|e| {
+            e.evctrl()
+                .modify(|_, w| unsafe { w.bits(1 << P::ChId::ID) });
+        });
     }
 
     pub fn enable_interrupt(&mut self) {


### PR DESCRIPTION
# Summary

 A reattempt at #837 
 
 * BREAKING - D5X EIC - Take a reference to EIC clock in new function rather than consuming it (Examples have been updated accordingly)
 * EIC D5X - Add methods for switching the clock provider of EIC between OSC32K and GCLK
 * EIC D2x - Disable EIC around channel manipulation operations
 * EIC - Fix both implementations of `enable_event` to disable the EIC  in order to successfully perform the operation
