### PR TITLE
fix: Satisfy some clippy lints

### DIFF
--- a/atsamd-hal-macros/build.rs
+++ b/atsamd-hal-macros/build.rs
@@ -243,7 +243,7 @@ fn load_peripheral_mapping(
                 } else {
                     peripheral.name.clone()
                 };
-                let combined_name = format!("{}-{}", name, variant);
+                let combined_name = format!("{name}-{variant}");
                 let devices = family
                     .pins
                     .keys()


### PR DESCRIPTION
Simply satisfy a small nightly clippy lint before it makes it to stable `rustc`.