### PR TITLE
chore: consolidate workspace settings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,20 @@ members = [
 	"boards/*",
 ]
 
+[workspace.package]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/atsamd-rs/atsamd"
+rust-version = "1.77.2"
+
+[workspace.lints.rust]
+# TODO: add any workspace-wide rust lint configurations
+# TODO: enable to make identifier usage consistent per file
+# unused_qualifications = "warn"
+
+[workspace.lints.clippy]
+# TODO: add any workspace-wide clippy lint configurations
+
 [profile.dev]
 debug = true
 opt-level = 0

--- a/atsamd-hal-macros/Cargo.toml
+++ b/atsamd-hal-macros/Cargo.toml
@@ -1,14 +1,17 @@
 [package]
 authors = ["Tethys Svensson"]
 name = "atsamd-hal-macros"
-rust-version = "1.77.2"
 version = "0.2.4"
-edition = "2021"
-license = "MIT OR Apache-2.0"
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Procedural macros for the atsamd-hal library"
 documentation = "https://docs.rs/crate/atsamd-hal-macros/"
-repository = "https://github.com/atsamd-rs/atsamd"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
 
 [lib]
 proc-macro = true

--- a/boards/arduino_mkr1000/Cargo.toml
+++ b/boards/arduino_mkr1000/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Eric Rushing <rushinge@gmail.com>"]
 description = "Board Support crate for the Arduino MKR 1000 WiFi"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/arduino_mkrvidor4000/Cargo.toml
+++ b/boards/arduino_mkrvidor4000/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Sameer Puri <purisame@spuri.io>"]
 description = "Board Support crate for the Arduino MKR VIDOR 4000"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/arduino_mkrzero/Cargo.toml
+++ b/boards/arduino_mkrzero/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Wez Furlong <wez@wezfurlong.org>", "David McGillicuddy <contact@djmc
 description = "Board Support crate for the Arduino MKRZERO"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/arduino_nano33iot/Cargo.toml
+++ b/boards/arduino_nano33iot/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Gus Wynn <guswynn@gmail.com>"]
 description = "Board Support crate for the Arduino Nano 33 IOT"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/atsame54_xpro/Cargo.toml
+++ b/boards/atsame54_xpro/Cargo.toml
@@ -5,13 +5,15 @@ authors = [
 ]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board Support crate for the SAM E54 Xplained Pro Evaluation Kit"
-edition = "2021"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "atsame54_xpro"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
 version = "0.11.3"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 optional = true

--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -4,10 +4,12 @@ version = "0.11.1"
 authors = ["Paul Sajna <paulsajna@gmail.com>"]
 description = "Board Support crate for the Adafruit Circuit Playground Express"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
 edition = "2018"
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -5,11 +5,13 @@ authors = ["Jacob Rosenthal <@jacobrosenthal>"]
 description = "Board Support crate for the Adafruit EdgeBadge"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
 exclude = ["assets"]
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -2,14 +2,15 @@
 authors = ["Ben Bergman <ben@benbergman.ca>"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board Support crate for the Adafruit Feather M0"
-edition = "2021"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "feather_m0"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
-resolver = "2"
 version = "0.18.3"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 # for cargo flash
 [package.metadata]

--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -3,13 +3,15 @@ authors = ["Theodore DeRego <tderego94@gmail.com>"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board Support crate for the Adafruit Feather M4"
 documentation = "https://atsamd-rs.github.io/atsamd/atsamd51j/feather_m4/"
-edition = "2021"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "feather_m4"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
 version = "0.16.3"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 # for cargo flash
 [package.metadata]

--- a/boards/gemma_m0/Cargo.toml
+++ b/boards/gemma_m0/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Wez Furlong <wez@wezfurlong.org>"]
 description = "Board Support crate for the Adafruit Gemma M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Dustin Little <dlittle@toyatech.net>"]
 description = "Board Support crate for the Adafruit Grand Central M4 Express"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-edition = "2021"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit ItsyBitsy M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 bitbang-hal = "0.3"

--- a/boards/itsybitsy_m4/Cargo.toml
+++ b/boards/itsybitsy_m4/Cargo.toml
@@ -8,10 +8,12 @@ authors = [
 description = "Board Support crate for the Adafruit ItsyBitsy M4 Express"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-edition = "2021"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 bitbang-hal = "0.3"

--- a/boards/matrix_portal_m4/Cargo.toml
+++ b/boards/matrix_portal_m4/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Salsa Steve <elmanstevelaguna@gmail.com>"]
 description = "Board Support crate for the Matrix Portal M4"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 # for cargo flash
 [package.metadata]

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -2,13 +2,15 @@
 authors = ["Wez Furlong <wez@wezfurlong.org>"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board Support crate for the Adafruit Metro M0"
-edition = "2021"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "metro_m0"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
 version = "0.18.3"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 # for cargo flash
 [package.metadata]

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -2,13 +2,15 @@
 authors = ["Paul Sajna <sajattack@gmail.com>", "Wez Furlong <wez@wezfurlong.org>"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board Support crate for the Adafruit Metro M4"
-edition = "2021"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "metro_m4"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
 version = "0.17.3"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 # for cargo flash
 [package.metadata]

--- a/boards/neo_trinkey/Cargo.toml
+++ b/boards/neo_trinkey/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Daniel Mason <daniel@danielmason.com>"]
 description = "Board Support crate for the Adafruit Neo Trinkey"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m-rt = { version = "0.7", optional = true }

--- a/boards/neokey_trinkey/Cargo.toml
+++ b/boards/neokey_trinkey/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Broderick Carlin <broderick.carlin@gmail.com>"]
 description = "Board Support crate for the Adafruit Neokey Trinkey"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.panic-semihosting]
 version = "0.6"

--- a/boards/p1am_100/Cargo.toml
+++ b/boards/p1am_100/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Quentin Smith <quentin@mit.edu>"]
 description = "Board Support crate for the Facts Engineering P1AM-100"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/pfza_proto1/Cargo.toml
+++ b/boards/pfza_proto1/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Michael van Niekerk <mvniekerk@gmail.com>"]
 description = "Board Support crate for the PathfinderZA Proto1"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -5,14 +5,16 @@ authors = [
 ]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board Support crate for the Adafruit PyGamer"
-edition = "2021"
 exclude = ["assets"]
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "pygamer"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
 version = "0.14.3"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = {version = "0.7", features = ["critical-section-single-core"]}

--- a/boards/pyportal/Cargo.toml
+++ b/boards/pyportal/Cargo.toml
@@ -9,10 +9,12 @@ authors = [
 description = "Board Support crate for the Adafruit PyPortal"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7.5"

--- a/boards/qt_py_m0/Cargo.toml
+++ b/boards/qt_py_m0/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Garret Kelly <gkelly@gkel.ly>"]
 description = "Board Support crate for the Adafruit QT Py"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
 edition = "2018"
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m-rt = { version = "0.7", optional = true }

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 authors = ["Jesse Braham <jesse@beta7.io>"]
 description = "Support crate for the ATSAMD11C"
-edition = "2018"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "samd11_bare"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
 version = "0.14.3"
+edition = "2018"
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 # for cargo flash
 [package.metadata]

--- a/boards/samd21_mini/Cargo.toml
+++ b/boards/samd21_mini/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Ze'ev Klapow <zklapow@gmail.com>"]
 description = "Board Support crate for the Sparkfun SAMD21 Mini Breakout"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/serpente/Cargo.toml
+++ b/boards/serpente/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Jens Andersen <jens.andersen@gmail.com>"]
 description = "Board Support crate for the Serpente board"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.panic-semihosting]
 version = "0.6"

--- a/boards/sodaq_one/Cargo.toml
+++ b/boards/sodaq_one/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Robert Hennig <robert.hennig@freylax.de>"]
 description = "Board Support crate for the SODAQ ONE"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/sodaq_sara_aff/Cargo.toml
+++ b/boards/sodaq_sara_aff/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Stefan de Lange <langestefan@msn.com>"]
 description = "Board Support crate for the Sodaq SARA AFF"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.panic-semihosting]
 version = "0.6"

--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -9,10 +9,12 @@ authors = [
 description = "Board Support crate for the Adafruit NeoTrellis M4 Express"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-edition = "2021"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [package.metadata.docs.rs]
 features = ["adxl343", "keypad-unproven"]

--- a/boards/trinket_m0/Cargo.toml
+++ b/boards/trinket_m0/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit Trinket M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 bitbang-hal = "0.3"

--- a/boards/wio_lite_mg126/Cargo.toml
+++ b/boards/wio_lite_mg126/Cargo.toml
@@ -5,11 +5,13 @@ authors = ["Max Khardin <max.khardin@gmail.com"]
 description = "Board Support crate for the Wio Lite MG126"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
 documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g/wio_lite_mg126/"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/wio_lite_w600/Cargo.toml
+++ b/boards/wio_lite_w600/Cargo.toml
@@ -5,11 +5,13 @@ authors = ["Daniel Mason <daniel@danielmason.com"]
 description = "Board Support crate for the Wio Lite W600"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
 documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g/wio_lite_w600/"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -5,12 +5,8 @@ authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Tom <twitchyliquid64@ciphersink.net>"
 ]
-edition = "2021"
 description = "Board support crate for the Seeed Studio Wio Terminal"
 documentation = "https://docs.rs/wio-terminal/"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
-license = "MIT OR Apache-2.0"
 keywords = [
     "arm",
     "cortex-m",
@@ -22,8 +18,13 @@ categories = [
     "hardware-support",
     "no-std",
 ]
-
 exclude = ["assets"]
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 # for cargo flash
 [package.metadata]

--- a/boards/xiao_m0/Cargo.toml
+++ b/boards/xiao_m0/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Garret Kelly <gdk@google.com>", "Maciej Procyk <macieekprocyk@gmail.
 description = "Board support crate for the Seeed Studio Seeeduino XIAO"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -13,14 +13,16 @@ authors = [
 categories = ["embedded", "hardware-support", "no-std"]
 description = "HAL and Peripheral access API for ATSAMD11, ATSAMD21, ATSAMD51, ATSAME51, ATSAME53 and ATSAME54 microcontrollers"
 documentation = "https://docs.rs/crate/atsamd-hal/"
-edition = "2021"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "atsamd-hal"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
-rust-version = "1.77.2"
 version = "0.21.2"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
 
 [package.metadata.docs.rs]
 features = ["samd21g", "samd21g-rt", "usb", "dma", "async", "rtic"]

--- a/pac/atsamd11c/Cargo.toml
+++ b/pac/atsamd11c/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Jesse Braham <jesse@beta7.io>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd11d/Cargo.toml
+++ b/pac/atsamd11d/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Victor Koenders <oss@trangar.com>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd21e/Cargo.toml
+++ b/pac/atsamd21e/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Wez Furlong <wez@wezfurlong.org>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd21g/Cargo.toml
+++ b/pac/atsamd21g/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Wez Furlong <wez@wezfurlong.org>", "Blake Johnson <johnsonblake1@gmail.com>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd21j/Cargo.toml
+++ b/pac/atsamd21j/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Wez Furlong <wez@wezfurlong.org>", "Paul Sajna <sajattack@gmail.com>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd51g/Cargo.toml
+++ b/pac/atsamd51g/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Wez Furlong <wez@wezfurlong.org>", "Tony Arcieri <bascule@gmail.com>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd51j/Cargo.toml
+++ b/pac/atsamd51j/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Wez Furlong <wez@wezfurlong.org>", "Paul Sajna <sajattack@gmail.com>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd51n/Cargo.toml
+++ b/pac/atsamd51n/Cargo.toml
@@ -9,10 +9,12 @@ authors = [
 ]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd51p/Cargo.toml
+++ b/pac/atsamd51p/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Jesse Braham <jesse@beta7.io>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsame51g/Cargo.toml
+++ b/pac/atsame51g/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Karsten Große <karsten.grosse@sympatron.de>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsame51j/Cargo.toml
+++ b/pac/atsame51j/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Karsten Große <karsten.grosse@sympatron.de>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsame51n/Cargo.toml
+++ b/pac/atsame51n/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Karsten Große <karsten.grosse@sympatron.de>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsame53j/Cargo.toml
+++ b/pac/atsame53j/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Karsten Große <karsten.grosse@sympatron.de>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsame53n/Cargo.toml
+++ b/pac/atsame53n/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Karsten Große <karsten.grosse@sympatron.de>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsame54n/Cargo.toml
+++ b/pac/atsame54n/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Karsten Große <karsten.grosse@sympatron.de>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsame54p/Cargo.toml
+++ b/pac/atsame54p/Cargo.toml
@@ -10,10 +10,12 @@ authors = [
 ]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"


### PR DESCRIPTION
# Summary
* Ensure all crates are consistently configured and validated using workspace features
* move edition, license, repo, and rust-version (where used) to workspace
* remove readme setting (already set by default)
* add lints section - this should be used in a separate PR
