### PR TITLE
Hal: implement SpiBus for tx-only spi device

### DIFF
--- a/hal/src/sercom/spi/impl_ehal/mod.rs
+++ b/hal/src/sercom/spi/impl_ehal/mod.rs
@@ -212,3 +212,41 @@ where
         Ok(())
     }
 }
+
+/// [`SpiBus`] implementation for [`Spi`], using word-by-word transfers.
+impl<P, M, C> SpiBus<Word<C>> for Spi<Config<P, M, C>, Tx>
+where
+    Config<P, M, C>: ValidConfig,
+    P: ValidPads,
+    M: MasterMode,
+    C: Size + 'static,
+    C::Word: PrimInt + AsPrimitive<DataWidth> + Copy,
+    DataWidth: AsPrimitive<C::Word>,
+{
+    #[inline]
+    fn read(&mut self, _words: &mut [Word<C>]) -> Result<(), Self::Error> {
+        //  There is nothing to do for Tx configured device
+        Ok(())
+    }
+
+    #[inline]
+    fn write(&mut self, words: &[Word<C>]) -> Result<(), Self::Error> {
+        self.write_word_by_word(words)
+    }
+
+    #[inline]
+    fn transfer(&mut self, _read: &mut [Word<C>], write: &[Word<C>]) -> Result<(), Self::Error> {
+        self.write_word_by_word(write)
+    }
+
+    #[inline]
+    fn transfer_in_place(&mut self, words: &mut [Word<C>]) -> Result<(), Self::Error> {
+        self.write_word_by_word(words)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> Result<(), Error> {
+        self.flush_tx();
+        Ok(())
+    }
+}


### PR DESCRIPTION
# Summary
This interface is needed for implementation of the display tx-only SPI interface. 

# Checklist
  - [ ] All new or modified code is well documented, especially public items
  - [ ] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 

## If Adding a new Board
  - [ ] Board CI added to `crates.json`
  - [ ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"

## If Adding a new cargo `feature` to the HAL
  - [ ] Feature is added to the test matrix for applicable boards / PACs in `crates.json`

#### Note
The crate changelogs **should no longer** be manually updated! Changelogs are now automatically generated. Instead:

- If your PR is contained to a single crate, or a single feature:
  - Nothing else to do; your PR will likely be squashed down to a single commit.
  - Please consider using [conventional commmit phrasing](https://www.conventionalcommits.org) in the PR title.
- If your PR brings in large, sweeping changes across multiple crates:
  - Organize your commits such that each commit only touches a single crate, or a single feature across multiple crates. Please don't create commits that span multiple features over multiple crates.
  - Use [conventional commmits](https://www.conventionalcommits.org) for your commit messages.
