### PR TITLE
chore: multiple minor cleanups

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,20 @@ members = [
 	"boards/*",
 ]
 
+[workspace.package]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/atsamd-rs/atsamd"
+rust-version = "1.77.2"
+
+[workspace.lints.rust]
+# TODO: add any workspace-wide rust lint configurations
+# TODO: enable to make identifier usage consistent per file
+# unused_qualifications = "warn"
+
+[workspace.lints.clippy]
+# TODO: add any workspace-wide clippy lint configurations
+
 [profile.dev]
 debug = true
 opt-level = 0
@@ -21,7 +35,6 @@ lto = false
 inherits = "dev"
 opt-level = 2
 lto = "thin"
-
 
 [profile.release]
 lto = true

--- a/atsamd-hal-macros/Cargo.toml
+++ b/atsamd-hal-macros/Cargo.toml
@@ -1,14 +1,17 @@
 [package]
 authors = ["Tethys Svensson"]
 name = "atsamd-hal-macros"
-rust-version = "1.77.2"
 version = "0.2.5"
-edition = "2021"
-license = "MIT OR Apache-2.0"
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Procedural macros for the atsamd-hal library"
 documentation = "https://docs.rs/crate/atsamd-hal-macros/"
-repository = "https://github.com/atsamd-rs/atsamd"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
 
 [lib]
 proc-macro = true

--- a/atsamd-hal-macros/src/lib.rs
+++ b/atsamd-hal-macros/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! The main purpose of this crate is to separate the task of writing the code
 //! to support peripherals of the atsamd families from the task of figuring out
-//! which specific devices has those peripherals.
+//! which specific devices have those peripherals.
 //!
 //! The actual mapping of devices to peripherals is specified in the
 //! `devices.yaml` file. In the `atsamd-hal` crate you then only need to care
@@ -40,8 +40,8 @@ use parsing::{eat_attribute, eat_eof, eat_group, eat_hal_expr, eat_operator, eat
 /// It can be used like `#[hal_cfg([peripheral expression])]`.
 ///
 /// The macro will look up all devices that fulfill the expression and expand
-/// the macro into a cfg attribute of the form `#[cfg(any(feature = "device1",
-/// feature = "device2", ...)]`.
+/// the macro into a cfg attribute of the form
+/// `#[cfg(any(feature = "device1", feature = "device2", ...)]`.
 #[proc_macro_attribute]
 pub fn hal_cfg(args: TokenStream, input: TokenStream) -> TokenStream {
     hal_cfg_impl(args).map_or_else(
@@ -61,8 +61,7 @@ fn hal_cfg_impl(args: TokenStream) -> Result<Group, Error> {
     Ok(cfgs)
 }
 
-/// Macro which expands to a `mod foo;` item with different paths for each
-/// device.
+/// Macro, which expands to a `mod foo;` item with different paths for each device.
 ///
 /// It can be used like this:
 ///
@@ -92,7 +91,7 @@ fn hal_cfg_impl(args: TokenStream) -> Result<Group, Error> {
 /// ```
 ///
 /// Ideally you would be to write `pub mod calibration;` instead of
-/// `pub mod calibration {}`, but unfortunately non-inline modules are not
+/// `pub mod calibration {}`, but unfortunately, non-inline modules are not
 /// currently supposed in proc macros. See
 /// [rust#54727](https://github.com/rust-lang/rust/issues/54727) for details.
 #[proc_macro_attribute]
@@ -156,7 +155,7 @@ fn hal_module_impl(args: TokenStream, input: TokenStream) -> Result<TokenStream,
 
 /// Helper macro to allow using `#[hal_cfg(..)]` macro in more places
 ///
-/// Normally the `#[cfg(..)]` macro is allowed in many more places than
+/// Normally, the `#[cfg(..)]` macro is allowed in many more places than
 /// proc-macros, such as directly on a statement. This mitigates that
 /// restriction.
 ///
@@ -170,7 +169,7 @@ fn hal_module_impl(args: TokenStream, input: TokenStream) -> Result<TokenStream,
 /// }
 /// ```
 ///
-/// This works, because attributes are allowed on the outer item.
+/// This works because attributes are allowed on the outer item.
 ///
 /// The `#[hal_macro_helper]` will search through the item and replace all
 /// instances of the `#[hal_cfg(..)]` attribute with the corresponding

--- a/boards/arduino_mkr1000/Cargo.toml
+++ b/boards/arduino_mkr1000/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Eric Rushing <rushinge@gmail.com>"]
 description = "Board Support crate for the Arduino MKR 1000 WiFi"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/arduino_mkrvidor4000/Cargo.toml
+++ b/boards/arduino_mkrvidor4000/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Sameer Puri <purisame@spuri.io>"]
 description = "Board Support crate for the Arduino MKR VIDOR 4000"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/arduino_mkrzero/Cargo.toml
+++ b/boards/arduino_mkrzero/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Wez Furlong <wez@wezfurlong.org>", "David McGillicuddy <contact@djmc
 description = "Board Support crate for the Arduino MKRZERO"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/arduino_nano33iot/Cargo.toml
+++ b/boards/arduino_nano33iot/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Gus Wynn <guswynn@gmail.com>"]
 description = "Board Support crate for the Arduino Nano 33 IOT"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/atsame54_xpro/Cargo.toml
+++ b/boards/atsame54_xpro/Cargo.toml
@@ -1,17 +1,20 @@
 [package]
 authors = [
-  "Karsten Große <karsten.grosse@sympatron.de>",
-  "John Little <johngigantic@gmail.com>",
+    "Karsten Große <karsten.grosse@sympatron.de>",
+    "John Little <johngigantic@gmail.com>",
 ]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board Support crate for the SAM E54 Xplained Pro Evaluation Kit"
-edition = "2021"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "atsame54_xpro"
 readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
 version = "0.12.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 optional = true
@@ -32,9 +35,9 @@ version = "0.3.1"
 
 [dev-dependencies]
 mcan = "0.2"
-panic-rtt-target = {version = "0.1", features = ["cortex-m"]}
-rtic = {version = "2.1.2", features = ["thumbv7-backend"]}
-rtt-target = {version = "0.3", features = ["cortex-m"]}
+panic-rtt-target = { version = "0.1", features = ["cortex-m"] }
+rtic = { version = "2.1.2", features = ["thumbv7-backend"] }
+rtt-target = { version = "0.3", features = ["cortex-m"] }
 
 [features]
 default = ["rt", "atsamd-hal/same54p"]

--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -4,10 +4,12 @@ version = "0.11.1"
 authors = ["Paul Sajna <paulsajna@gmail.com>"]
 description = "Board Support crate for the Adafruit Circuit Playground Express"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2018"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/edgebadge/Cargo.toml
+++ b/boards/edgebadge/Cargo.toml
@@ -5,11 +5,13 @@ authors = ["Jacob Rosenthal <@jacobrosenthal>"]
 description = "Board Support crate for the Adafruit EdgeBadge"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
 exclude = ["assets"]
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -2,14 +2,15 @@
 authors = ["Ben Bergman <ben@benbergman.ca>"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board Support crate for the Adafruit Feather M0"
-edition = "2021"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "feather_m0"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
-resolver = "2"
 version = "0.19.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 # for cargo flash
 [package.metadata]
@@ -47,14 +48,14 @@ cortex-m-semihosting = "0.3"
 defmt = "0.3"
 defmt-rtt = "0.4"
 drogue-nom-utils = "0.1"
-embassy-executor = {version = "0.6.2", features = ["arch-cortex-m", "executor-thread", "task-arena-size-64"]}
+embassy-executor = { version = "0.6.2", features = ["arch-cortex-m", "executor-thread", "task-arena-size-64"] }
 embedded-graphics = "0.7.1"
 heapless = "0.8"
-nom = {version = "5", default-features = false}
+nom = { version = "5", default-features = false }
 panic-halt = "0.2"
 panic-probe = "0.3"
 panic-semihosting = "0.6"
-rtic-monotonics = {version = "1.3.0", features = ["cortex-m-systick", "systick-10khz"]}
+rtic-monotonics = { version = "1.3.0", features = ["cortex-m-systick", "systick-10khz"] }
 ssd1306 = "0.7"
 usbd-serial = "0.2"
 

--- a/boards/feather_m4/Cargo.toml
+++ b/boards/feather_m4/Cargo.toml
@@ -3,13 +3,15 @@ authors = ["Theodore DeRego <tderego94@gmail.com>"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board Support crate for the Adafruit Feather M4"
 documentation = "https://atsamd-rs.github.io/atsamd/atsamd51j/feather_m4/"
-edition = "2021"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "feather_m4"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
 version = "0.17.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 # for cargo flash
 [package.metadata]
@@ -36,7 +38,7 @@ version = "0.3.1"
 heapless = "0.7"
 panic-halt = "0.2"
 panic-semihosting = "0.5"
-rtic = {version = "2.1.1", features = ["thumbv7-backend"]}
+rtic = { version = "2.1.1", features = ["thumbv7-backend"] }
 smart-leds = "0.3"
 usbd-serial = "0.2"
 ws2812-timer-delay = "0.3"

--- a/boards/gemma_m0/Cargo.toml
+++ b/boards/gemma_m0/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Wez Furlong <wez@wezfurlong.org>"]
 description = "Board Support crate for the Adafruit Gemma M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Dustin Little <dlittle@toyatech.net>"]
 description = "Board Support crate for the Adafruit Grand Central M4 Express"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-edition = "2021"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/itsybitsy_m0/Cargo.toml
+++ b/boards/itsybitsy_m0/Cargo.toml
@@ -5,15 +5,17 @@ authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit ItsyBitsy M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 bitbang-hal = "0.3"
 apa102-spi = "0.3"
-embedded-hal-02 = {package = "embedded-hal", version = "0.2", features = ["unproven"]}
+embedded-hal-02 = { package = "embedded-hal", version = "0.2", features = ["unproven"] }
 smart-leds = "0.3"
 
 [dependencies.cortex-m-rt]
@@ -34,7 +36,7 @@ optional = true
 
 [dev-dependencies]
 cortex-m-rtic = "1.0"
-cortex-m = {version = "0.7", features = ["critical-section-single-core"]}
+cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 usbd-serial = "0.2.2"
 usbd-hid = "0.8.2"
 cortex-m-semihosting = "0.3"

--- a/boards/itsybitsy_m4/Cargo.toml
+++ b/boards/itsybitsy_m4/Cargo.toml
@@ -8,15 +8,17 @@ authors = [
 description = "Board Support crate for the Adafruit ItsyBitsy M4 Express"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-edition = "2021"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 bitbang-hal = "0.3"
 apa102-spi = "0.3"
-embedded-hal-02 = {package = "embedded-hal", version = "0.2", features = ["unproven"]}
+embedded-hal-02 = { package = "embedded-hal", version = "0.2", features = ["unproven"] }
 smart-leds = "0.3"
 
 [dependencies.cortex-m-rt]
@@ -32,7 +34,7 @@ version = "0.3.1"
 optional = true
 
 [dev-dependencies]
-cortex-m = {version = "0.7", features = ["critical-section-single-core"]}
+cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 usbd-serial = "0.2.2"
 panic-halt = "0.2"
 panic-semihosting = "0.6"

--- a/boards/matrix_portal_m4/Cargo.toml
+++ b/boards/matrix_portal_m4/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Salsa Steve <elmanstevelaguna@gmail.com>"]
 description = "Board Support crate for the Matrix Portal M4"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 # for cargo flash
 [package.metadata]

--- a/boards/metro_m0/Cargo.toml
+++ b/boards/metro_m0/Cargo.toml
@@ -2,13 +2,15 @@
 authors = ["Wez Furlong <wez@wezfurlong.org>"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board Support crate for the Adafruit Metro M0"
-edition = "2021"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "metro_m0"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
 version = "0.19.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 # for cargo flash
 [package.metadata]

--- a/boards/metro_m4/Cargo.toml
+++ b/boards/metro_m4/Cargo.toml
@@ -2,13 +2,15 @@
 authors = ["Paul Sajna <sajattack@gmail.com>", "Wez Furlong <wez@wezfurlong.org>"]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board Support crate for the Adafruit Metro M4"
-edition = "2021"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "metro_m4"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
 version = "0.18.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 # for cargo flash
 [package.metadata]
@@ -36,16 +38,16 @@ cortex-m = "0.7"
 cortex-m-semihosting = "0.3"
 defmt = "0.3"
 defmt-rtt = "0.4"
-embassy-executor = {version = "0.6.2", features = ["arch-cortex-m", "executor-thread", "task-arena-size-8192"]}
+embassy-executor = { version = "0.6.2", features = ["arch-cortex-m", "executor-thread", "task-arena-size-8192"] }
 embedded-hal = "1.0"
 embedded-hal-nb = "1.0"
 panic-halt = "0.2"
 panic-probe = "0.3"
-panic-rtt-target = {version = "0.1.1", features = ["cortex-m"]}
+panic-rtt-target = { version = "0.1.1", features = ["cortex-m"] }
 panic-semihosting = "0.5"
-rtic = {version = "2.1.1", features = ["thumbv7-backend"]}
-rtic-monotonics = {version = "2.0.1", features = ["cortex-m-systick"]}
-rtt-target = {version = "0.3.0", features = ["cortex-m"]}
+rtic = { version = "2.1.1", features = ["thumbv7-backend"] }
+rtic-monotonics = { version = "2.0.1", features = ["cortex-m-systick"] }
+rtt-target = { version = "0.3.0", features = ["cortex-m"] }
 smart-leds = "0.3"
 usbd-serial = "0.2"
 

--- a/boards/neo_trinkey/Cargo.toml
+++ b/boards/neo_trinkey/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Daniel Mason <daniel@danielmason.com>"]
 description = "Board Support crate for the Adafruit Neo Trinkey"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m-rt = { version = "0.7", optional = true }

--- a/boards/neokey_trinkey/Cargo.toml
+++ b/boards/neokey_trinkey/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Broderick Carlin <broderick.carlin@gmail.com>"]
 description = "Board Support crate for the Adafruit Neokey Trinkey"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.panic-semihosting]
 version = "0.6"

--- a/boards/p1am_100/Cargo.toml
+++ b/boards/p1am_100/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Quentin Smith <quentin@mit.edu>"]
 description = "Board Support crate for the Facts Engineering P1AM-100"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"
@@ -27,7 +29,7 @@ cortex-m = "0.7"
 usbd-serial = "0.1"
 cortex-m-semihosting = "0.3"
 drogue-nom-utils = "0.1"
-nom = { version = "5.1", default-features= false }
+nom = { version = "5.1", default-features = false }
 heapless = "0.7"
 cortex-m-rtic = "1.0"
 panic-halt = "0.2"

--- a/boards/pfza_proto1/Cargo.toml
+++ b/boards/pfza_proto1/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Michael van Niekerk <mvniekerk@gmail.com>"]
 description = "Board Support crate for the PathfinderZA Proto1"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/pygamer/Cargo.toml
+++ b/boards/pygamer/Cargo.toml
@@ -1,21 +1,23 @@
 [package]
 authors = [
-  "Paul Sajna <sajattack@gmail.com>",
-  "Wez Furlong <wez@wezfurlong.org>",
+    "Paul Sajna <sajattack@gmail.com>",
+    "Wez Furlong <wez@wezfurlong.org>",
 ]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "Board Support crate for the Adafruit PyGamer"
-edition = "2021"
 exclude = ["assets"]
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "pygamer"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
 version = "0.15.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
-cortex-m = {version = "0.7", features = ["critical-section-single-core"]}
+cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
 embedded-hal-bus = "0.3.0"
 # This version is pinned as recommended by: https://docs.rs/embedded-hal-bus/0.2.0/embedded_hal_bus/spi/struct.ExclusiveDevice.html#method.new_no_delay
 st7735-lcd = "=0.10.0"
@@ -44,7 +46,7 @@ embedded-sdmmc = "0.8.1"
 lis3dh = "0.4.3"
 micromath = "2.1"
 panic-halt = "1"
-rtic = {version = "2.1.2", features = ["thumbv7-backend"]}
+rtic = { version = "2.1.2", features = ["thumbv7-backend"] }
 smart-leds = "0.4"
 tinybmp = "0.6"
 usbd-serial = "0.2"

--- a/boards/pyportal/Cargo.toml
+++ b/boards/pyportal/Cargo.toml
@@ -9,10 +9,12 @@ authors = [
 description = "Board Support crate for the Adafruit PyPortal"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7.5"
@@ -23,12 +25,12 @@ version = "0.21.0"
 default-features = false
 
 [dependencies.display-interface-parallel-gpio]
-version="0.7.0"
-optional=true
+version = "0.7.0"
+optional = true
 
 [dependencies.ili9341]
-version="0.6.0"
-optional=true
+version = "0.6.0"
+optional = true
 
 [dependencies.usb-device]
 version = "0.3.2"

--- a/boards/qt_py_m0/Cargo.toml
+++ b/boards/qt_py_m0/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Garret Kelly <gkelly@gkel.ly>"]
 description = "Board Support crate for the Adafruit QT Py"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2018"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m-rt = { version = "0.7", optional = true }

--- a/boards/samd11_bare/Cargo.toml
+++ b/boards/samd11_bare/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 authors = ["Jesse Braham <jesse@beta7.io>"]
 description = "Support crate for the ATSAMD11C"
-edition = "2018"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "samd11_bare"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
 version = "0.15.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 # for cargo flash
 [package.metadata]
@@ -36,7 +38,7 @@ cortex-m = "0.7"
 panic-halt = "0.2"
 panic-probe = "0.2.0"
 panic-semihosting = "0.5"
-rtt-target = {version = "0.3.0", features = ["cortex-m"]}
+rtt-target = { version = "0.3.0", features = ["cortex-m"] }
 
 [features]
 # ask the HAL to enable atsamd11c support

--- a/boards/samd21_mini/Cargo.toml
+++ b/boards/samd21_mini/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Ze'ev Klapow <zklapow@gmail.com>"]
 description = "Board Support crate for the Sparkfun SAMD21 Mini Breakout"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/serpente/Cargo.toml
+++ b/boards/serpente/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Jens Andersen <jens.andersen@gmail.com>"]
 description = "Board Support crate for the Serpente board"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.panic-semihosting]
 version = "0.6"

--- a/boards/sodaq_one/Cargo.toml
+++ b/boards/sodaq_one/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Robert Hennig <robert.hennig@freylax.de>"]
 description = "Board Support crate for the SODAQ ONE"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/sodaq_sara_aff/Cargo.toml
+++ b/boards/sodaq_sara_aff/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Stefan de Lange <langestefan@msn.com>"]
 description = "Board Support crate for the Sodaq SARA AFF"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.panic-semihosting]
 version = "0.6"

--- a/boards/trellis_m4/Cargo.toml
+++ b/boards/trellis_m4/Cargo.toml
@@ -9,10 +9,12 @@ authors = [
 description = "Board Support crate for the Adafruit NeoTrellis M4 Express"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-edition = "2021"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [package.metadata.docs.rs]
 features = ["adxl343", "keypad-unproven"]

--- a/boards/trinket_m0/Cargo.toml
+++ b/boards/trinket_m0/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Ben Bergman <ben@benbergman.ca>"]
 description = "Board Support crate for the Adafruit Trinket M0"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-edition = "2021"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 bitbang-hal = "0.3"

--- a/boards/wio_lite_mg126/Cargo.toml
+++ b/boards/wio_lite_mg126/Cargo.toml
@@ -5,11 +5,13 @@ authors = ["Max Khardin <max.khardin@gmail.com"]
 description = "Board Support crate for the Wio Lite MG126"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
 documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g/wio_lite_mg126/"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/boards/wio_lite_w600/Cargo.toml
+++ b/boards/wio_lite_w600/Cargo.toml
@@ -5,11 +5,13 @@ authors = ["Daniel Mason <daniel@danielmason.com"]
 description = "Board Support crate for the Wio Lite W600"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
 documentation = "https://atsamd-rs.github.io/atsamd/atsamd21g/wio_lite_w600/"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -5,12 +5,8 @@ authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Tom <twitchyliquid64@ciphersink.net>"
 ]
-edition = "2021"
 description = "Board support crate for the Seeed Studio Wio Terminal"
 documentation = "https://docs.rs/wio-terminal/"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
-license = "MIT OR Apache-2.0"
 keywords = [
     "arm",
     "cortex-m",
@@ -22,8 +18,13 @@ categories = [
     "hardware-support",
     "no-std",
 ]
-
 exclude = ["assets"]
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 # for cargo flash
 [package.metadata]

--- a/boards/xiao_m0/Cargo.toml
+++ b/boards/xiao_m0/Cargo.toml
@@ -5,10 +5,12 @@ authors = ["Garret Kelly <gdk@google.com>", "Maciej Procyk <macieekprocyk@gmail.
 description = "Board support crate for the Seeed Studio Seeeduino XIAO"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies.cortex-m-rt]
 version = "0.7"

--- a/crates.json
+++ b/crates.json
@@ -175,85 +175,35 @@
   },
   "hal_doc_variants": {
     "samd11c": {
-      "features": [
-        "samd11c",
-        "dma",
-        "defmt",
-        "async"
-      ],
+      "features": [ "samd11c", "dma", "defmt", "async" ],
       "target": "thumbv6m-none-eabi"
     },
     "samd11d": {
-      "features": [
-        "samd11d",
-        "dma",
-        "defmt",
-        "async"
-      ],
+      "features": [ "samd11d", "dma", "defmt", "async" ],
       "target": "thumbv6m-none-eabi"
     },
     "samd21g": {
-      "features": [
-        "samd21g",
-        "usb",
-        "dma",
-        "defmt",
-        "async"
-      ],
+      "features": [ "samd21g", "usb", "dma", "defmt", "async" ],
       "target": "thumbv6m-none-eabi"
     },
     "samd21j": {
-      "features": [
-        "samd21j",
-        "usb",
-        "dma",
-        "defmt",
-        "async"
-      ],
+      "features": [ "samd21j", "usb", "dma", "defmt", "async" ],
       "target": "thumbv6m-none-eabi"
     },
     "samd51g": {
-      "features": [
-        "samd51g",
-        "usb",
-        "sdmmc",
-        "dma",
-        "defmt",
-        "async"
-      ],
+      "features": [ "samd51g", "usb", "sdmmc", "dma", "defmt", "async" ],
       "target": "thumbv7em-none-eabihf"
     },
     "samd51j": {
-      "features": [
-        "samd51j",
-        "usb",
-        "sdmmc",
-        "dma",
-        "defmt",
-        "async"
-      ],
+      "features": [ "samd51j", "usb", "sdmmc", "dma", "defmt", "async" ],
       "target": "thumbv7em-none-eabihf"
     },
     "samd51n": {
-      "features": [
-        "samd51n",
-        "usb",
-        "sdmmc",
-        "dma",
-        "defmt",
-        "async"
-      ],
+      "features": [ "samd51n", "usb", "sdmmc", "dma", "defmt", "async" ],
       "target": "thumbv7em-none-eabihf"
     },
     "samd51p": {
-      "features": [
-        "samd51p",
-        "usb",
-        "sdmmc",
-        "dma",
-        "defmt",
-        "async"
-      ],
+      "features": [ "samd51p", "usb", "sdmmc", "dma", "defmt", "async" ],
       "target": "thumbv7em-none-eabihf"
     }
   },

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -4,23 +4,25 @@
 
 [package]
 authors = [
-  "Wez Furlong <wez@wezfurlong.org>",
-  "Paul Sajna <sajattack@gmail.com>",
-  "Michael van Niekerk <mvniekerk@gmail.com>",
-  "Jesse Braham <jesse@beta7.io>",
-  "Bradley Harden <bradleyharden@gmail.com>",
+    "Wez Furlong <wez@wezfurlong.org>",
+    "Paul Sajna <sajattack@gmail.com>",
+    "Michael van Niekerk <mvniekerk@gmail.com>",
+    "Jesse Braham <jesse@beta7.io>",
+    "Bradley Harden <bradleyharden@gmail.com>",
 ]
 categories = ["embedded", "hardware-support", "no-std"]
 description = "HAL and Peripheral access API for ATSAMD11, ATSAMD21, ATSAMD51, ATSAME51, ATSAME53 and ATSAME54 microcontrollers"
 documentation = "https://docs.rs/crate/atsamd-hal/"
-edition = "2021"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
-license = "MIT OR Apache-2.0"
 name = "atsamd-hal"
-readme = "README.md"
-repository = "https://github.com/atsamd-rs/atsamd"
-rust-version = "1.77.2"
 version = "0.22.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
 
 [package.metadata.docs.rs]
 features = ["samd21g", "samd21g-rt", "usb", "dma", "async", "rtic"]
@@ -37,40 +39,40 @@ bitflags = "2.6.0"
 cipher = "0.3"
 critical-section = "1.2.0"
 cortex-m = "0.7"
-embedded-hal-02 = {package = "embedded-hal", version = "0.2", features = ["unproven"]}
-embedded-hal-1 = {package = "embedded-hal", version = "1.0.0"}
+embedded-hal-02 = { package = "embedded-hal", version = "0.2", features = ["unproven"] }
+embedded-hal-1 = { package = "embedded-hal", version = "1.0.0" }
 embedded-hal-nb = "1.0.0"
 embedded-io = "0.6"
 fugit = "0.3"
 heapless = "0.8"
 modular-bitfield = "0.11"
 nb = "1.1"
-num-traits = {version = "0.2.19", default-features = false}
+num-traits = { version = "0.2.19", default-features = false }
 opaque-debug = "0.3.0"
 paste = "1.0.15"
-portable-atomic = {version = "1.10.0", optional = true, features = ["critical-section"]}
+portable-atomic = { version = "1.10.0", optional = true, features = ["critical-section"] }
 rand_core = "0.6"
 seq-macro = "0.3"
 sorted-hlist = "0.2.0"
 typenum = "1.12.0"
 vcell = "0.1"
-void = {version = "1.0", default-features = false}
+void = { version = "1.0", default-features = false }
 
 #===============================================================================
 # Optional depdendencies
 #===============================================================================
 
-defmt = { version = "0.3.8", optional = true}
-embassy-sync = {version = "0.6.0", optional = true}
-embedded-hal-async = {version = "1.0.0", optional = true}
-embedded-io-async = {version = "0.6.1", optional = true}
-embedded-sdmmc = {version = "0.3", optional = true}
-futures = {version = "0.3.31", default-features = false, features = ["async-await"], optional = true}
-jlink_rtt = {version = "0.2", optional = true}
-mcan-core = {version = "0.2", optional = true}
-rtic-monotonic = {version = "1.0", optional = true}
-usb-device = {version = "0.3.2", optional = true}
-rtic-time = {version = "2.0", optional = true}
+defmt = { version = "0.3.8", optional = true }
+embassy-sync = { version = "0.6.0", optional = true }
+embedded-hal-async = { version = "1.0.0", optional = true }
+embedded-io-async = { version = "0.6.1", optional = true }
+embedded-sdmmc = { version = "0.3", optional = true }
+futures = { version = "0.3.31", default-features = false, features = ["async-await"], optional = true }
+jlink_rtt = { version = "0.2", optional = true }
+mcan-core = { version = "0.2", optional = true }
+rtic-monotonic = { version = "1.0", optional = true }
+usb-device = { version = "0.3.2", optional = true }
+rtic-time = { version = "2.0", optional = true }
 
 #===============================================================================
 # PACs
@@ -82,27 +84,27 @@ rtic-time = {version = "2.0", optional = true}
 # users should specify a corresponding variant (see below). The variant features
 # will select the correct PAC, as well as other configuration features.
 
-atsamd11c = {version = "0.14.1", path = "../pac/atsamd11c", optional = true}
-atsamd11d = {version = "0.14.1", path = "../pac/atsamd11d", optional = true}
+atsamd11c = { version = "0.14.1", path = "../pac/atsamd11c", optional = true }
+atsamd11d = { version = "0.14.1", path = "../pac/atsamd11d", optional = true }
 
-atsamd21e = {version = "0.14.1", path = "../pac/atsamd21e", optional = true}
-atsamd21g = {version = "0.14.1", path = "../pac/atsamd21g", optional = true}
-atsamd21j = {version = "0.14.1", path = "../pac/atsamd21j", optional = true}
+atsamd21e = { version = "0.14.1", path = "../pac/atsamd21e", optional = true }
+atsamd21g = { version = "0.14.1", path = "../pac/atsamd21g", optional = true }
+atsamd21j = { version = "0.14.1", path = "../pac/atsamd21j", optional = true }
 
-atsamd51g = {version = "0.14.1", path = "../pac/atsamd51g", optional = true}
-atsamd51j = {version = "0.14.1", path = "../pac/atsamd51j", optional = true}
-atsamd51n = {version = "0.14.1", path = "../pac/atsamd51n", optional = true}
-atsamd51p = {version = "0.14.1", path = "../pac/atsamd51p", optional = true}
+atsamd51g = { version = "0.14.1", path = "../pac/atsamd51g", optional = true }
+atsamd51j = { version = "0.14.1", path = "../pac/atsamd51j", optional = true }
+atsamd51n = { version = "0.14.1", path = "../pac/atsamd51n", optional = true }
+atsamd51p = { version = "0.14.1", path = "../pac/atsamd51p", optional = true }
 
-atsame51g = {version = "0.14.1", path = "../pac/atsame51g", optional = true}
-atsame51j = {version = "0.14.1", path = "../pac/atsame51j", optional = true}
-atsame51n = {version = "0.14.1", path = "../pac/atsame51n", optional = true}
+atsame51g = { version = "0.14.1", path = "../pac/atsame51g", optional = true }
+atsame51j = { version = "0.14.1", path = "../pac/atsame51j", optional = true }
+atsame51n = { version = "0.14.1", path = "../pac/atsame51n", optional = true }
 
-atsame53j = {version = "0.14.1", path = "../pac/atsame53j", optional = true}
-atsame53n = {version = "0.14.1", path = "../pac/atsame53n", optional = true}
+atsame53j = { version = "0.14.1", path = "../pac/atsame53j", optional = true }
+atsame53n = { version = "0.14.1", path = "../pac/atsame53n", optional = true }
 
-atsame54n = {version = "0.14.1", path = "../pac/atsame54n", optional = true}
-atsame54p = {version = "0.14.1", path = "../pac/atsame54p", optional = true}
+atsame54n = { version = "0.14.1", path = "../pac/atsame54n", optional = true }
+atsame54p = { version = "0.14.1", path = "../pac/atsame54p", optional = true }
 
 #===============================================================================
 # Features

--- a/hal/src/gpio/mod.rs
+++ b/hal/src/gpio/mod.rs
@@ -16,10 +16,7 @@
 //!
 //! ## Features
 //!
-//! - Converting between pin modes no longer requires access to the `Port` type.
-//!
-//! As a consequence, pin mode conversions can now be implemented using
-//! [`From`]/[`Into`].
+//! Pin mode conversions can be implemented using [`From`]/[`Into`].
 //! ```
 //! let pins = Pins::new(peripherals.PORT);
 //! let pa08: Pin<PA08, PushPullOutput> = pins.pa08.into();

--- a/pac/atsamd11c/Cargo.toml
+++ b/pac/atsamd11c/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Jesse Braham <jesse@beta7.io>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd11d/Cargo.toml
+++ b/pac/atsamd11d/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Victor Koenders <oss@trangar.com>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd21e/Cargo.toml
+++ b/pac/atsamd21e/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Wez Furlong <wez@wezfurlong.org>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd21g/Cargo.toml
+++ b/pac/atsamd21g/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Wez Furlong <wez@wezfurlong.org>", "Blake Johnson <johnsonblake1@gmail.com>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd21j/Cargo.toml
+++ b/pac/atsamd21j/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Wez Furlong <wez@wezfurlong.org>", "Paul Sajna <sajattack@gmail.com>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd51g/Cargo.toml
+++ b/pac/atsamd51g/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Wez Furlong <wez@wezfurlong.org>", "Tony Arcieri <bascule@gmail.com>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd51j/Cargo.toml
+++ b/pac/atsamd51j/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Wez Furlong <wez@wezfurlong.org>", "Paul Sajna <sajattack@gmail.com>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd51n/Cargo.toml
+++ b/pac/atsamd51n/Cargo.toml
@@ -3,16 +3,18 @@ name = "atsamd51n"
 description = "Peripheral access API for ATSAMD51N microcontrollers (generated using svd2rust)"
 version = "0.14.1"
 authors = [
-   "Wez Furlong <wez@wezfurlong.org>",
-   "Paul Sajna <sajattack@gmail.com>",
-   "Bradley Harden <bradleyharden@gmail.com>",
+    "Wez Furlong <wez@wezfurlong.org>",
+    "Paul Sajna <sajattack@gmail.com>",
+    "Bradley Harden <bradleyharden@gmail.com>",
 ]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsamd51p/Cargo.toml
+++ b/pac/atsamd51p/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Jesse Braham <jesse@beta7.io>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsame51g/Cargo.toml
+++ b/pac/atsame51g/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Karsten Große <karsten.grosse@sympatron.de>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsame51j/Cargo.toml
+++ b/pac/atsame51j/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Karsten Große <karsten.grosse@sympatron.de>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsame51n/Cargo.toml
+++ b/pac/atsame51n/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Karsten Große <karsten.grosse@sympatron.de>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsame53j/Cargo.toml
+++ b/pac/atsame53j/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Karsten Große <karsten.grosse@sympatron.de>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsame53n/Cargo.toml
+++ b/pac/atsame53n/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Karsten Große <karsten.grosse@sympatron.de>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsame54n/Cargo.toml
+++ b/pac/atsame54n/Cargo.toml
@@ -5,10 +5,12 @@ version = "0.14.1"
 authors = ["Karsten Große <karsten.grosse@sympatron.de>"]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"

--- a/pac/atsame54p/Cargo.toml
+++ b/pac/atsame54p/Cargo.toml
@@ -3,17 +3,19 @@ name = "atsame54p"
 description = "Peripheral access API for ATSAME54P microcontrollers (generated using svd2rust)"
 version = "0.14.1"
 authors = [
-   "Wez Furlong <wez@wezfurlong.org>",
-   "Paul Sajna <sajattack@gmail.com>",
-   "Shella Stephens <shella@infracoven.io",
-   "Michael van Niekerk <mvniekerk@gmail.com>"
+    "Wez Furlong <wez@wezfurlong.org>",
+    "Paul Sajna <sajattack@gmail.com>",
+    "Shella Stephens <shella@infracoven.io",
+    "Michael van Niekerk <mvniekerk@gmail.com>"
 ]
 keywords = ["no-std", "arm", "cortex-m"]
 categories = ["embedded", "hardware-support", "no-std"]
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/atsamd-rs/atsamd"
-readme = "README.md"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
 
 [dependencies]
 cortex-m = "0.7"


### PR DESCRIPTION
Per @ianrrees review (thx!), this consolidates #860 #861#862

### consolidate workspace settings
* Ensure all crates are consistently configured and validated using workspace features
* move edition, license, repo, and rust-version (where used) to workspace
* remove readme setting (already set by default)
* add lints section - this should be used in a separate PR

### Code changes
* Migrate several examples to 2021 edition

### Other changes
* `crates.json` reformatted for consistency and ease-of-reading
* Reformat all Cargo.toml that have already been modified with consistent spacing using intellij built-in formatter (pretty similar to what was already used, and it is being proposed for the toml formatting in rustfmt, but that has stalled)
* Minor docs cleanup for syntax, style, and address @ianrrees text suggestions
