### PR TITLE
Update Wio Terminal embedded-sdmmc dependency

### DIFF
--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -38,7 +38,7 @@ display-interface-spi = "0.5"
 heapless = "0.8"
 ili9341 = "0.6.0"
 lis3dh = "0.3.0"
-embedded-sdmmc = "0.3.0"
+embedded-sdmmc = "0.8.0"
 usb-device = { version = "0.3", optional = true }
 nb = "1.0"
 bbqueue = { version = "0.5", optional = true }

--- a/boards/wio_terminal/examples/sdcard.rs
+++ b/boards/wio_terminal/examples/sdcard.rs
@@ -3,8 +3,9 @@
 
 /// Makes the wio_terminal read the SD card and print the filenames
 /// of the first few entries.
-/// In case of missing SD card, it will be stuck in an infinite loop inside of the embedded-sdmmc crate
-/// trying to initialize and not giving any feedback to the user.
+/// In case of missing SD card, it will be stuck in an infinite loop inside of
+/// the embedded-sdmmc crate trying to initialize and not giving any feedback to
+/// the user.
 use embedded_graphics as eg;
 use panic_halt as _;
 use wio_terminal as wio;

--- a/boards/wio_terminal/examples/sdcard.rs
+++ b/boards/wio_terminal/examples/sdcard.rs
@@ -3,6 +3,8 @@
 
 /// Makes the wio_terminal read the SD card and print the filenames
 /// of the first few entries.
+/// In case of missing SD card, it will be stuck in an infinite loop inside of the embedded-sdmmc crate
+/// trying to initialize and not giving any feedback to the user.
 use embedded_graphics as eg;
 use panic_halt as _;
 use wio_terminal as wio;
@@ -22,7 +24,7 @@ use wio::prelude::*;
 use core::fmt::Write;
 use heapless::String;
 
-use embedded_sdmmc::{TimeSource, Timestamp, VolumeIdx};
+use embedded_sdmmc::{sdcard::Error as SdCardError, TimeSource, Timestamp, VolumeIdx};
 use wio::SDCardController;
 
 #[entry]
@@ -41,16 +43,6 @@ fn main() -> ! {
     let mut delay = Delay::new(core.SYST, &mut clocks);
     let sets = wio::Pins::new(peripherals.port).split();
 
-    let (mut cont, _sd_present) = sets
-        .sd_card
-        .init(
-            &mut clocks,
-            peripherals.sercom6,
-            &mut peripherals.mclk,
-            Clock,
-        )
-        .unwrap();
-
     // Initialize the ILI9341-based LCD display. Create a black backdrop the size of
     // the screen.
     let (mut display, _backlight) = sets
@@ -65,45 +57,36 @@ fn main() -> ! {
         .unwrap();
 
     let style = MonoTextStyle::new(&FONT_9X15, Rgb565::WHITE);
+    let (mut sd_controller, _sd_present) = sets
+        .sd_card
+        .init(
+            &mut clocks,
+            peripherals.sercom6,
+            &mut peripherals.mclk,
+            delay,
+            Clock,
+        )
+        .expect("Failed to initialize peripherals and driver structures");
 
     loop {
-        match cont.device().init() {
-            Ok(_) => {
-                // Now that we have initialized, we can run the SPI bus at
-                // a reasonable speed.
-                cont.set_baud(20.MHz());
-
-                let mut data = String::<128>::new();
-                write!(data, "OK! ").unwrap();
-                match cont.device().card_size_bytes() {
-                    Ok(size) => writeln!(data, "{}Mb", size / 1024 / 1024).unwrap(),
-                    Err(e) => writeln!(data, "Err: {:?}", e).unwrap(),
-                }
-                Text::with_baseline(data.as_str(), Point::new(4, 2), style, Baseline::Top)
-                    .draw(&mut display)
-                    .ok()
-                    .unwrap();
-
-                if let Err(e) = print_contents(&mut cont, &mut display) {
-                    let mut data = String::<128>::new();
-                    writeln!(data, "Err: {:?}", e).unwrap();
-                    Text::with_baseline(data.as_str(), Point::new(4, 20), style, Baseline::Top)
-                        .draw(&mut display)
-                        .ok()
-                        .unwrap();
-                }
-            }
-            Err(e) => {
-                let mut data = String::<128>::new();
-                writeln!(data, "Error!: {:?}", e).unwrap();
-                Text::with_baseline(data.as_str(), Point::new(4, 2), style, Baseline::Top)
-                    .draw(&mut display)
-                    .ok()
-                    .unwrap();
-            }
+        let mut data = String::<128>::new();
+        match sd_controller.device().num_bytes() {
+            Ok(size) => writeln!(data, "{}Mb", size / 1024 / 1024).unwrap(),
+            Err(e) => writeln!(data, "Err: {:?}", e).unwrap(),
+        }
+        Text::with_baseline(data.as_str(), Point::new(4, 2), style, Baseline::Top)
+            .draw(&mut display)
+            .ok()
+            .unwrap();
+        if let Err(e) = print_contents(&mut sd_controller, &mut display) {
+            let mut data = String::<128>::new();
+            writeln!(data, "Err: {:?}", e).unwrap();
+            Text::with_baseline(data.as_str(), Point::new(4, 20), style, Baseline::Top)
+                .draw(&mut display)
+                .ok()
+                .unwrap();
         }
 
-        delay.delay_ms(2500_u16);
         Rectangle::with_corners(Point::new(0, 0), Point::new(320, 240))
             .into_styled(
                 PrimitiveStyleBuilder::new()
@@ -113,35 +96,40 @@ fn main() -> ! {
             .draw(&mut display)
             .ok()
             .unwrap();
+        sd_controller.device().mark_card_uninit();
     }
 }
 
 fn print_contents(
-    cont: &mut SDCardController<Clock>,
+    sd_controller: &mut SDCardController<Clock>,
     lcd: &mut wio::LCD,
-) -> Result<(), embedded_sdmmc::Error<embedded_sdmmc::SdMmcError>> {
+) -> Result<(), embedded_sdmmc::Error<SdCardError>> {
     let style = MonoTextStyle::new(&FONT_9X15, Rgb565::WHITE);
 
-    let volume = cont.get_volume(VolumeIdx(0))?;
-    let dir = cont.open_root_dir(&volume)?;
+    match sd_controller.open_volume(VolumeIdx(0)) {
+        Ok(mut volume) => {
+            let mut dir = volume.open_root_dir().expect("Failed to open root dir");
 
-    let mut count = 0;
-    let out = cont.iterate_dir(&volume, &dir, |ent| {
-        let mut data = String::<128>::new();
-        writeln!(data, "{} - {:?}", ent.name, ent.attributes).unwrap();
-        Text::with_baseline(
-            data.as_str(),
-            Point::new(4, 20 + count * 16),
-            style,
-            Baseline::Top,
-        )
-        .draw(lcd)
-        .ok()
-        .unwrap();
-        count += 1;
-    });
-    cont.close_dir(&volume, dir);
-    out
+            let mut count = 0;
+            let out = dir.iterate_dir(|ent| {
+                let mut data = String::<128>::new();
+                writeln!(data, "{} - {:?}", ent.name, ent.attributes).unwrap();
+                Text::with_baseline(
+                    data.as_str(),
+                    Point::new(4, 20 + count * 16),
+                    style,
+                    Baseline::Top,
+                )
+                .draw(lcd)
+                .ok()
+                .unwrap();
+                count += 1;
+            });
+            let _ = dir.close();
+            out
+        }
+        Err(e) => return Err(e),
+    }
 }
 
 struct Clock;

--- a/boards/wio_terminal/src/storage.rs
+++ b/boards/wio_terminal/src/storage.rs
@@ -90,8 +90,8 @@ impl<TS: TimeSource> core::ops::DerefMut for SDCardController<TS> {
 
 impl SDCard {
     /// Initialize the controller and its corresponding SPI bus peripheral.
-    /// It is suggested to set higher buad rates after initialization, but it is for now
-    /// left as the user responsibility.
+    /// It is suggested to set higher buad rates after initialization, but it is
+    /// for now left as the user responsibility.
     pub fn init<TS: TimeSource>(
         self,
         clocks: &mut GenericClockController,


### PR DESCRIPTION
Update from 0.3 to 0.8 version.
Sacrifice delay to embedded sdmmc.
Possibly missing SPI interface baud to higher speed after controller initialization.

# Summary
[describe your changes here]

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 

## If Adding a new Board
  - [x] Board CI added to `crates.json`
  - [x] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"

## If Adding a new cargo `feature` to the HAL
  - [x] Feature is added to the test matrix for applicable boards / PACs in `crates.json`

#### Note
The crate changelogs **should no longer** be manually updated! Changelogs are now automatically generated. Instead:

- If your PR is contained to a single crate, or a single feature:
  - Nothing else to do; your PR will likely be squashed down to a single commit.
  - Please consider using [conventional commmit phrasing](https://www.conventionalcommits.org) in the PR title.
- If your PR brings in large, sweeping changes across multiple crates:
  - Organize your commits such that each commit only touches a single crate, or a single feature across multiple crates. Please don't create commits that span multiple features over multiple crates.
  - Use [conventional commmits](https://www.conventionalcommits.org) for your commit messages.
