### PR TITLE
chore: Manual release

### DIFF
--- a/boards/wio_terminal/CHANGELOG.md
+++ b/boards/wio_terminal/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Dependencies
 
 - *(wio_terminal)* [**breaking**] Update wio_terminal to hal 0.21.0 ([#865](https://github.com/atsamd-rs/atsamd/pull/865))
+- *(wio_terminal)* [**breaking**] Update `embedded_sdmmc` dependency from `0.3` to `0.8` ([#874](https://github.com/atsamd-rs/atsamd/pull/874))
 
 ## [0.7.3](https://github.com/atsamd-rs/atsamd/compare/wio_terminal-0.7.2...wio_terminal-0.7.3) - 2025-04-17
 

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [**breaking**] Refactor IoSet trait using sorted HList.
+- [**breaking**] Refactor IoSet trait using sorted HList ([#844](https://github.com/atsamd-rs/atsamd/pull/844)).
 
     SERCOM peripherals no longer need to specify the IoSet inside their `Pads` type. It is checked automatically and
     transparently by the compiler. For example,
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     + // To this
     + pub type I2cPads = i2c::Pads<I2cSercom, Sda, Scl>;
     ```
+
+### Fixed
+
+- [**breaking**] Fix bugs with EIC and allow clock provider switching (ATSAMx5x) ([#850](https://github.com/atsamd-rs/atsamd/pull/850))
 
 ### Documentation
 

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Relax rules for when DMA channels can be added/removed to/from `Spi` and `SpiFuture` ([#883](https://github.com/atsamd-rs/atsamd/pull/883))
 - [**breaking**] Fix bugs with EIC and allow clock provider switching (ATSAMx5x) ([#850](https://github.com/atsamd-rs/atsamd/pull/850))
 
 ### Documentation

--- a/hal/CHANGELOG.md
+++ b/hal/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Improve watchdog start documentation ([#881](https://github.com/atsamd-rs/atsamd/pull/881))
 - Fix inconsistency in UART+async+DMA docs ([#849](https://github.com/atsamd-rs/atsamd/pull/849))
 
 ### Fixed


### PR DESCRIPTION
Since I had to manually update some crate versions (which are still unreleased), `release-plz` will not open release PRs and automatically add new commits to the crate changelogs.

This PR will serve to manually update the changelogs and cargo manifests until we are ready to cut a new release, at which point `release-plz` will start working again.

## Caution

Merging this PR will trigger a new release! Don't merge until ready.