### PR TITLE
Improve watchdog start documentation

### DIFF
--- a/hal/src/peripherals/watchdog.rs
+++ b/hal/src/peripherals/watchdog.rs
@@ -64,7 +64,13 @@ impl watchdog::WatchdogEnable for Watchdog {
     type Time = u8;
 
     /// Enables a watchdog timer to reset the processor if software is frozen
-    /// or stalled.
+    /// or stalled. Pass [`WatchdogTimeout`] as the period.
+    /// 
+    /// As WDT is driven by a 1024Hz clock, the time until timeout can be calculated
+    /// as `(1 second/1024)*period`
+    /// 
+    /// EG:
+    /// `Timeout of 2048 cycles = (1/1024)*2048 = 2 seconds`
     #[hal_macro_helper]
     fn start<T>(&mut self, period: T)
     where


### PR DESCRIPTION
# Summary

This PR documents that you should provide [WatchdogTimeout] to the start function, as it was not intuitive what 'T' is when looking at the docs (And it can simply accept a u8). It also provides a brief example on how to calculate the watchdog timeout duration.
