### PR TITLE
example(grand_central_m4): Added new async example

### DIFF
--- a/boards/grand_central_m4/Cargo.toml
+++ b/boards/grand_central_m4/Cargo.toml
@@ -30,9 +30,17 @@ features = ["critical-section-single-core"]
 cortex-m = "0.7"
 usbd-serial = "0.2"
 panic-halt = "1.0.0"
+panic-probe = "1.0.0"
 panic-semihosting = "0.6"
 smart-leds = "0.3"
 ws2812-timer-delay = "0.3"
+embassy-executor = { version = "0.7.0", features = [
+	"arch-cortex-m",
+	"executor-thread",
+	"task-arena-size-8192",
+] }
+defmt = "1.0.1"
+defmt-rtt = "1.0.0"
 
 [features]
 default = ["rt", "atsamd-hal/samd51p"]
@@ -41,6 +49,8 @@ max-channels = ["dma", "atsamd-hal/max-channels"]
 rt = ["cortex-m-rt", "atsamd-hal/samd51p-rt"]
 usb = ["atsamd-hal/usb", "usb-device"]
 use_semihosting = []
+async = ["atsamd-hal/async"]
+
 
 # for cargo flash
 [package.metadata]
@@ -62,3 +72,7 @@ name = "neopixel_rainbow"
 [[example]]
 name = "usb_serial"
 required-features = ["usb"]
+
+[[example]]
+name = "async_eic"
+required-features = ["async"]

--- a/boards/grand_central_m4/examples/async_eic.rs
+++ b/boards/grand_central_m4/examples/async_eic.rs
@@ -1,0 +1,63 @@
+//! Uses an external interrupt to blink an LED.
+//!
+//! You need to connect a button between D46 and ground. Each time the button
+//! is pressed, the LED will toggle.
+#![no_std]
+#![no_main]
+
+use defmt_rtt as _;
+use panic_probe as _;
+
+use bsp::hal;
+use bsp::pac;
+use bsp::pin_alias;
+use grand_central_m4 as bsp;
+
+use hal::{
+    clock::{ClockGenId, ClockSource, GenericClockController},
+    eic::{Eic, Sense},
+    gpio::{Pin, PullUpInterrupt},
+    prelude::*,
+};
+use pac::{CorePeripherals, Peripherals};
+
+atsamd_hal::bind_interrupts!(struct Irqs {
+    EIC_EXTINT_6 => atsamd_hal::eic::InterruptHandler;
+});
+
+#[embassy_executor::main]
+async fn main(_s: embassy_executor::Spawner) -> ! {
+    let mut peripherals = Peripherals::take().unwrap();
+    let mut _core = CorePeripherals::take().unwrap();
+    let mut clocks = GenericClockController::with_internal_32kosc(
+        peripherals.gclk,
+        &mut peripherals.mclk,
+        &mut peripherals.osc32kctrl,
+        &mut peripherals.oscctrl,
+        &mut peripherals.nvmctrl,
+    );
+    let pins = bsp::Pins::new(peripherals.port);
+    let mut red_led: bsp::RedLed = pin_alias!(pins.red_led).into();
+
+    let _internal_clock = clocks
+        .configure_gclk_divider_and_source(ClockGenId::Gclk2, 1, ClockSource::Osculp32k, false)
+        .unwrap();
+    clocks.configure_standby(ClockGenId::Gclk2, true);
+
+    // Configure a clock for the EIC peripheral
+    let gclk2 = clocks.get_gclk(ClockGenId::Gclk2).unwrap();
+    let eic_clock = clocks.eic(&gclk2).unwrap();
+
+    let eic_channels = Eic::new(&mut peripherals.mclk, eic_clock, peripherals.eic).split();
+
+    let button: Pin<_, PullUpInterrupt> = pins.d46.into();
+    let mut extint = eic_channels.6.with_pin(button).into_future(Irqs);
+    extint.enable_interrupt();
+
+    loop {
+        // Here we show straight falling edge detection without
+        extint.wait(Sense::Fall).await;
+        defmt::info!("Falling edge detected");
+        red_led.toggle().unwrap();
+    }
+}


### PR DESCRIPTION
# Summary
I added a new async example for External Interrupt Controller. 

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 
