### PR TITLE
DAC Support (Sync + Async) for both D5x and D11/D21

### DIFF
--- a/hal/src/peripherals/adc/d11/mod.rs
+++ b/hal/src/peripherals/adc/d11/mod.rs
@@ -6,6 +6,7 @@ use super::{
 #[cfg(feature = "async")]
 use super::{FutureAdc, async_api};
 
+use crate::dac::DacWriteHandle;
 use crate::{calibration, pac};
 use pac::Peripherals;
 use pac::Sysctrl;
@@ -239,6 +240,15 @@ impl<I: AdcInstance> Adc<I> {
 
 impl<I: AdcInstance + PrimaryAdc> Adc<I> {
     #[inline]
+    /// Reads the output of DAC0
+    pub async fn read_dac0_output(
+        &mut self,
+        _channel: &DacWriteHandle<'_>,
+    ) -> u16 {
+        self.read_channel(0x1C)
+    }
+
+    #[inline]
     /// Returns the CPU temperature in degrees C
     ///
     /// NOTE: The temperature sensor is known to be out by up to ±10C, it
@@ -283,6 +293,15 @@ impl<I: AdcInstance + PrimaryAdc, F> FutureAdc<I, F>
 where
     F: crate::async_hal::interrupts::Binding<I::Interrupt, async_api::InterruptHandler<I>>,
 {
+
+    /// Reads the output of DAC0
+    pub async fn read_dac0_output(
+        &mut self,
+        _channel: &DacWriteHandle<'_>,
+    ) -> u16 {
+        self.read_channel(0x1C).await
+    }
+
     /// Reads the CPU temperature. Value returned is in Celcius
     pub async fn read_cpu_temperature(&mut self, sysctrl: &mut Sysctrl) -> f32 {
         let old_state = sysctrl.vref().read().tsen().bit();

--- a/hal/src/peripherals/dac/d11.rs
+++ b/hal/src/peripherals/dac/d11.rs
@@ -1,0 +1,243 @@
+//! Digital-to-Analog Converter
+
+use atsamd21g::Pm;
+use atsamd_hal_macros::{hal_cfg, hal_macro_helper};
+use core::mem::ManuallyDrop;
+use num_traits::clamp;
+use pac::dac;
+
+use crate::{
+    clock::DacClock,
+    gpio::{self, AlternateB, Pin, PA02, PA05},
+    pac,
+};
+
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// The DAC clock exceeds the maximum
+    /// of 350Khz
+    ClockTooFast,
+}
+
+pub struct Dac {
+    inner: pac::Dac,
+}
+
+pub struct DacWriteHandle {
+    pin: Pin<PA02, AlternateB>,
+    reg: ManuallyDrop<pac::Dac>,
+}
+
+impl DacWriteHandle {
+    pub fn new(dac: pac::Dac, pin: Pin<PA02, AlternateB>) -> Self {
+        Self {
+            reg: ManuallyDrop::new(dac),
+            pin,
+        }
+    }
+}
+
+impl Dac {
+    /// Construct a new DAC. The DAC VREF is set to 3.3V
+    /// (VDDANA) to allow for maximum output voltage of 3.3V
+    ///
+    /// This function also checks the clock frequency provided
+    /// to the DAC, erroring out if the Clock exceeds the maximum
+    /// DAC clock frequency:
+    ///
+    /// * **SAMD/E5x** - 12Mhz
+    /// * **SAMC/D21** - 350Khz
+    /// * **SAMD11** - 350Khz
+    pub fn new(dac: pac::Dac, clk: DacClock, pm: &mut Pm) -> Result<Self, Error> {
+        if clk.freq().to_Hz() > 350_000 {
+            return Err(Error::ClockTooFast);
+        }
+        dac.ctrla().write(|w| w.swrst().set_bit());
+        let s = Self { inner: dac };
+        s.sync();
+        s.with_disable(|dac| {
+            // Set VREF
+            dac.ctrlb().modify(|_, w| w.refsel().avcc());
+        });
+        Ok(s)
+    }
+
+    pub(crate) fn with_disable<R, F: FnOnce(&pac::Dac) -> R>(&self, f: F) -> R {
+        self.inner.ctrla().write(|w| w.enable().clear_bit());
+        self.sync();
+        let ret = f(&self.inner);
+        self.inner.ctrla().write(|w| w.enable().set_bit());
+        self.sync();
+        ret
+    }
+
+    pub fn sync(&self) {
+        while self.inner.status().read().syncbusy().bit_is_set() {
+            core::hint::spin_loop();
+        }
+    }
+
+    /// Converts input voltage in millivolts to DAC output value (RAW)
+    /// The input voltage is clamped between 0 and 3300mv,
+    /// resulting in an output between 0 and 1024
+    ///
+    /// Use this function for single channel mode DAC
+    pub fn voltage_to_raw(mv: u16) -> u16 {
+        // Up to 4096 output
+        const RATIO: f32 = 1024.0 / 3300.0;
+        let targ = core::cmp::min(3300, mv) as f32;
+        (targ * RATIO) as u16
+    }
+
+    /// Get a handle to DAC 0 output. This consumes PA02, since
+    /// the DAC is now enabled and using this pin
+    pub fn dac0(&self, pin: Pin<PA02, AlternateB>) -> DacWriteHandle {
+        self.inner.ctrla().modify(|_, w| w.enable().set_bit());
+        self.sync();
+        DacWriteHandle::new(unsafe { core::ptr::read(&self.inner as *const _) }, pin)
+    }
+}
+
+impl DacWriteHandle {
+    pub fn sync(&self) {
+        while self.reg.status().read().syncbusy().bit_is_set() {
+            core::hint::spin_loop();
+        }
+    }
+
+    pub(crate) fn with_dac_disable<R, F: FnOnce(&pac::Dac) -> R>(&self, f: F) -> R {
+        self.reg.ctrla().write(|w| w.enable().clear_bit());
+        self.sync();
+        let ret = f(&self.reg);
+        self.reg.ctrla().write(|w| w.enable().set_bit());
+        self.sync();
+        ret
+    }
+
+    pub fn write_val(&mut self, val: u16) {
+        unsafe {
+            self.reg.data().write(|w| w.bits(val));
+        }
+    }
+
+    /// Writes a voltage to the DAC.
+    #[inline]
+    pub fn write_voltage(&mut self, mv: u16) {
+        let raw = Dac::voltage_to_raw(mv);
+        self.write_val(raw);
+    }
+
+    /// Stop the DAC write handle, releasing the pin
+    pub fn stop(self) -> Pin<PA02, AlternateB> {
+        self.with_dac_disable(|dac| {
+            dac.ctrla().modify(|_, w| w.enable().clear_bit());
+        });
+        self.pin
+    }
+}
+
+#[cfg(feature = "dma")]
+mod dma {
+    use pac::dmac::chctrlb::Trigactselect as TriggerAction;
+    use pac::dmac::chctrlb::Trigsrcselect as TriggerSource;
+
+    #[cfg(feature = "async")]
+    use crate::dmac::ReadyFuture;
+    use crate::{
+        dmac::{self, AnyChannel, Buffer, Ready},
+        sercom::dma::SharedSliceBuffer,
+    };
+
+    use super::*;
+
+    struct DacDmaPtr(pub *mut u16);
+
+    impl DacDmaPtr {
+        pub fn new(reg: &pac::Dac) -> Self {
+            Self(reg.data().as_ptr())
+        }
+    }
+
+    unsafe impl Buffer for DacDmaPtr {
+        type Beat = u16;
+
+        fn dma_ptr(&mut self) -> *mut Self::Beat {
+            self.0
+        }
+
+        fn incrementing(&self) -> bool {
+            false
+        }
+
+        fn buffer_len(&self) -> usize {
+            1
+        }
+    }
+
+    impl DacWriteHandle {
+        /// Writes a buffer to the DAC using DMA. Each buffer value is DAC
+        /// RAW output (0-1024). Use [Dac::voltage_to_raw] to convert
+        /// between target voltage output of the DAC and the value to write
+        /// to the DAC
+        ///
+        /// The samples are consumed at the sample rate of the DAC
+        #[hal_macro_helper]
+        pub fn write_buffer_blocking<CH>(
+            &mut self,
+            buf: &[u16],
+            channel: &mut CH,
+        ) -> Result<(), dmac::Error>
+        where
+            CH: AnyChannel<Status = Ready>,
+        {
+            let mut bytes = SharedSliceBuffer::from_slice(buf);
+            let trigger_action = TriggerAction::Beat;
+
+            let mut dest = DacDmaPtr::new(&self.reg);
+
+            unsafe {
+                channel.as_mut().transfer(
+                    &mut bytes,
+                    &mut dest,
+                    TriggerSource::DacEmpty,
+                    trigger_action,
+                    None,
+                )
+            }
+        }
+
+        /// Writes a buffer to the DAC using DMA (Async version).
+        /// Each buffer value is DAC RAW output (0-4096).
+        /// Use [Dac::voltage_to_raw] to convert between target
+        /// voltage output of the DAC and the value to write
+        /// to the DAC
+        ///
+        /// The samples are consumed at the sample rate of the DAC
+        #[cfg(feature = "async")]
+        #[hal_macro_helper]
+        pub async fn write_buffer<CH>(
+            &mut self,
+            buf: &[u16],
+            channel: &mut CH,
+        ) -> Result<(), dmac::Error>
+        where
+            CH: AnyChannel<Status = ReadyFuture>,
+        {
+            let bytes = SharedSliceBuffer::from_slice(buf);
+
+            #[hal_cfg(any("dac-d5x"))]
+            let trigger_action = TriggerAction::Burst;
+
+            #[hal_cfg(any("dac-d21", "dac-d11"))]
+            let trigger_action = TriggerAction::Beat;
+
+            let dest = DacDmaPtr::new(&self.reg);
+
+            channel
+                .as_mut()
+                .transfer_future(bytes, dest, TriggerSource::DacEmpty, trigger_action)
+                .await
+        }
+    }
+}

--- a/hal/src/peripherals/dac/d11.rs
+++ b/hal/src/peripherals/dac/d11.rs
@@ -1,7 +1,6 @@
 //! Digital-to-Analog Converter
 
-use atsamd21g::Pm;
-use atsamd_hal_macros::{hal_cfg, hal_macro_helper};
+use pac::Pm;
 use core::mem::ManuallyDrop;
 use num_traits::clamp;
 use pac::dac;
@@ -182,7 +181,6 @@ mod dma {
         /// to the DAC
         ///
         /// The samples are consumed at the sample rate of the DAC
-        #[hal_macro_helper]
         pub fn write_buffer_blocking<CH>(
             &mut self,
             buf: &[u16],
@@ -215,7 +213,6 @@ mod dma {
         ///
         /// The samples are consumed at the sample rate of the DAC
         #[cfg(feature = "async")]
-        #[hal_macro_helper]
         pub async fn write_buffer<CH>(
             &mut self,
             buf: &[u16],
@@ -225,13 +222,7 @@ mod dma {
             CH: AnyChannel<Status = ReadyFuture>,
         {
             let bytes = SharedSliceBuffer::from_slice(buf);
-
-            #[hal_cfg(any("dac-d5x"))]
-            let trigger_action = TriggerAction::Burst;
-
-            #[hal_cfg(any("dac-d21", "dac-d11"))]
             let trigger_action = TriggerAction::Beat;
-
             let dest = DacDmaPtr::new(&self.reg);
 
             channel

--- a/hal/src/peripherals/dac/d11.rs
+++ b/hal/src/peripherals/dac/d11.rs
@@ -2,12 +2,10 @@
 
 use pac::Pm;
 use core::mem::ManuallyDrop;
-use num_traits::clamp;
-use pac::dac;
 
 use crate::{
     clock::DacClock,
-    gpio::{self, AlternateB, Pin, PA02, PA05},
+    gpio::{AlternateB, Pin, PA02},
     pac,
 };
 
@@ -52,6 +50,7 @@ impl Dac {
         if clk.freq().to_Hz() > 350_000 {
             return Err(Error::ClockTooFast);
         }
+        pm.apbcmask().modify(|_, w| w.dac_().set_bit());
         dac.ctrla().write(|w| w.swrst().set_bit());
         let s = Self { inner: dac };
         s.sync();

--- a/hal/src/peripherals/dac/d11.rs
+++ b/hal/src/peripherals/dac/d11.rs
@@ -201,8 +201,12 @@ mod dma {
                     TriggerSource::DacEmpty,
                     trigger_action,
                     None,
-                )
+                )?;
             }
+            while channel.as_mut().xfer_complete() {
+                core::hint::spin_loop();
+            }
+            channel.as_mut().xfer_success()
         }
 
         /// Writes a buffer to the DAC using DMA (Async version).

--- a/hal/src/peripherals/dac/d11.rs
+++ b/hal/src/peripherals/dac/d11.rs
@@ -106,7 +106,7 @@ impl<'a> DacWriteHandle<'a> {
     pub(crate) fn with_dac_disable<R, F: FnOnce(&pac::Dac) -> R>(&self, f: F) -> R {
         self.reg.ctrla().write(|w| w.enable().clear_bit());
         self.sync();
-        let ret = f(&self.reg);
+        let ret = f(self.reg);
         self.reg.ctrla().write(|w| w.enable().set_bit());
         self.sync();
         ret

--- a/hal/src/peripherals/dac/d11.rs
+++ b/hal/src/peripherals/dac/d11.rs
@@ -86,7 +86,7 @@ impl Dac {
 
     /// Get a handle to DAC 0 output. This consumes PA02, since
     /// the DAC is now enabled and using this pin
-    pub fn dac0(&self, pin: Pin<PA02, AlternateB>) -> DacWriteHandle {
+    pub fn dac0(&self, pin: Pin<PA02, AlternateB>) -> DacWriteHandle<'_> {
         self.inner.ctrla().modify(|_, w| w.enable().set_bit());
         self.sync();
         DacWriteHandle::new(&self.inner, pin)
@@ -103,7 +103,7 @@ impl Dac {
     }
 }
 
-impl<'a> DacWriteHandle<'a> {
+impl DacWriteHandle<'_> {
     pub fn sync(&self) {
         while self.reg.status().read().syncbusy().bit_is_set() {
             core::hint::spin_loop();
@@ -179,7 +179,7 @@ mod dma {
         }
     }
 
-    impl<'a> DacWriteHandle<'a> {
+    impl DacWriteHandle<'_> {
         /// Writes a buffer to the DAC using DMA. Each buffer value is DAC
         /// RAW output (0-1024). Use [Dac::voltage_to_raw] to convert
         /// between target voltage output of the DAC and the value to write

--- a/hal/src/peripherals/dac/d5x.rs
+++ b/hal/src/peripherals/dac/d5x.rs
@@ -453,8 +453,9 @@ mod dma {
             // SAFETY - This case is safe, since it just allows
             // us to not have a new DacDmaPtr type with i16.
             // The DAC interprets the data as i16 for differential mode
-            let mut bytes =
-                SharedSliceBuffer::from_slice(unsafe { core::mem::transmute::<_, &[u16]>(buf) });
+            let mut bytes = SharedSliceBuffer::from_slice(unsafe {
+                core::mem::transmute::<&[i16], &[u16]>(buf)
+            });
 
             let trigger_action = TriggerAction::Burst;
 
@@ -494,8 +495,9 @@ mod dma {
             // SAFETY - This case is safe, since it just allows
             // us to not have a new DacDmaPtr type with i16.
             // The DAC interprets the data as i16 for differential mode
-            let bytes =
-                SharedSliceBuffer::from_slice(unsafe { core::mem::transmute::<_, &[u16]>(buf) });
+            let bytes = SharedSliceBuffer::from_slice(unsafe {
+                core::mem::transmute::<&[i16], &[u16]>(buf)
+            });
 
             let trigger_action = TriggerAction::Burst;
 

--- a/hal/src/peripherals/dac/d5x.rs
+++ b/hal/src/peripherals/dac/d5x.rs
@@ -219,7 +219,7 @@ impl Dac {
         &self,
         d0: Pin<PA02, AlternateB>,
         d1: Pin<PA05, AlternateB>,
-    ) -> DacWriteHandle<Differential<Dac0, Dac1>> {
+    ) -> DacWriteHandle<'_, Differential<Dac0, Dac1>> {
         self.with_disable(|dac| {
             dac.ctrlb().modify(|_, w| w.diff().set_bit());
             dac.dacctrl(0).modify(|_, w| w.enable().set_bit());
@@ -236,7 +236,7 @@ impl Dac {
         )
     }
 
-    pub fn dac0(&self, pin: Pin<PA02, AlternateB>) -> DacWriteHandle<Single<Dac0>> {
+    pub fn dac0(&self, pin: Pin<PA02, AlternateB>) -> DacWriteHandle<'_, Single<Dac0>> {
         self.with_disable(|dac| {
             dac.ctrlb().modify(|_, w| w.diff().clear_bit());
             dac.dacctrl(Dac0::IDX).modify(|_, w| w.enable().set_bit())
@@ -247,7 +247,7 @@ impl Dac {
         DacWriteHandle::new(&self.inner, Single { pin })
     }
 
-    pub fn dac1(&self, pin: Pin<PA05, AlternateB>) -> DacWriteHandle<Single<Dac1>> {
+    pub fn dac1(&self, pin: Pin<PA05, AlternateB>) -> DacWriteHandle<'_, Single<Dac1>> {
         self.with_disable(|dac| {
             dac.ctrlb().modify(|_, w| w.diff().clear_bit());
             dac.dacctrl(Dac1::IDX).modify(|_, w| w.enable().set_bit())

--- a/hal/src/peripherals/dac/d5x.rs
+++ b/hal/src/peripherals/dac/d5x.rs
@@ -467,8 +467,12 @@ mod dma {
                     D0::DMA_TX_TRIGGER,
                     trigger_action,
                     None,
-                )
+                )?;
             }
+            while channel.as_mut().xfer_complete() {
+                core::hint::spin_loop();
+            }
+            channel.as_mut().xfer_success()
         }
 
         /// Writes a buffer to the DAC using DMA (Async version).

--- a/hal/src/peripherals/dac/d5x.rs
+++ b/hal/src/peripherals/dac/d5x.rs
@@ -271,7 +271,7 @@ impl<PS: PclkSourceId> Dac<PS> {
 
     /// Destroy the DAC peripheral, returning resources.
     /// The DAC will be disabled and reset before being released
-    pub fn release(self) -> (pac::Dac, ApbClk<types::Dac>, Pclk<types::Dac, PS>) {
+    pub fn free(self) -> (pac::Dac, ApbClk<types::Dac>, Pclk<types::Dac, PS>) {
         self.inner.ctrla().modify(|_, w| w.enable().clear_bit());
         self.sync();
         self.inner.ctrla().write(|w| w.swrst().set_bit());

--- a/hal/src/peripherals/dac/d5x.rs
+++ b/hal/src/peripherals/dac/d5x.rs
@@ -256,7 +256,7 @@ impl<'a, M: DacMode> DacWriteHandle<'a, M> {
     pub(crate) fn with_dac_disable<R, F: FnOnce(&pac::Dac) -> R>(&self, f: F) -> R {
         self.reg.ctrla().write(|w| w.enable().clear_bit());
         self.sync();
-        let ret = f(&self.reg);
+        let ret = f(self.reg);
         self.reg.ctrla().write(|w| w.enable().set_bit());
         self.sync();
         ret

--- a/hal/src/peripherals/dac/mod.rs
+++ b/hal/src/peripherals/dac/mod.rs
@@ -1,16 +1,17 @@
 //! Digital-to-Analog Converter
 
-use core::{marker::PhantomData, mem::ManuallyDrop, ops::Deref};
-
-use atsamd_hal_macros::{hal_cfg, hal_module};
-use pac::{dac, Peripherals};
+use core::mem::ManuallyDrop;
+use num_traits::clamp;
+use pac::dac;
 
 use crate::{
-    clock::v2::{pclk::Pclk, types},
-    gpio::{self, AlternateB, AnyPin, Output, Pin, PushPullOutput, PA02, PA05},
+    clock::v2::types,
+    gpio::{self, AlternateB, Pin, PA02, PA05},
     pac,
-    typelevel::{NoneT, Sealed},
 };
+
+#[cfg(feature = "dma")]
+use pac::dmac::channel::chctrla::Trigsrcselect as TriggerSource;
 
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -28,9 +29,15 @@ pub trait DacInstance {
     type PinId: gpio::AnyPin;
     const IDX: usize;
 
+    #[cfg(feature = "dma")]
+    const DMA_TX_TRIGGER: TriggerSource;
+
     fn data(reg: &pac::Dac) -> bool;
     fn ready(reg: &pac::Dac) -> bool;
     fn eoc(reg: &pac::Dac) -> bool;
+
+    #[cfg(feature = "dma")]
+    fn dma_data_ptr(reg: &pac::Dac) -> *mut u16;
 }
 
 pub struct Single<D: DacInstance> {
@@ -66,6 +73,10 @@ pub struct Dac1;
 impl DacInstance for Dac0 {
     type PinId = Pin<PA02, AlternateB>;
     const IDX: usize = 0;
+
+    #[cfg(feature = "dma")]
+    const DMA_TX_TRIGGER: TriggerSource = TriggerSource::DacEmpty0;
+
     fn ready(reg: &pac::Dac) -> bool {
         reg.status().read().ready0().bit_is_set()
     }
@@ -77,11 +88,20 @@ impl DacInstance for Dac0 {
     fn eoc(reg: &pac::Dac) -> bool {
         reg.status().read().eoc0().bit_is_set()
     }
+
+    #[cfg(feature = "dma")]
+    fn dma_data_ptr(reg: &pac::Dac) -> *mut u16 {
+        reg.data(0).as_ptr()
+    }
 }
 
 impl DacInstance for Dac1 {
     type PinId = Pin<PA05, AlternateB>;
     const IDX: usize = 1;
+
+    #[cfg(feature = "dma")]
+    const DMA_TX_TRIGGER: TriggerSource = TriggerSource::DacEmpty1;
+
     fn ready(reg: &pac::Dac) -> bool {
         reg.status().read().ready1().bit_is_set()
     }
@@ -93,19 +113,34 @@ impl DacInstance for Dac1 {
     fn eoc(reg: &pac::Dac) -> bool {
         reg.status().read().eoc1().bit_is_set()
     }
+
+    #[cfg(feature = "dma")]
+    fn dma_data_ptr(reg: &pac::Dac) -> *mut u16 {
+        reg.data(1).as_ptr()
+    }
 }
 
 impl Dac {
+    /// Construct a new DAC. The DAC VREF is set to 3.3V
+    /// (VDDANA) to allow for maximum output voltage of 3.3V
+    ///
+    /// This function also checks the clock frequency provided
+    /// to the DAC, erroring out if the Clock exceeds the maximum
+    /// DAC clock frequency:
+    ///
+    /// * **SAMD/E5x** - 12Mhz
+    /// * **SAMC/D21** - 350Khz
+    /// * **SAMD11** - 350Khz
     pub fn new<PS: crate::clock::v2::pclk::PclkSourceId>(
         dac: pac::Dac,
-        clk: crate::clock::v2::apb::ApbClk<types::Dac>,
+        _clk: crate::clock::v2::apb::ApbClk<types::Dac>,
         pclk: &crate::clock::v2::pclk::Pclk<types::Dac, PS>,
     ) -> Result<Self, Error> {
         if pclk.freq().to_Hz() > 12_000_000 {
             return Err(Error::ClockTooFast);
         }
         dac.ctrla().write(|w| w.swrst().set_bit());
-        let mut s = Self { inner: dac };
+        let s = Self { inner: dac };
         s.sync();
         s.with_disable(|dac| {
             // Set VREF
@@ -138,6 +173,37 @@ impl Dac {
         }
     }
 
+    /// Converts input voltage in millivolts to DAC output value (RAW)
+    /// The input voltage is clamped between 0 and 3300mv,
+    /// resulting in an output between 0 and 4096
+    ///
+    /// Use this function for single channel mode DAC
+    pub fn voltage_to_raw(mv: u16) -> u16 {
+        // Up to 4096 output
+        const RATIO: f32 = 4096.0 / 3300.0;
+        let targ = core::cmp::min(3300, mv) as f32;
+        (targ * RATIO) as u16
+    }
+
+    /// Converts input voltage in millivolts to DAC output value (RAW)
+    /// The input voltage is clamped between -1650mv and +1650mv,
+    /// resulting in an output between -2048 and +2048
+    ///
+    /// Use this function for differential mode DAC
+    pub fn voltage_to_raw_signed(mv: i16) -> i16 {
+        // Up to +/-2048 output
+        const RATIO: f32 = 4096.0 / 3300.0;
+        let targ = clamp(mv, -1650, 1650) as f32;
+        (targ * RATIO) as i16
+    }
+
+    /// Sets the DAC up in differential mode.
+    /// 
+    /// In this mode, Dac0 is output D0, and Dac1 is output D1.
+    /// 
+    /// When writing to the Differential pair, The baseline voltage 
+    /// is 1.65V, with D0 writing `1.65+x`, and D1 writing `1.65-x`.
+    /// This is why in differential mode, the write value is signed.
     pub fn differential(
         &self,
         d0: Pin<PA02, AlternateB>,
@@ -208,7 +274,10 @@ impl<M: DacMode> DacWriteHandle<M> {
 
 // For single DAC modes (Dac0/Dac1)
 impl<DAC: DacInstance> DacWriteHandle<Single<DAC>> {
-    pub fn write(&mut self, val: u16) {
+    /// Writes a raw value to the DAC. Input value is between
+    /// 0 and 4096. If you want the DAC to output a specific
+    /// voltage, use [Self::write_voltage] instead.
+    pub fn write_val(&mut self, val: u16) {
         unsafe {
             self.reg.data(DAC::IDX).write(|w| w.bits(val));
         }
@@ -220,6 +289,14 @@ impl<DAC: DacInstance> DacWriteHandle<Single<DAC>> {
         }
     }
 
+    /// Writes a voltage to the DAC.
+    #[inline]
+    pub fn write_voltage(&mut self, mv: u16) {
+        let raw = Dac::voltage_to_raw(mv);
+        self.write_val(raw);
+    }
+
+    /// Stop the DAC in single mode, releasing the pin
     pub fn stop(self) -> DAC::PinId {
         self.with_dac_disable(|dac| {
             dac.dacctrl(DAC::IDX).modify(|_, w| w.enable().clear_bit());
@@ -230,7 +307,10 @@ impl<DAC: DacInstance> DacWriteHandle<Single<DAC>> {
 
 // For differential mode
 impl<D0: DacInstance, D1: DacInstance> DacWriteHandle<Differential<D0, D1>> {
-    pub fn write(&mut self, val: i16) {
+    /// Writes a raw value to the DAC. Input value is between
+    /// -2048 and +2048. If you want the DAC to output a specific
+    /// voltage, use [Self::write_voltage] instead.
+    pub fn write_val(&mut self, val: i16) {
         // Manipulation for differential mode is done via DAC0 channel info
         unsafe {
             self.reg.data(0).write(|w| w.bits(val as u16));
@@ -243,6 +323,14 @@ impl<D0: DacInstance, D1: DacInstance> DacWriteHandle<Differential<D0, D1>> {
         }
     }
 
+    /// Writes a voltage to the DAC.
+    #[inline]
+    pub fn write_voltage(&mut self, mv: i16) {
+        let raw = Dac::voltage_to_raw_signed(mv);
+        self.write_val(raw);
+    }
+
+    /// Stop the DAC in differential mode, releasing both pins
     pub fn stop(self) -> (D0::PinId, D1::PinId) {
         self.with_dac_disable(|dac| {
             dac.dacctrl(0).modify(|_, w| w.enable().clear_bit());
@@ -253,5 +341,169 @@ impl<D0: DacInstance, D1: DacInstance> DacWriteHandle<Differential<D0, D1>> {
 
 #[cfg(feature = "dma")]
 mod dma {
-    // TODO - DMA
+    use pac::dmac::channel::chctrla::Trigactselect as TriggerAction;
+
+    #[cfg(feature = "async")]
+    use crate::dmac::ReadyFuture;
+    use crate::{
+        dmac::{self, AnyChannel, Buffer, Ready},
+        sercom::dma::SharedSliceBuffer,
+    };
+
+    use super::*;
+
+    struct DacDmaPtr(pub *mut u16);
+
+    impl DacDmaPtr {
+        pub fn new<D: DacInstance>(reg: &pac::Dac) -> Self {
+            Self(D::dma_data_ptr(reg))
+        }
+    }
+
+    unsafe impl Buffer for DacDmaPtr {
+        type Beat = u16;
+
+        fn dma_ptr(&mut self) -> *mut Self::Beat {
+            self.0
+        }
+
+        fn incrementing(&self) -> bool {
+            false
+        }
+
+        fn buffer_len(&self) -> usize {
+            1
+        }
+    }
+
+    impl<DAC: DacInstance> DacWriteHandle<Single<DAC>> {
+        /// Writes a buffer to the DAC using DMA. Each buffer value is DAC
+        /// RAW output (0-4096). Use [Dac::voltage_to_raw] to convert
+        /// between target voltage output of the DAC and the value to write
+        /// to the DAC
+        ///
+        /// The samples are consumed at the sample rate of the DAC
+        pub fn write_buffer_blocking<CH>(
+            &mut self,
+            buf: &[u16],
+            channel: &mut CH,
+        ) -> Result<(), dmac::Error>
+        where
+            CH: AnyChannel<Status = Ready>,
+        {
+            let mut bytes = SharedSliceBuffer::from_slice(buf);
+
+            let trigger_action = TriggerAction::Burst;
+
+            let mut dest = DacDmaPtr::new::<DAC>(&self.reg);
+
+            unsafe {
+                channel.as_mut().transfer(
+                    &mut bytes,
+                    &mut dest,
+                    DAC::DMA_TX_TRIGGER,
+                    trigger_action,
+                    None,
+                )
+            }
+        }
+
+        /// Writes a buffer to the DAC using DMA (Async version).
+        /// Each buffer value is DAC RAW output (0-4096).
+        /// Use [Dac::voltage_to_raw] to convert between target
+        /// voltage output of the DAC and the value to write
+        /// to the DAC
+        ///
+        /// The samples are consumed at the sample rate of the DAC
+        #[cfg(feature = "async")]
+        pub async fn write_buffer<CH>(
+            &mut self,
+            buf: &[u16],
+            channel: &mut CH,
+        ) -> Result<(), dmac::Error>
+        where
+            CH: AnyChannel<Status = ReadyFuture>,
+        {
+            let bytes = SharedSliceBuffer::from_slice(buf);
+
+            let trigger_action = TriggerAction::Burst;
+
+            let dest = DacDmaPtr::new::<DAC>(&self.reg);
+
+            channel
+                .as_mut()
+                .transfer_future(bytes, dest, DAC::DMA_TX_TRIGGER, trigger_action)
+                .await
+        }
+    }
+
+    impl<D0: DacInstance, D1: DacInstance> DacWriteHandle<Differential<D0, D1>> {
+        /// Writes a buffer to the DAC using DMA (Async version).
+        /// Each buffer value is DAC RAW output (0-4096).
+        /// Use [Dac::voltage_to_raw_signed] to convert between target
+        /// voltage output of the DAC and the value to write
+        /// to the DAC.
+        ///
+        /// The samples are consumed at the sample rate of the DAC
+        pub fn write_buffer_blocking<CH>(
+            &mut self,
+            buf: &[i16],
+            channel: &mut CH,
+        ) -> Result<(), dmac::Error>
+        where
+            CH: AnyChannel<Status = Ready>,
+        {
+            // SAFETY - This case is safe, since it just allows
+            // us to not have a new DacDmaPtr type with i16.
+            // The DAC interprets the data as i16 for differential mode
+            let mut bytes =
+                SharedSliceBuffer::from_slice(unsafe { core::mem::transmute::<_, &[u16]>(buf) });
+
+            let trigger_action = TriggerAction::Burst;
+
+            let mut dest = DacDmaPtr::new::<D0>(&self.reg);
+
+            unsafe {
+                channel.as_mut().transfer(
+                    &mut bytes,
+                    &mut dest,
+                    D0::DMA_TX_TRIGGER,
+                    trigger_action,
+                    None,
+                )
+            }
+        }
+
+        /// Writes a buffer to the DAC using DMA (Async version).
+        /// Each buffer value is DAC RAW output (0-4096).
+        /// Use [Dac::voltage_to_raw_signed] to convert between target
+        /// voltage output of the DAC and the value to write
+        /// to the DAC.
+        ///
+        /// The samples are consumed at the sample rate of the DAC
+        #[cfg(feature = "async")]
+        pub async fn write_buffer<CH>(
+            &mut self,
+            buf: &[i16],
+            channel: &mut CH,
+        ) -> Result<(), dmac::Error>
+        where
+            CH: AnyChannel<Status = ReadyFuture>,
+        {
+            // SAFETY - This case is safe, since it just allows
+            // us to not have a new DacDmaPtr type with i16.
+            // The DAC interprets the data as i16 for differential mode
+            let bytes =
+                SharedSliceBuffer::from_slice(unsafe { core::mem::transmute::<_, &[u16]>(buf) });
+
+            let trigger_action = TriggerAction::Burst;
+
+            let dest = DacDmaPtr::new::<D0>(&self.reg);
+
+            channel
+                .as_mut()
+                .transfer_future(bytes, dest, D0::DMA_TX_TRIGGER, trigger_action)
+                .await
+        }
+    }
 }

--- a/hal/src/peripherals/dac/mod.rs
+++ b/hal/src/peripherals/dac/mod.rs
@@ -1,0 +1,257 @@
+//! Digital-to-Analog Converter
+
+use core::{marker::PhantomData, mem::ManuallyDrop, ops::Deref};
+
+use atsamd_hal_macros::{hal_cfg, hal_module};
+use pac::{dac, Peripherals};
+
+use crate::{
+    clock::v2::{pclk::Pclk, types},
+    gpio::{self, AlternateB, AnyPin, Output, Pin, PushPullOutput, PA02, PA05},
+    pac,
+    typelevel::{NoneT, Sealed},
+};
+
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// The DAC clock exceeds the maximum
+    /// of 12Mhz
+    ClockTooFast,
+}
+
+pub struct Dac {
+    inner: pac::Dac,
+}
+
+pub trait DacInstance {
+    type PinId: gpio::AnyPin;
+    const IDX: usize;
+
+    fn data(reg: &pac::Dac) -> bool;
+    fn ready(reg: &pac::Dac) -> bool;
+    fn eoc(reg: &pac::Dac) -> bool;
+}
+
+pub struct Single<D: DacInstance> {
+    pin: D::PinId,
+}
+pub struct Differential<D0: DacInstance, D1: DacInstance> {
+    pin_0: D0::PinId,
+    pin_1: D1::PinId,
+}
+
+pub trait DacMode {}
+
+impl<D: DacInstance> DacMode for Single<D> {}
+impl<D0: DacInstance, D1: DacInstance> DacMode for Differential<D0, D1> {}
+
+pub struct DacWriteHandle<M: DacMode> {
+    reg: ManuallyDrop<pac::Dac>,
+    mode: M,
+}
+
+impl<M: DacMode> DacWriteHandle<M> {
+    pub fn new(dac: pac::Dac, mode: M) -> Self {
+        Self {
+            reg: ManuallyDrop::new(dac),
+            mode,
+        }
+    }
+}
+
+pub struct Dac0;
+pub struct Dac1;
+
+impl DacInstance for Dac0 {
+    type PinId = Pin<PA02, AlternateB>;
+    const IDX: usize = 0;
+    fn ready(reg: &pac::Dac) -> bool {
+        reg.status().read().ready0().bit_is_set()
+    }
+
+    fn data(reg: &pac::Dac) -> bool {
+        reg.syncbusy().read().data0().bit_is_set()
+    }
+
+    fn eoc(reg: &pac::Dac) -> bool {
+        reg.status().read().eoc0().bit_is_set()
+    }
+}
+
+impl DacInstance for Dac1 {
+    type PinId = Pin<PA05, AlternateB>;
+    const IDX: usize = 1;
+    fn ready(reg: &pac::Dac) -> bool {
+        reg.status().read().ready1().bit_is_set()
+    }
+
+    fn data(reg: &pac::Dac) -> bool {
+        reg.syncbusy().read().data1().bit_is_set()
+    }
+
+    fn eoc(reg: &pac::Dac) -> bool {
+        reg.status().read().eoc1().bit_is_set()
+    }
+}
+
+impl Dac {
+    pub fn new<PS: crate::clock::v2::pclk::PclkSourceId>(
+        dac: pac::Dac,
+        clk: crate::clock::v2::apb::ApbClk<types::Dac>,
+        pclk: &crate::clock::v2::pclk::Pclk<types::Dac, PS>,
+    ) -> Result<Self, Error> {
+        if pclk.freq().to_Hz() > 12_000_000 {
+            return Err(Error::ClockTooFast);
+        }
+        dac.ctrla().write(|w| w.swrst().set_bit());
+        let mut s = Self { inner: dac };
+        s.sync();
+        s.with_disable(|dac| {
+            // Set VREF
+            dac.ctrlb().modify(|_, w| w.refsel().vddana());
+
+            // Setup CC size based on GCLK Freq
+            let cc = match pclk.freq().to_Hz() {
+                ..1_200_000 => dac::dacctrl::Cctrlselect::Cc100k,
+                1_200_000..=6_000_000 => dac::dacctrl::Cctrlselect::Cc1m,
+                _ => dac::dacctrl::Cctrlselect::Cc12m,
+            };
+            dac.dacctrl(0).modify(|_, w| w.cctrl().variant(cc));
+            dac.dacctrl(1).modify(|_, w| w.cctrl().variant(cc));
+        });
+        Ok(s)
+    }
+
+    pub(crate) fn with_disable<R, F: FnOnce(&pac::Dac) -> R>(&self, f: F) -> R {
+        self.inner.ctrla().write(|w| w.enable().clear_bit());
+        self.sync();
+        let ret = f(&self.inner);
+        self.inner.ctrla().write(|w| w.enable().set_bit());
+        self.sync();
+        ret
+    }
+
+    pub fn sync(&self) {
+        while self.inner.syncbusy().read().bits() != 0 {
+            core::hint::spin_loop();
+        }
+    }
+
+    pub fn differential(
+        &self,
+        d0: Pin<PA02, AlternateB>,
+        d1: Pin<PA05, AlternateB>,
+    ) -> DacWriteHandle<Differential<Dac0, Dac1>> {
+        self.with_disable(|dac| {
+            dac.ctrlb().modify(|_, w| w.diff().set_bit());
+            dac.dacctrl(0).modify(|_, w| w.enable().set_bit());
+        });
+        while !Dac0::ready(&self.inner) {
+            core::hint::spin_loop();
+        }
+        DacWriteHandle::new(
+            unsafe { core::ptr::read(&self.inner as *const _) },
+            Differential {
+                pin_0: d0,
+                pin_1: d1,
+            },
+        )
+    }
+
+    pub fn dac0(&self, pin: Pin<PA02, AlternateB>) -> DacWriteHandle<Single<Dac0>> {
+        self.with_disable(|dac| {
+            dac.ctrlb().modify(|_, w| w.diff().clear_bit());
+            dac.dacctrl(Dac0::IDX).modify(|_, w| w.enable().set_bit())
+        });
+        while !Dac0::ready(&self.inner) {
+            core::hint::spin_loop();
+        }
+        DacWriteHandle::new(
+            unsafe { core::ptr::read(&self.inner as *const _) },
+            Single { pin },
+        )
+    }
+
+    pub fn dac1(&self, pin: Pin<PA05, AlternateB>) -> DacWriteHandle<Single<Dac1>> {
+        self.with_disable(|dac| {
+            dac.ctrlb().modify(|_, w| w.diff().clear_bit());
+            dac.dacctrl(Dac1::IDX).modify(|_, w| w.enable().set_bit())
+        });
+        while !Dac1::ready(&self.inner) {
+            core::hint::spin_loop();
+        }
+        DacWriteHandle::new(
+            unsafe { core::ptr::read(&self.inner as *const _) },
+            Single { pin },
+        )
+    }
+}
+
+// For all modes
+impl<M: DacMode> DacWriteHandle<M> {
+    pub fn sync(&self) {
+        while self.reg.syncbusy().read().bits() != 0 {
+            core::hint::spin_loop();
+        }
+    }
+
+    pub(crate) fn with_dac_disable<R, F: FnOnce(&pac::Dac) -> R>(&self, f: F) -> R {
+        self.reg.ctrla().write(|w| w.enable().clear_bit());
+        self.sync();
+        let ret = f(&self.reg);
+        self.reg.ctrla().write(|w| w.enable().set_bit());
+        self.sync();
+        ret
+    }
+}
+
+// For single DAC modes (Dac0/Dac1)
+impl<DAC: DacInstance> DacWriteHandle<Single<DAC>> {
+    pub fn write(&mut self, val: u16) {
+        unsafe {
+            self.reg.data(DAC::IDX).write(|w| w.bits(val));
+        }
+        while DAC::data(&self.reg) {
+            core::hint::spin_loop();
+        }
+        while !DAC::eoc(&self.reg) {
+            core::hint::spin_loop();
+        }
+    }
+
+    pub fn stop(self) -> DAC::PinId {
+        self.with_dac_disable(|dac| {
+            dac.dacctrl(DAC::IDX).modify(|_, w| w.enable().clear_bit());
+        });
+        self.mode.pin
+    }
+}
+
+// For differential mode
+impl<D0: DacInstance, D1: DacInstance> DacWriteHandle<Differential<D0, D1>> {
+    pub fn write(&mut self, val: i16) {
+        // Manipulation for differential mode is done via DAC0 channel info
+        unsafe {
+            self.reg.data(0).write(|w| w.bits(val as u16));
+        }
+        while Dac0::data(&self.reg) {
+            core::hint::spin_loop();
+        }
+        while !Dac0::eoc(&self.reg) {
+            core::hint::spin_loop();
+        }
+    }
+
+    pub fn stop(self) -> (D0::PinId, D1::PinId) {
+        self.with_dac_disable(|dac| {
+            dac.dacctrl(0).modify(|_, w| w.enable().clear_bit());
+        });
+        (self.mode.pin_0, self.mode.pin_1)
+    }
+}
+
+#[cfg(feature = "dma")]
+mod dma {
+    // TODO - DMA
+}

--- a/hal/src/peripherals/mod.rs
+++ b/hal/src/peripherals/mod.rs
@@ -3,6 +3,9 @@ use atsamd_hal_macros::{hal_cfg, hal_module};
 #[cfg(feature = "device")]
 pub mod adc;
 
+#[cfg(feature = "device")]
+pub mod dac;
+
 #[hal_module(
     any("nvmctrl-d11", "nvmctrl-d21") => "calibration/d11.rs",
     "nvmctrl-d5x" => "calibration/d5x.rs",

--- a/hal/src/peripherals/mod.rs
+++ b/hal/src/peripherals/mod.rs
@@ -3,8 +3,11 @@ use atsamd_hal_macros::{hal_cfg, hal_module};
 #[cfg(feature = "device")]
 pub mod adc;
 
-#[cfg(feature = "device")]
-pub mod dac;
+#[hal_module(
+    any("dac-d11", "dac-d21") => "dac/d11.rs",
+    "dac-d5x" => "dac/d5x.rs",
+)]
+pub mod dac {}
 
 #[hal_module(
     any("nvmctrl-d11", "nvmctrl-d21") => "calibration/d11.rs",


### PR DESCRIPTION
# Summary
Adds DAC support for D5x and D11

Both implementations contain oneshot write functions (Just write a voltage and keep the DAC output going), and a DMA functions (Both blocking and async) for writing buffers to the DAC.

It is also possible to monitor the DAC output voltage via the ADC now with `Adc::read_dac0_output` (Both sync and async functions provided)

Closes #696 and #39
