### PR TITLE
update to `atsamd-hal-0.22` and other latest dependencies

### DIFF
--- a/boards/neo_trinkey/Cargo.toml
+++ b/boards/neo_trinkey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neo_trinkey"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Daniel Mason <daniel@danielmason.com>"]
 description = "Board Support crate for the Adafruit Neo Trinkey"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]

--- a/boards/neo_trinkey/Cargo.toml
+++ b/boards/neo_trinkey/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neo_trinkey"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Daniel Mason <daniel@danielmason.com>"]
 description = "Board Support crate for the Adafruit Neo Trinkey"
 keywords = ["no-std", "arm", "cortex-m", "embedded-hal"]
@@ -17,7 +17,7 @@ smart-leds = { version = "0.3.0", optional = true }
 ws2812-timer-delay = { version = "0.3.0", features = ["slow"], optional = true }
 
 [dependencies.atsamd-hal]
-version = "0.14"
+version = "0.16"
 default-features = false
 
 [dev-dependencies]

--- a/boards/neo_trinkey/Cargo.toml
+++ b/boards/neo_trinkey/Cargo.toml
@@ -17,7 +17,7 @@ smart-leds = { version = "0.3.0", optional = true }
 ws2812-timer-delay = { version = "0.3.0", features = ["slow"], optional = true }
 
 [dependencies.atsamd-hal]
-version = "0.17"
+version = "0.18"
 default-features = false
 
 [dependencies.cortex-m]

--- a/boards/neo_trinkey/Cargo.toml
+++ b/boards/neo_trinkey/Cargo.toml
@@ -12,17 +12,20 @@ edition = "2021"
 
 [dependencies]
 cortex-m-rt = { version = "0.7", optional = true }
-usb-device = { version = "0.2", optional = true }
+usb-device = { version = "0.3.1", optional = true }
 smart-leds = { version = "0.3.0", optional = true }
 ws2812-timer-delay = { version = "0.3.0", features = ["slow"], optional = true }
 
 [dependencies.atsamd-hal]
-version = "0.16"
+version = "0.17"
 default-features = false
 
+[dependencies.cortex-m]
+version = "0.7"
+features = ["critical-section-single-core"]
+
 [dev-dependencies]
-cortex-m = "0.7"
-usbd-serial = "0.1"
+usbd-serial = "0.2"
 panic-halt = "0.2"
 
 [features]
@@ -30,7 +33,6 @@ panic-halt = "0.2"
 default = ["rt", "atsamd-hal/samd21e"]
 leds = ["ws2812-timer-delay", "smart-leds"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21e-rt"]
-unproven = ["atsamd-hal/unproven"]
 use_semihosting = []
 usb = ["atsamd-hal/usb", "usb-device"]
 

--- a/boards/neo_trinkey/Cargo.toml
+++ b/boards/neo_trinkey/Cargo.toml
@@ -17,7 +17,7 @@ smart-leds = { version = "0.3.0", optional = true }
 ws2812-timer-delay = { version = "0.3.0", features = ["slow"], optional = true }
 
 [dependencies.atsamd-hal]
-version = "0.18"
+version = "0.22"
 default-features = false
 
 [dependencies.cortex-m]

--- a/boards/neo_trinkey/examples/blinky_basic.rs
+++ b/boards/neo_trinkey/examples/blinky_basic.rs
@@ -24,17 +24,17 @@ fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
     let mut clocks = GenericClockController::with_internal_32kosc(
-        peripherals.GCLK,
-        &mut peripherals.PM,
-        &mut peripherals.SYSCTRL,
-        &mut peripherals.NVMCTRL,
+        peripherals.gclk,
+        &mut peripherals.pm,
+        &mut peripherals.sysctrl,
+        &mut peripherals.nvmctrl,
     );
 
-    let pins = bsp::Pins::new(peripherals.PORT);
+    let pins = bsp::Pins::new(peripherals.port);
 
     let gclk0 = clocks.gclk0();
     let timer_clock = clocks.tcc2_tc3(&gclk0).unwrap();
-    let mut timer = TimerCounter::tc3_(&timer_clock, peripherals.TC3, &mut peripherals.PM);
+    let mut timer = TimerCounter::tc3_(&timer_clock, peripherals.tc3, &mut peripherals.pm);
     timer.start(Hertz::MHz(3).into_duration());
     let neo_pixel = pins.neo_pixel.into_push_pull_output();
     let mut ws2812 = Ws2812::new(timer, neo_pixel);

--- a/boards/neo_trinkey/examples/blinky_basic.rs
+++ b/boards/neo_trinkey/examples/blinky_basic.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+
 use panic_halt as _;
 
 use neo_trinkey as bsp;
@@ -11,6 +12,7 @@ use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::pac::{CorePeripherals, Peripherals};
 use hal::prelude::*;
+use hal::time::Hertz;
 use hal::timer::TimerCounter;
 
 use smart_leds::{hsv::RGB8, SmartLedsWrite};
@@ -32,7 +34,7 @@ fn main() -> ! {
     let gclk0 = clocks.gclk0();
     let timer_clock = clocks.tcc2_tc3(&gclk0).unwrap();
     let mut timer = TimerCounter::tc3_(&timer_clock, peripherals.TC3, &mut peripherals.PM);
-    timer.start(3.mhz());
+    timer.start(Hertz::MHz(3).into_duration());
     let neo_pixel = pins.neo_pixel.into_push_pull_output();
     let mut ws2812 = Ws2812::new(timer, neo_pixel);
 

--- a/boards/neo_trinkey/examples/blinky_basic.rs
+++ b/boards/neo_trinkey/examples/blinky_basic.rs
@@ -10,10 +10,11 @@ use bsp::hal;
 
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
+use hal::ehal::delay::DelayNs;
 use hal::pac::{CorePeripherals, Peripherals};
-use hal::prelude::*;
 use hal::time::Hertz;
 use hal::timer::TimerCounter;
+use hal::timer_traits::InterruptDrivenTimer;
 
 use smart_leds::{hsv::RGB8, SmartLedsWrite};
 use ws2812_timer_delay::Ws2812;
@@ -51,8 +52,8 @@ fn main() -> ! {
 
     loop {
         ws2812.write(off.iter().cloned()).unwrap();
-        delay.delay_ms(500u16);
+        delay.delay_ms(500);
         ws2812.write(on.iter().cloned()).unwrap();
-        delay.delay_ms(500u16);
+        delay.delay_ms(500);
     }
 }

--- a/boards/neo_trinkey/examples/blinky_rainbow.rs
+++ b/boards/neo_trinkey/examples/blinky_rainbow.rs
@@ -10,10 +10,11 @@ use bsp::hal;
 
 use hal::clock::GenericClockController;
 use hal::delay::Delay;
+use hal::ehal::delay::DelayNs;
 use hal::pac::{CorePeripherals, Peripherals};
-use hal::prelude::*;
 use hal::time::Hertz;
 use hal::timer::TimerCounter;
+use hal::timer_traits::InterruptDrivenTimer;
 
 use smart_leds::{brightness, hsv::RGB8, SmartLedsWrite};
 use ws2812_timer_delay::Ws2812;
@@ -49,7 +50,7 @@ fn main() -> ! {
                 data[i] = wheel((((i * 256) as u16 / NUM_LEDS as u16 + j as u16) & 255) as u8);
             }
             ws2812.write(brightness(data.iter().cloned(), 32)).unwrap();
-            delay.delay_ms(5u8);
+            delay.delay_ms(5);
         }
     }
 }

--- a/boards/neo_trinkey/examples/blinky_rainbow.rs
+++ b/boards/neo_trinkey/examples/blinky_rainbow.rs
@@ -24,17 +24,17 @@ fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
     let mut clocks = GenericClockController::with_internal_32kosc(
-        peripherals.GCLK,
-        &mut peripherals.PM,
-        &mut peripherals.SYSCTRL,
-        &mut peripherals.NVMCTRL,
+        peripherals.gclk,
+        &mut peripherals.pm,
+        &mut peripherals.sysctrl,
+        &mut peripherals.nvmctrl,
     );
 
-    let pins = bsp::Pins::new(peripherals.PORT);
+    let pins = bsp::Pins::new(peripherals.port);
 
     let gclk0 = clocks.gclk0();
     let timer_clock = clocks.tcc2_tc3(&gclk0).unwrap();
-    let mut timer = TimerCounter::tc3_(&timer_clock, peripherals.TC3, &mut peripherals.PM);
+    let mut timer = TimerCounter::tc3_(&timer_clock, peripherals.tc3, &mut peripherals.pm);
     timer.start(Hertz::MHz(3).into_duration());
     let neo_pixel = pins.neo_pixel.into_push_pull_output();
     let mut ws2812 = Ws2812::new(timer, neo_pixel);

--- a/boards/neo_trinkey/examples/blinky_rainbow.rs
+++ b/boards/neo_trinkey/examples/blinky_rainbow.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+
 use panic_halt as _;
 
 use neo_trinkey as bsp;
@@ -11,6 +12,7 @@ use hal::clock::GenericClockController;
 use hal::delay::Delay;
 use hal::pac::{CorePeripherals, Peripherals};
 use hal::prelude::*;
+use hal::time::Hertz;
 use hal::timer::TimerCounter;
 
 use smart_leds::{brightness, hsv::RGB8, SmartLedsWrite};
@@ -32,7 +34,7 @@ fn main() -> ! {
     let gclk0 = clocks.gclk0();
     let timer_clock = clocks.tcc2_tc3(&gclk0).unwrap();
     let mut timer = TimerCounter::tc3_(&timer_clock, peripherals.TC3, &mut peripherals.PM);
-    timer.start(3.mhz());
+    timer.start(Hertz::MHz(3).into_duration());
     let neo_pixel = pins.neo_pixel.into_push_pull_output();
     let mut ws2812 = Ws2812::new(timer, neo_pixel);
 

--- a/boards/neo_trinkey/examples/blinky_rainbow.rs
+++ b/boards/neo_trinkey/examples/blinky_rainbow.rs
@@ -46,8 +46,8 @@ fn main() -> ! {
 
     loop {
         for j in 0..(256 * 5) {
-            for i in 0..NUM_LEDS {
-                data[i] = wheel((((i * 256) as u16 / NUM_LEDS as u16 + j as u16) & 255) as u8);
+            for (i, item) in data.iter_mut().enumerate().take(NUM_LEDS) {
+                *item = wheel((((i * 256) as u16 / NUM_LEDS as u16 + j as u16) & 255) as u8);
             }
             ws2812.write(brightness(data.iter().cloned(), 32)).unwrap();
             delay.delay_ms(5);

--- a/boards/neo_trinkey/examples/usb_ack.rs
+++ b/boards/neo_trinkey/examples/usb_ack.rs
@@ -45,9 +45,11 @@ fn main() -> ! {
         USB_SERIAL = Some(SerialPort::new(&bus_allocator));
         USB_BUS = Some(
             UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x16c0, 0x27dd))
-                .manufacturer("Fake company")
-                .product("Serial port")
-                .serial_number("TRINKEY_ACK")
+                .strings(&[StringDescriptors::new(LangID::EN_US)
+                    .manufacturer("Fake company")
+                    .product("Serial port")
+                    .serial_number("TRINKEY_ACK")])
+                .expect("Failed to set strings")
                 .device_class(USB_CLASS_CDC)
                 .build(),
         );

--- a/boards/neo_trinkey/examples/usb_ack.rs
+++ b/boards/neo_trinkey/examples/usb_ack.rs
@@ -23,18 +23,18 @@ fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let mut core = CorePeripherals::take().unwrap();
     let mut clocks = GenericClockController::with_internal_32kosc(
-        peripherals.GCLK,
-        &mut peripherals.PM,
-        &mut peripherals.SYSCTRL,
-        &mut peripherals.NVMCTRL,
+        peripherals.gclk,
+        &mut peripherals.pm,
+        &mut peripherals.sysctrl,
+        &mut peripherals.nvmctrl,
     );
-    let pins = bsp::Pins::new(peripherals.PORT);
+    let pins = bsp::Pins::new(peripherals.port);
 
     let bus_allocator = unsafe {
         USB_ALLOCATOR = Some(bsp::usb_allocator(
-            peripherals.USB,
+            peripherals.usb,
             &mut clocks,
-            &mut peripherals.PM,
+            &mut peripherals.pm,
             pins.usb_dm,
             pins.usb_dp,
         ));

--- a/boards/neo_trinkey/examples/usb_ack.rs
+++ b/boards/neo_trinkey/examples/usb_ack.rs
@@ -42,9 +42,9 @@ fn main() -> ! {
     };
 
     unsafe {
-        USB_SERIAL = Some(SerialPort::new(&bus_allocator));
+        USB_SERIAL = Some(SerialPort::new(bus_allocator));
         USB_BUS = Some(
-            UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x16c0, 0x27dd))
+            UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x16c0, 0x27dd))
                 .strings(&[StringDescriptors::new(LangID::EN_US)
                     .manufacturer("Fake company")
                     .product("Serial port")
@@ -71,23 +71,21 @@ static mut USB_SERIAL: Option<SerialPort<UsbBus>> = None;
 
 fn poll_usb() {
     unsafe {
-        USB_BUS.as_mut().map(|usb_dev| {
-            USB_SERIAL.as_mut().map(|serial| {
+        if let Some(usb_dev) = USB_BUS.as_mut() { 
+            if let Some(serial) = USB_SERIAL.as_mut() {
                 usb_dev.poll(&mut [serial]);
                 let mut buf = [0u8; 64];
-
                 if let Ok(count) = serial.read(&mut buf) {
                     for (i, c) in buf.iter().enumerate() {
                         if i >= count {
                             break;
                         }
                         serial.write("Received: ".as_bytes()).ok();
-                        serial.write(&[c.clone()]).ok();
+                        serial.write(core::slice::from_ref(c)).ok();
                         serial.write("\r\n".as_bytes()).ok();
                     }
-                };
-            });
-        });
+                }
+            } }
     };
 }
 

--- a/boards/neo_trinkey/examples/usb_ack.rs
+++ b/boards/neo_trinkey/examples/usb_ack.rs
@@ -71,7 +71,7 @@ static mut USB_SERIAL: Option<SerialPort<UsbBus>> = None;
 
 fn poll_usb() {
     unsafe {
-        if let Some(usb_dev) = USB_BUS.as_mut() { 
+        if let Some(usb_dev) = USB_BUS.as_mut() {
             if let Some(serial) = USB_SERIAL.as_mut() {
                 usb_dev.poll(&mut [serial]);
                 let mut buf = [0u8; 64];
@@ -85,7 +85,8 @@ fn poll_usb() {
                         serial.write("\r\n".as_bytes()).ok();
                     }
                 }
-            } }
+            }
+        }
     };
 }
 

--- a/boards/neo_trinkey/src/lib.rs
+++ b/boards/neo_trinkey/src/lib.rs
@@ -61,9 +61,9 @@ hal::bsp_pins!(
 ///     &mut peripherals.SYSCTRL,
 ///     &mut peripherals.NVMCTRL,
 /// );
-/// let pins = bsp::Pins::new(peripherals.PORT);
+/// let pins = neo_trinkey::Pins::new(peripherals.PORT);
 ///
-/// let bus_allocator = bsp::usb_allocator(
+/// let bus_allocator = neo_trinkey::usb_allocator(
 ///     peripherals.USB,
 ///     &mut clocks,
 ///     &mut peripherals.PM,

--- a/boards/neo_trinkey/src/lib.rs
+++ b/boards/neo_trinkey/src/lib.rs
@@ -56,17 +56,17 @@ hal::bsp_pins!(
 ///
 /// let mut peripherals = Peripherals::take().unwrap();
 /// let mut clocks = GenericClockController::with_internal_32kosc(
-///     peripherals.GCLK,
-///     &mut peripherals.PM,
-///     &mut peripherals.SYSCTRL,
-///     &mut peripherals.NVMCTRL,
+///     peripherals.gclk,
+///     &mut peripherals.pm,
+///     &mut peripherals.sysctrl,
+///     &mut peripherals.nvmctrl,
 /// );
-/// let pins = neo_trinkey::Pins::new(peripherals.PORT);
+/// let pins = neo_trinkey::Pins::new(peripherals.port);
 ///
 /// let bus_allocator = neo_trinkey::usb_allocator(
-///     peripherals.USB,
+///     peripherals.usb,
 ///     &mut clocks,
-///     &mut peripherals.PM,
+///     &mut peripherals.pm,
 ///     pins.usb_dm,
 ///     pins.usb_dp,
 /// );
@@ -75,9 +75,9 @@ hal::bsp_pins!(
 /// rust. See the USB code examples in the `examples/` directory of the project.
 #[cfg(feature = "usb")]
 pub fn usb_allocator(
-    usb: pac::USB,
+    usb: pac::Usb,
     clocks: &mut hal::clock::GenericClockController,
-    pm: &mut pac::PM,
+    pm: &mut pac::Pm,
     dm: impl Into<UsbDm>,
     dp: impl Into<UsbDp>,
 ) -> UsbBusAllocator<UsbBus> {


### PR DESCRIPTION
# Summary

This upgrades the Adafruit Neo Trinkey board to the latest hal version.

I mainly followed what other boards did while upgrading.

- An explicit dependency was added for `cortex-m`
- `usb-device` was upgraded to `0.3.1`
- Examples were updated, and (most) clippy warnings resolved
- The usb_allocator doc string was corrected

# Checklist
  - [X] All new or modified code is well documented, especially public items - *No changes to API*
  - [X] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 

## If Adding a new Board
  - [ /] ~Board CI added to `crates.json`~
  - [ /] ~Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"~

## If Adding a new cargo `feature` to the HAL
  - [ /] ~Feature is added to the test matrix for applicable boards / PACs in `crates.json`~

#### Note
The crate changelogs **should no longer** be manually updated! Changelogs are now automatically generated. Instead:

- If your PR is contained to a single crate, or a single feature:
  - Nothing else to do; your PR will likely be squashed down to a single commit.
  - Please consider using [conventional commmit phrasing](https://www.conventionalcommits.org) in the PR title.
- If your PR brings in large, sweeping changes across multiple crates:
  - Organize your commits such that each commit only touches a single crate, or a single feature across multiple crates. Please don't create commits that span multiple features over multiple crates.
  - Use [conventional commmits](https://www.conventionalcommits.org) for your commit messages.
