### PR TITLE
bsp(wio_terminal): Bump version 0.8.1 -> 0.9.0

### DIFF
--- a/boards/wio_terminal/Cargo.toml
+++ b/boards/wio_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wio_terminal"
-version = "0.8.1"
+version = "0.8.0"
 authors = [
     "Jesse Braham <jesse@beta7.io>",
     "Tom <twitchyliquid64@ciphersink.net>"


### PR DESCRIPTION
I missed in the recent PR, that the crate re-exports seeed-erpc types, so the previous change was breaking.
