### PR TITLE
CAN: Remove GCLK requirement for Dependencies

### DIFF
--- a/boards/atsame54_xpro/examples/mcan.rs
+++ b/boards/atsame54_xpro/examples/mcan.rs
@@ -161,8 +161,7 @@ mod app {
 
         let (pclk_can1, gclk0) = clock::pclk::Pclk::enable(tokens.pclks.can1, gclk0);
 
-        let (dependencies, _gclk0) = hal::can::Dependencies::new(
-            gclk0,
+        let dependencies = hal::can::Dependencies::new(
             pclk_can1,
             clocks.ahbs.can1,
             can1_rx,

--- a/boards/atsame54_xpro/examples/mcan.rs
+++ b/boards/atsame54_xpro/examples/mcan.rs
@@ -161,13 +161,8 @@ mod app {
 
         let (pclk_can1, gclk0) = clock::pclk::Pclk::enable(tokens.pclks.can1, gclk0);
 
-        let dependencies = hal::can::Dependencies::new(
-            pclk_can1,
-            clocks.ahbs.can1,
-            can1_rx,
-            can1_tx,
-            device.can1,
-        );
+        let dependencies =
+            hal::can::Dependencies::new(pclk_can1, clocks.ahbs.can1, can1_rx, can1_tx, device.can1);
 
         let mut can =
             mcan::bus::CanConfigurable::new(375.kHz(), dependencies, ctx.local.can_memory).unwrap();

--- a/hal/src/peripherals/can.rs
+++ b/hal/src/peripherals/can.rs
@@ -12,13 +12,12 @@
 //! [`mcan`]: https://crates.io/crates/mcan
 use crate::{
     clock::v2::{
-        Source,
         ahb::{AhbClk, AhbId},
         pclk::{Pclk, PclkId, PclkSourceId},
         types::Can0,
     },
     gpio::*,
-    typelevel::{Decrement, Increment, Sealed},
+    typelevel::Sealed,
 };
 use atsamd_hal_macros::hal_cfg;
 
@@ -62,8 +61,7 @@ impl<ID: PclkId + AhbId, PS: PclkSourceId, RX, TX, CAN> Dependencies<ID, PS, RX,
     ///
     /// Releases all enclosed objects back to the user.
     #[allow(clippy::type_complexity)]
-    pub fn free(self) -> (Pclk<ID, PS>, HertzU32, AhbClk<ID>, RX, TX, CAN)
-    {
+    pub fn free(self) -> (Pclk<ID, PS>, HertzU32, AhbClk<ID>, RX, TX, CAN) {
         let Self {
             pclk,
             host_freq,


### PR DESCRIPTION
# Summary
As discussed in Matrix, this PR will modify the clock V2 handling of the CAN Dependencies such that the GCLK argument is not required.

