### PR TITLE
Updates the AES peripheral to use the `clock::v2` API and make it safer.

### DIFF
--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -34,7 +34,7 @@ aes = "0.8.4"
 atsamd-hal-macros = {version = "0.3.0", path = "../atsamd-hal-macros"}
 bitfield = "0.13"
 bitflags = "2.6.0"
-cipher = "0.3"
+cipher = "0.4"
 cortex-m = "0.7"
 critical-section = "1.2.0"
 embedded-hal-02 = {package = "embedded-hal", version = "0.2", features = ["unproven"]}
@@ -192,7 +192,6 @@ async = [
 can = ["mcan-core"]
 defmt = ["dep:defmt"]
 dma = []
-enable_unsafe_aes_newblock_cipher = []
 max-channels = ["dma"]
 rtic = ["rtic-monotonic", "rtic-time", "portable-atomic"]
 sdmmc = ["embedded-sdmmc"]

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -30,13 +30,13 @@ features = ["samd21g", "samd21g-rt", "usb", "dma", "async", "rtic"]
 #===============================================================================
 
 [dependencies]
-aes = "0.7.5"
-atsamd-hal-macros = { version = "0.3.0", path = "../atsamd-hal-macros" }
+aes = "0.8.4"
+atsamd-hal-macros = {version = "0.3.0", path = "../atsamd-hal-macros"}
 bitfield = "0.13"
 bitflags = "2.6.0"
 cipher = "0.3"
-critical-section = "1.2.0"
 cortex-m = "0.7"
+critical-section = "1.2.0"
 embedded-hal-02 = {package = "embedded-hal", version = "0.2", features = ["unproven"]}
 embedded-hal-1 = {package = "embedded-hal", version = "1.0.0"}
 embedded-hal-nb = "1.0.0"
@@ -59,7 +59,7 @@ void = {version = "1.0", default-features = false}
 # Optional depdendencies
 #===============================================================================
 
-defmt = { version = "1.0.1", optional = true}
+defmt = {version = "1.0.1", optional = true}
 embassy-sync = {version = "0.6.0", optional = true}
 embedded-hal-async = {version = "1.0.0", optional = true}
 embedded-io-async = {version = "0.6.1", optional = true}
@@ -68,8 +68,8 @@ futures = {version = "0.3.31", default-features = false, features = ["async-awai
 jlink_rtt = {version = "0.2", optional = true}
 mcan-core = {version = "0.2", optional = true}
 rtic-monotonic = {version = "1.0", optional = true}
-usb-device = {version = "0.3.2", optional = true}
 rtic-time = {version = "2.0", optional = true}
+usb-device = {version = "0.3.2", optional = true}
 
 #===============================================================================
 # PACs
@@ -81,27 +81,27 @@ rtic-time = {version = "2.0", optional = true}
 # users should specify a corresponding variant (see below). The variant features
 # will select the correct PAC, as well as other configuration features.
 
-atsamd11c = { version = "0.14.2", path = "../pac/atsamd11c", optional = true}
-atsamd11d = { version = "0.14.2", path = "../pac/atsamd11d", optional = true}
+atsamd11c = {version = "0.14.2", path = "../pac/atsamd11c", optional = true}
+atsamd11d = {version = "0.14.2", path = "../pac/atsamd11d", optional = true}
 
-atsamd21e = { version = "0.14.2", path = "../pac/atsamd21e", optional = true}
-atsamd21g = { version = "0.14.2", path = "../pac/atsamd21g", optional = true}
-atsamd21j = { version = "0.14.2", path = "../pac/atsamd21j", optional = true}
+atsamd21e = {version = "0.14.2", path = "../pac/atsamd21e", optional = true}
+atsamd21g = {version = "0.14.2", path = "../pac/atsamd21g", optional = true}
+atsamd21j = {version = "0.14.2", path = "../pac/atsamd21j", optional = true}
 
-atsamd51g = { version = "0.14.2", path = "../pac/atsamd51g", optional = true}
-atsamd51j = { version = "0.14.2", path = "../pac/atsamd51j", optional = true}
-atsamd51n = { version = "0.14.2", path = "../pac/atsamd51n", optional = true}
-atsamd51p = { version = "0.14.2", path = "../pac/atsamd51p", optional = true}
+atsamd51g = {version = "0.14.2", path = "../pac/atsamd51g", optional = true}
+atsamd51j = {version = "0.14.2", path = "../pac/atsamd51j", optional = true}
+atsamd51n = {version = "0.14.2", path = "../pac/atsamd51n", optional = true}
+atsamd51p = {version = "0.14.2", path = "../pac/atsamd51p", optional = true}
 
-atsame51g = { version = "0.14.2", path = "../pac/atsame51g", optional = true}
-atsame51j = { version = "0.14.2", path = "../pac/atsame51j", optional = true}
-atsame51n = { version = "0.14.2", path = "../pac/atsame51n", optional = true}
+atsame51g = {version = "0.14.2", path = "../pac/atsame51g", optional = true}
+atsame51j = {version = "0.14.2", path = "../pac/atsame51j", optional = true}
+atsame51n = {version = "0.14.2", path = "../pac/atsame51n", optional = true}
 
-atsame53j = { version = "0.14.2", path = "../pac/atsame53j", optional = true}
-atsame53n = { version = "0.14.2", path = "../pac/atsame53n", optional = true}
+atsame53j = {version = "0.14.2", path = "../pac/atsame53j", optional = true}
+atsame53n = {version = "0.14.2", path = "../pac/atsame53n", optional = true}
 
-atsame54n = { version = "0.14.2", path = "../pac/atsame54n", optional = true}
-atsame54p = { version = "0.14.2", path = "../pac/atsame54p", optional = true}
+atsame54n = {version = "0.14.2", path = "../pac/atsame54n", optional = true}
+atsame54p = {version = "0.14.2", path = "../pac/atsame54p", optional = true}
 
 #===============================================================================
 # Features
@@ -182,6 +182,13 @@ same54p-rt = ["same54p", "atsame54p/rt"]
 
 # These features are user-selectable and enable additional features within the
 # HAL, like USB or DMA support.
+async = [
+  "embassy-sync",
+  "embedded-hal-async",
+  "embedded-io-async",
+  "futures",
+  "portable-atomic",
+]
 can = ["mcan-core"]
 defmt = ["dep:defmt"]
 dma = []
@@ -191,13 +198,6 @@ rtic = ["rtic-monotonic", "rtic-time", "portable-atomic"]
 sdmmc = ["embedded-sdmmc"]
 usb = ["usb-device"]
 use_rtt = ["jlink_rtt"]
-async = [
-    "embassy-sync",
-    "embedded-hal-async",
-    "embedded-io-async",
-    "futures",
-    "portable-atomic"
-]
 
 #===============================================================================
 # Implementation-details

--- a/hal/src/peripherals/aes/mod.rs
+++ b/hal/src/peripherals/aes/mod.rs
@@ -76,31 +76,48 @@
 //! provided that the Aes128, Aes192 or Aes256 type
 //! comes from this implementation.
 //!
-//! See example directly from RustCrypto AES ECB:
+//! Here is an example using the RustCrypto AES API:
 //!
 //! ```no_run
-//!     use atsamd_hal::aes::*;
+//! use atsamd_hal::aes::*;
 //!
-//!     // AES RustCrypto Example
+//! // AES RustCrypto Example
+//! let mut peripherals = atsamd_hal::pac::Peripherals::take().unwrap();
+//! let (mut buses, _clocks, tokens) = atsamd_hal::clock::v2::clock_system_at_reset(
+//!     peripherals.oscctrl,
+//!     peripherals.osc32kctrl,
+//!     peripherals.gclk,
+//!     peripherals.mclk,
+//!     &mut peripherals.nvmctrl,
+//! );
 //!
-//!     let key = GenericArray::from_slice(&[0u8; 16]);
-//!     let mut block = aes::Block::default();
+//! // Enable the APB clock
+//! let apb_clk = buses.apb.enable(tokens.apbs.aes);
 //!
-//!     // Initialize cipher
-//!     let cipher = atsamd_hal::aes::Aes128::new(key);
+//! // Setup the AES peripheral
+//! let aes = atsamd_hal::aes::Aes::new(peripherals.aes, apb_clk);
 //!
-//!     let block_copy = block;
+//! // Activate the RustCrypto backend
+//! let crypto = aes.activate_rustcrypto_backend();
 //!
-//!     // Encrypt block in-place
-//!     cipher.encrypt_block(&mut block);
+//! let key = GenericArray::from_slice(&[0u8; 16]);
+//! let mut block = aes::Block::default();
 //!
-//!     // And decrypt it back
-//!     cipher.decrypt_block(&mut block);
-//!     assert_eq!(block, block_copy);
+//! // Initialize cipher
+//! let cipher = crypto.new_128bit(key);
+//!
+//! let block_copy = block;
+//!
+//! // Encrypt block in-place
+//! cipher.encrypt_block(&mut block);
+//!
+//! // And decrypt it back
+//! cipher.decrypt_block(&mut block);
+//! assert_eq!(block, block_copy);
 //! ```
 
 // Re-exports
-pub use crate::pac::aes::ctrla::{
+pub use pac::aes::ctrla::{
     Aesmodeselect, Cfbsselect, Cipherselect, Keysizeselect, Lodselect, Startmodeselect,
     Xorkeyselect,
 };
@@ -115,14 +132,17 @@ pub use rustcrypto::{Aes128, Aes192, Aes256};
 
 #[cfg(feature = "enable_unsafe_aes_newblock_cipher")]
 pub use cipher::{
-    consts::{U1, U16, U24, U32, U8},
-    generic_array::*,
     BlockCipher, BlockDecrypt, BlockEncrypt, NewBlockCipher,
+    consts::{U1, U8, U16, U24, U32},
+    generic_array::*,
 };
 
-use crate::pac::aes::{self, *};
+use crate::pac;
+use pac::aes::*;
 
 use bitfield::BitRange;
+
+type AesApbClk = crate::clock::v2::apb::ApbClk<crate::clock::v2::types::Aes>;
 
 #[cfg(feature = "enable_unsafe_aes_newblock_cipher")]
 use aes::Block;
@@ -207,16 +227,6 @@ pub struct AesRustCrypto {
 #[cfg(feature = "enable_unsafe_aes_newblock_cipher")]
 impl AesRustCrypto {
     /// Use the AES peripheral as hardware backend for RustCrypto AES
-    ///
-    /// Don't forget to enable the `APB` bus for AES
-    ///
-    /// `AHB` bus is on by default at reset
-    ///
-    /// Clock::v1
-    /// `mclk.apbcmask.modify(|_, w| w.aes_().set_bit());`
-    ///
-    /// Clock::v2
-    /// `tokens.apbs.aes.enable();`
     #[inline]
     pub fn new(aes: Aes) -> Self {
         Self { aes }
@@ -225,7 +235,7 @@ impl AesRustCrypto {
     /// Destroy the AES RustCrypto backend and return the underlying AES
     /// register
     #[inline]
-    pub fn destroy(self) -> Aes {
+    pub fn free(self) -> Aes {
         self.aes
     }
 
@@ -249,24 +259,15 @@ impl AesRustCrypto {
 /// and provides an interface to the AES hardware
 pub struct Aes {
     /// AES pac register providing hardware access
-    aes: crate::pac::Aes,
+    aes: pac::Aes,
+    _clk: AesApbClk,
 }
 
 impl Aes {
     /// Create the interface for the AES peripheral
-    ///
-    /// Don't forget to enable the `APB` bus for AES
-    ///
-    /// `AHB` bus is on by default at reset
-    ///
-    /// Clock::v1
-    /// `mclk.apbcmask.modify(|_, w| w.aes_().set_bit());`
-    ///
-    /// Clock::v2
-    /// `tokens.apbs.aes.enable();`
     #[inline]
-    pub fn new(aes: crate::pac::Aes) -> Self {
-        Self { aes }
+    pub fn new(aes: pac::Aes, clk: AesApbClk) -> Self {
+        Self { aes, _clk: clk }
     }
 
     /// Use the AES peripheral as hardware backend for RustCrypto AES
@@ -275,16 +276,6 @@ impl Aes {
     ///
     /// > **WARNING**
     /// > RustCrypto backend assumes full ownership of AES hardware peripheral
-    ///
-    /// Don't forget to enable the `APB` bus for AES
-    ///
-    /// `AHB` bus is on by default at reset
-    ///
-    /// Clock::v1
-    /// `mclk.apbcmask.modify(|_, w| w.aes_().set_bit());`
-    ///
-    /// Clock::v2
-    /// `tokens.apbs.aes.enable();`
     #[cfg(feature = "enable_unsafe_aes_newblock_cipher")]
     #[inline]
     pub fn activate_rustcrypto_backend(self) -> AesRustCrypto {
@@ -355,7 +346,7 @@ impl Aes {
     /// Reading INDATA register will return 0’s when AES is performing
     /// encryption or decryption operation
     #[inline]
-    fn indata(&self) -> &aes::Indata {
+    fn indata(&self) -> &pac::aes::Indata {
         self.aes().indata()
     }
 
@@ -363,7 +354,7 @@ impl Aes {
     ///
     /// Cipher length
     #[inline]
-    fn ciplen(&self) -> &aes::Ciplen {
+    fn ciplen(&self) -> &pac::aes::Ciplen {
         self.aes().ciplen()
     }
 
@@ -393,10 +384,10 @@ impl Aes {
         self.ctrla().modify(|_, w| w.swrst().set_bit());
     }
 
-    /// Destroy the AES peripheral and return the underlying AES register
+    /// Destroy the AES peripheral and returns the underlying AES resources.
     #[inline]
-    pub fn destroy(self) -> crate::pac::Aes {
-        self.aes
+    pub fn free(self) -> (pac::Aes, AesApbClk) {
+        (self.aes, self._clk)
     }
 
     // Control A

--- a/hal/src/peripherals/aes/rustcrypto/decrypt.rs
+++ b/hal/src/peripherals/aes/rustcrypto/decrypt.rs
@@ -1,6 +1,6 @@
 //! AES decryption support
 
-use crate::aes::KEYSIZE_A;
+use crate::aes::Keysizeselect;
 use aes::Block;
 
 /// Perform AES decryption using the given key.
@@ -8,17 +8,17 @@ use aes::Block;
 /// Atsamd AES Hardware does key expansion on the
 /// fly given the key
 pub(super) unsafe fn decrypt<const N: usize>(key: &[u8; N], block: &mut Block) {
+    let aes = unsafe { crate::pac::Aes::steal() };
+
     // Reset the AES peripheral to ensure clean slate
-    (*crate::pac::AES::ptr())
-        .ctrla
-        .write(|w| w.swrst().set_bit());
+    aes.ctrla().write(|w| w.swrst().set_bit());
     // Wait for completion
-    while (*crate::pac::AES::ptr()).ctrla.read().swrst().bit_is_set() {}
+    while aes.ctrla().read().swrst().bit_is_set() {}
 
     let keysize = match N {
-        16 => KEYSIZE_A::_128BIT,
-        24 => KEYSIZE_A::_192BIT,
-        32 => KEYSIZE_A::_256BIT,
+        16 => Keysizeselect::_128bit,
+        24 => Keysizeselect::_192bit,
+        32 => Keysizeselect::_256bit,
         // TODO Better way to handle this?
         _ => panic!("Invalid AES keysize!"),
     };
@@ -26,7 +26,7 @@ pub(super) unsafe fn decrypt<const N: usize>(key: &[u8; N], block: &mut Block) {
     // Set peripheral to decryption mode
     // Set AES keysize based on key length
     // Enable the AES peripheral
-    (*crate::pac::AES::ptr()).ctrla.write(|w| {
+    aes.ctrla().write(|w| {
         w.cipher()
             .dec()
             .keysize()
@@ -39,7 +39,7 @@ pub(super) unsafe fn decrypt<const N: usize>(key: &[u8; N], block: &mut Block) {
     for (index, _) in key.iter().enumerate().step_by(4) {
         // Combine four u8 into one u32
         let data = u32::from_le_bytes([key[index], key[index + 1], key[index + 2], key[index + 3]]);
-        (*crate::pac::AES::ptr()).keyword[index / 4].write(|w| unsafe { w.bits(data) });
+        aes.keyword(index / 4).write(|w| unsafe { w.bits(data) });
     }
 
     // Provide cryptotext to AES module (little endian)
@@ -52,28 +52,19 @@ pub(super) unsafe fn decrypt<const N: usize>(key: &[u8; N], block: &mut Block) {
             block[index + 3],
         ]);
         // Write to same indata, hardware increments DATABUFPTR.INDATPTR
-        (*crate::pac::AES::ptr())
-            .indata
-            .write(|w| unsafe { w.bits(data) });
+        aes.indata().write(|w| unsafe { w.bits(data) });
     }
 
     // Start AES computation
-    (*crate::pac::AES::ptr())
-        .ctrlb
-        .modify(|_, w| w.start().set_bit());
+    aes.ctrlb().modify(|_, w| w.start().set_bit());
 
     // Wait for completion
-    while (*crate::pac::AES::ptr())
-        .intflag
-        .read()
-        .enccmp()
-        .bit_is_clear()
-    {}
+    while aes.intflag().read().enccmp().bit_is_clear() {}
 
     // Read cleartext
     for index in (0..block.len()).into_iter().step_by(4) {
         // Need to split u32 into four u8
-        let buf = (*crate::pac::AES::ptr()).indata.read().bits();
+        let buf = aes.indata().read().bits();
         for (bytepos, byte) in u32::to_ne_bytes(buf).iter().enumerate() {
             block[index + bytepos] = *byte;
         }

--- a/hal/src/peripherals/aes/rustcrypto/encrypt.rs
+++ b/hal/src/peripherals/aes/rustcrypto/encrypt.rs
@@ -1,6 +1,6 @@
 //! AES encryption support
 
-use crate::aes::KEYSIZE_A;
+use crate::aes::Keysizeselect;
 use aes::Block;
 
 /// Perform AES encryption using the given key.
@@ -8,24 +8,24 @@ use aes::Block;
 /// Atsamd AES Hardware does key expansion on the
 /// fly given the key
 pub(super) unsafe fn encrypt<const N: usize>(key: &[u8; N], block: &mut Block) {
+    let aes = unsafe { crate::pac::Aes::steal() };
+
     // Reset the AES peripheral to ensure clean slate
-    (*crate::pac::AES::ptr())
-        .ctrla
-        .write(|w| w.swrst().set_bit());
+    aes.ctrla().write(|w| w.swrst().set_bit());
     // Wait for completion
-    while (*crate::pac::AES::ptr()).ctrla.read().swrst().bit_is_set() {}
+    while aes.ctrla().read().swrst().bit_is_set() {}
 
     let keysize = match N {
-        16 => KEYSIZE_A::_128BIT,
-        24 => KEYSIZE_A::_192BIT,
-        32 => KEYSIZE_A::_256BIT,
+        16 => Keysizeselect::_128bit,
+        24 => Keysizeselect::_192bit,
+        32 => Keysizeselect::_256bit,
         _ => panic!("Invalid AES keysize!"),
     };
 
     // Set peripheral to encryption mode
     // Set AES keysize based on key length
     // Enable the AES peripheral
-    (*crate::pac::AES::ptr()).ctrla.write(|w| {
+    aes.ctrla().write(|w| {
         w.cipher()
             .enc()
             .keysize()
@@ -38,7 +38,7 @@ pub(super) unsafe fn encrypt<const N: usize>(key: &[u8; N], block: &mut Block) {
     for (index, _) in key.iter().enumerate().step_by(4) {
         // Combine four u8 into one u32
         let data = u32::from_le_bytes([key[index], key[index + 1], key[index + 2], key[index + 3]]);
-        (*crate::pac::AES::ptr()).keyword[index / 4].write(|w| unsafe { w.bits(data) });
+        aes.keyword(index / 4).write(|w| unsafe { w.bits(data) });
     }
 
     // Provide cleartext to AES module (little endian)
@@ -51,28 +51,19 @@ pub(super) unsafe fn encrypt<const N: usize>(key: &[u8; N], block: &mut Block) {
             block[index + 3],
         ]);
         // Write to same indata, hardware increments DATABUFPTR.INDATPTR
-        (*crate::pac::AES::ptr())
-            .indata
-            .write(|w| unsafe { w.bits(data) });
+        aes.indata().write(|w| unsafe { w.bits(data) });
     }
 
     // Start AES computation
-    (*crate::pac::AES::ptr())
-        .ctrlb
-        .write(|w| w.start().set_bit());
+    aes.ctrlb().write(|w| w.start().set_bit());
 
     // Wait for completion
-    while (*crate::pac::AES::ptr())
-        .intflag
-        .read()
-        .enccmp()
-        .bit_is_clear()
-    {}
+    while aes.intflag().read().enccmp().bit_is_clear() {}
 
     // Read cryptotext
     for index in (0..block.len()).into_iter().step_by(4) {
         // Need to split u32 into four u8
-        let buf = (*crate::pac::AES::ptr()).indata.read().bits();
+        let buf = aes.indata().read().bits();
         for (bytepos, byte) in u32::to_ne_bytes(buf).iter().enumerate() {
             block[index + bytepos] = *byte;
         }

--- a/hal/src/peripherals/aes/rustcrypto/encrypt.rs
+++ b/hal/src/peripherals/aes/rustcrypto/encrypt.rs
@@ -1,15 +1,19 @@
 //! AES encryption support
 
 use crate::aes::Keysizeselect;
+use crate::pac;
 use aes::Block;
+use cipher::inout::InOut;
 
 /// Perform AES encryption using the given key.
 ///
 /// Atsamd AES Hardware does key expansion on the
 /// fly given the key
-pub(super) unsafe fn encrypt<const N: usize>(key: &[u8; N], block: &mut Block) {
-    let aes = unsafe { crate::pac::Aes::steal() };
-
+pub(super) fn encrypt<'a, const N: usize>(
+    aes: &pac::Aes,
+    key: &[u8; N],
+    mut blocks: InOut<'a, 'a, Block>,
+) {
     // Reset the AES peripheral to ensure clean slate
     aes.ctrla().write(|w| w.swrst().set_bit());
     // Wait for completion
@@ -42,13 +46,14 @@ pub(super) unsafe fn encrypt<const N: usize>(key: &[u8; N], block: &mut Block) {
     }
 
     // Provide cleartext to AES module (little endian)
-    for (index, _) in block.iter().enumerate().step_by(4) {
+    let in_block = blocks.get_in();
+    for (index, _) in in_block.iter().enumerate().step_by(4) {
         // Combine four u8 into one u32
         let data = u32::from_le_bytes([
-            block[index],
-            block[index + 1],
-            block[index + 2],
-            block[index + 3],
+            in_block[index],
+            in_block[index + 1],
+            in_block[index + 2],
+            in_block[index + 3],
         ]);
         // Write to same indata, hardware increments DATABUFPTR.INDATPTR
         aes.indata().write(|w| unsafe { w.bits(data) });
@@ -61,11 +66,12 @@ pub(super) unsafe fn encrypt<const N: usize>(key: &[u8; N], block: &mut Block) {
     while aes.intflag().read().enccmp().bit_is_clear() {}
 
     // Read cryptotext
-    for index in (0..block.len()).into_iter().step_by(4) {
+    let out_block = blocks.get_out();
+    for index in (0..out_block.len()).step_by(4) {
         // Need to split u32 into four u8
         let buf = aes.indata().read().bits();
         for (bytepos, byte) in u32::to_ne_bytes(buf).iter().enumerate() {
-            block[index + bytepos] = *byte;
+            out_block[index + bytepos] = *byte;
         }
     }
 }


### PR DESCRIPTION
# Summary
As part of the `clock::v2` effort tracked in Issue #912, this PR updates the `aes` to use the `clock::v2` API as well as some other refactors. Note that the AES module is only available on `thumbv7` targets so there was no need to maintain `clock::v1` compatibility for `thumbv6` targets.

The module was out of date, so some dependencies were updated, which now allows the ciphers to be used in a safe way, so this was refactored to make things safer, removing the now-unneeded `enable_unsafe_aes_newblock_cipher` feature.

See the commit messages for more details.

# Checklist
  - [X] All new or modified code is well documented, especially public items
  - [X] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment.