### PR TITLE
Updates the DSU peripheral to use the `clock::v2` API

### DIFF
--- a/hal/src/peripherals/dsu.rs
+++ b/hal/src/peripherals/dsu.rs
@@ -15,9 +15,9 @@ pub struct Dsu {
     /// PAC peripheral
     dsu: pac::Dsu,
     // AHB clock
-    _ahb_clk: DsuAhbClk,
+    ahb_clk: DsuAhbClk,
     // APB clock
-    _apb_clk: DsuApbClk,
+    apb_clk: DsuApbClk,
 }
 
 /// Errors from hardware
@@ -64,8 +64,8 @@ impl Dsu {
         } else {
             Ok(Self {
                 dsu,
-                _ahb_clk: ahb_clk,
-                _apb_clk: apb_clk,
+                ahb_clk,
+                apb_clk,
             })
         }
     }
@@ -76,7 +76,7 @@ impl Dsu {
         pac.wrctrl()
             .write(|w| unsafe { w.perid().bits(33).key().set_() });
 
-        (self.dsu, self._ahb_clk, self._apb_clk)
+        (self.dsu, self.ahb_clk, self.apb_clk)
     }
 
     /// Clear bus error bit


### PR DESCRIPTION
# Summary
As part of the `clock::v2` effort tracked in Issue #912, this PR updates the `dsu` to use the `clock::v2` API by requiring ownership of its `AhbClk` and `ApbClk`. Note that this peripheral is only on `thumbv7` targets.

The following Tier 1 BSP examples are now broken and cannot be fixed until the noted peripherals are also migrated and merged (see the notes about this in Issue #912):
- `feather_m4/nvm_dsu` (`usb::UsbBus`)

# Checklist
  - [X] All new or modified code is well documented, especially public items
  - [X] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment.
  