### PR TITLE
QSPI overhaul and QSPI ClockV2

### DIFF
--- a/boards/metro_m4/src/lib.rs
+++ b/boards/metro_m4/src/lib.rs
@@ -267,32 +267,6 @@ pub fn spi_master(
         .enable()
 }
 
-/// Convenience for setting up the onboard QSPI flash.
-/// Enables the clocks for the QSPI peripheral in single data rate mode
-/// assuming 120MHz system clock, for 4MHz QSPI mode 0 operation.
-#[allow(clippy::too_many_arguments)]
-pub fn qspi_master(
-    mclk: &mut Mclk,
-    qspi: pac::Qspi,
-    sclk: impl Into<FlashSclk>,
-    cs: impl Into<FlashCs>,
-    data0: impl Into<FlashD0>,
-    data1: impl Into<FlashD1>,
-    data2: impl Into<FlashD2>,
-    data3: impl Into<FlashD3>,
-) -> Qspi<OneShot> {
-    Qspi::new(
-        mclk,
-        qspi,
-        sclk.into(),
-        cs.into(),
-        data0.into(),
-        data1.into(),
-        data2.into(),
-        data3.into(),
-    )
-}
-
 /// I2C pads for the labelled I2C peripheral
 ///
 /// You can use these pads with other, user-defined [`i2c::Config`]urations.

--- a/boards/pygamer/examples/qspi.rs
+++ b/boards/pygamer/examples/qspi.rs
@@ -57,11 +57,11 @@ fn main() -> ! {
     let ahb_qspi = clocks.ahbs.qspi;
 
     let (mut flash, gclk0) = QspiBuilder::new(
-        sets.flash.sclk, 
-        sets.flash.cs, 
-        sets.flash.data0, 
-        sets.flash.data1, 
-        sets.flash.data2, 
+        sets.flash.sclk,
+        sets.flash.cs,
+        sets.flash.data0,
+        sets.flash.data1,
+        sets.flash.data2,
         sets.flash.data3
     )
     // 48Mhz since this is as fast as the CPU runs after reset,

--- a/boards/pygamer/examples/qspi.rs
+++ b/boards/pygamer/examples/qspi.rs
@@ -40,7 +40,6 @@ fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
 
-
     let (mut buses, clocks, tokens) = clock_system_at_reset(
         peripherals.oscctrl,
         peripherals.osc32kctrl,

--- a/boards/pygamer/src/pins.rs
+++ b/boards/pygamer/src/pins.rs
@@ -883,14 +883,6 @@ pub struct QSPIFlash {
     pub data3: QspiD3Reset,
 }
 
-impl QSPIFlash {
-    pub fn init(self, mclk: &mut pac::Mclk, qspi: pac::Qspi) -> qspi::Qspi<qspi::OneShot> {
-        qspi::Qspi::new(
-            mclk, qspi, self.sclk, self.cs, self.data0, self.data1, self.data2, self.data3,
-        )
-    }
-}
-
 /// Button pins
 pub struct Buttons {
     /// Button Latch

--- a/boards/pygamer/src/pins.rs
+++ b/boards/pygamer/src/pins.rs
@@ -8,7 +8,6 @@ use embedded_hal_bus::spi as bspi;
 use hal::clock::GenericClockController;
 use hal::gpio::PA01;
 use hal::pwm;
-use hal::qspi;
 use hal::sercom::uart::{self, BaudMode, Oversampling};
 use hal::sercom::{i2c, spi, Sercom1, Sercom4};
 use hal::time::Hertz;

--- a/hal/src/peripherals/qspi.rs
+++ b/hal/src/peripherals/qspi.rs
@@ -188,6 +188,7 @@ impl QspiBuilder {
 
     /// Initialize the QSPI peripheral, and start communication
     /// in regular SPI mode
+    #[allow(clippy::type_complexity)]
     pub fn build<I: GclkSourceId, S: Increment>(
         self,
         qspi: pac::Qspi,
@@ -200,6 +201,7 @@ impl QspiBuilder {
 }
 
 impl Qspi<OneShot> {
+    #[allow(clippy::type_complexity)]
     pub(crate) fn new<I: GclkSourceId, S: Increment>(
         qspi: pac::Qspi,
         ahb: AhbClk<QspiClock>,

--- a/hal/src/peripherals/qspi.rs
+++ b/hal/src/peripherals/qspi.rs
@@ -71,16 +71,16 @@ pub struct XIP;
 
 pub struct Qspi<MODE> {
     qspi: pac::Qspi,
-    _ahb: AhbClk<QspiClock>,
-    _apb: ApbClk<QspiClock>,
+    ahb: AhbClk<QspiClock>,
+    apb: ApbClk<QspiClock>,
     gclk0_freq: u32,
-    _sck: Pin<PB10, AlternateH>,
-    _cs: Pin<PB11, AlternateH>,
-    _io0: Pin<PA08, AlternateH>,
-    _io1: Pin<PA09, AlternateH>,
-    _io2: Pin<PA10, AlternateH>,
-    _io3: Pin<PA11, AlternateH>,
-    _mode: PhantomData<MODE>,
+    sck: Pin<PB10, AlternateH>,
+    cs: Pin<PB11, AlternateH>,
+    io0: Pin<PA08, AlternateH>,
+    io1: Pin<PA09, AlternateH>,
+    io2: Pin<PA10, AlternateH>,
+    io3: Pin<PA11, AlternateH>,
+    mode: PhantomData<MODE>,
 }
 
 /// QSPI signal operating modes
@@ -257,16 +257,16 @@ impl Qspi<OneShot> {
         Ok((
             Self {
                 qspi,
-                _ahb: ahb,
-                _apb: apb,
+                ahb,
+                apb,
                 gclk0_freq,
-                _sck: builder.sck,
-                _cs: builder.cs,
-                _io0: builder.io0,
-                _io1: builder.io1,
-                _io2: builder.io2,
-                _io3: builder.io3,
-                _mode: PhantomData,
+                sck: builder.sck,
+                cs: builder.cs,
+                io0: builder.io0,
+                io1: builder.io1,
+                io2: builder.io2,
+                io3: builder.io3,
+                mode: PhantomData,
             },
             gclk0.inc(),
         ))
@@ -415,16 +415,16 @@ impl Qspi<OneShot> {
 
         Qspi::<XIP> {
             qspi: self.qspi,
-            _ahb: self._ahb,
-            _apb: self._apb,
+            ahb: self.ahb,
+            apb: self.apb,
             gclk0_freq: self.gclk0_freq,
-            _sck: self._sck,
-            _cs: self._cs,
-            _io0: self._io0,
-            _io1: self._io1,
-            _io2: self._io2,
-            _io3: self._io3,
-            _mode: PhantomData,
+            sck: self.sck,
+            cs: self.cs,
+            io0: self.io0,
+            io1: self.io1,
+            io2: self.io2,
+            io3: self.io3,
+            mode: PhantomData,
         }
     }
 
@@ -449,15 +449,15 @@ impl Qspi<OneShot> {
     ) {
         (
             self.qspi,
-            self._ahb,
-            self._apb,
+            self.ahb,
+            self.apb,
             gclk0.dec(),
-            self._sck,
-            self._cs,
-            self._io0,
-            self._io1,
-            self._io2,
-            self._io3,
+            self.sck,
+            self.cs,
+            self.io0,
+            self.io1,
+            self.io2,
+            self.io3,
         )
     }
 }
@@ -471,16 +471,16 @@ impl Qspi<XIP> {
 
         Qspi::<OneShot> {
             qspi: self.qspi,
-            _ahb: self._ahb,
-            _apb: self._apb,
+            ahb: self.ahb,
+            apb: self.apb,
             gclk0_freq: self.gclk0_freq,
-            _sck: self._sck,
-            _cs: self._cs,
-            _io0: self._io0,
-            _io1: self._io1,
-            _io2: self._io2,
-            _io3: self._io3,
-            _mode: PhantomData,
+            sck: self.sck,
+            cs: self.cs,
+            io0: self.io0,
+            io1: self.io1,
+            io2: self.io2,
+            io3: self.io3,
+            mode: PhantomData,
         }
     }
 }

--- a/hal/src/peripherals/qspi.rs
+++ b/hal/src/peripherals/qspi.rs
@@ -130,6 +130,14 @@ pub enum QspiError {
     CommandFunctionMismatch,
 }
 
+/// # QSPI Configuration Builder
+///
+/// This structure contains methods that configures the QSPI module.
+///
+/// Setting frequency [`Self::with_freq`] and SPI mode [`Self::with_mode`]
+/// are required to get QSPI running, without calling these, the [`Self::build`]
+/// function will return a [`QspiError`]. Other configuration options are
+/// optional, so are not required
 impl QspiBuilder {
     pub fn new(
         sck: impl Into<Pin<PB10, AlternateH>>,

--- a/hal/src/peripherals/qspi.rs
+++ b/hal/src/peripherals/qspi.rs
@@ -206,7 +206,7 @@ impl Qspi<OneShot> {
         qspi: pac::Qspi,
         ahb: AhbClk<QspiClock>,
         apb: ApbClk<QspiClock>,
-        gclk0: Enabled<Gclk<Gclk0Id, I>, S>,
+        gclk0: EnabledGclk0<I, S>,
         builder: QspiBuilder,
     ) -> Result<(Qspi<OneShot>, EnabledGclk0<I, S::Inc>), QspiError> {
         let targ_freq = builder.freq.ok_or(QspiError::NoFreq)?;

--- a/hal/src/peripherals/qspi.rs
+++ b/hal/src/peripherals/qspi.rs
@@ -52,10 +52,10 @@
 
 use crate::{
     clock::v2::{
-        Enabled, Source,
+        Source,
         ahb::AhbClk,
         apb::ApbClk,
-        gclk::{EnabledGclk0, Gclk, Gclk0Id, Gclk0Io, GclkSourceId},
+        gclk::{EnabledGclk0, Gclk0Io, GclkSourceId},
         types::Qspi as QspiClock,
     },
     gpio::{AlternateH, PA08, PA09, PA10, PA11, PB10, PB11, Pin},

--- a/hal/src/peripherals/qspi.rs
+++ b/hal/src/peripherals/qspi.rs
@@ -176,11 +176,11 @@ impl QspiBuilder {
     ///
     /// * Key - 32 bit key to use for the scramble
     /// * Random - Enable if the hardware based extra key should be
-    /// applied - This means that a QSPI chip will appear scrambled,
-    /// even to another processor. Disabling the random mode ensures
-    /// that whilst the QSPI chip itself is scrambled, it is only using
-    /// the user provided key - Thus allowing other processors with the
-    /// same key to read the QSPI chip
+    ///   applied - This means that a QSPI chip will appear scrambled,
+    ///   even to another processor. Disabling the random mode ensures
+    ///   that whilst the QSPI chip itself is scrambled, it is only using
+    ///   the user provided key - Thus allowing other processors with the
+    ///   same key to read the QSPI chip
     pub fn with_scramble(mut self, key: u32, random: bool) -> Self {
         self.scramble_mode = Some((key, random));
         self

--- a/hal/src/peripherals/qspi.rs
+++ b/hal/src/peripherals/qspi.rs
@@ -55,7 +55,7 @@ use crate::{
         Enabled, Source,
         ahb::AhbClk,
         apb::ApbClk,
-        gclk::{EnabledGclk, EnabledGclk0, Gclk, Gclk0Id, Gclk0Io, GclkSourceId},
+        gclk::{EnabledGclk0, Gclk, Gclk0Id, Gclk0Io, GclkSourceId},
         types::Qspi as QspiClock,
     },
     gpio::{AlternateH, PA08, PA09, PA10, PA11, PB10, PB11, Pin},
@@ -193,8 +193,8 @@ impl QspiBuilder {
         qspi: pac::Qspi,
         ahb: AhbClk<QspiClock>,
         apb: ApbClk<QspiClock>,
-        gclk0: EnabledGclk<Gclk0Id, I, S>,
-    ) -> Result<(Qspi<OneShot>, EnabledGclk<Gclk0Id, I, S::Inc>), QspiError> {
+        gclk0: EnabledGclk0<I, S>,
+    ) -> Result<(Qspi<OneShot>, EnabledGclk0<I, S::Inc>), QspiError> {
         Qspi::new(qspi, ahb, apb, gclk0, self)
     }
 }
@@ -206,7 +206,7 @@ impl Qspi<OneShot> {
         apb: ApbClk<QspiClock>,
         gclk0: Enabled<Gclk<Gclk0Id, I>, S>,
         builder: QspiBuilder,
-    ) -> Result<(Qspi<OneShot>, Enabled<Gclk<Gclk0Id, I>, S::Inc>), QspiError> {
+    ) -> Result<(Qspi<OneShot>, EnabledGclk0<I, S::Inc>), QspiError> {
         let targ_freq = builder.freq.ok_or(QspiError::NoFreq)?;
         let mode = builder.mode.ok_or(QspiError::NoMode)?;
         let gclk0_freq = gclk0.freq().to_Hz();


### PR DESCRIPTION
# Summary
As part of #912 , this PR overhauls the QSPI module (Only used for ThumbV7 targets) to use the ClockV2 API. In doing so, I have also overhauled the module such that it no longer goes on assumptions like it did before.

## New features
* QSPI builder - Set target SPI speed and SPI operation mode
*  Use Clock V2 API (user has to pass EnabledGCLK0 to QSPI builder) - EnabledGclk0 is used as QSPI is tied 1:1 to CPU speed, which is tied to Gclk0.
* Add scramble support for QSPI
* Use AHB Token rather than mclk
* Added documentation to the QSPI module on how to use it, and document pitfalls that a user might encounter (Warning of the fact QSPI stalls the CPU so long operations like Erase can make the program freeze)
* Removed QSPI builder functions in the BSPs (Now redundant)
* Migrate pygame QSPI example to Clock::V2

## Improvements
* Don't force SPI Mode 0
* Don't force 4Mhz SPI operation by default
* Don't assume the CPU is always running at 120Mhz
* Invalid QSPI freq (more than 1/2 CPU freq) will be caught and returned as an error

~~Marked as a draft at the moment as examples are broken.~~
