### PR TITLE
Updates the SYSTICK `delay::Delay` to be in line with the `clock::v2` migration guidelines

### DIFF
--- a/boards/atsame54_xpro/examples/blinky_basic.rs
+++ b/boards/atsame54_xpro/examples/blinky_basic.rs
@@ -7,7 +7,7 @@ use bsp::hal;
 use panic_rtt_target as _;
 use rtt_target::{rprintln, rtt_init_print};
 
-use hal::clock::GenericClockController;
+use hal::clock::v2::clock_system_at_reset;
 use hal::delay::Delay;
 use hal::pac::{CorePeripherals, Peripherals};
 use hal::prelude::*;
@@ -15,18 +15,18 @@ use hal::prelude::*;
 #[cortex_m_rt::entry]
 fn main() -> ! {
     rtt_init_print!();
+
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
-
-    let mut clocks = GenericClockController::with_external_32kosc(
+    let (mut _buses, clocks, _tokens) = clock_system_at_reset(
+        peripherals.oscctrl,
+        peripherals.osc32kctrl,
         peripherals.gclk,
-        &mut peripherals.mclk,
-        &mut peripherals.osc32kctrl,
-        &mut peripherals.oscctrl,
+        peripherals.mclk,
         &mut peripherals.nvmctrl,
     );
 
-    let mut delay = Delay::new(core.SYST, &mut clocks);
+    let (mut delay, _gclk0) = Delay::new(core.SYST, clocks.gclk0);
 
     let pins = bsp::Pins::new(peripherals.port);
     let mut led = bsp::pin_alias!(pins.led).into_push_pull_output();

--- a/boards/feather_m4/examples/blinky_basic.rs
+++ b/boards/feather_m4/examples/blinky_basic.rs
@@ -9,7 +9,7 @@ use panic_semihosting as _;
 
 use bsp::entry;
 use bsp::hal;
-use hal::clock::GenericClockController;
+use hal::clock::v2::clock_system_at_reset;
 use hal::delay::Delay;
 use hal::pac::{CorePeripherals, Peripherals};
 use hal::prelude::*;
@@ -18,16 +18,17 @@ use hal::prelude::*;
 fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
-    let mut clocks = GenericClockController::with_external_32kosc(
+    let (mut _buses, clocks, _tokens) = clock_system_at_reset(
+        peripherals.oscctrl,
+        peripherals.osc32kctrl,
         peripherals.gclk,
-        &mut peripherals.mclk,
-        &mut peripherals.osc32kctrl,
-        &mut peripherals.oscctrl,
+        peripherals.mclk,
         &mut peripherals.nvmctrl,
     );
+
     let pins = bsp::Pins::new(peripherals.port);
     let mut red_led = pins.d13.into_push_pull_output();
-    let mut delay = Delay::new(core.SYST, &mut clocks);
+    let (mut delay, _gclk0) = Delay::new(core.SYST, clocks.gclk0);
     loop {
         delay.delay_ms(2000u16);
         red_led.set_high().unwrap();

--- a/boards/pygamer/examples/blinky_basic.rs
+++ b/boards/pygamer/examples/blinky_basic.rs
@@ -8,7 +8,7 @@ use bsp::{entry, hal, pac, Pins, RedLed};
 use panic_halt as _;
 use pygamer as bsp;
 
-use hal::clock::GenericClockController;
+use hal::clock::v2::clock_system_at_reset;
 use hal::delay::Delay;
 use hal::prelude::*;
 use hal::watchdog::{Watchdog, WatchdogTimeout};
@@ -18,14 +18,15 @@ use pac::{CorePeripherals, Peripherals};
 fn main() -> ! {
     let mut peripherals = Peripherals::take().unwrap();
     let core = CorePeripherals::take().unwrap();
-    let mut clocks = GenericClockController::with_internal_32kosc(
+    let (mut _buses, clocks, _tokens) = clock_system_at_reset(
+        peripherals.oscctrl,
+        peripherals.osc32kctrl,
         peripherals.gclk,
-        &mut peripherals.mclk,
-        &mut peripherals.osc32kctrl,
-        &mut peripherals.oscctrl,
+        peripherals.mclk,
         &mut peripherals.nvmctrl,
     );
-    let mut delay = Delay::new(core.SYST, &mut clocks);
+
+    let (mut delay, _gclk0) = Delay::new(core.SYST, clocks.gclk0);
     delay.delay_ms(400u16);
 
     let pins = Pins::new(peripherals.port);


### PR DESCRIPTION
# Summary
As part of the `clock::v2` effort tracked in Issue #912, this PR brings the SYSTICK-based `delay::Delay` in line with the migration guidelines and makes it consistent with the other migrated peripherals.

See the commit message for details.

The following Tier 1 BSP examples were also updated to include the change:
- `atsame54_xpro/blinky_basic`
- `atsame54_xpro/mcan`
- `metro_m4/blinky_basic`
- `pygamer/blinky_basic`

The following Tier 1 BSP examples are now broken and cannot be fixed until the noted peripherals are also migrated and merged (see the notes about this in Issue #912):
- `feather_m4/neopixel_rainbow` (`timer::TimerCounter`)
- `feather_m4/pwm` (`pwm::Pwmx`)
- `feather_m4/serial` (`sercom::uart::Config`)
- `feather_m4/trng` (`trng::Trng`)
- `feather_m4/uart_poll_echo` (`sercom::uart::Config`)
- `metro_m4/neopixel_blink` (`timer::TimerCounter`)
- `metro_m4/neopixel_rainbow` (`timer::TimerCounter`)
- `metro_m4/pwm` (`pwm::Pwmx`)
- `metro_m4/serial` (`sercom::uart::Config`)
- `metro_m4/trng` (`trng::Trng`)
- `pygamer/ferris_img` (`pwm::Pwmx`, `sercom::spi::Config`)
- `pygamer/pwm_tc4` (`pwm::Pwmx`)
- `pygamer/pwm_tcc0` (`pwm::TccxPwm`)
- `pygamer/qspi` (`qspi::Qspi`)
- `pygamer/sd_card` (`pwm::Pwmx`, `sercom::spi::Config`)

# Checklist
  - [X] All new or modified code is well documented, especially public items
  - [X] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment.
