### PR TITLE
Re-add GCLK0 for CAN dependencies

### DIFF
--- a/boards/atsame54_xpro/examples/mcan.rs
+++ b/boards/atsame54_xpro/examples/mcan.rs
@@ -161,8 +161,14 @@ mod app {
 
         let (pclk_can1, gclk0) = clock::pclk::Pclk::enable(tokens.pclks.can1, gclk0);
 
-        let dependencies =
-            hal::can::Dependencies::new(pclk_can1, clocks.ahbs.can1, can1_rx, can1_tx, device.can1);
+        let (dependencies, _gclk0) = hal::can::Dependencies::new(
+            gclk0,
+            pclk_can1,
+            clocks.ahbs.can1,
+            can1_rx,
+            can1_tx,
+            device.can1,
+        );
 
         let mut can =
             mcan::bus::CanConfigurable::new(375.kHz(), dependencies, ctx.local.can_memory).unwrap();


### PR DESCRIPTION
# Summary

Reverts the changes done in #919, whilst also ensuring that the provided GCLK is EnabledGclk0, rather than potentially any GCLK source like it was prior.  The way GCLK0 is provided is the same as in the QSPI rework PR (#926), since both peripherals require proof of GCLK0, so both peripherals should have a consistent way of doing this. 

@glaeqen would I be able to ask for your input on this?
