### PR TITLE
fix(dmac): DMAC handler now waits for channel to report as disabled

### DIFF
--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -719,17 +719,13 @@ impl<Id: ChId> Channel<Id, ReadyFuture> {
 
         self.configure_trigger(trig_src, trig_act);
 
-        transfer_future::TransferFuture::new(self, trig_src).await;
+        transfer_future::TransferFuture::new(self, trig_src).await
 
         // No need to defensively disable channel here; it's automatically stopped when
         // TransferFuture is dropped. Even though `stop()` is implicitly called
         // through TransferFuture::drop, it *absolutely* must be called before
         // this function is returned, because it emits the compiler fence which ensures
         // memory operations aren't reordered beyond the DMA transfer's bounds.
-
-        // TODO currently this will always return Ok(()) since we unconditionally clear
-        // ERROR
-        self.xfer_success()
     }
 }
 
@@ -769,7 +765,7 @@ mod transfer_future {
     }
 
     impl<Id: ChId> core::future::Future for TransferFuture<'_, Id> {
-        type Output = ();
+        type Output = Result<(), super::Error>;
 
         fn poll(
             mut self: core::pin::Pin<&mut Self>,
@@ -778,29 +774,25 @@ mod transfer_future {
             use crate::dmac::waker::WAKERS;
             use core::task::Poll;
 
-            self.chan._enable_private();
-
-            if !self.triggered && self.trig_src == TriggerSource::Disable {
-                self.triggered = true;
-                self.chan._trigger_private();
-            }
-
             let flags_to_check = InterruptFlags::new().with_tcmpl(true).with_terr(true);
+            let triggered_flags = self.chan.check_and_clear_interrupts(flags_to_check);
 
-            if self.chan.check_and_clear_interrupts(flags_to_check).tcmpl() {
-                return Poll::Ready(());
+            if triggered_flags.tcmpl() {
+                Poll::Ready(Ok(()))
+            } else if triggered_flags.terr() {
+                Poll::Ready(Err(super::Error::TransferError))
+            } else {
+                WAKERS[Id::USIZE].register(cx.waker());
+                self.chan.enable_interrupts(flags_to_check);
+                self.chan._enable_private();
+
+                if !self.triggered && self.trig_src == TriggerSource::Disable {
+                    self.triggered = true;
+                    self.chan._trigger_private();
+                }
+
+                Poll::Pending
             }
-
-            WAKERS[Id::USIZE].register(cx.waker());
-            self.chan.enable_interrupts(flags_to_check);
-
-            if self.chan.check_and_clear_interrupts(flags_to_check).tcmpl() {
-                self.chan.disable_interrupts(flags_to_check);
-
-                return Poll::Ready(());
-            }
-
-            Poll::Pending
         }
     }
 }


### PR DESCRIPTION
# Summary

I was running into an issue with using multiple SPI+DMA transactions in a very tight control loop: sometimes the `spi.transfer` would hang indefinitely because the RX DMA channel was enabled, but somehow the TX DMA channel was disabled. 

I managed to figure out that this was happening because the DMAC interrupt handler does not wait for the channel to finish disabling itself, meaning that sometimes the disable doesn't finish until _after_ my loop's next SPI enable is dispatched. 

The fix is for the DMAC interrupt handler to wait for the channel to finish disabling before waking the future up again.

--

Note that `TransferFuture` is not a public item, so it should be OK for its return type to change.

# Checklist
  - [ ] All new or modified code is well documented, especially public items
  - [ ] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 
