### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/build-bsp.yml
+++ b/.github/workflows/build-bsp.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         set -ex
         build_invocation=$(cat ./crates.json | jq -Mr --arg board '${{ matrix.bsp.name }}' -c '.boards | .[$board] | .build')
-        clippy_invocation=$(echo ${build_invocation} | sed 's/cargo build/cargo clippy/g')
+        clippy_invocation=$(echo ${build_invocation} | sed 's/cargo build/cargo +nightly clippy/g')
         cd boards/${{ matrix.bsp.name }}
         $(${clippy_invocation})
 

--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -195,7 +195,7 @@ pub(super) fn new_chan_future<Id: ChId>(_id: PhantomData<Id>) -> Channel<Id, Uni
 /// These methods may be used on any DMA channel in any configuration
 impl<Id: ChId, S: Status> Channel<Id, S> {
     /// Configure the DMA channel so that it is ready to be used by a
-    /// [`Transfer`](super::transfer::Transfer).
+    /// [`Transfer`].
     ///
     /// # Return
     ///

--- a/hal/src/gpio/pin.rs
+++ b/hal/src/gpio/pin.rs
@@ -1089,7 +1089,7 @@ macro_rules! pins{
             }
             impl Pins {
                 /// Take ownership of the PAC
-                /// [`Port`](crate::pac::Port) and split it into
+                /// [`Port`] and split it into
                 /// discrete [`Pin`]s
                 #[inline]
                 pub fn new(port: Port) -> Pins {
@@ -1112,7 +1112,7 @@ macro_rules! pins{
                 /// Direct access to the [`Port`] could allow you to invalidate
                 /// the compiler's type-level tracking, so it is unsafe.
                 ///
-                /// [`Port`](crate::pac::Port)
+                /// [`Port`]
                 #[inline]
                 pub unsafe fn port(&mut self) -> Port {
                     self.port.take().unwrap()

--- a/hal/src/sercom/dma.rs
+++ b/hal/src/sercom/dma.rs
@@ -177,7 +177,7 @@ where
     ///
     /// In order to be (safely) non-blocking, his method has to take a `'static`
     /// buffer. If you'd rather use DMA with the blocking
-    /// [`embedded_io::Read`](crate::embedded_io::Read) trait, and avoid having
+    /// [`embedded_io::Read`] trait, and avoid having
     /// to use static buffers,
     /// use [`Uart::with_rx_channel`](Self::with_tx_channel) instead.
     #[inline]
@@ -219,7 +219,7 @@ where
     ///
     /// In order to be (safely) non-blocking, his method takes a `'static`
     /// buffer. If you'd rather use DMA with the blocking
-    /// [`embedded_io::Write`](crate::embedded_io::Write) trait, and avoid
+    /// [`embedded_io::Write`] trait, and avoid
     /// having to use static buffers,
     /// use[`Uart::with_tx_channel`](Self::with_tx_channel) instead.
     #[inline]

--- a/rustfmt.sh
+++ b/rustfmt.sh
@@ -6,7 +6,7 @@ echo $DIRECTORIES
 for DIR in $DIRECTORIES
 do
     pushd $(dirname $DIR)
-    cargo fmt -- --check
+    cargo +nightly fmt -- --check
     RET=$(($RET + $?))
     popd
 done
@@ -17,7 +17,7 @@ echo $DIRECTORIES
 for DIR in $DIRECTORIES
 do
     pushd $(dirname $DIR)
-    cargo fmt -- --check
+    cargo +nightly fmt -- --check
     RET=$(($RET + $?))
     popd
 done


### PR DESCRIPTION
# Summary
CI is broken on master, that's not good!

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 

## If Adding a new Board
  - [ ] Board CI added to `crates.json`
  - [ ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"

## If Adding a new cargo `feature` to the HAL
  - [ ] Feature is added to the test matrix for applicable boards / PACs in `crates.json`

#### Note
The crate changelogs **should no longer** be manually updated! Changelogs are now automatically generated. Instead:

- If your PR is contained to a single crate, or a single feature:
  - Nothing else to do; your PR will likely be squashed down to a single commit.
  - Please consider using [conventional commmit phrasing](https://www.conventionalcommits.org) in the PR title.
- If your PR brings in large, sweeping changes across multiple crates:
  - Organize your commits such that each commit only touches a single crate, or a single feature across multiple crates. Please don't create commits that span multiple features over multiple crates.
  - Use [conventional commmits](https://www.conventionalcommits.org) for your commit messages.
