### PR TITLE
Document order of calling enable_interrupt for interrupt timer

### DIFF
--- a/hal/src/peripherals/timer/common.rs
+++ b/hal/src/peripherals/timer/common.rs
@@ -29,6 +29,10 @@ where
         self.tc.count_16().intenset().write(|w| w.ovf().set_bit());
     }
 
+    /// Starts the countdown of the timer.
+    ///
+    /// You should call [Self::enable_interrupt] after calling start
+    /// in order to enable the interrupt generation
     fn start<T>(&mut self, timeout: T)
     where
         T: Into<NanosDurationU32>,


### PR DESCRIPTION
# Summary
This commit adds some documentation to the InterruptTimer to document the fact that enable_interrupt must be called after timer start to actually enable  the interrupts (Since calling start resets the timer peripheral and interrupt flags)