### PR TITLE
fix(ci): silence deprecation warning we have no power over

### DIFF
--- a/hal/src/peripherals/aes/mod.rs
+++ b/hal/src/peripherals/aes/mod.rs
@@ -119,6 +119,11 @@
 //! assert_eq!(block, block_copy);
 //! ```
 
+// The cipher crate has an outdated dependency on the generic-array crate
+// (by way of the crypto_common crate)
+// Nothing we can do about this until the dependency chain is up to date
+#![allow(deprecated)]
+
 // Re-exports
 pub use pac::aes::ctrla::{
     Aesmodeselect, Cfbsselect, Cipherselect, Keysizeselect, Lodselect, Startmodeselect,


### PR DESCRIPTION
# Summary
Allow deprecation warnings in the aes module, because rustcrypto is borked.

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 

## If Adding a new Board
  - [ ] Board CI added to `crates.json`
  - [ ] Board is properly following "Tier 2" conventions, unless otherwise decided to be "Tier 1"

## If Adding a new cargo `feature` to the HAL
  - [ ] Feature is added to the test matrix for applicable boards / PACs in `crates.json`

#### Note
The crate changelogs **should no longer** be manually updated! Changelogs are now automatically generated. Instead:

- If your PR is contained to a single crate, or a single feature:
  - Nothing else to do; your PR will likely be squashed down to a single commit.
  - Please consider using [conventional commmit phrasing](https://www.conventionalcommits.org) in the PR title.
- If your PR brings in large, sweeping changes across multiple crates:
  - Organize your commits such that each commit only touches a single crate, or a single feature across multiple crates. Please don't create commits that span multiple features over multiple crates.
  - Use [conventional commmits](https://www.conventionalcommits.org) for your commit messages.
