### PR TITLE
Fix and improve EIC Event control

### DIFF
--- a/hal/src/peripherals/eic/d11/pin.rs
+++ b/hal/src/peripherals/eic/d11/pin.rs
@@ -62,6 +62,15 @@ where
                 .modify(|r, w| unsafe { w.bits(r.bits() | 1 << P::ChId::ID) });
         });
     }
+
+    /// Disables the event output of the channel for the event system.
+    ///
+    /// Note that whilst this function is executed, the EIC peripheral is disabled
+    /// in order to write to the evctrl register
+    pub fn disable_event(&mut self) {
+        self.chan.with_disable(|e| {
+            e.evctrl()
+                .modify(|r, w| unsafe { w.bits(r.bits() & !(1 << P::ChId::ID)) });
         });
     }
 

--- a/hal/src/peripherals/eic/d5x/pin.rs
+++ b/hal/src/peripherals/eic/d5x/pin.rs
@@ -69,6 +69,14 @@ where
         });
     }
 
+    /// Disables the event output of the channel for the event system.
+    ///
+    /// Note that whilst this function is executed, the EIC peripheral is disabled
+    /// in order to write to the evctrl register
+    pub fn disable_event(&mut self) {
+        self.chan.with_disable(|e| {
+            e.evctrl()
+                .modify(|r, w| unsafe { w.bits(r.bits() & !(1 << P::ChId::ID)) });
         });
     }
 


### PR DESCRIPTION
# Summary
The EIC Evctrl register works differently to intset/intclear. There is just one register, and the user must set the bit for each channel in it according to if the event system should be enabled or not per channel. 

Before, this was done by writing to the register directly, rather than ORing it with whats already in it. This would cause the last value of the register to be overwritten, meaning, it would only ever be possible to have 1 event system channel output enabled at once.

For completion, I've also added a `disable_event` method, which turns off a channels Event system output.

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 