### PR TITLE
samd11/21: fix off-by-one Pwm period

### DIFF
--- a/hal/src/peripherals/pwm/d11.rs
+++ b/hal/src/peripherals/pwm/d11.rs
@@ -46,7 +46,7 @@ impl $TYPE {
             }
         });
         count.ctrla().write(|w| w.wavegen().mpwm());
-        count.cc(0).write(|w| unsafe { w.cc().bits(params.cycles as u16) });
+        count.cc(0).write(|w| unsafe { w.cc().bits(params.cycles as u16 - 1) });
         count.cc(1).write(|w| unsafe { w.cc().bits(0) });
         count.ctrla().modify(|_, w| w.enable().set_bit());
         while count.status().read().syncbusy().bit_is_set() {}
@@ -78,7 +78,7 @@ impl $TYPE {
         });
         count.ctrla().modify(|_, w| w.enable().set_bit());
         while count.status().read().syncbusy().bit_is_set() {}
-        count.cc(0).write(|w| unsafe { w.cc().bits(params.cycles as u16) });
+        count.cc(0).write(|w| unsafe { w.cc().bits(params.cycles as u16 - 1) });
     }
 
     pub fn get_period(&self) -> Hertz {
@@ -210,7 +210,7 @@ impl $TYPE {
             });
             tcc.wave().write(|w| w.wavegen().npwm());
             while tcc.syncbusy().read().wave().bit_is_set() {}
-            tcc.per().write(|w| unsafe { w.bits(params.cycles as u32) });
+            tcc.per().write(|w| unsafe { w.bits(params.cycles as u32 - 1) });
             while tcc.syncbusy().read().per().bit_is_set() {}
             tcc.ctrla().modify(|_, w| w.enable().set_bit());
             while tcc.syncbusy().read().enable().bit_is_set() {}
@@ -283,7 +283,7 @@ impl $crate::ehal_02::Pwm for $TYPE {
         });
         self.tcc.ctrla().modify(|_, w| w.enable().set_bit());
         while self.tcc.syncbusy().read().enable().bit_is_set() {}
-        self.tcc.per().write(|w| unsafe { w.bits(params.cycles as u32) });
+        self.tcc.per().write(|w| unsafe { w.bits(params.cycles as u32 - 1) });
         while self.tcc.syncbusy().read().per().bit() {}
     }
 }

--- a/hal/src/peripherals/pwm/d5x.rs
+++ b/hal/src/peripherals/pwm/d5x.rs
@@ -171,7 +171,7 @@ impl<I: PinId> $TYPE<I> {
             }
         });
         count.wave().write(|w| w.wavegen().mpwm());
-        count.cc(0).write(|w| unsafe { w.cc().bits(params.cycles as u16) });
+        count.cc(0).write(|w| unsafe { w.cc().bits(params.cycles as u16 - 1) });
         while count.syncbusy().read().cc0().bit_is_set() {}
         count.cc(1).write(|w| unsafe { w.cc().bits(0) });
         while count.syncbusy().read().cc1().bit_is_set() {}
@@ -214,7 +214,7 @@ impl<I: PinId> $TYPE<I> {
             });
         count.ctrla().modify(|_, w| w.enable().set_bit());
         while count.syncbusy().read().enable().bit_is_set() {}
-        count.cc(0).write(|w| unsafe { w.cc().bits(params.cycles as u16) });
+        count.cc(0).write(|w| unsafe { w.cc().bits(params.cycles as u16 - 1) });
         while count.syncbusy().read().cc0().bit_is_set() {}
     }
 }
@@ -595,7 +595,7 @@ impl<I: PinId, M: PinMode> $TYPE<I, M> {
         });
         tcc.wave().write(|w| w.wavegen().npwm());
         while tcc.syncbusy().read().wave().bit_is_set() {}
-        tcc.per().write(|w| unsafe { w.bits(params.cycles as u32) });
+        tcc.per().write(|w| unsafe { w.bits(params.cycles as u32 - 1) });
         while tcc.syncbusy().read().per().bit_is_set() {}
         tcc.ctrla().modify(|_, w| w.enable().set_bit());
         while tcc.syncbusy().read().enable().bit_is_set() {}
@@ -667,7 +667,7 @@ impl<I: PinId, M: PinMode> $crate::ehal_02::Pwm for $TYPE<I, M> {
         });
         self.tcc.ctrla().modify(|_, w| w.enable().set_bit());
         while self.tcc.syncbusy().read().enable().bit_is_set() {}
-        self.tcc.per().write(|w| unsafe { w.bits(params.cycles as u32) });
+        self.tcc.per().write(|w| unsafe { w.bits(params.cycles as u32 - 1) });
         while self.tcc.syncbusy().read().per().bit() {}
     }
 }


### PR DESCRIPTION
# Summary

This change fixes the `Pwm` period off-by-one issue on SAMD11/21, as described in #948.
