### PR TITLE
fix: Update feather_m0 usb-device crate.

### DIFF
--- a/boards/feather_m0/Cargo.toml
+++ b/boards/feather_m0/Cargo.toml
@@ -35,7 +35,7 @@ version = "2.1.1"
 
 [dependencies.usb-device]
 optional = true
-version = "0.3.1"
+version = "0.3.2"
 
 [dependencies.embedded-sdmmc]
 optional = true


### PR DESCRIPTION
This crate needs to be the same as the atsamd-hal, which uses version 0.3.2.

# Summary
I updated the usb-device dependency of the feather_m0 support crate to match the version used in atsamd-hal.

# Checklist
  - [X] All new or modified code is well documented, especially public items
  - [X] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment.