### PR TITLE
Switch itsybitsy_m4 BSP to latest HAL release.

### DIFF
--- a/boards/itsybitsy_m4/Cargo.toml
+++ b/boards/itsybitsy_m4/Cargo.toml
@@ -24,7 +24,7 @@ version = "0.7"
 optional = true
 
 [dependencies.atsamd-hal]
-version = "0.21"
+version = "0.22.2"
 default-features = false
 
 [dependencies.usb-device]

--- a/boards/itsybitsy_m4/examples/sercom_interrupt.rs
+++ b/boards/itsybitsy_m4/examples/sercom_interrupt.rs
@@ -42,12 +42,12 @@ use bsp::hal::{
     prelude::*,
     sercom::{
         uart::{self, BaudMode, Flags, Oversampling},
-        IoSet3, Sercom0,
+        Sercom0,
     },
     time::Hertz,
 };
 
-type UartPads0 = uart::Pads<Sercom0, IoSet3, IoSet3Sercom0Pad2, IoSet3Sercom0Pad0>;
+type UartPads0 = uart::Pads<Sercom0, IoSet3Sercom0Pad2, IoSet3Sercom0Pad0>;
 type Uart0 = uart::Uart<uart::Config<UartPads0>, uart::Duplex>;
 
 /// Utility function for setting up SERCOM0 pins as an additional

--- a/boards/itsybitsy_m4/src/lib.rs
+++ b/boards/itsybitsy_m4/src/lib.rs
@@ -288,7 +288,7 @@ pub fn qspi_master(
 /// I2C pads for the labelled I2C peripheral
 ///
 /// You can use these pads with other, user-defined [`i2c::Config`]urations.
-pub type I2cPads = i2c::Pads<I2cSercom, IoSet1, Sda, Scl>;
+pub type I2cPads = i2c::Pads<I2cSercom, Sda, Scl>;
 
 /// I2C master for the labelled I2C peripheral
 ///
@@ -318,7 +318,7 @@ pub fn i2c_master(
 }
 
 /// UART Pads for the labelled UART peripheral
-pub type UartPads = uart::Pads<UartSercom, IoSet3, UartRx, UartTx>;
+pub type UartPads = uart::Pads<UartSercom, UartRx, UartTx>;
 
 /// UART device for the labelled RX & TX pins
 pub type Uart = uart::Uart<uart::Config<UartPads>, uart::Duplex>;
@@ -375,7 +375,7 @@ pub fn dotstar_bitbang<T: CountDown + Periodic>(
 /// SPI pads for the labelled SPI peripheral
 ///
 /// You can use these pads with other, user-defined [`spi::Config`]urations.
-pub type SpiPads = spi::Pads<SpiSercom, UndocIoSet2, Miso, Mosi, Sck>;
+pub type SpiPads = spi::Pads<SpiSercom, Miso, Mosi, Sck>;
 
 /// SPI master for the labelled SPI peripheral
 ///


### PR DESCRIPTION
# Summary

Changes necessary to make `itsybitsy_m4` BSP/examples build properly with HAL version `0.22`.
I had to make this change to test #948 on my ItsyBitsy M4 Express board.

BTW, I can see some inconsistencies when it comes to using HAL from repo vs pulling a crate. Some BSPs (e.g. `feather_m4`) use `path` to reference the repo:
```
[dependencies.atsamd-hal]
default-features = false
path = "../../hal"
version = "0.22.2"
```
while others (like `itsybitsy_m4`) simply pull the crate as a dependency. 
Is there any policy in place?
