### PR TITLE
chore: Remove deprecated warning in aes module

### DIFF
--- a/hal/src/peripherals/aes/mod.rs
+++ b/hal/src/peripherals/aes/mod.rs
@@ -119,11 +119,6 @@
 //! assert_eq!(block, block_copy);
 //! ```
 
-// The cipher crate has an outdated dependency on the generic-array crate
-// (by way of the crypto_common crate)
-// Nothing we can do about this until the dependency chain is up to date
-#![allow(deprecated)]
-
 // Re-exports
 pub use pac::aes::ctrla::{
     Aesmodeselect, Cfbsselect, Cipherselect, Keysizeselect, Lodselect, Startmodeselect,


### PR DESCRIPTION
Looks like the dependency chain has been updated and we no longer get deprecated warnings.

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 