### PR TITLE
feature: Add a couple more undoc I2C pads for samd21.

### DIFF
--- a/hal/src/sercom/pad/impl_pad_thumbv6m.rs
+++ b/hal/src/sercom/pad/impl_pad_thumbv6m.rs
@@ -437,13 +437,23 @@ pad_table!(
     }
     #[hal_cfg("pb02")]
     PB02 {
+        #[cfg(not(feature = "undoc-features"))]
         #[hal_cfg("sercom5")]
         D: (Sercom5, Pad0),
+
+        #[cfg(feature = "undoc-features")]
+        #[hal_cfg("sercom5")]
+        D: (Sercom5, Pad0) + I2C,
     }
     #[hal_cfg("pb03")]
     PB03 {
+        #[cfg(not(feature = "undoc-features"))]
         #[hal_cfg("sercom5")]
         D: (Sercom5, Pad1),
+
+        #[cfg(feature = "undoc-features")]
+        #[hal_cfg("sercom5")]
+        D: (Sercom5, Pad1) + I2C,
     }
     #[hal_cfg("pb08")]
     PB08 {


### PR DESCRIPTION
# Summary

The circuit-playground-express uses these pads as the Sda/Scl pads. This is required for #953.

# Checklist
  - [ ] All new or modified code is well documented, especially public items
  - [ ] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 