### PR TITLE
Fix for off-by-one in get_max_duty()

### DIFF
--- a/hal/src/peripherals/pwm/d11.rs
+++ b/hal/src/peripherals/pwm/d11.rs
@@ -97,7 +97,7 @@ impl $crate::ehal::pwm::SetDutyCycle for $TYPE {
     fn max_duty_cycle(&self) -> u16 {
         let count = self.tc.count16();
         let top = count.cc(0).read().cc().bits();
-        top + 1
+        top.saturating_add(1)
     }
 
     fn set_duty_cycle(&mut self, duty: u16) -> Result<(), Self::Error> {

--- a/hal/src/peripherals/pwm/d5x.rs
+++ b/hal/src/peripherals/pwm/d5x.rs
@@ -227,7 +227,7 @@ impl<I: PinId> $crate::ehal::pwm::SetDutyCycle for $TYPE<I> {
     fn max_duty_cycle(&self) -> u16 {
         let count = self.tc.count16();
         let top = count.cc(0).read().cc().bits();
-        top + 1
+        top.saturating_add(1)
     }
 
     fn set_duty_cycle(&mut self, duty: u16) -> Result<(), Self::Error> {


### PR DESCRIPTION
# Summary

This PR fixes off-by-one issue in TC/TCC `get_max_duty()` function, for details see #911.

Change verified with Adafruit ItsiBitsy M4 and Sparkfun ATSAMD21G Mini boards.