### PR TITLE
docs: Document newly undoc I2C-capable pins (PB02,PB03)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ Currently, we provide these features undocumented features:
 
 * Mark `PA01` as I2C-capable according to `circuit_playground_express`.
 
+* Mark `PB02` as I2C-capable according to `circuit_playground_express`.
+
+* Mark `PB03` as I2C-capable according to `circuit_playground_express`.
+
 ### SAMx5x devices:
 * `UndocIoSet1`: Implement an undocumented `IoSet` for PA16, PA17, PB22 &
   PB23 configured for `Sercom1`. The `pygamer` & `feather_m4` use this

--- a/hal/src/sercom/mod.rs
+++ b/hal/src/sercom/mod.rs
@@ -18,6 +18,12 @@
 //! * `PA01` is I2C-capable according to `circuit_playground_express`. As such,
 //!   PA01 implements [`IsI2cPad`].
 //!
+//! * `PB02` is I2C-capable according to `circuit_playground_express`. As such,
+//!   PB02 implements [`IsI2cPad`].
+//!
+//! * `PB03` is I2C-capable according to `circuit_playground_express`. As such,
+//!   PB03 implements [`IsI2cPad`].
+//!
 //! ## SAMx5x devices:
 //! * `UndocIoSet1`: Implement an undocumented `IoSet` for PA16, PA17, PB22 &
 //!   PB23 configured for [`Sercom1`]. The `pygamer` & `feather_m4` use this


### PR DESCRIPTION
The documentation for these 2 newly undocumented I2C-capable pins was missing.