### PR TITLE
Make all shebangs for shell scripts consistent.

### DIFF
--- a/format-all.sh
+++ b/format-all.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -xe
 
 HERE=$PWD

--- a/rustfmt.sh
+++ b/rustfmt.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 RET=0
 
 # first, all boards & their examples


### PR DESCRIPTION
# Summary
This change makes sure that all shell scripts use the same form of shebang line.

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 