### PR TITLE
Feature: Add RTIC support for CPE

### DIFF
--- a/boards/circuit_playground_express/Cargo.toml
+++ b/boards/circuit_playground_express/Cargo.toml
@@ -22,6 +22,11 @@ default-features = false
 features = ["critical-section-single-core"]
 version = "0.7"
 
+[dependencies.rtic]
+features = ["thumbv6-backend"]
+optional = true
+version = "2.1.1"
+
 [dependencies.usb-device]
 version = "0.3.2"
 optional = true
@@ -43,6 +48,7 @@ version = "0.3.0"
 default = ["rt", "atsamd-hal/samd21g", "atsamd-hal/undoc-features"]
 dma = ["atsamd-hal/dma"]
 rt = ["cortex-m-rt", "atsamd-hal/samd21g-rt"]
+rtic = ["dep:rtic", "atsamd-hal/rtic"]
 usb = ["atsamd-hal/usb", "usb-device"]
 use_semihosting = []
 


### PR DESCRIPTION
# Summary
This change simply allows rtic to be used with the circuit-playground-express board.

# Checklist
  - [X] All new or modified code is well documented, especially public items
  - [X] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 