### PR TITLE
feat: add I2C capabilities to labelled pins for arduino_nano33iot

### DIFF
--- a/hal/src/sercom/pad/impl_pad_thumbv6m.rs
+++ b/hal/src/sercom/pad/impl_pad_thumbv6m.rs
@@ -457,13 +457,23 @@ pad_table!(
     }
     #[hal_cfg("pb08")]
     PB08 {
+        #[cfg(not(feature = "undoc-features"))]
         #[hal_cfg("sercom4")]
         D: (Sercom4, Pad0),
+
+        #[cfg(feature = "undoc-features")]
+        #[hal_cfg("sercom4")]
+        D: (Sercom4, Pad0) + I2C,
     }
     #[hal_cfg("pb09")]
     PB09 {
+        #[cfg(not(feature = "undoc-features"))]
         #[hal_cfg("sercom4")]
         D: (Sercom4, Pad1),
+
+        #[cfg(feature = "undoc-features")]
+        #[hal_cfg("sercom4")]
+        D: (Sercom4, Pad1) + I2C,
     }
     #[hal_cfg("pb10")]
     PB10 {


### PR DESCRIPTION
# Summary
Splitting out the HAL change from #971 - this adds the I2C trait to the pins labelled on the Arduino nano 33 iot board.

# Checklist
  - [ ] All new or modified code is well documented, especially public items
  - [ ] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 
