### PR TITLE
fix(dmac): Check+document that the DMAC transfer lengths fit in a u16

### DIFF
--- a/hal/src/dmac/channel/mod.rs
+++ b/hal/src/dmac/channel/mod.rs
@@ -543,6 +543,8 @@ impl<Id: ChId> Channel<Id, Ready> {
     ///   compatible lengths. You must guarantee that:
     ///   - Either `source` or `dest` has a buffer length of 1, or
     ///   - Both buffers have the same length.
+    /// * The source and destination buffers must have a length smaller or equal
+    ///   to `u16::MAX`.
     /// * You must ensure that the transfer is completed or stopped before
     ///   returning the [`Channel`]. Doing otherwise breaks type safety, because
     ///   a [`Ready`] channel would still be in the middle of a transfer.
@@ -676,10 +678,6 @@ impl<Id: ChId> Channel<Id, ReadyFuture> {
     ///
     /// # Safety
     ///
-    /// * This method does not check that the two provided buffers have
-    ///   compatible lengths. You must guarantee that:
-    ///   - Either `source` or `dest` has a buffer length of 1, or
-    ///   - Both buffers have the same length.
     /// * You must ensure that the transfer is completed or stopped before
     ///   returning the [`Channel`]. Doing otherwise breaks type safety, because
     ///   a [`ReadyFuture`] channel would still be in the middle of a transfer.
@@ -841,6 +839,13 @@ impl Default for InterruptFlags {
 ///   location, or be null. They must not be circular (ie, points to itself).
 ///   Any linked transfer must strictly be a read transaction (destination
 ///   pointer is a byte buffer, source pointer is the SERCOM DATA register).
+///
+/// * The length of both the source and destination buffers must be smaller or
+///   equal to `u16::MAX`.
+///
+/// * Either:
+///      - `source` or `dest` has a buffer length of 1, or
+///      - Both buffers have the same length.
 #[inline]
 pub(crate) unsafe fn write_descriptor<Src: Buffer, Dst: Buffer<Beat = Src::Beat>>(
     descriptor: &mut DmacDescriptor,
@@ -856,6 +861,8 @@ pub(crate) unsafe fn write_descriptor<Src: Buffer, Dst: Buffer<Beat = Src::Beat>
     let dst_inc = destination.incrementing();
     let dst_len = destination.buffer_len();
 
+    // This is sufficient since buffers of unequal lengths breaks the safety
+    // contract if neither buffer has a length of 1.
     let length = core::cmp::max(src_len, dst_len);
 
     // Channel::xfer_complete() tests the channel enable bit, which indicates

--- a/hal/src/dmac/mod.rs
+++ b/hal/src/dmac/mod.rs
@@ -264,12 +264,16 @@ pub enum Error {
     /// Buffers need to either have the same length in beats, or one should have
     /// length == 1.  In cases where one buffer is length 1, that buffer will be
     /// the source or destination of each beat in the transfer.  If both buffers
-    /// had length >1, but not equal to each other, then it would not be clear
+    /// had length > 1, but not equal to each other, then it would not be clear
     /// how to structure the transfer.
     LengthMismatch,
 
+    /// The DMAC only supports up to `u16::MAX` beats in a single transfer.
+    TooManyBeats,
+
     /// Operation is not valid in the current state of the object.
     InvalidState,
+
     /// Chip reported an error during transfer
     TransferError,
 }

--- a/hal/src/dmac/transfer.rs
+++ b/hal/src/dmac/transfer.rs
@@ -329,8 +329,10 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`Error::LengthMismatch`] if both
-    /// buffers have a length > 1 and are not of equal length.
+    /// * Returns [`Error::LengthMismatch`] if both buffers have a length > 1
+    ///   and are not of equal length.
+    /// * Returns [`Error::TooManyBeats`] if the number of beats are greater
+    ///   than `u16::MAX``.
     #[allow(clippy::new_ret_no_self)]
     #[inline]
     pub fn new(
@@ -360,6 +362,8 @@ where
 
         if src_len > 1 && dst_len > 1 && src_len != dst_len {
             Err(Error::LengthMismatch)
+        } else if src_len.max(dst_len) > u16::MAX.into() {
+            Err(Error::TooManyBeats)
         } else {
             Ok(())
         }
@@ -387,6 +391,9 @@ where
     ///   exacly the same, unless one or both buffers are of length 1. The
     ///   transfer length will be set to the longest of both buffers if they are
     ///   not of equal size.
+    ///
+    /// * The source and destination buffers should have a length smaller or
+    ///   equal to `u16::MAX`.
     #[inline]
     pub unsafe fn new_unchecked(
         mut chan: C,


### PR DESCRIPTION
# Summary
The BTCNT field of a DMAC transfer descriptor is a u16. We currently truncate the transfer lengths to u16, leading to potentially surprising results.

Here this PR adds a length check to the `check_buffer_pair` methods, and documents the buffer length requirement in all unsafe functions where the buffer pairs are explicitly unchecked.

Potentially fixes #981 