### PR TITLE
fix(adc):  clearing flags when reading mutible channels & make it somewhat consistent

### DIFF
--- a/hal/src/peripherals/adc/mod.rs
+++ b/hal/src/peripherals/adc/mod.rs
@@ -358,6 +358,7 @@ impl<I: AdcInstance> Adc<I> {
             while !self.read_flags().contains(Flags::RESRDY) {
                 core::hint::spin_loop();
             }
+            self.clear_all_flags();
             self.discard = false;
         }
     }
@@ -381,15 +382,7 @@ impl<I: AdcInstance> Adc<I> {
         self.mux(ch);
         self.enable_freerunning();
         self.start_conversion();
-        if self.discard {
-            // Discard first result
-            while !self.read_flags().contains(Flags::RESRDY) {
-                core::hint::spin_loop();
-            }
-            self.clear_all_flags();
-            self.discard = false;
-        }
-
+        self.check_read_discard();
         for result in dst.iter_mut() {
             while !self.read_flags().contains(Flags::RESRDY) {
                 core::hint::spin_loop();
@@ -468,7 +461,7 @@ where
             self.inner.start_conversion();
             let _ = self.wait_flags(Flags::RESRDY).await;
             self.inner.discard = false;
-            let _ = self.inner.conversion_result();
+            self.inner.clear_all_flags();
         }
         self.inner.start_conversion();
         // Here we explicitly ignore the result, because we know that


### PR DESCRIPTION
# Summary
Fixes ADC reads with on multible channels\
Make the way reads are discarded consistent

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 
