### PR TITLE
Introduce more peripheral free methods for consistency

### DIFF
--- a/hal/src/peripherals/nvm/mod.rs
+++ b/hal/src/peripherals/nvm/mod.rs
@@ -176,6 +176,12 @@ impl Nvm {
         Self { nvm }
     }
 
+    /// Releases the NvmCtrl resource
+    #[inline]
+    pub fn free(self) -> Nvmctrl {
+        self.nvm
+    }
+
     /// Raw access to the registers.
     ///
     /// # Safety

--- a/hal/src/peripherals/pwm/d11.rs
+++ b/hal/src/peripherals/pwm/d11.rs
@@ -58,11 +58,12 @@ impl $TYPE {
     }
 
     #[inline]
-    // Disables the TCC, then releases it
+    // Disables the TC, then releases it
     pub fn free(self) -> crate::pac::$TC {
-        self.tcc.ctrla().write(|w| w.swrst().set_bit());
-        while self.tcc.syncbusy().read().swrst().bit_is_set() {}
-        self.tcc
+        let count = self.tc.count16();
+        count.ctrla().write(|w| w.swrst().set_bit());
+        while count.ctrla().read().bits() & 1 != 0 {}
+        self.tc
     }
 
     pub fn set_period(&mut self, period: Hertz)

--- a/hal/src/peripherals/pwm/d11.rs
+++ b/hal/src/peripherals/pwm/d11.rs
@@ -57,6 +57,14 @@ impl $TYPE {
         }
     }
 
+    #[inline]
+    // Disables the TCC, then releases it
+    pub fn free(self) -> $TC {
+        self.tcc.ctrla().write(|w| w.swrst().set_bit());
+        while self.tcc.syncbusy().read().swrst().bit_is_set() {}
+        self.tcc
+    }
+
     pub fn set_period(&mut self, period: Hertz)
     {
         let params = TimerParams::new(period, self.clock_freq);

--- a/hal/src/peripherals/pwm/d11.rs
+++ b/hal/src/peripherals/pwm/d11.rs
@@ -59,7 +59,7 @@ impl $TYPE {
 
     #[inline]
     // Disables the TCC, then releases it
-    pub fn free(self) -> $TC {
+    pub fn free(self) -> crate::pac::$TC {
         self.tcc.ctrla().write(|w| w.swrst().set_bit());
         while self.tcc.syncbusy().read().swrst().bit_is_set() {}
         self.tcc

--- a/hal/src/peripherals/pwm/d5x.rs
+++ b/hal/src/peripherals/pwm/d5x.rs
@@ -606,6 +606,14 @@ impl<I: PinId, M: PinMode> $TYPE<I, M> {
             pinout,
         }
     }
+
+    #[inline]
+    // Disables the TCC, then releases it
+    pub fn free(self) -> $TCC {
+        self.tcc.ctrla().write(|w| w.swrst().set_bit());
+        while self.tcc.syncbusy().read().swrst().bit_is_set() {}
+        self.tcc
+    }
 }
 
 impl<I: PinId, M: PinMode> $crate::ehal_02::Pwm for $TYPE<I, M> {

--- a/hal/src/peripherals/pwm/d5x.rs
+++ b/hal/src/peripherals/pwm/d5x.rs
@@ -609,7 +609,7 @@ impl<I: PinId, M: PinMode> $TYPE<I, M> {
 
     #[inline]
     // Disables the TCC, then releases it
-    pub fn free(self) -> $TCC {
+    pub fn free(self) -> crate::pac::$TCC {
         self.tcc.ctrla().write(|w| w.swrst().set_bit());
         while self.tcc.syncbusy().read().swrst().bit_is_set() {}
         self.tcc

--- a/hal/src/peripherals/timer/d11.rs
+++ b/hal/src/peripherals/timer/d11.rs
@@ -129,6 +129,15 @@ impl TimerCounter<$TC>
             tc,
         }
     }
+
+    #[inline]
+    // Disables the TC, then releases it
+    pub fn free(self) -> $TC {
+        let count = self.tc.count_16();
+        count.ctrla().write(|w| w.swrst().set_bit());
+        while count.syncbusy().read().swrst().bit_is_set() {}
+        self.tc
+    }
 }
         )+
     }

--- a/hal/src/peripherals/timer/d11.rs
+++ b/hal/src/peripherals/timer/d11.rs
@@ -133,9 +133,9 @@ impl TimerCounter<$TC>
     #[inline]
     // Disables the TC, then releases it
     pub fn free(self) -> $TC {
-        let count = self.tc.count_16();
+        let count = self.tc.count16();
         count.ctrla().write(|w| w.swrst().set_bit());
-        while count.syncbusy().read().swrst().bit_is_set() {}
+        while count.ctrla().read().bits() & 1 != 0 {}
         self.tc
     }
 }

--- a/hal/src/peripherals/timer/d5x.rs
+++ b/hal/src/peripherals/timer/d5x.rs
@@ -128,6 +128,15 @@ impl TimerCounter<$TC>
             tc,
         }
     }
+
+    #[inline]
+    // Disables the TC, then releases it
+    pub fn free(self) -> $TC {
+        let count = self.tc.count_16();
+        count.ctrla().write(|w| w.swrst().set_bit());
+        while count.syncbusy().read().swrst().bit_is_set() {}
+        self.tc
+    }
 }
         )+
     }

--- a/hal/src/peripherals/trng.rs
+++ b/hal/src/peripherals/trng.rs
@@ -13,6 +13,11 @@ impl Trng {
         Self(trng)
     }
 
+    /// Releases the Trng resource
+    pub fn free(self) -> pac::Trng {
+        self.0
+    }
+
     pub fn random(&self, buf: &mut [u8]) {
         for chunk in buf.chunks_mut(4) {
             chunk.copy_from_slice(&self.random_u32().to_le_bytes()[..chunk.len()]);


### PR DESCRIPTION
# Summary

This PR adds free methods for TC,TCC,NVM and TRNG peripherals. The DSU peripheral free implementation is covered in #998 , so I decided to not add it here as well.

I do have a couple observations @jbeaurivage before a potential merge regarding the other peripherals (Maybe worthy of a new issue created).

Essentially, looking at all the peripherals, there is inconsistency with how we handle free/new methods.

1. I noticed that some new/free methods are marked as `#[inline]` and some are not, even when there are bigger constructors (Look at the ADC), we mark it with `#[inline]` whilst some small constructors are not marked as `#[inline]`

2. Some free methods trigger a swrst on the peripheral being freed, and others do not. Which approach is better? - And, if swrst is the better option, why also not disable mclk on the chip too when the peripheral is freed?