### PR TITLE
Timer - Fix misuse of ctrlbset and ctrlbclr

### DIFF
--- a/hal/src/peripherals/timer/d11.rs
+++ b/hal/src/peripherals/timer/d11.rs
@@ -57,11 +57,11 @@ where
         // need to manually read the bit here
         while count.ctrla().read().bits() & 1 != 0 {}
 
-        count.ctrlbset().write(|w| {
+        count.ctrlbclr().write(|w| {
             // Count up when the direction bit is zero
-            w.dir().clear_bit();
+            w.dir().set_bit();
             // Periodic
-            w.oneshot().clear_bit()
+            w.oneshot().set_bit()
         });
 
         // Set TOP value for mfrq mode

--- a/hal/src/peripherals/timer/d5x.rs
+++ b/hal/src/peripherals/timer/d5x.rs
@@ -55,11 +55,11 @@ where
         count.ctrla().write(|w| w.swrst().set_bit());
         while count.syncbusy().read().swrst().bit_is_set() {}
 
-        count.ctrlbset().write(|w| {
+        count.ctrlbclr().write(|w| {
             // Count up when the direction bit is zero
-            w.dir().clear_bit();
+            w.dir().set_bit();
             // Periodic
-            w.oneshot().clear_bit()
+            w.oneshot().set_bit()
         });
 
         // Set TOP value for mfrq mode


### PR DESCRIPTION
# Summary

The Timer TC Ctrlbset and Ctrlbclr can only have a one written to them to modify the peripherals non exposed CTRLB register.

This PR fixes the user of CTRLBSET and CTRLBCLR, such that there is no writing 0 to them (Which results in nothing happening) - Instead, the opposite register is used to have the intended effect
