### PR TITLE
fix(spi): flush transmitter after write to prevent spurious reads (#1007)

### DIFF
--- a/hal/src/sercom/spi/impl_ehal/dma.rs
+++ b/hal/src/sercom/spi/impl_ehal/dma.rs
@@ -70,6 +70,8 @@ where
 
         // Reenable receiver only if necessary
         if D::RX_ENABLE {
+            // must wait for transmit to complete before re-enable to avoid spurious receives
+            self.flush_tx();
             self.config.as_mut().regs.rx_enable();
         }
 

--- a/hal/src/sercom/spi/impl_ehal/dma.rs
+++ b/hal/src/sercom/spi/impl_ehal/dma.rs
@@ -70,7 +70,7 @@ where
 
         // Reenable receiver only if necessary
         if D::RX_ENABLE {
-            // must wait for transmit to complete before re-enable to avoid spurious receives
+            // must wait for write to complete first to avoid spurious receives
             self.flush_tx();
             self.config.as_mut().regs.rx_enable();
         }

--- a/hal/src/sercom/spi/impl_ehal/mod.rs
+++ b/hal/src/sercom/spi/impl_ehal/mod.rs
@@ -165,7 +165,7 @@ where
 
         // Reenable receiver only if necessary
         if D::RX_ENABLE {
-            // must wait for transmit to complete before re-enable to avoid spurious receives
+            // must wait for write to complete first to avoid spurious receives
             self.flush_tx();
             self.config.as_mut().regs.rx_enable();
         }

--- a/hal/src/sercom/spi/impl_ehal/mod.rs
+++ b/hal/src/sercom/spi/impl_ehal/mod.rs
@@ -165,6 +165,8 @@ where
 
         // Reenable receiver only if necessary
         if D::RX_ENABLE {
+            // must wait for transmit to complete before re-enable to avoid spurious receives
+            self.flush_tx();
             self.config.as_mut().regs.rx_enable();
         }
         Ok(())


### PR DESCRIPTION
# Summary

Wait for SPI write transmissions to complete before re-enabling the receiver. If you don't, then code compiled for the samd21 with optimizations is fast enough to re-enable the receiver before the write occurs, resulting in occasional spurious bytes in the receive buffer. This does disable pipelined writes (partially counteracts 8243da6).

An alternative fix suggested in rust-embedded/embedded-hal#739 would be to have the flush occur at the start of a read instead of at the end of a write. That'd allow writes to be pipelined and mixed write/read transactions to work correctly, but requires more changes. I prefer to first fix the faulty behaviour with a minimal change.

Only fixes the sync implementation (regular and DMA), as I'm not familiar enough with the async to know if this is an issue there.

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 