### PR TITLE
fix(rtc): Bound RTIC monotonic spin to sync horizon, verify compare arming

### DIFF
--- a/hal/src/rtc/rtic/backends.rs
+++ b/hal/src/rtc/rtic/backends.rs
@@ -38,8 +38,17 @@ macro_rules! __internal_backend_methods {
             // before `RtcBackend::on_interrupt` is called.
             if <$mode>::check_interrupt_flag::<$rtic_int>(&rtc) {
                 let compare = <$mode>::get_compare(&rtc, 0);
+                let limit =
+                    <$mode>::count(&rtc).wrapping_add(<$mode>::SYNC_SLACK_TICKS);
 
-                while less_than_with_wrap(<$mode>::count(&rtc), compare) {}
+                // A compare that actually fired can be at most the sync
+                // staleness ahead of our read. If CC0 is further out than
+                // that, it was re-armed to a later deadline after this flag
+                // was raised and there is nothing to catch up to. Otherwise
+                // the wait below is bounded by the slack (~370µs @ 32.768 kHz).
+                if !less_than_with_wrap(limit, compare) {
+                    while less_than_with_wrap(<$mode>::count(&rtc), compare) {}
+                }
             }
 
             unsafe { Self::timer_queue().on_monotonic_interrupt(); }
@@ -146,17 +155,33 @@ macro_rules! __internal_basic_backend {
             fn set_compare(mut instant: Self::Ticks) {
                 let rtc = unsafe { pac::Rtc::steal() };
 
-                // Evidently the compare interrupt will not trigger if the instant is within a
-                // couple of ticks, so delay it a bit if it is too close.
-                // This is not mentioned in the documentation or errata, but is known to be an
-                // issue for other microcontrollers as well (e.g. nRF family).
+                // A compare armed within the sync slack of the (possibly
+                // stale) COUNT read may already be in the past by the time
+                // the write synchronizes, and would then never trigger, so
+                // delay it past the sync horizon.
                 if instant.saturating_sub(Self::now())
-                    < <$mode>::MIN_COMPARE_TICKS
+                    < <$mode>::SYNC_SLACK_TICKS
                 {
-                    instant = instant.wrapping_add(<$mode>::MIN_COMPARE_TICKS)
+                    instant = instant.wrapping_add(<$mode>::SYNC_SLACK_TICKS)
                 }
 
                 unsafe { <$mode>::set_compare(&rtc, 0, instant) };
+
+                // Verify the arm: the compare only matches on equality, and
+                // COUNT reads lag the counter by up to the sync slack. If the
+                // counter may have reached the armed value before the write
+                // latched, the match may never fire and the wake would be
+                // lost until a full counter wrap — re-pend the handler so the
+                // queue is re-evaluated and re-armed. A false positive costs
+                // one spurious, idempotent handler pass.
+                let read = <$mode>::count(&rtc);
+                if read
+                    .wrapping_add(<$mode>::SYNC_SLACK_TICKS)
+                    .wrapping_sub(instant)
+                    < <$mode>::HALF_PERIOD
+                {
+                    pac::NVIC::pend(pac::Interrupt::RTC);
+                }
             }
 
             fn clear_compare_flag() {
@@ -289,16 +314,18 @@ macro_rules! __internal_half_period_counting_backend {
 
                     // Wrapping_sub deals with the u64 overflow corner case
                     let diff = instant.wrapping_sub(now);
-                    let val = if diff <= MAX {
+                    let near = diff <= MAX;
+                    let val = if near {
                         // Now we know `instant` will happen within one `MAX` time duration.
 
-                        // Evidently the compare interrupt will not trigger if the instant is within a
-                        // couple of ticks, so delay it a bit if it is too close.
-                        // This is not mentioned in the documentation or errata, but is known to be an
-                        // issue for other microcontrollers as well (e.g. nRF family).
-                        if diff < <$mode>::MIN_COMPARE_TICKS.into() {
+                        // A compare armed within the sync slack of the
+                        // (possibly stale) COUNT read may already be in the
+                        // past by the time the write synchronizes, and would
+                        // then never trigger, so delay it past the sync
+                        // horizon.
+                        if diff < <$mode>::SYNC_SLACK_TICKS.into() {
                             instant = instant
-                                .wrapping_add(<$mode>::MIN_COMPARE_TICKS.into());
+                                .wrapping_add(<$mode>::SYNC_SLACK_TICKS.into());
                         }
 
                         (instant & MAX) as <$mode as RtcMode>::Count
@@ -308,6 +335,25 @@ macro_rules! __internal_half_period_counting_backend {
                     };
 
                     <$mode>::set_compare(&rtc, 0, val);
+
+                    // Verify the arm (near arms only — the far branch arms
+                    // behind COUNT on purpose to wait out a full period): if
+                    // the counter may have reached the armed value before the
+                    // write latched, the equality match may never fire and
+                    // the wake would be lost until a full counter wrap —
+                    // re-pend the handler so the queue is re-evaluated and
+                    // re-armed. A false positive costs one spurious,
+                    // idempotent handler pass.
+                    if near {
+                        let read = <$mode>::count(&rtc);
+                        if read
+                            .wrapping_add(<$mode>::SYNC_SLACK_TICKS)
+                            .wrapping_sub(val)
+                            < <$mode>::HALF_PERIOD
+                        {
+                            pac::NVIC::pend(pac::Interrupt::RTC);
+                        }
+                    }
                 });
             }
 

--- a/hal/src/rtc/rtic/mod.rs
+++ b/hal/src/rtc/rtic/mod.rs
@@ -223,20 +223,26 @@ pub mod rtc_clock {
 trait RtcModeMonotonic: RtcMode {
     /// The COUNT value representing a half period.
     const HALF_PERIOD: Self::Count;
-    /// The minimum number of ticks that compares need to be ahead of the COUNT
-    /// in order to trigger.
-    const MIN_COMPARE_TICKS: Self::Count;
+    /// Slack covering the COUNT register synchronization horizon.
+    ///
+    /// A read of COUNT returns the last synchronized value, which can lag the
+    /// counter by up to two synchronization periods of 5-6 CLK_RTC cycles
+    /// each (DS60001507M 13.3.3/13.3.7), i.e. ~12 ticks at DIV1. This bounds
+    /// both how far a compare that actually fired can be ahead of a read
+    /// (the interrupt handler's catch-up wait) and the minimum margin a
+    /// compare must be armed ahead of the COUNT in order to reliably trigger.
+    const SYNC_SLACK_TICKS: Self::Count;
 }
 
 #[hal_cfg("rtc-d5x")]
 impl RtcModeMonotonic for RtcMode0 {
     const HALF_PERIOD: Self::Count = 0x8000_0000;
-    const MIN_COMPARE_TICKS: Self::Count = 8;
+    const SYNC_SLACK_TICKS: Self::Count = 12;
 }
 #[hal_cfg(any("rtc-d11", "rtc-d21"))]
 impl RtcModeMonotonic for RtcMode1 {
     const HALF_PERIOD: Self::Count = 0x8000;
-    const MIN_COMPARE_TICKS: Self::Count = 8;
+    const SYNC_SLACK_TICKS: Self::Count = 12;
 }
 
 mod backend {


### PR DESCRIPTION
# Summary

The RTC interrupt handler currently spins on count < compare, to ensure that a stale count read does not reach the on_monotonic_interrupt fn. 

This is fine during normal operation, but when the handler arms a compare only a few ticks ahead of the counter the match can fire after the handler has already moved CC0 on to the next queued deadline. The re-pended handler then observes a flag raised by an already-serviced compare alongside a CC0 holding an arbitrarily distant target, and spins until COUNT reaches it. Since RTIC places the RTC vector at the same priority as the highest-priority async task, everything at or below that priority is frozen for the duration.

I ran into this causing intermittent issues with my serial comms, specifically under high load, due to the timer getting stuck spinning for longer than my comms timeout.

This commit adds a check that the compare lies within the sync horizon of the current count before spinning, so that if the compare value has been overwritten in a way that would cause a long spin, it will instead be skipped - eliminating the stall. It also replaces MIN_COMPARE_TICKS with a new unified SYNC_SLACK_TICKS based on the worst-case read latency detailed in the datasheet.

set_compare now also re-reads COUNT after the synced write and re-pends the handler if the armed value may already have been passed - an equality match armed in the past otherwise never fires, wedging the queue until counter wrap.

Some RTT logs captured with [my reproduction](https://github.com/QuartzShard/rtc_mono_bug_demo/tree/spin_bug):
[post_fix_no_stalls.txt](https://github.com/user-attachments/files/30758517/post_fix_no_stalls.txt)
[baseline_stalls.txt](https://github.com/user-attachments/files/30758518/baseline_stalls.txt)
[baseline_lost_wake.txt](https://github.com/user-attachments/files/30758519/baseline_lost_wake.txt)

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [x] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 
