### PR TITLE
Add loop to blinky example. fixes #1014

### DIFF
--- a/boards/atsame54_xpro/examples/blinky_rtic.rs
+++ b/boards/atsame54_xpro/examples/blinky_rtic.rs
@@ -69,15 +69,17 @@ mod app {
     /// This function is spawned and never returns.
     #[task(priority = 1, local=[led])]
     async fn blink_led(ctx: blink_led::Context) {
-        StatefulOutputPin::toggle(ctx.local.led).unwrap();
-        rprintln!(
-            "LED {}!",
-            if ctx.local.led.is_set_high().unwrap() {
-                "OFF"
-            } else {
-                "ON"
-            }
-        );
-        Mono::delay(200u64.millis()).await;
+        loop {
+            StatefulOutputPin::toggle(ctx.local.led).unwrap();
+            rprintln!(
+                "LED {}!",
+                if ctx.local.led.is_set_high().unwrap() {
+                    "OFF"
+                } else {
+                    "ON"
+                }
+            );
+            Mono::delay(200u64.millis()).await;
+        }
     }
 }


### PR DESCRIPTION
# Summary
Added a `loop{}` to the blinky rtic task 

# Checklist
  - [x] All new or modified code is well documented, especially public items
  - [ ] No new warnings or clippy suggestions have been introduced - CI will **deny** clippy warnings by default! You may `#[allow]` certain lints where reasonable, but ideally justify those with a short comment. 

This is one new symbol, see the issue for the bug. Hopefully I don't need that many words to describe this diff.

Maybe annotate the task with `-> !`? IIRC that means it does not return.